### PR TITLE
Fix quality metric type

### DIFF
--- a/measures/measures-data.json
+++ b/measures/measures-data.json
@@ -1561,7 +1561,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Acute Otitis Externa (AOE): Systemic Antimicrobial Therapy - Avoidance of Inappropriate Use",
     "description": "Percentage of patients aged 2 years and older with a diagnosis of AOE who were not prescribed systemic antimicrobial therapy",
     "nationalQualityCode": "ECR",
@@ -1576,7 +1576,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Otolaryngology-Head and Neck Surgery",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -1591,7 +1591,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Acute Otitis Externa (AOE): Topical Therapy",
     "description": "Percentage of patients aged 2 years and older with a diagnosis of AOE who were prescribed topical preparations",
     "nationalQualityCode": "ECC",
@@ -1606,7 +1606,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Otolaryngology-Head and Neck Surgery",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -1620,7 +1620,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "ADHD: Follow-Up Care for Children Prescribed Attention-Deficit/Hyperactivity Disorder (ADHD) Medication",
     "description": "Percentage of children 6-12 years of age and newly dispensed a medication for attention-deficit/hyperactivity disorder (ADHD) who had appropriate follow-up care.  Two rates are reported.  \na. Percentage of children who had one follow-up visit with a practitioner with prescribing authority during the 30-Day Initiation Phase.\nb. Percentage of children who remained on ADHD medication for at least 210 days and who, in addition to the visit in the Initiation Phase, had at least two additional follow-up visits with a practitioner within 270 days (9 months) after the Initiation Phase ended.\n",
     "nationalQualityCode": "ECC",
@@ -1635,7 +1635,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": [
@@ -1647,7 +1647,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Adherence to Antipsychotic Medications For Individuals with Schizophrenia",
     "description": "Percentage of individuals at least 18 years of age as of the beginning of the measurement period with schizophrenia or schizoaffective disorder who had at least two prescriptions filled for any antipsychotic medication and who had a Proportion of Days Covered (PDC) of at least 0.8 for antipsychotic medications during the measurement period (12 consecutive months)",
     "nationalQualityCode": "PS",
@@ -1662,7 +1662,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Health Services Advisory Group ",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -1673,7 +1673,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Adult Kidney Disease: Blood Pressure Management",
     "description": "Percentage of patient visits for those patients aged 18 years and older with a diagnosis of chronic kidney disease (CKD) (stage 3, 4, or 5, not receiving Renal Replacement Therapy [RRT]) with a blood pressure < 140/90 mmHg OR >= 140/90 mmHg with a documented plan of care",
     "nationalQualityCode": "ECC",
@@ -1688,7 +1688,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Renal Physicians Association",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -1697,7 +1697,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Adult Kidney Disease: Catheter Use at Initiation of Hemodialysis",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of End Stage Renal Disease (ESRD) who initiate maintenance hemodialysis during the measurement period, whose mode of vascular access is a catheter at the time maintenance hemodialysis is initiated",
     "nationalQualityCode": "ECC",
@@ -1712,7 +1712,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Renal Physicians Association",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -1721,7 +1721,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Adult Kidney Disease: Catheter Use for Greater Than or Equal to 90 Days",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of End Stage Renal Disease (ESRD) receiving maintenance hemodialysis for greater than or equal to 90 days whose mode of vascular access is a catheter",
     "nationalQualityCode": "PS",
@@ -1736,7 +1736,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Renal Physicians Association",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -1745,7 +1745,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Adult Kidney Disease: Referral to Hospice",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of ESRD who withdraw from hemodialysis or peritoneal dialysis who are referred to hospice care",
     "nationalQualityCode": "PCCEO",
@@ -1760,7 +1760,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Renal Physicians Association",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -1769,7 +1769,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Adult Major Depressive Disorder (MDD): Coordination of Care of Patients with Specific Comorbid Conditions",
     "description": "Percentage of medical records of patients aged 18 years and older with a diagnosis of major depressive disorder (MDD) and a specific diagnosed comorbid condition (diabetes, coronary artery disease, ischemic stroke, intracranial hemorrhage, chronic kidney disease [stages 4 or 5], End Stage Renal Disease [ESRD] or congestive heart failure) being treated by another clinician with communication to the clinician treating the comorbid condition",
     "nationalQualityCode": "CCC",
@@ -1784,7 +1784,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Psychiatric Association",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -1795,7 +1795,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Adult Major Depressive Disorder (MDD): Suicide Risk Assessment",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of major depressive disorder (MDD) with a suicide risk assessment completed during the visit in which a new diagnosis or recurrent episode was identified",
     "nationalQualityCode": "ECC",
@@ -1810,7 +1810,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": []
@@ -1819,7 +1819,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Adult Primary Rhegmatogenous Retinal Detachment Surgery: No Return to the Operating Room Within 90 Days of Surgery",
     "description": "Patients aged 18 years and older who had surgery for primary rhegmatogenous retinal detachment who did not require a return to the operating room within 90 days of surgery",
     "nationalQualityCode": "ECC",
@@ -1834,7 +1834,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Ophthalmology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -1845,7 +1845,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Adult Primary Rhegmatogenous Retinal Detachment Surgery: Visual Acuity Improvement Within 90 Days of Surgery",
     "description": "Patients aged 18 years and older who had surgery for primary rhegmatogenous retinal detachment and achieved an improvement in their visual acuity, from their preoperative level, within 90 days of surgery in the operative eye",
     "nationalQualityCode": "ECC",
@@ -1860,7 +1860,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Ophthalmology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -1871,7 +1871,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Adult Sinusitis: Antibiotic Prescribed for Acute Sinusitis (Overuse)",
     "description": "Percentage of patients, aged 18 years and older, with a diagnosis of acute sinusitis who were prescribed an antibiotic within 10 days after onset of symptoms",
     "nationalQualityCode": "ECR",
@@ -1886,7 +1886,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Otolaryngology-Head and Neck Surgery",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -1900,7 +1900,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Adult Sinusitis: Appropriate Choice of Antibiotic: Amoxicillin With or Without Clavulanate Prescribed for Patients with Acute Bacterial Sinusitis (Appropriate Use)",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of acute bacterial sinusitis that were prescribed amoxicillin, with or without clavulanate, as a first line antibiotic at the time of diagnosis",
     "nationalQualityCode": "ECR",
@@ -1915,7 +1915,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Otolaryngology-Head and Neck Surgery",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -1929,7 +1929,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Adult Sinusitis: Computerized Tomography (CT) for Acute Sinusitis (Overuse)",
     "description": "Percentage of patients aged 18 years and older, with a diagnosis of acute sinusitis who had a computerized tomography (CT) scan of the paranasal sinuses ordered at the time of diagnosis or received within 28 days after date of diagnosis",
     "nationalQualityCode": "ECR",
@@ -1944,7 +1944,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Otolaryngology-Head and Neck Surgery",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -1958,7 +1958,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Adult Sinusitis: More than One Computerized Tomography (CT) Scan Within 90 Days for Chronic Sinusitis (Overuse)",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of chronic sinusitis who had more than one CT scan of the paranasal sinuses ordered or received within 90 days after the date of diagnosis",
     "nationalQualityCode": "ECR",
@@ -1973,7 +1973,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Otolaryngology-Head and Neck Surgery",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -1987,7 +1987,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Age Appropriate Screening Colonoscopy",
     "description": "The percentage of patients greater than 85 years of age who received a screening colonoscopy from January 1 to December 31",
     "nationalQualityCode": "ECR",
@@ -2002,7 +2002,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Gastroenterological Association",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -2013,7 +2013,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Age-Related Macular Degeneration (AMD): Counseling on Antioxidant Supplement",
     "description": "Percentage of patients aged 50 years and older with a diagnosis of age-related macular degeneration (AMD) or their caregiver(s) who were counseled within 12 months on the benefits and/or risks of the Age-Related Eye Disease Study  (AREDS) formulation for preventing progression of AMD",
     "nationalQualityCode": "ECC",
@@ -2028,7 +2028,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Ophthalmology",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -2040,7 +2040,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Age-Related Macular Degeneration (AMD): Dilated Macular Examination",
     "description": "Percentage of patients aged 50 years and older with a diagnosis of age-related macular degeneration (AMD) who had a dilated macular examination performed which included documentation of the presence or absence of macular thickening or hemorrhage AND the level of macular degeneration severity during one or more office visits within 12 months",
     "nationalQualityCode": "ECC",
@@ -2055,7 +2055,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Ophthalmology",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -2067,7 +2067,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "All-cause Hospital Readmission",
     "description": "The 30-day All-Cause Hospital Readmission measure is a risk-standardized readmission rate for beneficiaries age 65 or older who were hospitalized at a short-stay acute care hospital and experienced an unplanned readmission for any cause to an acute care hospital within 30 days of discharge.",
     "nationalQualityCode": "CCC",
@@ -2082,7 +2082,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Yale University",
-    "methods": [
+    "submissionMethods": [
       "administrativeClaims"
     ],
     "measureSets": []
@@ -2091,7 +2091,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Amyotrophic Lateral Sclerosis (ALS) Patient Care Preferences",
     "description": "Percentage of patients diagnosed with Amyotrophic Lateral Sclerosis (ALS) who were offered assistance in planning for end of life issues (e.g., advance directives, invasive ventilation, hospice) at least once annually",
     "nationalQualityCode": "PCCEO",
@@ -2106,7 +2106,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Neurology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -2117,7 +2117,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Anastomotic Leak Intervention",
     "description": "Percentage of patients aged 18 years and older who required an anastomotic leak intervention following gastric bypass or colectomy surgery",
     "nationalQualityCode": "PS",
@@ -2132,7 +2132,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -2143,7 +2143,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Anesthesiology Smoking Abstinence",
     "description": "The percentage of current smokers who abstain from cigarettes prior to anesthesia on the day of elective surgery or procedure",
     "nationalQualityCode": "ECC",
@@ -2158,7 +2158,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Anesthesiologists",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -2169,7 +2169,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Annual Hepatitis C Virus (HCV) Screening for Patients who are Active Injection Drug Users",
     "description": "Percentage of patients, regardless of age, who are active injection drug users who received screening for HCV infection within the 12 month reporting period",
     "nationalQualityCode": "ECC",
@@ -2184,7 +2184,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -2196,7 +2196,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Anti-Depressant Medication Management",
     "description": "Percentage of patients 18 years of age and older who were treated with antidepressant medication, had a diagnosis of major depression, and who remained on an antidepressant medication treatment. Two rates are reported. \na. Percentage of patients who remained on an antidepressant medication for at least 84 days (12 weeks). \nb. Percentage of patients who remained on an antidepressant medication for at least 180 days (6 months).\n",
     "nationalQualityCode": "ECC",
@@ -2211,7 +2211,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": [
@@ -2224,7 +2224,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Appropriate Assessment of Retrievable Inferior Vena Cava (IVC) Filters for Removal",
     "description": "Percentage of patients in whom a retrievable IVC filter is placed who, within 3 months post-placement, have a documented assessment for the appropriateness of continued filtration, device removal or the inability to contact the patient with at least two attempts",
     "nationalQualityCode": "ECC",
@@ -2239,7 +2239,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society of Interventional Radiology ",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -2248,7 +2248,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Appropriate Follow-up Imaging for Incidental Abdominal Lesions",
     "description": "Percentage of final reports for abdominal imaging studies for asymptomatic patients aged 18 years and older with one or more of the following noted incidentally with follow-up imaging recommended:\n<br/><ul><li> Liver lesion <= 0.5 cm\n</li><li> Cystic kidney lesion < 1.0 cm\n</li><li> Adrenal lesion <= 1.0 cm\n\n\n</li></ul>",
     "nationalQualityCode": "ECC",
@@ -2263,7 +2263,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Radiology",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -2275,7 +2275,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Appropriate Follow-up Imaging for Incidental Thyroid Nodules in Patients",
     "description": "Percentage of final reports for computed tomography (CT), CT angiography (CTA) or magnetic resonance imaging (MRI) or magnetic resonance angiogram (MRA) studies of the chest or neck or ultrasound of the neck for patients aged 18 years and older with no known thyroid disease with a thyroid nodule < 1.0 cm noted incidentally with follow-up imaging recommended",
     "nationalQualityCode": "ECC",
@@ -2290,7 +2290,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Radiology",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -2302,7 +2302,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients",
     "description": "Percentage of patients aged 50 to 75 years of age receiving a screening colonoscopy without biopsy or polypectomy who had a recommended follow-up interval of at least 10 years for repeat colonoscopy documented in their colonoscopy report",
     "nationalQualityCode": "CCC",
@@ -2317,7 +2317,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Gastroenterological Association",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -2329,7 +2329,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Appropriate Testing for Children with Pharyngitis",
     "description": "Percentage of children 3-18 years of age who were diagnosed with pharyngitis, ordered an antibiotic and received a group A streptococcus (strep) test for the episode",
     "nationalQualityCode": "ECR",
@@ -2344,7 +2344,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "ehr",
       "registry"
     ],
@@ -2358,7 +2358,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Appropriate Treatment for Children with Upper Respiratory Infection (URI)",
     "description": "Percentage of children 3 months-18 years of age who were diagnosed with upper respiratory infection (URI) and were not dispensed an antibiotic prescription on or three days after the episode",
     "nationalQualityCode": "ECR",
@@ -2373,7 +2373,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "ehr",
       "registry"
     ],
@@ -2386,7 +2386,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Appropriate Treatment of Methicillin-Sensitive Staphylococcus Aureus (MSSA) Bacteremia",
     "description": "Percentage of patients with sepsis due to MSSA bacteremia who received beta-lactam antibiotic (e.g. nafcillin, oxacillin or cefazolin) as definitive therapy",
     "nationalQualityCode": "ECC",
@@ -2401,7 +2401,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Infectious Diseases Society of America",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -2413,7 +2413,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Appropriate Workup Prior to Endometrial Ablation",
     "description": "Percentage of women, aged 18 years and older, who undergo   endometrial sampling or hysteroscopy with biopsy  before undergoing an endometrial ablation",
     "nationalQualityCode": "PS",
@@ -2428,7 +2428,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -2439,7 +2439,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Atrial Fibrillation and Atrial Flutter: Chronic Anticoagulation Therapy",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of nonvalvular atrial fibrillation (AF) or atrial flutter whose assessment of the specified thromboembolic risk factors indicate one or more high-risk factors or more than one moderate risk factor, as determined by CHADS2 risk stratification, who are prescribed warfarin OR another oral anticoagulant drug that is FDA approved for the prevention of thromboembolism",
     "nationalQualityCode": "ECC",
@@ -2454,7 +2454,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Cardiology",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -2468,7 +2468,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Avoidance of Antibiotic Treatment in Adults With Acute Bronchitis",
     "description": "The percentage of adults 18-64 years of age with a diagnosis of acute bronchitis who were not dispensed an antibiotic prescription",
     "nationalQualityCode": "ECR",
@@ -2483,7 +2483,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -2496,7 +2496,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Barrett's Esophagus",
     "description": "Percentage of esophageal biopsy reports that document the presence of Barrett's mucosa that also include a statement about dysplasia",
     "nationalQualityCode": "ECC",
@@ -2511,7 +2511,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "College of American Pathologists",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -2523,7 +2523,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Basal Cell Carcinoma (BCC)/Squamous Cell Carcinoma: Biopsy Reporting Time - Pathologist to Clinician",
     "description": "Percentage of biopsies with a diagnosis of cutaneous Basal Cell Carcinoma (BCC) and Squamous Cell Carcinoma (SCC) (including in situ disease) in which the pathologist communicates results to the clinician within 7 days of  biopsy date",
     "nationalQualityCode": "CCC",
@@ -2538,7 +2538,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Dermatology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -2547,7 +2547,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Biopsy Follow-Up",
     "description": "Percentage of new patients whose biopsy results have been reviewed and communicated to the primary care/referring physician and patient by the performing physician",
     "nationalQualityCode": "CCC",
@@ -2562,7 +2562,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Dermatology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -2576,7 +2576,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Bipolar Disorder and Major Depression: Appraisal for alcohol or chemical substance use",
     "description": "Percentage of patients with depression or bipolar disorder with evidence of an initial assessment that includes an appraisal for alcohol or chemical substance use",
     "nationalQualityCode": "ECC",
@@ -2591,7 +2591,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Center for Quality Assessment and Improvement in Mental Health",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": []
@@ -2600,7 +2600,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Breast Cancer Resection Pathology Reporting: pT Category (Primary Tumor) and pN Category (Regional Lymph Nodes) with Histologic Grade",
     "description": "Percentage of breast cancer resection pathology reports that include the pT category (primary tumor), the pN category (regional lymph nodes), and the histologic grade",
     "nationalQualityCode": "ECC",
@@ -2615,7 +2615,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "College of American Pathologists",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -2627,7 +2627,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Breast Cancer Screening",
     "description": "Percentage of women 50-74 years of age who had a mammogram to screen for breast cancer.",
     "nationalQualityCode": "ECC",
@@ -2642,7 +2642,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "ehr",
       "cmsWebInterface",
@@ -2659,7 +2659,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "CAHPS for PQRS Clinician/Group Survey",
     "description": "<br/><ul><li> Getting timely care, appointments, and information;\n</li><li> How well providers Communicate;\n</li><li> Patient's Rating of Provider;\n</li><li> Access to Specialists;\n</li><li> Health Promotion & Education;\n</li><li> Shared Decision Making;\n</li><li> Health Status/Functional Status;\n</li><li> Courteous and Helpful Office Staff;\n</li><li> Care Coordination;\n</li><li> Between Visit Communication;\n</li><li> Helping Your to Take Medication as Directed; and\n</li><li> Stewardship of Patient Resources</li></ul>",
     "nationalQualityCode": "PCCEO",
@@ -2674,7 +2674,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Agency for Healthcare Research & Quality",
-    "methods": [
+    "submissionMethods": [
       "csv"
     ],
     "measureSets": [
@@ -2685,7 +2685,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Cardiac Rehabilitation Patient Referral from an Outpatient Setting",
     "description": "Percentage of patients evaluated in an outpatient setting who within the previous 12 months have experienced an acute myocardial infarction (MI), coronary artery bypass graft (CABG) surgery, a percutaneous coronary intervention (PCI), cardiac valve surgery, or cardiac transplantation, or who have chronic stable angina (CSA) and have not already participated in an early outpatient cardiac rehabilitation/secondary prevention (CR) program for the qualifying event/diagnosis who were referred to a CR program",
     "nationalQualityCode": "CCC",
@@ -2700,7 +2700,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Cardiology Foundation",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -2709,7 +2709,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low Risk Surgery Patients",
     "description": "Percentage of stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), or cardiac magnetic resonance (CMR) performed in low risk surgery patients 18 years or older for preoperative evaluation during the 12-month reporting period",
     "nationalQualityCode": "ECR",
@@ -2724,7 +2724,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Cardiology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -2735,7 +2735,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Routine Testing After Percutaneous Coronary Intervention (PCI)",
     "description": "Percentage of all stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), and cardiovascular magnetic resonance (CMR) performed in patients aged 18 years and older routinely after percutaneous coronary intervention (PCI), with reference to timing of test after PCI and symptom status",
     "nationalQualityCode": "ECR",
@@ -2750,7 +2750,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Cardiology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -2761,7 +2761,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Testing in Asymptomatic, Low-Risk Patients",
     "description": "Percentage of all stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), and cardiovascular magnetic resonance (CMR) performed in asymptomatic, low coronary heart disease (CHD) risk patients 18 years and older for initial detection and risk assessment",
     "nationalQualityCode": "ECR",
@@ -2776,7 +2776,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Cardiology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -2787,7 +2787,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Care Plan",
     "description": "Percentage of patients aged 65 years and older who have an advance care plan or surrogate decision maker documented in the medical record or documentation in the medical record that an advance care plan was discussed but the patient did not wish or was not able to name a surrogate decision maker or provide an advance care plan",
     "nationalQualityCode": "CCC",
@@ -2802,7 +2802,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -2834,7 +2834,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Cataracts: 20/40 or Better Visual Acuity within 90 Days Following Cataract Surgery",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of uncomplicated cataract who had cataract surgery and no significant ocular conditions impacting the visual outcome of surgery and had best-corrected visual acuity of 20/40 or better (distance or near) achieved within 90 days following the cataract surgery",
     "nationalQualityCode": "ECC",
@@ -2849,7 +2849,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
-    "methods": [
+    "submissionMethods": [
       "ehr",
       "registry"
     ],
@@ -2861,7 +2861,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Cataracts: Complications within 30 Days Following Cataract Surgery Requiring Additional Surgical Procedures",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of uncomplicated cataract who had cataract surgery and had any of a specified list of surgical procedures in the 30 days following cataract surgery which would indicate the occurrence of any of the following major complications: retained nuclear fragments, endophthalmitis, dislocated or wrong power IOL, retinal detachment, or wound dehiscence",
     "nationalQualityCode": "PS",
@@ -2876,7 +2876,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
-    "methods": [
+    "submissionMethods": [
       "ehr",
       "registry"
     ],
@@ -2888,7 +2888,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Cataracts: Improvement in Patient's Visual Function within 90 Days Following Cataract Surgery",
     "description": "Percentage of patients aged 18 years and older who had cataract surgery and had improvement in visual function achieved within 90 days following the cataract surgery, based on completing a pre-operative and post-operative visual function survey",
     "nationalQualityCode": "PCCEO",
@@ -2903,7 +2903,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Ophthalmology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -2914,7 +2914,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Cataracts: Patient Satisfaction within 90 Days Following Cataract Surgery",
     "description": "Percentage of patients aged 18 years and older  who had cataract surgery and were satisfied with their care within 90 days following the cataract surgery, based on completion of the Consumer Assessment of Healthcare Providers and Systems Surgical Care Survey",
     "nationalQualityCode": "PCCEO",
@@ -2929,7 +2929,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Ophthalmology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -2940,7 +2940,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Cataract Surgery: Difference Between Planned and Final Refraction",
     "description": "Percentage of patients aged 18 years and older who had cataract surgery performed and who achieved a final refraction within +/- 1.0 diopters of their planned (target) refraction",
     "nationalQualityCode": "ECC",
@@ -2955,7 +2955,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Ophthalmology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -2966,7 +2966,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Cataract Surgery with Intra-Operative Complications (Unplanned Rupture of Posterior Capsule Requiring Unplanned Vitrectomy)",
     "description": "Percentage of patients aged 18 years and older who had cataract surgery performed and had an unplanned rupture of the posterior capsule requiring vitrectomy",
     "nationalQualityCode": "PS",
@@ -2981,7 +2981,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Ophthalmology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -2992,7 +2992,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Cervical Cancer Screening",
     "description": "Percentage of women 21-64 years of age who were screened for cervical cancer using either of the following criteria:\n*  Women age 21-64 who had cervical cytology performed every 3 years\n*  Women age 30-64 who had cervical cytology/human papillomavirus (HPV) co-testing performed every 5 years\n",
     "nationalQualityCode": "ECC",
@@ -3007,7 +3007,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": [
@@ -3019,7 +3019,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Child and Adolescent Major Depressive Disorder (MDD): Suicide Risk Assessment",
     "description": "Percentage of patient visits for those patients aged 6 through 17 years with a diagnosis of major depressive disorder with an assessment for suicide risk\n",
     "nationalQualityCode": "PS",
@@ -3034,7 +3034,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": [
@@ -3046,7 +3046,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Childhood Immunization Status",
     "description": "Percentage of children 2 years of age who had four diphtheria, tetanus and acellular pertussis (DTaP); three polio (IPV), one measles, mumps and rubella (MMR); three H influenza type B (HiB); three hepatitis B (Hep B); one chicken pox (VZV); four pneumococcal conjugate (PCV); one hepatitis A (Hep A); two or three rotavirus (RV); and two influenza (flu) vaccines by their second birthday",
     "nationalQualityCode": "CPH",
@@ -3061,7 +3061,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": [
@@ -3072,7 +3072,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Children Who Have Dental Decay or Cavities",
     "description": "Percentage of children, age 0-20 years, who have had tooth decay or cavities during the measurement period",
     "nationalQualityCode": "CPH",
@@ -3087,7 +3087,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": []
@@ -3096,7 +3096,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Chlamydia Screening and Follow Up",
     "description": "The percentage of female adolescents 16 years of age who had a chlamydia screening test with proper follow-up during the measurement period",
     "nationalQualityCode": "CPH",
@@ -3111,7 +3111,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -3122,7 +3122,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Chlamydia Screening for Women",
     "description": "Percentage of women 16-24 years of age who were identified as sexually active and who had at least one test for chlamydia during the measurement period",
     "nationalQualityCode": "CPH",
@@ -3137,7 +3137,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": [
@@ -3149,7 +3149,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Chronic Obstructive Pulmonary Disease (COPD): Long-Acting Inhaled Bronchodilator Therapy",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of COPD (FEV1/FVC < 70%) and who have an FEV1 less than 60% predicted and have symptoms who were prescribed an long-acting inhaled bronchodilator",
     "nationalQualityCode": "ECC",
@@ -3164,7 +3164,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Thoracic Society",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -3174,7 +3174,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Chronic Obstructive Pulmonary Disease (COPD): Spirometry Evaluation",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of COPD who had spirometry results documented",
     "nationalQualityCode": "ECC",
@@ -3189,7 +3189,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Thoracic Society",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -3199,7 +3199,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Clinical Outcome Post Endovascular Stroke Treatment",
     "description": "Percentage of patients with a mRs score of 0 to 2 at 90 days following endovascular stroke intervention",
     "nationalQualityCode": "ECC",
@@ -3214,7 +3214,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society of Interventional Radiology ",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -3223,7 +3223,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Closing the Referral Loop: Receipt of Specialist Report",
     "description": "Percentage of patients with referrals, regardless of age, for which the referring provider receives a report from the provider to whom the patient was referred",
     "nationalQualityCode": "CCC",
@@ -3238,7 +3238,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": [
@@ -3269,7 +3269,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Colonoscopy Interval for Patients with a History of Adenomatous Polyps\n- Avoidance of Inappropriate Use",
     "description": "Percentage of patients aged 18 years and older receiving a surveillance colonoscopy, with a history of a prior adenomatous polyp(s) in previous colonoscopy findings, which had an interval of 3 or more years since their last colonoscopy",
     "nationalQualityCode": "CCC",
@@ -3284,7 +3284,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Gastroenterological Association",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -3296,7 +3296,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Colorectal Cancer Resection Pathology Reporting: pT Category (Primary Tumor) and pN Category (Regional Lymph Nodes) with Histologic Grade",
     "description": "Percentage of colon and rectum cancer resection pathology reports that include the pT category (primary tumor), the pN category (regional lymph nodes) and the histologic grade",
     "nationalQualityCode": "ECC",
@@ -3311,7 +3311,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "College of American Pathologists",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -3323,7 +3323,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Colorectal Cancer Screening",
     "description": "Percentage of adults 50-75 years of age who had appropriate screening for colorectal cancer.",
     "nationalQualityCode": "ECC",
@@ -3338,7 +3338,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "ehr",
       "cmsWebInterface",
@@ -3353,7 +3353,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Communication with the Physician or Other Clinician Managing On-going Care Post-Fracture for Men and Women Aged 50 Years and Older",
     "description": "Percentage of patients aged 50 years and older treated for a fracture with documentation of communication, between the physician treating the fracture and the physician or other clinician managing the patient's on-going care, that a fracture occurred and that the patient was or should be considered for osteoporosis treatment or testing. This measure is reported by the physician who treats the fracture and who therefore is held accountable for the communication",
     "nationalQualityCode": "CCC",
@@ -3368,7 +3368,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -3380,7 +3380,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Controlling High Blood Pressure",
     "description": "Percentage of patients 18-85 years of age who had a diagnosis of hypertension and whose blood pressure was adequately controlled (<140/90mmHg) during the measurement period",
     "nationalQualityCode": "ECC",
@@ -3395,7 +3395,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "ehr",
       "cmsWebInterface",
@@ -3415,7 +3415,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Coronary Artery Bypass Graft (CABG): Deep Sternal Wound Infection Rate",
     "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery who, within 30 days postoperatively, develop deep sternal wound infection involving muscle, bone, and/or mediastinum requiring operative intervention",
     "nationalQualityCode": "ECC",
@@ -3430,7 +3430,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society of Thoracic Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -3441,7 +3441,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Coronary Artery Bypass Graft (CABG): Postoperative Renal Failure",
     "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery (without pre-existing renal failure) who develop postoperative renal failure or require dialysis",
     "nationalQualityCode": "ECC",
@@ -3456,7 +3456,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society of Thoracic Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -3467,7 +3467,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Coronary Artery Bypass Graft (CABG): Preoperative Beta-Blocker in Patients with Isolated CABG Surgery",
     "description": "Percentage of isolated Coronary Artery Bypass Graft (CABG) surgeries for patients aged 18 years and older who received a beta-blocker within 24 hours prior to surgical incision",
     "nationalQualityCode": "ECC",
@@ -3482,7 +3482,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -3493,7 +3493,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Coronary Artery Bypass Graft (CABG): Prolonged Intubation",
     "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery who require postoperative intubation > 24 hours",
     "nationalQualityCode": "ECC",
@@ -3508,7 +3508,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society of Thoracic Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -3519,7 +3519,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Coronary Artery Bypass Graft (CABG): Stroke",
     "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery who have a postoperative stroke (i.e., any confirmed neurological deficit of abrupt onset caused by a disturbance in blood supply to the brain) that did not resolve within 24 hours",
     "nationalQualityCode": "ECC",
@@ -3534,7 +3534,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society of Thoracic Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -3545,7 +3545,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Coronary Artery Bypass Graft (CABG): Surgical Re-Exploration",
     "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery who require a return to the operating room (OR) during the current hospitalization for mediastinal bleeding with or without tamponade, graft occlusion, valve dysfunction, or other cardiac reason",
     "nationalQualityCode": "ECC",
@@ -3560,7 +3560,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society of Thoracic Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -3571,7 +3571,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Coronary Artery Bypass Graft (CABG): Use of Internal Mammary Artery (IMA) in Patients with Isolated CABG Surgery",
     "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery who received an IMA graft",
     "nationalQualityCode": "ECC",
@@ -3586,7 +3586,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society of Thoracic Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -3595,7 +3595,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Coronary Artery Disease (CAD): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy - Diabetes or Left Ventricular Systolic Dysfunction (LVEF < 40%)",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease seen within a 12 month period who also have diabetes OR a current or prior Left Ventricular Ejection Fraction (LVEF) < 40% who were prescribed ACE inhibitor or ARB therapy",
     "nationalQualityCode": "ECC",
@@ -3610,7 +3610,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Heart Association",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -3621,7 +3621,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Coronary Artery Disease (CAD): Antiplatelet Therapy",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease (CAD) seen within a 12 month period who were prescribed aspirin or clopidogrel",
     "nationalQualityCode": "ECC",
@@ -3636,7 +3636,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Heart Association",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -3647,7 +3647,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Coronary Artery Disease (CAD): Beta-Blocker Therapy-Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF <40%)",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease seen within a 12 month period who also have a prior MI or a current or prior LVEF <40% who were prescribed beta-blocker therapy",
     "nationalQualityCode": "ECC",
@@ -3662,7 +3662,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
-    "methods": [
+    "submissionMethods": [
       "ehr",
       "registry"
     ],
@@ -3675,7 +3675,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Dementia: Caregiver Education and Support",
     "description": "Percentage of patients, regardless of age, with a diagnosis of dementia whose caregiver(s) were provided with education on dementia disease management and health behavior changes AND referred to additional resources for support within a 12 month period",
     "nationalQualityCode": "CCC",
@@ -3690,7 +3690,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Neurology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -3702,7 +3702,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Dementia: Cognitive Assessment",
     "description": "Percentage of patients, regardless of age, with a diagnosis of dementia for whom an assessment of cognition is performed and the results reviewed at least once within a 12 month period",
     "nationalQualityCode": "ECC",
@@ -3717,7 +3717,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": [
@@ -3729,7 +3729,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Dementia: Counseling Regarding Safety Concerns",
     "description": "Percentage of patients, regardless of age, with a diagnosis of dementia or their caregiver(s) who were counseled or referred for counseling regarding safety concerns within a 12 month period",
     "nationalQualityCode": "PS",
@@ -3744,7 +3744,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Neurology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -3756,7 +3756,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Dementia: Functional Status Assessment",
     "description": "Percentage of patients, regardless of age, with a diagnosis of dementia for whom an assessment of functional status is performed and the results reviewed at least once within a 12 month period",
     "nationalQualityCode": "ECC",
@@ -3771,7 +3771,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Neurology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -3783,7 +3783,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Dementia: Management of Neuropsychiatric Symptoms",
     "description": "Percentage of patients, regardless of age, with a diagnosis of dementia who have one or more neuropsychiatric symptoms who received or were recommended to receive an intervention for neuropsychiatric symptoms within a 12 month period",
     "nationalQualityCode": "ECC",
@@ -3798,7 +3798,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Neurology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -3810,7 +3810,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Dementia: Neuropsychiatric Symptom Assessment",
     "description": "Percentage of patients, regardless of age, with a diagnosis of dementia and for whom an assessment of neuropsychiatric symptoms is performed and results reviewed at least once in a 12 month period",
     "nationalQualityCode": "ECC",
@@ -3825,7 +3825,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Neurology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -3837,7 +3837,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Depression Remission at Six Months",
     "description": "Adult patients age 18 years and older with major depression or dysthymia and an initial PHQ-9 score > 9 who demonstrate remission at six months defined as a PHQ-9 score less than 5. This measure applies to both patients with newly diagnosed and existing depression whose current PHQ-9 score indicates a need for treatment. This measure additionally promotes ongoing contact between the patient and provider as patients who do not have a follow-up PHQ-9 score at six months (+/- 30 days) are also included in the denominator",
     "nationalQualityCode": "ECC",
@@ -3852,7 +3852,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Minnesota Community Measurement",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -3863,7 +3863,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Depression Remission at Twelve Months",
     "description": "Patients age 18 and older with major depression or dysthymia and an initial Patient Health Questionnaire (PHQ-9) score greater than nine who demonstrate remission at twelve months (+/- 30 days after an index visit) defined as a PHQ-9 score less than five. This measure applies to both patients with newly diagnosed and existing depression whose current PHQ-9 score indicates a need for treatment.",
     "nationalQualityCode": "ECC",
@@ -3878,7 +3878,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Minnesota Community Measurement",
-    "methods": [
+    "submissionMethods": [
       "ehr",
       "cmsWebInterface",
       "registry"
@@ -3892,7 +3892,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Depression Utilization of the PHQ-9 Tool",
     "description": "Patients age 18 and older with the diagnosis of major depression or dysthymia who have a Patient Health Questionnaire (PHQ-9) tool administered at least once during a 4-month period in which there was a qualifying visit",
     "nationalQualityCode": "ECC",
@@ -3907,7 +3907,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Minnesota Community Measurement",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": [
@@ -3918,7 +3918,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Diabetes: Eye Exam",
     "description": "Percentage of patients 18-75 years of age with diabetes who had a retinal or dilated eye exam by an eye care professional during the measurement period or a negative retinal exam (no evidence of retinopathy) in the 12 months prior to the measurement period",
     "nationalQualityCode": "ECC",
@@ -3933,7 +3933,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "ehr",
       "cmsWebInterface",
@@ -3949,7 +3949,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Diabetes: Foot Exam",
     "description": "The percentage of patients 18-75 years of age with diabetes (type 1 and type 2) who received a foot exam (visual inspection and sensory exam with mono filament and a pulse exam) during the measurement year",
     "nationalQualityCode": "ECC",
@@ -3964,7 +3964,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": [
@@ -3976,7 +3976,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%)",
     "description": "Percentage of patients 18-75 years of age with diabetes who had hemoglobin A1c > 9.0% during the measurement period",
     "nationalQualityCode": "ECC",
@@ -3991,7 +3991,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "ehr",
       "cmsWebInterface",
@@ -4007,7 +4007,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Diabetes: Medical Attention for Nephropathy",
     "description": "The percentage of patients 18-75 years of age with diabetes who had a nephropathy screening test or evidence of nephropathy during the measurement period.",
     "nationalQualityCode": "ECC",
@@ -4022,7 +4022,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "ehr",
       "registry"
     ],
@@ -4034,7 +4034,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Diabetes Mellitus: Diabetic Foot and Ankle Care, Peripheral Neuropathy - Neurological Evaluation",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of diabetes mellitus who had a neurological examination of their lower extremities within 12 months",
     "nationalQualityCode": "ECC",
@@ -4049,7 +4049,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Podiatric Medical Association",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -4058,7 +4058,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Diabetes Mellitus: Diabetic Foot and Ankle Care, Ulcer Prevention - Evaluation of Footwear",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of diabetes mellitus who were evaluated for proper footwear and sizing",
     "nationalQualityCode": "ECC",
@@ -4073,7 +4073,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Podiatric Medical Association",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -4082,7 +4082,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of diabetic retinopathy who had a dilated macular or fundus exam performed with documented communication to the physician who manages the ongoing care of the patient with diabetes mellitus regarding the findings of the macular or fundus exam at least once within 12 months",
     "nationalQualityCode": "CCC",
@@ -4097,7 +4097,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "ehr",
       "registry"
@@ -4110,7 +4110,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Diabetic Retinopathy: Documentation of Presence or Absence of Macular Edema and Level of Severity of Retinopathy",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of diabetic retinopathy who had a dilated macular or fundus exam performed which included documentation of the level of severity of retinopathy and the presence or absence of macular edema during one or more office visits within 12 months",
     "nationalQualityCode": "ECC",
@@ -4125,7 +4125,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": [
@@ -4136,7 +4136,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Documentation of Current Medications in the Medical Record",
     "description": "Percentage of visits for patients aged 18 years and older for which the eligible professional attests to documenting a list of current medications using all immediate resources available on the date of the encounter.  This list must include ALL known prescriptions, over-the-counters, herbals, and vitamin/mineral/dietary (nutritional) supplements AND must contain the medications' name, dosage, frequency and route of administration.",
     "nationalQualityCode": "PS",
@@ -4151,7 +4151,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "ehr",
       "registry"
@@ -4187,7 +4187,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Documentation of Signed Opioid Treatment Agreement",
     "description": "All patients 18 and older prescribed opiates for longer than six weeks duration who signed an opioid treatment agreement at least once during Opioid Therapy documented in the medical record.",
     "nationalQualityCode": "ECC",
@@ -4202,7 +4202,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Neurology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -4216,7 +4216,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Door to Puncture Time for Endovascular Stroke Treatment",
     "description": "Percentage of patients undergoing endovascular stroke treatment who have a door to puncture time of less than two hours",
     "nationalQualityCode": "ECC",
@@ -4231,7 +4231,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society of Interventional Radiology ",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -4240,7 +4240,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Elder Maltreatment Screen and Follow-Up Plan",
     "description": "Percentage of patients aged 65 years and older with a documented elder maltreatment screen using an Elder Maltreatment Screening tool on the date of encounter AND a documented follow-up plan on the date of the positive screen",
     "nationalQualityCode": "PS",
@@ -4255,7 +4255,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -4269,7 +4269,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older",
     "description": "Percentage of emergency department visits for patients aged 18 years and older who presented within 24 hours of a minor blunt head trauma with a Glasgow Coma Scale (GCS) score of 15 and who had a head CT for trauma ordered by an emergency care provider who have an indication for a head CT",
     "nationalQualityCode": "ECR",
@@ -4284,7 +4284,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Emergency Physicians",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -4296,7 +4296,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years",
     "description": "Percentage of emergency department visits for patients aged 2 through 17 years who presented within 24 hours of a minor blunt head trauma with a Glasgow Coma Scale (GCS) score of 15 and who had a head CT for trauma ordered by an emergency care provider who are classified as low risk according to the Pediatric Emergency Care Applied Research Network (PECARN) prediction rules for traumatic brain injury",
     "nationalQualityCode": "ECR",
@@ -4311,7 +4311,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Emergency Physicians",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -4323,7 +4323,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Epilepsy: Counseling for Women of Childbearing Potential with Epilepsy",
     "description": "All female patients of childbearing potential (12 - 44 years old) diagnosed with epilepsy who were counseled or referred for counseling for how epilepsy and its treatment may affect contraception OR pregnancy at least once a year",
     "nationalQualityCode": "ECC",
@@ -4338,7 +4338,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Neurology",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -4350,7 +4350,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Evaluation or Interview for Risk of Opioid Misuse",
     "description": "All patients 18 and older prescribed opiates for longer than six weeks duration evaluated for risk of opioid misuse using a brief validated instrument (e.g. Opioid Risk Tool, SOAPP-R) or patient interview documented at least once during Opioid Therapy in the medical record",
     "nationalQualityCode": "ECC",
@@ -4365,7 +4365,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Neurology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -4379,7 +4379,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Falls: Plan of Care",
     "description": "Percentage of patients aged 65 years and older with a history of falls that had a plan of care for falls documented within 12 months",
     "nationalQualityCode": "CCC",
@@ -4394,7 +4394,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -4407,7 +4407,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Falls: Risk Assessment",
     "description": "Percentage of patients aged 65 years and older with a history of falls that had a risk assessment for falls completed within 12 months",
     "nationalQualityCode": "PS",
@@ -4422,7 +4422,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -4435,7 +4435,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Falls: Screening for Future Fall Risk",
     "description": "Percentage of patients 65 years of age and older who were screened for future fall risk during the measurement period.",
     "nationalQualityCode": "PS",
@@ -4450,7 +4450,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "ehr",
       "cmsWebInterface"
     ],
@@ -4460,7 +4460,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Follow-Up After Hospitalization for Mental Illness (FUH)",
     "description": "The percentage of discharges for patients 6 years of age and older who were hospitalized for treatment of selected mental illness diagnoses and who had an outpatient visit, an intensive outpatient encounter or partial hospitalization with a mental health practitioner. Two rates are reported:\n<br/><ul><li> The percentage of discharges for which the patient received follow-up within 30 days of discharge.\n</li><li> The percentage of discharges for which the patient received follow-up within 7 days of discharge\n\n</li></ul>",
     "nationalQualityCode": "CCC",
@@ -4475,7 +4475,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -4487,7 +4487,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Functional Outcome Assessment",
     "description": "Percentage of visits for patients aged 18 years and older with documentation of a current functional outcome assessment using a standardized functional outcome assessment tool on the date of the encounter AND documentation of a care plan based on identified functional outcome deficiencies on the date of the identified deficiencies",
     "nationalQualityCode": "CCC",
@@ -4502,7 +4502,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -4514,7 +4514,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Functional Status Assessment for Total Hip Replacement",
     "description": "Percentage of patients 18 years of age and older with primary total hip arthroplasty (THA) who completed baseline and follow-up patient-reported functional status assessments",
     "nationalQualityCode": "PCCEO",
@@ -4529,7 +4529,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": [
@@ -4540,7 +4540,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Functional Status Assessment for Total Knee Replacement",
     "description": "Percentage of patients 18 years of age and older with primary total knee arthroplasty (TKA) who completed baseline and follow-up patient-reported functional status assessments",
     "nationalQualityCode": "PCCEO",
@@ -4555,7 +4555,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": [
@@ -4566,7 +4566,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Functional Status Assessments for Congestive Heart Failure",
     "description": "Percentage of patients 65 years of age and older with congestive  heart failure who completed initial and follow-up patient-reported functional status assessments",
     "nationalQualityCode": "PCCEO",
@@ -4581,7 +4581,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": []
@@ -4590,7 +4590,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Functional Status Change for Patients with Elbow, Wrist or Hand Impairments",
     "description": "A self-report outcome measure of functional status (FS) for patients 14 years+ with elbow, wrist or hand impairments. The change in FS assessed using FOTO (elbow, wrist and hand) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS  outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality",
     "nationalQualityCode": "CCC",
@@ -4605,7 +4605,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Focus on Therapeutic Outcomes, Inc.",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -4614,7 +4614,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Functional Status Change for Patients with Foot or Ankle Impairments",
     "description": "A self-report measure of change in functional status (FS) for patients 14 years+ with foot and ankle impairments. The change in functional status (FS) assessed using FOTO's (foot and ankle) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality",
     "nationalQualityCode": "CCC",
@@ -4629,7 +4629,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Focus on Therapeutic Outcomes, Inc.",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -4638,7 +4638,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Functional Status Change for Patients with General Orthopaedic Impairments",
     "description": "A self-report outcome measure of functional status (FS) for patients 14 years+ with general orthopaedic impairments (neck, cranium, mandible, thoracic spine, ribs or other general orthopaedic impairment). The change in FS assessed using FOTO (general orthopaedic) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level by to assess quality",
     "nationalQualityCode": "CCC",
@@ -4653,7 +4653,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Focus on Therapeutic Outcomes, Inc.",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -4662,7 +4662,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Functional Status Change for Patients with Hip Impairments",
     "description": "A self-report measure of change in functional status (FS) for patients 14 years+ with hip impairments. The change in functional status (FS) assessed using FOTO's (hip) PROM (patient- reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality",
     "nationalQualityCode": "CCC",
@@ -4677,7 +4677,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Focus on Therapeutic Outcomes, Inc.",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -4686,7 +4686,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Functional Status Change for Patients with Knee Impairments",
     "description": "A self-report measure of change in functional status for patients 14 year+ with knee impairments. The change in functional status (FS) assessed using FOTO's (knee ) PROM (patient-reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality",
     "nationalQualityCode": "CCC",
@@ -4701,7 +4701,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Focus on Therapeutic Outcomes, Inc.",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -4710,7 +4710,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Functional Status Change for Patients with Lumbar Impairments",
     "description": "A self-report outcome measure of change in functional status for patients 14 years+ with lumbar impairments. The change in functional status (FS) assessed using FOTO (lumbar) PROM (patient reported outcome measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level by to assess quality",
     "nationalQualityCode": "CCC",
@@ -4725,7 +4725,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Focus on Therapeutic Outcomes, Inc.",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -4734,7 +4734,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Functional Status Change for Patients with Shoulder Impairments",
     "description": "A self-report outcome measure of change in functional status (FS) for patients 14 years+ with shoulder impairments. The change in functional status (FS) assessed using FOTO's (shoulder) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality",
     "nationalQualityCode": "CCC",
@@ -4749,7 +4749,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Focus on Therapeutic Outcomes, Inc.",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -4758,7 +4758,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy for Left Ventricular Systolic Dysfunction (LVSD)",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of heart failure (HF) with a current or prior left ventricular ejection fraction (LVEF) < 40% who were prescribed ACE inhibitor or ARB therapy either within a 12 month period when seen in the outpatient setting OR at each hospital discharge",
     "nationalQualityCode": "ECC",
@@ -4773,7 +4773,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
-    "methods": [
+    "submissionMethods": [
       "ehr",
       "registry"
     ],
@@ -4788,7 +4788,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Heart Failure (HF): Beta-Blocker Therapy for Left Ventricular Systolic Dysfunction (LVSD)",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of heart failure (HF) with a current or prior left ventricular ejection fraction (LVEF) < 40% who were prescribed beta-blocker therapy either within a 12 month period when seen in the outpatient setting OR at each hospital discharge",
     "nationalQualityCode": "ECC",
@@ -4803,7 +4803,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
-    "methods": [
+    "submissionMethods": [
       "ehr",
       "registry"
     ],
@@ -4817,7 +4817,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Hematology: Chronic Lymphocytic Leukemia (CLL): Baseline Flow Cytometry",
     "description": "Percentage of patients aged 18 years and older, seen within a 12 month reporting period, with a diagnosis of chronic lymphocytic leukemia (CLL) made at any time during or prior to the reporting period who had baseline flow cytometry studies performed and documented in the chart",
     "nationalQualityCode": "ECC",
@@ -4832,7 +4832,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -4841,7 +4841,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Hematology: Multiple Myeloma: Treatment with Bisphosphonates",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of multiple myeloma, not in remission, who were prescribed or received intravenous bisphosphonate therapy within the 12 month reporting period",
     "nationalQualityCode": "ECC",
@@ -4856,7 +4856,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Hematology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -4865,7 +4865,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Hematology: Myelodysplastic Syndrome (MDS) and Acute Leukemias: Baseline Cytogenetic Testing Performed on Bone Marrow",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of myelodysplastic syndrome (MDS) or an acute leukemia who had baseline cytogenetic testing performed on bone marrow",
     "nationalQualityCode": "ECC",
@@ -4880,7 +4880,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Hematology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -4889,7 +4889,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Hematology: Myelodysplastic Syndrome (MDS): Documentation of Iron Stores in Patients Receiving Erythropoietin Therapy",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of myelodysplastic syndrome (MDS) who are receiving erythropoietin therapy with documentation of iron stores within 60 days prior to initiating erythropoietin therapy",
     "nationalQualityCode": "ECC",
@@ -4904,7 +4904,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Hematology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -4913,7 +4913,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Hepatitis C: Discussion and Shared Decision Making Surrounding Treatment Options",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of hepatitis C with whom a physician or other qualified healthcare professional reviewed the range of treatment options appropriate to their genotype and demonstrated a shared decision making approach with the patient. To meet the measure, there must be documentation in the patient record of a discussion between the physician or other qualified healthcare professional and the patient that includes all of the following: treatment choices appropriate to genotype, risks and benefits, evidence of effectiveness, and patient preferences toward treatment\n",
     "nationalQualityCode": "PCCEO",
@@ -4928,7 +4928,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Gastroenterological Association",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -4939,7 +4939,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Hepatitis C: Screening for Hepatocellular Carcinoma (HCC) in Patients with Cirrhosis",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of chronic hepatitis C cirrhosis who underwent imaging with either ultrasound, contrast enhanced CT or MRI for hepatocellular carcinoma (HCC) at least once within the 12 month reporting period",
     "nationalQualityCode": "ECC",
@@ -4954,7 +4954,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Gastroenterological Association",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -4967,7 +4967,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "HER2 Negative or Undocumented Breast Cancer Patients Spared Treatment with HER2-Targeted Therapies",
     "description": "Proportion of female patients (aged 18 years and older) with breast cancer who are human epidermal growth factor receptor 2 (HER2)/neu negative who are not administered HER2-targeted therapies",
     "nationalQualityCode": "ECR",
@@ -4982,7 +4982,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Clinical Oncology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -4993,7 +4993,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "HIV/AIDS: Pneumocystis Jiroveci Pneumonia (PCP) Prophylaxis",
     "description": "Percentage of patients aged 6 weeks and older with a diagnosis of HIV/AIDS who were prescribed Pneumocystis jiroveci pneumonia (PCP) prophylaxis",
     "nationalQualityCode": "ECC",
@@ -5008,7 +5008,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": [
@@ -5020,7 +5020,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "HIV/AIDS: Sexually Transmitted Disease Screening for Chlamydia, Gonorrhea, and Syphilis",
     "description": "Percentage of patients aged 13 years and older with a diagnosis of HIV/AIDS for whom chlamydia, gonorrhea, and syphilis screenings were performed at least once since the diagnosis of HIV infection",
     "nationalQualityCode": "ECC",
@@ -5035,7 +5035,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -5046,7 +5046,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "HIV Medical Visit Frequency",
     "description": "Percentage of patients, regardless of age with a diagnosis of HIV who had at least one medical visit in each 6 month period of the 24 month measurement period, with a minimum of 60 days between medical visits",
     "nationalQualityCode": "ECR",
@@ -5061,7 +5061,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Health Resources and Services Administration",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -5070,7 +5070,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "HIV Viral Load Suppression",
     "description": "The percentage of patients, regardless of age, with a diagnosis of HIV with a HIV viral load less than 200 copies/mL at last HIV viral load test during the measurement year",
     "nationalQualityCode": "ECC",
@@ -5085,7 +5085,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Health Resources and Services Administration",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -5096,7 +5096,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "HRS-12: Cardiac Tamponade and/or Pericardiocentesis Following Atrial Fibrillation Ablation",
     "description": "Rate of cardiac tamponade and/or pericardiocentesis following atrial fibrillation ablation This measure is reported as four rates stratified by age and gender:\n<br/><ul><li> Reporting Age Criteria 1: Females 18-64years of age\n</li><li> Reporting Age Criteria 2: Males 18-64 years of age\n</li><li> Reporting Age Criteria 3: Females 65 years of age and older\n</li><li> Reporting Age Criteria 4: Males 65 years of age and older\n</li></ul>",
     "nationalQualityCode": "PS",
@@ -5111,7 +5111,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "The Heart Rhythm Society",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -5122,7 +5122,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "HRS-3: Implantable Cardioverter-Defibrillator (ICD) Complications Rate",
     "description": "Patients with physician-specific risk-standardized rates of procedural complications following the first time implantation of an ICD",
     "nationalQualityCode": "PS",
@@ -5137,7 +5137,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "The Heart Rhythm Society",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -5148,7 +5148,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "HRS-9: Infection within 180 Days of Cardiac Implantable Electronic Device (CIED) Implantation, Replacement, or Revision",
     "description": "Infection rate following CIED device implantation, replacement, or revision\n",
     "nationalQualityCode": "PS",
@@ -5163,7 +5163,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "The Heart Rhythm Society",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -5174,7 +5174,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Hypertension: Improvement in Blood Pressure",
     "description": "Percentage of patients aged 18-85 years of age with a diagnosis of hypertension whose blood pressure improved during the measurement period.",
     "nationalQualityCode": "ECC",
@@ -5189,7 +5189,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": []
@@ -5198,7 +5198,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Image Confirmation of Successful Excision of Image-Localized Breast Lesion",
     "description": "Image confirmation of lesion(s) targeted for image guided excisional biopsy or image guided partial mastectomy in patients with nonpalpable, image-detected breast lesion(s). Lesions may include: microcalcifications, mammographic or sonographic mass or architectural distortion, focal suspicious abnormalities on magnetic resonance imaging (MRI) or other breast imaging amenable to localization such as positron emission tomography (PET) mammography, or a biopsy marker demarcating site of confirmed pathology as established by previous core biopsy",
     "nationalQualityCode": "PS",
@@ -5213,7 +5213,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Breast Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -5222,7 +5222,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Immunizations for Adolescents",
     "description": "The percentage of adolescents 13 years of age who had the recommended immunizations by their 13th birthday",
     "nationalQualityCode": "CPH",
@@ -5237,7 +5237,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -5249,7 +5249,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Inflammatory Bowel Disease (IBD): Assessment of Hepatitis B Virus (HBV) Status Before Initiating Anti-TNF (Tumor Necrosis Factor) Therapy",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of inflammatory bowel disease (IBD) who had Hepatitis B Virus (HBV) status assessed and results interpreted within one year prior to receiving a first course of anti-TNF (tumor necrosis factor) therapy",
     "nationalQualityCode": "ECC",
@@ -5264,7 +5264,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Gastroenterological Association",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -5275,7 +5275,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Inflammatory Bowel Disease (IBD): Preventive Care: Corticosteroid Related Iatrogenic Injury - Bone Loss Assessment",
     "description": "Percentage of patients aged 18 years and older with an inflammatory bowel disease encounter who were prescribed prednisone equivalents greater than or equal to 10 mg/day for 60 or greater consecutive days or a single prescription equating to 600 mg prednisone or greater for all fills and were documented for risk of bone loss once during the reporting year or the previous calendar year",
     "nationalQualityCode": "ECC",
@@ -5290,7 +5290,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Gastroenterological Association",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -5301,7 +5301,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Initiation and Engagement of Alcohol and Other Drug Dependence Treatment",
     "description": "Percentage of patients 13 years of age and older with a new episode of alcohol and other drug (AOD) dependence who received the following. Two rates are reported.\na. Percentage of patients who initiated treatment within 14 days of the diagnosis.\nb. Percentage of patients who initiated treatment and who had two or more additional services with an AOD diagnosis within 30 days of the initiation visit.\n",
     "nationalQualityCode": "ECC",
@@ -5316,7 +5316,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": []
@@ -5325,7 +5325,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Ischemic Vascular Disease (IVD) All or None Outcome Measure (Optimal Control)",
     "description": "The IVD All-or-None Measure is one outcome measure (optimal control). The measure contains four goals. All four goals within a measure must be reached in order to meet that measure. The numerator for the all-or-none measure should be collected from the organization's total IVD denominator. All-or-None Outcome Measure (Optimal Control) - Using the IVD denominator optimal results include: \n<br/><ul><li> Most recent blood pressure (BP) measurement is less than 140/90 mm Hg -- And \n</li><li> Most recent tobacco status is Tobacco Free -- And \n</li><li> Daily Aspirin or Other Antiplatelet Unless Contraindicated -- And \n</li><li> Statin Use\n</li></ul>",
     "nationalQualityCode": "ECC",
@@ -5340,7 +5340,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Wisconsin Collaborative for Healthcare Quality",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -5349,7 +5349,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Ischemic Vascular Disease (IVD): Use of Aspirin or Another Antiplatelet",
     "description": "Percentage of patients 18 years of age and older who were diagnosed with acute myocardial infarction (AMI), coronary artery bypass graft (CABG) or percutaneous coronary interventions (PCI) in the 12 months prior to the measurement period, or who had an active diagnosis of ischemic vascular disease (IVD) during the measurement period, and who had documentation of use of aspirin or another antiplatelet during the measurement period.",
     "nationalQualityCode": "ECC",
@@ -5364,7 +5364,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "ehr",
       "cmsWebInterface",
@@ -5380,7 +5380,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "KRAS Gene Mutation Testing Performed for Patients with Metastatic Colorectal Cancer who receive Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibody Therapy",
     "description": "Percentage of adult patients (aged 18 or over) with metastatic colorectal cancer who receive anti-epidermal growth factor receptor monoclonal antibody therapy for whom KRAS gene mutation testing was performed",
     "nationalQualityCode": "ECC",
@@ -5395,7 +5395,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Clinical Oncology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -5406,7 +5406,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Lung Cancer Reporting (Biopsy/Cytology Specimens)",
     "description": "Pathology reports based on biopsy and/or cytology specimens with a diagnosis of primary non-small cell lung cancer classified into specific histologic type or classified as NSCLC-NOS with an explanation included in the pathology report",
     "nationalQualityCode": "CCC",
@@ -5421,7 +5421,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "College of American Pathologists",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -5433,7 +5433,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Lung Cancer Reporting (Resection Specimens)",
     "description": "Pathology reports based on resection specimens with a diagnosis of primary lung carcinoma that include the pT category, pN category and for non-small cell lung cancer, histologic type",
     "nationalQualityCode": "CCC",
@@ -5448,7 +5448,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "College of American Pathologists",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -5460,7 +5460,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Maternal Depression Screening",
     "description": "The percentage of children who turned 6 months of age during the measurement year, who had a face-to-face visit between the clinician and the child during child's first 6 months, and who had a maternal depression screening for the mother at least once between 0 and 6 months of life.\n",
     "nationalQualityCode": "CPH",
@@ -5475,7 +5475,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": []
@@ -5484,7 +5484,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Maternity Care: Elective Delivery or Early Induction Without Medical Indication at >= 37 and < 39 Weeks (Overuse)",
     "description": "Percentage of patients, regardless of age, who gave birth during a 12-month period who delivered a live singleton at\n>= 37 and < 39 weeks of gestation completed who had elective deliveries or early inductions without medical indication\n",
     "nationalQualityCode": "PS",
@@ -5499,7 +5499,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -5508,7 +5508,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Maternity Care: Post-Partum Follow-Up and Care Coordination",
     "description": "Percentage of patients, regardless of age, who gave birth during a 12-month period who were seen for post-partum care within 8 weeks of giving birth who received a breast feeding evaluation and education, post-partum depression screening, post-partum glucose screening for gestational diabetes patients, and family and contraceptive planning",
     "nationalQualityCode": "CCC",
@@ -5523,7 +5523,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -5532,7 +5532,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Medication Management for People with Asthma",
     "description": "The percentage of patients 5-64 years of age during the measurement year who were identified as having persistent asthma and were dispensed appropriate medications that they remained on for at least 75% of their treatment period",
     "nationalQualityCode": "ECR",
@@ -5547,7 +5547,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -5560,7 +5560,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Medication Reconciliation Post-Discharge",
     "description": "The percentage of discharges from any inpatient facility (e.g. hospital, skilled nursing facility, or rehabilitation facility) for patients 18 years and older of age seen within 30 days following discharge in the office by the physician, prescribing practitioner, registered nurse, or clinical pharmacist providing on-going care for whom the discharge medication list was reconciled with the current medication list in the outpatient medical record.\nThis measure is reported as three rates stratified by age group:\n<br/><ul><li> Reporting Criteria 1: 18-64 years of age\n</li><li> Reporting Criteria 2: 65 years and older\n</li><li> Total Rate: All patients 18 years of age and older\n</li></ul>",
     "nationalQualityCode": "CCC",
@@ -5575,7 +5575,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "cmsWebInterface",
       "registry"
@@ -5586,7 +5586,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Melanoma: Continuity of Care - Recall System",
     "description": "Percentage of patients, regardless of age, with a current diagnosis of melanoma or a history of melanoma whose information was entered, at least once within a 12 month period, into a recall system that includes:\n<br/><ul><li> A target date for the next complete physical skin exam, AND\n</li><li> A process to follow up with patients who either did not make an appointment within the specified timeframe or who missed a scheduled appointment\n</li></ul>",
     "nationalQualityCode": "CCC",
@@ -5601,7 +5601,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Dermatology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -5612,7 +5612,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Melanoma: Coordination of Care",
     "description": "Percentage of patient visits, regardless of age, with a new occurrence of melanoma who have a treatment plan documented in the chart that was communicated to the physician(s) providing continuing care within one month of diagnosis",
     "nationalQualityCode": "CCC",
@@ -5627,7 +5627,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Dermatology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -5638,7 +5638,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Melanoma: Overutilization of Imaging Studies in Melanoma",
     "description": "Percentage of patients, regardless of age, with a current diagnosis of Stage 0 through IIC melanoma or a history of melanoma of any stage, without signs or symptoms suggesting systemic spread, seen for an office visit during the one-year measurement period, for whom no diagnostic imaging studies were ordered",
     "nationalQualityCode": "ECR",
@@ -5653,7 +5653,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Dermatology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -5664,7 +5664,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Melanoma Reporting",
     "description": "Pathology reports for primary malignant cutaneous melanoma that include the pT category and a statement on thickness and ulceration and for pT1, mitotic rate",
     "nationalQualityCode": "CCC",
@@ -5679,7 +5679,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "College of American Pathologists",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -5691,7 +5691,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Non-Recommended Cervical Cancer Screening in Adolescent Females",
     "description": "The percentage of adolescent females 16-20 years of age who were screened unnecessarily for cervical cancer",
     "nationalQualityCode": "PS",
@@ -5706,7 +5706,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -5718,7 +5718,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Nuclear Medicine: Correlation with Existing Imaging Studies for All Patients Undergoing Bone Scintigraphy",
     "description": "Percentage of final reports for all patients, regardless of age, undergoing bone scintigraphy that include physician documentation of correlation with existing relevant imaging studies (e.g., x-ray, MRI, CT, etc.) that were performed",
     "nationalQualityCode": "CCC",
@@ -5733,7 +5733,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society of Nuclear Medicine and Molecular Imaging",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -5745,7 +5745,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Oncology: Medical and Radiation - Pain Intensity Quantified",
     "description": "Percentage of patient visits, regardless of patient age, with a diagnosis of cancer currently receiving chemotherapy or radiation therapy in which pain intensity is quantified",
     "nationalQualityCode": "PCCEO",
@@ -5760,7 +5760,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
-    "methods": [
+    "submissionMethods": [
       "ehr",
       "registry"
     ],
@@ -5773,7 +5773,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Oncology: Medical and Radiation - Plan of Care for Pain",
     "description": "Percentage of visits for patients, regardless of age, with a diagnosis of cancer currently receiving chemotherapy or radiation therapy who report having pain with a documented plan of care to address pain",
     "nationalQualityCode": "PCCEO",
@@ -5788,7 +5788,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Clinical Oncology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -5799,7 +5799,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Oncology: Radiation Dose Limits to Normal Tissues",
     "description": "Percentage of patients, regardless of age, with a diagnosis of breast, rectal, pancreatic or lung cancer receiving 3D conformal radiation therapy who had documentation in medical record that radiation dose limits to normal tissues were established prior to the initiation of a course of 3D conformal radiation for a minimum of two tissues",
     "nationalQualityCode": "PS",
@@ -5814,7 +5814,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society for Radiation Oncology",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -5826,7 +5826,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "One-Time Screening for Hepatitis C Virus (HCV) for Patients at Risk",
     "description": "Percentage of patients aged 18 years and older with one or more of the following: a history of injection drug use, receipt of a blood transfusion prior to 1992, receiving maintenance hemodialysis, OR birthdate in the years 1945-1965 who received one-time screening for hepatitis C virus (HCV) infection",
     "nationalQualityCode": "ECC",
@@ -5841,7 +5841,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -5853,7 +5853,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Operative Mortality Stratified by the Five STS-EACTS Mortality Categories",
     "description": "Percent of patients undergoing index pediatric and/or congenital heart surgery who die, including both 1) all deaths occurring during the hospitalization in which the procedure was performed, even if after 30 days (including patients transferred to other acute care facilities), and 2) those deaths occurring after discharge from the hospital, but within 30 days of the procedure, stratified by the five STAT Mortality Levels, a multi-institutional validated complexity stratification tool",
     "nationalQualityCode": "PS",
@@ -5868,7 +5868,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society of Thoracic Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -5877,7 +5877,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Opioid Therapy Follow-up Evaluation",
     "description": "All patients 18 and older prescribed opiates for longer than six weeks duration who had a follow-up evaluation conducted at least every three months during Opioid Therapy documented in the medical record",
     "nationalQualityCode": "ECC",
@@ -5892,7 +5892,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Neurology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -5906,7 +5906,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Optimal Asthma Control",
     "description": "Composite measure of the percentage of pediatric and adult patients whose asthma is well-controlled as demonstrated by one of three age appropriate patient reported outcome tools and not at risk for exacerbation",
     "nationalQualityCode": "ECC",
@@ -5921,7 +5921,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Minnesota Community Measurement",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -5933,7 +5933,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Optimizing Patient Exposure to Ionizing Radiation: Appropriateness: Follow-up CT Imaging for Incidentally Detected Pulmonary Nodules According to Recommended Guidelines",
     "description": "Percentage of final reports for computed tomography (CT) imaging studies of the thorax for patients aged 18 years and older with documented follow-up recommendations for incidentally detected pulmonary nodules (e.g., follow-up CT imaging studies needed or that no follow-up is needed) based at a minimum on nodule size AND patient risk factors",
     "nationalQualityCode": "CCC",
@@ -5948,7 +5948,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Radiology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -5959,7 +5959,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Optimizing Patient Exposure to Ionizing Radiation: Computed Tomography (CT) Images Available for Patient Follow-up and Comparison Purposes",
     "description": "Percentage of final reports for computed tomography (CT) studies performed for all patients, regardless of age, which document that Digital Imaging and Communications in Medicine (DICOM) format image data are available to non-affiliated external healthcare facilities or entities on a secure, media free, reciprocally searchable basis with patient authorization for at least a 12-month period after the study",
     "nationalQualityCode": "CCC",
@@ -5974,7 +5974,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Radiology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -5985,7 +5985,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Optimizing Patient Exposure to Ionizing Radiation: Count of Potential High Dose Radiation Imaging Studies: Computed Tomography (CT) and Cardiac Nuclear Medicine Studies",
     "description": "Percentage of computed tomography (CT) and cardiac nuclear medicine (myocardial perfusion studies) imaging reports for all patients, regardless of age, that document a count of known previous CT (any type of CT) and cardiac nuclear medicine (myocardial perfusion) studies that the patient has received in the 12-month period prior to the current study",
     "nationalQualityCode": "PS",
@@ -6000,7 +6000,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Radiology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -6011,7 +6011,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Optimizing Patient Exposure to Ionizing Radiation: Reporting to a Radiation Dose Index Registry",
     "description": "Percentage of total computed tomography (CT) studies performed for all patients, regardless of age, that are reported to a radiation dose index registry that is capable of collecting at a minimum selected data elements",
     "nationalQualityCode": "PS",
@@ -6026,7 +6026,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Radiology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -6037,7 +6037,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Optimizing Patient Exposure to Ionizing Radiation: Search for Prior Computed Tomography (CT) Studies Through a Secure, Authorized, Media-Free, Shared Archive",
     "description": "Percentage of final reports of computed tomography (CT) studies performed for all patients, regardless of age, which document that a search for Digital Imaging and Communications in Medicine (DICOM) format images was conducted for prior patient CT imaging studies completed at non-affiliated external healthcare facilities or entities within the past 12-months and are available through a secure, authorized, media-free, shared archive prior to an imaging study being performed",
     "nationalQualityCode": "CCC",
@@ -6052,7 +6052,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Radiology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -6063,7 +6063,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Optimizing Patient Exposure to Ionizing Radiation: Utilization of a Standardized Nomenclature for Computed Tomography (CT) Imaging Description",
     "description": "Percentage of computed tomography (CT) imaging reports for all patients, regardless of age, with the imaging study named according to a standardized nomenclature and the standardized nomenclature is used in institution's computer systems",
     "nationalQualityCode": "CCC",
@@ -6078,7 +6078,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Radiology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -6089,7 +6089,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Osteoarthritis (OA): Function and Pain Assessment",
     "description": "Percentage of patient visits for patients aged 21 years and older with a diagnosis of osteoarthritis (OA) with assessment for function and pain",
     "nationalQualityCode": "PCCEO",
@@ -6104,7 +6104,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Orthopedic Surgeons",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -6120,7 +6120,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Osteoporosis Management in Women Who Had a Fracture",
     "description": "The percentage of women age 50-85 who suffered a fracture and who either had a bone mineral density test or received a prescription for a drug to treat osteoporosis in the six months after the fracture",
     "nationalQualityCode": "ECC",
@@ -6135,7 +6135,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -6149,7 +6149,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Overuse Of Neuroimaging For Patients With Primary Headache And A Normal Neurological Examination",
     "description": "Percentage of patients with a diagnosis of primary headache disorder whom advanced brain imaging was not ordered",
     "nationalQualityCode": "ECR",
@@ -6164,7 +6164,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Neurology",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -6176,7 +6176,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Pain Assessment and Follow-Up",
     "description": "Percentage of visits for patients aged 18 years and older with documentation of a pain assessment using a standardized tool(s) on each visit AND documentation of a follow-up plan when pain is present",
     "nationalQualityCode": "CCC",
@@ -6191,7 +6191,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -6203,7 +6203,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Pain Brought Under Control Within 48 Hours",
     "description": "Patients aged 18 and older who report being uncomfortable because of pain at the initial assessment (after admission to palliative care services) that report pain was brought to a comfortable level within 48 hours",
     "nationalQualityCode": "PCCEO",
@@ -6218,7 +6218,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Hospice and Palliative Care Organization",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -6229,7 +6229,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Parkinson's Disease: Cognitive Impairment or Dysfunction Assessment",
     "description": "All patients with a diagnosis of Parkinson's disease who were assessed for cognitive impairment or dysfunction  in the last 12 months",
     "nationalQualityCode": "ECC",
@@ -6244,7 +6244,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Neurology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -6255,7 +6255,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Parkinson's Disease: Parkinson's Disease Medical and Surgical Treatment Options Reviewed",
     "description": "All patients with a diagnosis of Parkinson's disease (or caregiver(s), as appropriate) who had the Parkinson's disease treatment options (e.g., non-pharmacological treatment, pharmacological treatment, or surgical treatment) reviewed at least annually",
     "nationalQualityCode": "CCC",
@@ -6270,7 +6270,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Neurology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -6281,7 +6281,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Parkinson's Disease: Psychiatric Symptoms Assessment for Patients with Parkinson's Disease",
     "description": "All patients with a diagnosis of Parkinson's disease who were assessed for psychiatric symptoms (e.g., psychosis, depression, anxiety disorder, apathy, or impulse control disorder) in the last 12 months",
     "nationalQualityCode": "ECC",
@@ -6296,7 +6296,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Neurology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -6307,7 +6307,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Parkinson's Disease: Rehabilitative Therapy Options",
     "description": "All patients with a diagnosis of Parkinson's Disease (or caregiver(s), as appropriate) who had rehabilitative therapy options (e.g., physical, occupational, or speech therapy) discussed  in the last 12 months",
     "nationalQualityCode": "CCC",
@@ -6322,7 +6322,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Neurology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -6333,7 +6333,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Patient-Centered Surgical Risk Assessment and Communication",
     "description": "Percentage of patients who underwent a non-emergency surgery who had their personalized risks of postoperative complications assessed by their surgical team prior to surgery using a clinical data-based, patient-specific risk calculator and who received personal discussion of those risks with the surgeon",
     "nationalQualityCode": "PCCEO",
@@ -6348,7 +6348,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -6364,7 +6364,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Patients with Metastatic Colorectal Cancer and KRAS Gene Mutation Spared Treatment with Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibodies",
     "description": "Percentage of adult patients (aged 18 or over) with metastatic colorectal cancer and KRAS gene mutation spared treatment with anti-EGFR monoclonal antibodies",
     "nationalQualityCode": "PS",
@@ -6379,7 +6379,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Clinical Oncology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -6390,7 +6390,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Pediatric Kidney Disease: Adequacy of Volume Management",
     "description": "Percentage of calendar months within a 12-month period during which patients aged 17 years and younger with a diagnosis of End Stage Renal Disease (ESRD) undergoing maintenance hemodialysis in an outpatient dialysis facility have an assessment of the adequacy of volume management from a nephrologist",
     "nationalQualityCode": "ECC",
@@ -6405,7 +6405,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Renal Physicians Association",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -6414,7 +6414,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Pediatric Kidney Disease: ESRD Patients Receiving Dialysis: Hemoglobin Level < 10 g/dL",
     "description": "Percentage of calendar months within a 12-month period during which patients aged 17 years and younger with a diagnosis of End Stage Renal Disease (ESRD) receiving hemodialysis or peritoneal dialysis have a hemoglobin level < 10 g/dL",
     "nationalQualityCode": "ECC",
@@ -6429,7 +6429,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Renal Physicians Association",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -6438,7 +6438,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Pelvic Organ Prolapse: Preoperative Assessment of Occult Stress Urinary Incontinence",
     "description": "Percentage of patients undergoing appropriate preoperative evaluation of stress urinary incontinence prior to pelvic organ prolapse surgery per ACOG/AUGS/AUA guidelines",
     "nationalQualityCode": "ECC",
@@ -6453,7 +6453,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Urogynecologic Society",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -6462,7 +6462,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Pelvic Organ Prolapse: Preoperative Screening for Uterine Malignancy",
     "description": "Percentage of patients who are screened for uterine malignancy prior to vaginal closure or obliterative surgery for pelvic organ prolapse",
     "nationalQualityCode": "PS",
@@ -6477,7 +6477,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Urogynecologic Society",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -6487,7 +6487,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Performing Cystoscopy at the Time of Hysterectomy for Pelvic Organ Prolapse to Detect Lower Urinary Tract Injury",
     "description": "Percentage of patients who undergo cystoscopy to evaluate for lower urinary tract injury at the time of hysterectomy for pelvic organ prolapse",
     "nationalQualityCode": "PS",
@@ -6502,7 +6502,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Urogynecologic Society",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -6514,7 +6514,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Perioperative Anti-platelet Therapy for Patients Undergoing Carotid Endarterectomy",
     "description": "Percentage of patients undergoing carotid endarterectomy (CEA) who are taking an anti-platelet agent within 48 hours prior to surgery and are prescribed this medication at hospital discharge following surgery",
     "nationalQualityCode": "ECC",
@@ -6529,7 +6529,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society for Vascular Surgeons",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -6539,7 +6539,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Perioperative Care: Selection of Prophylactic Antibiotic - First OR Second Generation Cephalosporin",
     "description": "Percentage of surgical patients aged 18 years and older undergoing procedures with the indications for a first OR second generation cephalosporin prophylactic antibiotic who had an order for a first OR second generation cephalosporin for antimicrobial prophylaxis",
     "nationalQualityCode": "PS",
@@ -6554,7 +6554,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Plastic Surgeons",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -6570,7 +6570,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Perioperative Care: Venous Thromboembolism (VTE) Prophylaxis (When Indicated in ALL Patients)",
     "description": "Percentage of surgical patients aged 18 years and older undergoing procedures for which venous thromboembolism (VTE) prophylaxis is indicated in all patients, who had an order for Low Molecular Weight Heparin (LMWH), Low- Dose Unfractionated Heparin (LDUH), adjusted-dose warfarin, fondaparinux or mechanical prophylaxis to be given within 24 hours prior to incision time or within 24 hours after surgery end time",
     "nationalQualityCode": "PS",
@@ -6585,7 +6585,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Plastic Surgeons",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -6601,7 +6601,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Perioperative Temperature Management",
     "description": "Percentage of patients, regardless of age, who undergo surgical or therapeutic procedures under general or neuraxial anesthesia of 60 minutes duration or longer for whom at least one body temperature greater than or equal to 35.5 degrees Celsius (or 95.9 degrees Fahrenheit) was recorded within the 30 minutes immediately before or the 15 minutes immediately after anesthesia end time",
     "nationalQualityCode": "PS",
@@ -6616,7 +6616,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Anesthesiologists",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -6627,7 +6627,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Persistence of Beta-Blocker Treatment After a Heart Attack",
     "description": "The percentage of patients 18 years of age and older during the measurement year who were hospitalized and discharged from July 1 of the year prior to the measurement year to June 30 of the measurement year with a diagnosis of acute myocardial infarction (AMI) and who were prescribed persistent beta-blocker treatment for six months after discharge",
     "nationalQualityCode": "ECC",
@@ -6642,7 +6642,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -6653,7 +6653,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Photodocumentation of Cecal Intubation",
     "description": "The rate of screening and surveillance colonoscopies for which photodocumentation of landmarks of cecal intubation is performed to establish a complete examination",
     "nationalQualityCode": "ECC",
@@ -6668,7 +6668,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society for Gastrointestinal Endoscopy",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -6678,7 +6678,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Pneumococcal Vaccination Status for Older Adults",
     "description": "Percentage of patients 65 years of age and older who have ever received a pneumococcal vaccine.",
     "nationalQualityCode": "CPH",
@@ -6693,7 +6693,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "ehr",
       "cmsWebInterface",
@@ -6708,7 +6708,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Post-Anesthetic Transfer of Care Measure: Procedure Room to a Post Anesthesia Care Unit (PACU)",
     "description": "Percentage of patients, regardless of age, who are under the care of an anesthesia practitioner and are admitted to a PACU in which a post-anesthetic formal transfer of care protocol or checklist which includes the key transfer of care elements is utilized",
     "nationalQualityCode": "CCC",
@@ -6723,7 +6723,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Anesthesiologists",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -6734,7 +6734,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Post-Anesthetic Transfer of Care: Use of Checklist or Protocol for Direct Transfer of Care from Procedure Room to Intensive Care Unit (ICU)",
     "description": "Percentage of patients, regardless of age, who undergo a procedure under anesthesia and are admitted to an Intensive Care Unit (ICU) directly from the anesthetizing location, who have a documented use of a checklist or protocol for the transfer of care from the responsible anesthesia practitioner to the responsible ICU team or team member",
     "nationalQualityCode": "CCC",
@@ -6749,7 +6749,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Anesthesiologists",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -6760,7 +6760,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Pregnant women that had HBsAg testing",
     "description": "This measure identifies pregnant women who had a HBsAg (hepatitis B) test during their pregnancy",
     "nationalQualityCode": "ECC",
@@ -6775,7 +6775,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "OptumInsight",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": []
@@ -6784,7 +6784,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Preoperative Diagnosis of Breast Cancer",
     "description": "The percent of patients undergoing breast cancer operations who obtained the diagnosis of breast cancer preoperatively by a minimally invasive biopsy method",
     "nationalQualityCode": "ECC",
@@ -6799,7 +6799,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Breast Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -6808,7 +6808,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Prevention of Central Venous Catheter (CVC) - Related Bloodstream Infections",
     "description": "Percentage of patients, regardless of age, who undergo central venous catheter (CVC) insertion for whom CVC was inserted with all elements of maximal sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound techniques followed",
     "nationalQualityCode": "PS",
@@ -6823,7 +6823,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Anesthesiologists",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -6836,7 +6836,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Prevention of Post-Operative Nausea and Vomiting (PONV) - Combination Therapy",
     "description": "Percentage of patients, aged 18 years and older, who undergo a procedure under an inhalational general anesthetic, AND who have three or more risk factors for post-operative nausea and vomiting (PONV), who receive combination therapy consisting of at least two prophylactic pharmacologic antiemetic agents of different classes preoperatively or intraoperatively",
     "nationalQualityCode": "PS",
@@ -6851,7 +6851,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Anesthesiologists",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -6862,7 +6862,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan",
     "description": "Percentage of patients aged 18 years and older with a BMI documented during the current encounter or during the previous six months AND with a BMI outside of normal parameters, a follow-up plan is documented during the encounter or during the previous six months of the current encounter  \n\nNormal Parameters:       Age 18 years and older BMI => 18.5 and < 25 kg/m2",
     "nationalQualityCode": "CPH",
@@ -6877,7 +6877,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "ehr",
       "cmsWebInterface",
@@ -6906,7 +6906,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Preventive Care and Screening: Influenza Immunization",
     "description": "Percentage of patients aged 6 months and older seen for a visit between October 1 and March 31 who received an influenza immunization OR who reported previous receipt of an influenza immunization",
     "nationalQualityCode": "CPH",
@@ -6921,7 +6921,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "ehr",
       "cmsWebInterface",
@@ -6940,7 +6940,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Preventive Care and Screening: Screening for Clinical Depression and Follow-Up Plan",
     "description": "Percentage of patients aged 12 years and older screened for depression on the date of the encounter using an age appropriate standardized depression screening tool AND if positive, a follow-up plan is documented on the date of the positive screen",
     "nationalQualityCode": "CPH",
@@ -6955,7 +6955,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "ehr",
       "cmsWebInterface",
@@ -6972,7 +6972,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented",
     "description": "Percentage of patients aged 18 years and older seen during the reporting period who were screened for high blood pressure AND a recommended follow-up plan is documented based on the current blood pressure (BP) reading as indicated",
     "nationalQualityCode": "CPH",
@@ -6987,7 +6987,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "ehr",
       "registry"
@@ -7023,7 +7023,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention",
     "description": "Percentage of patients aged 18 years and older who were screened for tobacco use one or more times within 24 months AND who received cessation counseling intervention if identified as a tobacco user",
     "nationalQualityCode": "CPH",
@@ -7038,7 +7038,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "ehr",
       "cmsWebInterface",
@@ -7074,7 +7074,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Preventive Care and Screening: Unhealthy Alcohol Use: Screening & Brief Counseling",
     "description": "Percentage of patients aged 18 years and older who were screened for unhealthy alcohol use using a systematic screening method at least once within the last 24 months AND who received brief counseling if identified as an unhealthy alcohol user",
     "nationalQualityCode": "CPH",
@@ -7089,7 +7089,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -7112,7 +7112,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Primary Caries Prevention Intervention as Offered by Primary Care Providers, including Dentists",
     "description": "Percentage of children, age 0-20 years, who received a fluoride varnish application during the measurement period.",
     "nationalQualityCode": "ECC",
@@ -7127,7 +7127,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": [
@@ -7138,7 +7138,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of primary open-angle glaucoma (POAG) who have an optic nerve head evaluation during one or more office visits within 12 months",
     "nationalQualityCode": "ECC",
@@ -7153,7 +7153,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "ehr",
       "registry"
@@ -7166,7 +7166,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of primary open-angle glaucoma (POAG) whose glaucoma treatment has not failed (the most recent IOP was reduced by at least 15% from the pre-intervention level) OR if the most recent IOP was not reduced by at least 15% from the pre-intervention level, a plan of care was documented within 12 months",
     "nationalQualityCode": "CCC",
@@ -7181,7 +7181,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Ophthalmology",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -7193,7 +7193,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Proportion Admitted to Hospice for less than 3 days",
     "description": "Proportion of patients who died from cancer, and admitted to hospice and spent less than 3 days there",
     "nationalQualityCode": "ECC",
@@ -7208,7 +7208,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Clinical Oncology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -7219,7 +7219,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Proportion Admitted to the Intensive Care Unit (ICU) in the Last 30 Days of Life",
     "description": "Proportion of patients who died from cancer admitted to the ICU in the last 30 days of life",
     "nationalQualityCode": "ECC",
@@ -7234,7 +7234,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Clinical Oncology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -7245,7 +7245,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Proportion Not Admitted To Hospice",
     "description": "Proportion  of patients who died from cancer not admitted to hospice",
     "nationalQualityCode": "ECC",
@@ -7260,7 +7260,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Clinical Oncology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -7271,7 +7271,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Proportion of Patients Sustaining a Bladder Injury at the Time of any Pelvic Organ Prolapse Repair",
     "description": "Percentage of patients undergoing any surgery to repair pelvic organ prolapse who sustains an injury to the bladder recognized either during or within 1 month after surgery",
     "nationalQualityCode": "PS",
@@ -7286,7 +7286,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Urogynecologic Society",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -7297,7 +7297,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Proportion of Patients Sustaining a Bowel Injury at the time of any Pelvic Organ Prolapse Repair",
     "description": "Percentage of patients undergoing surgical repair of pelvic organ prolapse that is complicated by a bowel injury at the time of index surgery that is recognized intraoperatively or within 1 month after surgery",
     "nationalQualityCode": "PS",
@@ -7312,7 +7312,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Urogynecologic Society",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -7323,7 +7323,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Proportion of Patients Sustaining a Ureter Injury at the Time of any Pelvic Organ Prolapse Repair",
     "description": "Percentage of patients undergoing pelvic organ prolapse repairs who sustain an injury to the ureter recognized either during or within 1 month after surgery",
     "nationalQualityCode": "PS",
@@ -7338,7 +7338,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Urogynecologic Society",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -7349,7 +7349,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Proportion of Patients who Died from Cancer with more than One Emergency Department Visit in the Last 30 Days of Life",
     "description": "Proportion of patients who died from cancer with more than one emergency department visit in the last 30 days of life",
     "nationalQualityCode": "ECC",
@@ -7364,7 +7364,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Clinical Oncology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -7375,7 +7375,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Proportion Receiving Chemotherapy in the Last 14 Days of Life",
     "description": "Proportion of patients who died from cancer receiving chemotherapy in the last 14 days of life",
     "nationalQualityCode": "ECC",
@@ -7390,7 +7390,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Clinical Oncology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -7401,7 +7401,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Prostate Cancer: Adjuvant Hormonal Therapy for High Risk or Very High Risk Prostate Cancer",
     "description": "Percentage of patients, regardless of age, with a diagnosis of prostate cancer at high or very high risk of recurrence receiving external beam radiotherapy to the prostate who were prescribed adjuvant hormonal therapy (GnRH [gonadotropin-releasing hormone] agonist or antagonist)",
     "nationalQualityCode": "ECC",
@@ -7416,7 +7416,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Urological Association Education and Research",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -7427,7 +7427,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients",
     "description": "Percentage of patients, regardless of age, with a diagnosis of prostate cancer at low (or very low) risk of recurrence receiving interstitial prostate brachytherapy, OR external beam radiotherapy to the prostate, OR radical prostatectomy, OR cryotherapy who did not have a bone scan performed at any time since diagnosis of prostate cancer",
     "nationalQualityCode": "ECR",
@@ -7442,7 +7442,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
-    "methods": [
+    "submissionMethods": [
       "ehr",
       "registry"
     ],
@@ -7456,7 +7456,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Psoriasis: Clinical Response to Oral Systemic or Biologic Medications",
     "description": "Percentage of psoriasis patients receiving oral systemic or biologic therapy who meet minimal physician-or patient- reported disease activity levels. It is implied that establishment and maintenance of an established minimum level of disease control as measured by physician-and/or patient-reported outcomes will increase patient satisfaction with and adherence to treatment",
     "nationalQualityCode": "PCCEO",
@@ -7471,7 +7471,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Dermatology",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -7483,7 +7483,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Quality of Life Assessment For Patients With Primary Headache Disorders",
     "description": "Percentage of patients with a diagnosis of primary headache disorder whose health related quality of life (HRQoL) was assessed with a tool(s) during at least two visits during the 12 month measurement period AND whose health related quality of life score stayed the same or improved",
     "nationalQualityCode": "ECC",
@@ -7498,7 +7498,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Neurology",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -7510,7 +7510,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Quantitative Immunohistochemical (IHC) Evaluation of Human Epidermal Growth Factor Receptor 2 Testing (HER2) for Breast Cancer Patients",
     "description": "This is a measure based on whether quantitative evaluation of Human Epidermal Growth Factor Receptor 2 Testing (HER2) by immunohistochemistry (IHC) uses the system recommended in the current ASCO/CAP Guidelines for Human Epidermal Growth Factor Receptor 2 Testing in breast cancer",
     "nationalQualityCode": "ECC",
@@ -7525,7 +7525,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "College of American Pathologists",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -7537,7 +7537,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Radiation Consideration for Adult CT: Utilization of Dose Lowering Techniques",
     "description": "Percentage of final reports for patients aged 18 years and older undergoing CT with documentation that one or more of the following dose reduction techniques were used:\n<br/><ul><li> Automated exposure control\n</li><li> Adjustment of the mA and/or kV according to patient size\n</li><li> Use of iterative reconstruction technique\n\n</li></ul>",
     "nationalQualityCode": "ECC",
@@ -7552,7 +7552,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Radiology",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -7564,7 +7564,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Radical Prostatectomy Pathology Reporting",
     "description": "Percentage of radical prostatectomy pathology reports that include the pT category, the pN category, the Gleason score and a statement about margin status",
     "nationalQualityCode": "ECC",
@@ -7579,7 +7579,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "College of American Pathologists",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -7592,7 +7592,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Radiology: Exposure Dose or Time Reported for Procedures Using Fluoroscopy",
     "description": "Final reports for procedures using fluoroscopy that document radiation exposure indices, or exposure time and number of fluorographic images (if radiation exposure indices are not available)",
     "nationalQualityCode": "PS",
@@ -7607,7 +7607,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Radiology",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -7619,7 +7619,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Radiology: Inappropriate Use of \"Probably Benign\" Assessment Category in Screening Mammograms",
     "description": "Percentage of final reports for screening mammograms that are classified as \"probably benign\"",
     "nationalQualityCode": "ECR",
@@ -7634,7 +7634,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Radiology",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -7646,7 +7646,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Radiology: Reminder System for Screening Mammograms",
     "description": "Percentage of patients undergoing a screening mammogram whose information is entered into a reminder system with a target due date for the next mammogram",
     "nationalQualityCode": "CCC",
@@ -7661,7 +7661,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Radiology",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -7673,7 +7673,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Radiology: Stenosis Measurement in Carotid Imaging Reports",
     "description": "Percentage of final reports for carotid imaging studies (neck magnetic resonance angiography [MRA], neck computed tomography angiography [CTA], neck duplex ultrasound, carotid angiogram) performed that include direct or indirect reference to measurements of distal internal carotid diameter as the denominator for stenosis measurement",
     "nationalQualityCode": "ECC",
@@ -7688,7 +7688,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Radiology",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -7700,7 +7700,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Rate of Carotid Artery Stenting (CAS) for Asymptomatic Patients, Without Major Complications (Discharged to Home by Post-Operative Day #2)",
     "description": "Percent of asymptomatic patients undergoing CAS who are discharged to home no later than post-operative day #2",
     "nationalQualityCode": "ECC",
@@ -7715,7 +7715,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society for Vascular Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -7727,7 +7727,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Rate of Carotid Endarterectomy (CEA) for Asymptomatic Patients, without Major Complications (Discharged to Home by Post-Operative Day #2)",
     "description": "Percent of asymptomatic patients undergoing CEA who are discharged to home no later than post-operative day #2",
     "nationalQualityCode": "PS",
@@ -7742,7 +7742,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society for Vascular Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -7753,7 +7753,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) Who Die While in Hospital",
     "description": "Percent of patients undergoing endovascular repair of small or moderate infrarenal abdominal aortic aneurysms (AAA) that die while in the hospital",
     "nationalQualityCode": "PS",
@@ -7768,7 +7768,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society for Vascular Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -7779,7 +7779,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post Operative Day #2)",
     "description": "Percent of patients undergoing endovascular repair of small or moderate non-ruptured infrarenal abdominal aortic aneurysms (AAA) that do not experience a major complication (discharged to home no later than post-operative day #2)",
     "nationalQualityCode": "PS",
@@ -7794,7 +7794,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society for Vascular Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -7806,7 +7806,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Rate of Open Repair of Small or Moderate Abdominal Aortic Aneurysms (AAA) Where Patients Are Discharged Alive",
     "description": "Percentage of patients undergoing open repair of small or moderate abdominal aortic aneurysms (AAA) who are discharged alive",
     "nationalQualityCode": "PS",
@@ -7821,7 +7821,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society for Vascular Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -7830,7 +7830,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Rate of Open Repair of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post-Operative Day #7)",
     "description": "Percent of patients undergoing open repair of small or moderate sized non-ruptured infrarenal abdominal aortic aneurysms who do not experience a major complication (discharge to home no later than post-operative day #7)",
     "nationalQualityCode": "PS",
@@ -7845,7 +7845,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society for Vascular Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -7856,7 +7856,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Rate of Postoperative Stroke or Death in Asymptomatic Patients Undergoing Carotid Artery Stenting (CAS)",
     "description": "Percent of asymptomatic patients undergoing CAS who experience stroke or death following surgery while in the hospital",
     "nationalQualityCode": "ECC",
@@ -7871,7 +7871,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society for Vascular Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -7883,7 +7883,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Rate of Postoperative Stroke or Death in Asymptomatic Patients Undergoing Carotid Endarterectomy (CEA)",
     "description": "Percent of asymptomatic patients undergoing CEA who experience stroke or death following surgery while in the hospital",
     "nationalQualityCode": "ECC",
@@ -7898,7 +7898,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society for Vascular Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -7907,7 +7907,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Rate of Surgical Conversion from Lower Extremity Endovascular Revascularization Procedure",
     "description": "Inpatients assigned to endovascular treatment for obstructive arterial disease, the percent of patients who undergo unplanned major amputation or surgical bypass within 48 hours of the index procedure",
     "nationalQualityCode": "PS",
@@ -7922,7 +7922,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society of Interventional Radiology ",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -7932,7 +7932,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Referral for Otologic Evaluation for Patients with Acute or Chronic Dizziness",
     "description": "Percentage of patients aged birth and older referred to a physician (preferably a physician specially trained in disorders of the ear) for an otologic evaluation subsequent to an audiologic evaluation after presenting with acute or chronic dizziness",
     "nationalQualityCode": "CCC",
@@ -7947,7 +7947,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Audiology Quality Consortium",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -7957,7 +7957,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Rheumatoid Arthritis (RA): Assessment and Classification of Disease Prognosis",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have an assessment and classification of disease prognosis at least once within 12 months",
     "nationalQualityCode": "ECC",
@@ -7972,7 +7972,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Rheumatology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -7984,7 +7984,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Rheumatoid Arthritis (RA): Functional Status Assessment",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) for whom a functional status assessment was performed at least once within 12 months",
     "nationalQualityCode": "ECC",
@@ -7999,7 +7999,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Rheumatology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -8011,7 +8011,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Rheumatoid Arthritis (RA): Glucocorticoid Management",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have been assessed for glucocorticoid use and, for those on prolonged doses of prednisone >= 10 mg daily (or equivalent) with improvement or no change in disease activity, documentation of glucocorticoid management plan within 12 months",
     "nationalQualityCode": "ECC",
@@ -8026,7 +8026,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Rheumatology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -8038,7 +8038,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Rheumatoid Arthritis (RA): Periodic Assessment of Disease Activity",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have an assessment and classification of disease activity within 12 months",
     "nationalQualityCode": "ECC",
@@ -8053,7 +8053,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Rheumatology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -8064,7 +8064,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Rheumatoid Arthritis (RA): Tuberculosis Screening",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have documentation of a tuberculosis (TB) screening performed and results interpreted within 6 months prior to receiving a first course of therapy using a biologic disease-modifying anti-rheumatic drug (DMARD)",
     "nationalQualityCode": "ECC",
@@ -8079,7 +8079,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Rheumatology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -8090,7 +8090,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Rh Immunoglobulin (Rhogam) for Rh-Negative Pregnant Women at Risk of Fetal Blood Exposure",
     "description": "Percentage of Rh-negative pregnant women aged 14-50 years at risk of fetal blood exposure who receive Rh- Immunoglobulin (Rhogam) in the emergency department (ED)",
     "nationalQualityCode": "ECC",
@@ -8105,7 +8105,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Emergency Physicians",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -8117,7 +8117,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Risk-Adjusted Operative Mortality for Coronary Artery Bypass Graft (CABG)",
     "description": "Percent of patients aged 18 years and older undergoing isolated CABG who die, including both all deaths occurring during the hospitalization in which the CABG was performed, even if after 30 days, and those deaths occurring after discharge from the hospital, but within 30 days of the procedure",
     "nationalQualityCode": "ECC",
@@ -8132,7 +8132,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society of Thoracic Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -8141,7 +8141,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Screening Colonoscopy Adenoma Detection Rate",
     "description": "The percentage of patients age 50 years or older with at least one conventional adenoma or colorectal cancer detected during screening colonoscopy",
     "nationalQualityCode": "ECC",
@@ -8156,7 +8156,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society for Gastrointestinal Endoscopy",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -8167,7 +8167,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Screening for Osteoporosis for Women Aged 65-85 Years of Age",
     "description": "Percentage of female patients aged 65-85 years of age who ever had a central dual-energy X-ray absorptiometry (DXA) to check for osteoporosis",
     "nationalQualityCode": "ECC",
@@ -8182,7 +8182,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -8194,7 +8194,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Sentinel Lymph Node Biopsy for Invasive Breast Cancer",
     "description": "The percentage of clinically node negative (clinical stage T1N0M0 or T2N0M0) breast cancer patients who undergo a sentinel lymph node (SLN) procedure",
     "nationalQualityCode": "ECC",
@@ -8209,7 +8209,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Breast Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -8218,7 +8218,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Sleep Apnea: Assessment of Adherence to Positive Airway Pressure Therapy",
     "description": "Percentage of visits for patients aged 18 years and older with a diagnosis of obstructive sleep apnea who were prescribed positive airway pressure therapy who had documentation that adherence to positive airway pressure therapy was objectively measured",
     "nationalQualityCode": "ECC",
@@ -8233,7 +8233,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Sleep Medicine",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -8242,7 +8242,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Sleep Apnea: Assessment of Sleep Symptoms",
     "description": "Percentage of visits for patients aged 18 years and older with a diagnosis of obstructive sleep apnea that includes documentation of an assessment of sleep symptoms, including presence or absence of snoring and daytime sleepiness",
     "nationalQualityCode": "ECC",
@@ -8257,7 +8257,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Sleep Medicine",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -8266,7 +8266,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Sleep Apnea: Positive Airway Pressure Therapy Prescribed",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of moderate or severe obstructive sleep apnea who were prescribed positive airway pressure therapy",
     "nationalQualityCode": "ECC",
@@ -8281,7 +8281,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Sleep Medicine",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -8290,7 +8290,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Sleep Apnea: Severity Assessment at Initial Diagnosis",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of obstructive sleep apnea who had an apnea hypopnea index (AHI) or a respiratory disturbance index (RDI) measured at the time of initial diagnosis",
     "nationalQualityCode": "ECC",
@@ -8305,7 +8305,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Sleep Medicine",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -8314,7 +8314,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Statin Therapy at Discharge after Lower Extremity Bypass (LEB)",
     "description": "Percentage of patients aged 18 years and older undergoing infra-inguinal lower extremity bypass who are prescribed a statin medication at discharge",
     "nationalQualityCode": "ECC",
@@ -8329,7 +8329,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society for Vascular Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -8338,7 +8338,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Statin Therapy for the Prevention and Treatment of Cardiovascular Disease",
     "description": "Percentage of the following patients-all considered at high risk of cardiovascular events-who were prescribed or were on statin therapy during the measurement period:\n<br/><ul><li> Adults aged >= 21 years who were previously diagnosed with or currently have an active diagnosis of clinical atherosclerotic cardiovascular disease (ASCVD); OR\n</li><li> Adults aged >=21 years who have ever had  a fasting or direct low-density lipoprotein cholesterol (LDL-C) level >= 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial or pure hypercholesterolemia; OR\n</li><li> Adults aged 40-75 years with a diagnosis of diabetes with a fasting or direct LDL-C level of 70-189 mg/dL\n\n</li></ul>",
     "nationalQualityCode": "ECC",
@@ -8353,7 +8353,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
-    "methods": [
+    "submissionMethods": [
       "cmsWebInterface",
       "registry"
     ],
@@ -8367,7 +8367,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Stroke and Stroke Rehabilitation: Discharged on Antithrombotic Therapy",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of ischemic stroke or transient ischemic attack (TIA) who were prescribed antithrombotic therapy at discharge",
     "nationalQualityCode": "ECC",
@@ -8382,7 +8382,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Neurology",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -8395,7 +8395,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Stroke and Stroke Rehabilitation: Thrombolytic Therapy",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of acute ischemic stroke who arrive at the hospital within two hours of time last known well and for whom IV t-PA was initiated within three hours of time last known well",
     "nationalQualityCode": "ECC",
@@ -8410,7 +8410,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Heart Association",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -8419,7 +8419,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Surgical Site Infection (SSI)",
     "description": "Percentage of patients aged 18 years and older who had a surgical site infection (SSI)",
     "nationalQualityCode": "ECC",
@@ -8434,7 +8434,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -8448,7 +8448,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Tobacco Use and Help with Quitting Among Adolescents",
     "description": "The percentage of adolescents 12 to 20 years of age with a primary care visit during the measurement year for whom tobacco use status was documented and received help with quitting if identified as a tobacco user",
     "nationalQualityCode": "CPH",
@@ -8463,7 +8463,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -8497,7 +8497,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Total Knee Replacement: Identification of Implanted Prosthesis in Operative Report",
     "description": "Percentage of patients regardless of age  undergoing a total knee replacement whose operative report identifies the prosthetic implant specifications including the prosthetic implant manufacturer, the brand name of the prosthetic implant and the size of each prosthetic implant",
     "nationalQualityCode": "PS",
@@ -8512,7 +8512,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Association of Hip and Knee Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -8523,7 +8523,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Total Knee Replacement: Preoperative Antibiotic Infusion with Proximal Tourniquet",
     "description": "Percentage of patients regardless of age undergoing a total knee replacement who had the prophylactic antibiotic completely infused prior to the inflation of the proximal tourniquet",
     "nationalQualityCode": "PS",
@@ -8538,7 +8538,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Association of Hip and Knee Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -8549,7 +8549,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Total Knee Replacement: Shared Decision-Making: Trial of Conservative (Non-surgical) Therapy",
     "description": "Percentage of patients regardless of age undergoing a total knee replacement with documented shared decision-making with discussion of conservative (non-surgical) therapy (e.g., non-steroidal anti-inflammatory drug (NSAIDs), analgesics, weight loss, exercise, injections) prior to the procedure",
     "nationalQualityCode": "CCC",
@@ -8564,7 +8564,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Association of Hip and Knee Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -8575,7 +8575,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Total Knee Replacement: Venous Thromboembolic and Cardiovascular Risk Evaluation",
     "description": "Percentage of patients regardless of age undergoing a total knee replacement who are evaluated for the presence or absence of venous thromboembolic and cardiovascular risk factors within 30 days prior to the procedure (e.g. history of Deep Vein Thrombosis (DVT), Pulmonary Embolism (PE), Myocardial Infarction (MI), Arrhythmia and Stroke)",
     "nationalQualityCode": "PS",
@@ -8590,7 +8590,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Association of Hip and Knee Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -8601,7 +8601,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Trastuzumab Received By Patients With AJCC Stage I (T1c) -  III And HER2 Positive Breast Cancer Receiving Adjuvant Chemotherapy",
     "description": "Proportion of female patients (aged 18 years and older) with AJCC stage I (T1c) - III, human epidermal growth factor receptor 2 (HER2) positive breast cancer receiving adjuvant chemotherapy who are also receiving trastuzumab",
     "nationalQualityCode": "ECR",
@@ -8616,7 +8616,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Society of Clinical Oncology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -8627,7 +8627,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Tuberculosis (TB) Prevention for Psoriasis, Psoriatic Arthritis and Rheumatoid Arthritis Patients on a Biological Immune Response Modifier",
     "description": "Percentage of patients whose providers are ensuring active tuberculosis prevention either through yearly negative standard tuberculosis screening tests or are reviewing the patient's history to determine if they have had appropriate management for a recent or prior positive test",
     "nationalQualityCode": "ECC",
@@ -8642,7 +8642,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American Academy of Dermatology",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -8655,7 +8655,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Ultrasound Determination of Pregnancy Location for Pregnant Patients with Abdominal Pain",
     "description": "Percentage of pregnant female patients aged 14 to 50 who present to the emergency department (ED) with a chief complaint of abdominal pain or vaginal bleeding who receive a trans-abdominal or trans-vaginal ultrasound to determine pregnancy location",
     "nationalQualityCode": "ECC",
@@ -8670,7 +8670,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Emergency Physicians",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -8682,7 +8682,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Unplanned Hospital Readmission within 30 Days of Principal Procedure",
     "description": "Percentage of patients aged 18 years and older who had an unplanned hospital readmission within 30 days of principal procedure",
     "nationalQualityCode": "ECC",
@@ -8697,7 +8697,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -8708,7 +8708,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Unplanned Reoperation within the 30 Day Postoperative Period",
     "description": "Percentage of patients aged 18 years and older who had any unplanned reoperation within the 30 day postoperative period",
     "nationalQualityCode": "PS",
@@ -8723,7 +8723,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "American College of Surgeons",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": [
@@ -8734,7 +8734,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Urinary Incontinence: Assessment of Presence or Absence of Urinary Incontinence in Women Aged 65 Years and Older",
     "description": "Percentage of female patients aged 65 years and older who were assessed for the presence or absence of urinary incontinence within 12 months",
     "nationalQualityCode": "ECC",
@@ -8749,7 +8749,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -8763,7 +8763,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Years and Older",
     "description": "Percentage of female patients aged 65 years and older with a diagnosis of urinary incontinence with a documented plan of care for urinary incontinence at least once within 12 months",
     "nationalQualityCode": "PCCEO",
@@ -8778,7 +8778,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "claims",
       "registry"
     ],
@@ -8793,7 +8793,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Use of High-Risk Medications in the Elderly",
     "description": "Percentage of patients 66 years of age and older who were ordered high-risk medications. Two rates are reported.\na. Percentage of patients who were ordered at least one high-risk medication. \nb. Percentage of patients who were ordered at least two different high-risk medications.",
     "nationalQualityCode": "PS",
@@ -8808,7 +8808,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "ehr",
       "registry"
     ],
@@ -8818,7 +8818,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Use of Imaging Studies for Low Back Pain",
     "description": "Percentage of patients 18-50 years of age with a diagnosis of low back pain who did not have an imaging study (plain X-ray, MRI, CT scan) within 28 days of the diagnosis.",
     "nationalQualityCode": "ECR",
@@ -8833,7 +8833,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": [
@@ -8846,7 +8846,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Varicose Vein Treatment with Saphenous Ablation: Outcome Survey",
     "description": "Percentage of patients treated for varicose veins (CEAP C2-S) who are treated with saphenous ablation (with or without adjunctive tributary treatment) that report an improvement on a disease specific patient reported outcome survey instrument after treatment",
     "nationalQualityCode": "ECC",
@@ -8861,7 +8861,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Society of Interventional Radiology ",
-    "methods": [
+    "submissionMethods": [
       "registry"
     ],
     "measureSets": []
@@ -8870,7 +8870,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRatio",
+    "metricType": "performanceRate",
     "title": "Weight Assessment and Counseling for Nutrition and Physical Activity for Children and Adolescents",
     "description": "Percentage of patients 3-17 years of age who had an outpatient visit with a Primary Care Physician (PCP) or Obstetrician/Gynecologist (OB/GYN) and who had evidence of the following during the measurement period. Three rates are reported.\n\n - Percentage of patients with height, weight, and body mass  index (BMI) percentile documentation\n - Percentage of patients with counseling for nutrition\n - Percentage of patients with counseling for physical activity",
     "nationalQualityCode": "CPH",
@@ -8885,7 +8885,7 @@
     "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
-    "methods": [
+    "submissionMethods": [
       "ehr"
     ],
     "measureSets": [

--- a/measures/measures-data.xml
+++ b/measures/measures-data.xml
@@ -1626,7 +1626,7 @@ Provision of same-day or next-day access to a consistent MIPS eligible clinician
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Acute Otitis Externa (AOE): Systemic Antimicrobial Therapy - Avoidance of Inappropriate Use</title>
     <description>Percentage of patients aged 2 years and older with a diagnosis of AOE who were not prescribed systemic antimicrobial therapy</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -1640,8 +1640,8 @@ Provision of same-day or next-day access to a consistent MIPS eligible clinician
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Otolaryngology-Head and Neck Surgery</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>emergencyMedicine</measureSets>
     <measureSets>otolaryngology</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
@@ -1651,7 +1651,7 @@ Provision of same-day or next-day access to a consistent MIPS eligible clinician
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Acute Otitis Externa (AOE): Topical Therapy</title>
     <description>Percentage of patients aged 2 years and older with a diagnosis of AOE who were prescribed topical preparations</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -1665,8 +1665,8 @@ Provision of same-day or next-day access to a consistent MIPS eligible clinician
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Otolaryngology-Head and Neck Surgery</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>emergencyMedicine</measureSets>
     <measureSets>otolaryngology</measureSets>
     <measureSets>pediatrics</measureSets>
@@ -1675,7 +1675,7 @@ Provision of same-day or next-day access to a consistent MIPS eligible clinician
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>ADHD: Follow-Up Care for Children Prescribed Attention-Deficit/Hyperactivity Disorder (ADHD) Medication</title>
     <description>Percentage of children 6-12 years of age and newly dispensed a medication for attention-deficit/hyperactivity disorder (ADHD) who had appropriate follow-up care.  Two rates are reported.  
 a. Percentage of children who had one follow-up visit with a practitioner with prescribing authority during the 30-Day Initiation Phase.
@@ -1692,7 +1692,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
     <measureSets>mentalBehavioralHealth</measureSets>
     <measureSets>pediatrics</measureSets>
   </measure>
@@ -1700,7 +1700,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Adherence to Antipsychotic Medications For Individuals with Schizophrenia</title>
     <description>Percentage of individuals at least 18 years of age as of the beginning of the measurement period with schizophrenia or schizoaffective disorder who had at least two prescriptions filled for any antipsychotic medication and who had a Proportion of Days Covered (PDC) of at least 0.8 for antipsychotic medications during the measurement period (12 consecutive months)</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -1714,14 +1714,14 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Health Services Advisory Group </primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>mentalBehavioralHealth</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Adult Kidney Disease: Blood Pressure Management</title>
     <description>Percentage of patient visits for those patients aged 18 years and older with a diagnosis of chronic kidney disease (CKD) (stage 3, 4, or 5, not receiving Renal Replacement Therapy [RRT]) with a blood pressure &lt; 140/90 mmHg OR &gt;= 140/90 mmHg with a documented plan of care</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -1735,13 +1735,13 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Renal Physicians Association</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Adult Kidney Disease: Catheter Use at Initiation of Hemodialysis</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of End Stage Renal Disease (ESRD) who initiate maintenance hemodialysis during the measurement period, whose mode of vascular access is a catheter at the time maintenance hemodialysis is initiated</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -1755,13 +1755,13 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Renal Physicians Association</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Adult Kidney Disease: Catheter Use for Greater Than or Equal to 90 Days</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of End Stage Renal Disease (ESRD) receiving maintenance hemodialysis for greater than or equal to 90 days whose mode of vascular access is a catheter</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -1775,13 +1775,13 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Renal Physicians Association</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Adult Kidney Disease: Referral to Hospice</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of ESRD who withdraw from hemodialysis or peritoneal dialysis who are referred to hospice care</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -1795,13 +1795,13 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Renal Physicians Association</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Adult Major Depressive Disorder (MDD): Coordination of Care of Patients with Specific Comorbid Conditions</title>
     <description>Percentage of medical records of patients aged 18 years and older with a diagnosis of major depressive disorder (MDD) and a specific diagnosed comorbid condition (diabetes, coronary artery disease, ischemic stroke, intracranial hemorrhage, chronic kidney disease [stages 4 or 5], End Stage Renal Disease [ESRD] or congestive heart failure) being treated by another clinician with communication to the clinician treating the comorbid condition</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -1815,14 +1815,14 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Psychiatric Association</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>mentalBehavioralHealth</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Adult Major Depressive Disorder (MDD): Suicide Risk Assessment</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of major depressive disorder (MDD) with a suicide risk assessment completed during the visit in which a new diagnosis or recurrent episode was identified</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -1836,13 +1836,13 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Adult Primary Rhegmatogenous Retinal Detachment Surgery: No Return to the Operating Room Within 90 Days of Surgery</title>
     <description>Patients aged 18 years and older who had surgery for primary rhegmatogenous retinal detachment who did not require a return to the operating room within 90 days of surgery</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -1856,14 +1856,14 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Ophthalmology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>ophthalmology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Adult Primary Rhegmatogenous Retinal Detachment Surgery: Visual Acuity Improvement Within 90 Days of Surgery</title>
     <description>Patients aged 18 years and older who had surgery for primary rhegmatogenous retinal detachment and achieved an improvement in their visual acuity, from their preoperative level, within 90 days of surgery in the operative eye</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -1877,14 +1877,14 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Ophthalmology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>ophthalmology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Adult Sinusitis: Antibiotic Prescribed for Acute Sinusitis (Overuse)</title>
     <description>Percentage of patients, aged 18 years and older, with a diagnosis of acute sinusitis who were prescribed an antibiotic within 10 days after onset of symptoms</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -1898,7 +1898,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Otolaryngology-Head and Neck Surgery</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>allergyImmunology</measureSets>
     <measureSets>internalMedicine</measureSets>
     <measureSets>otolaryngology</measureSets>
@@ -1908,7 +1908,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Adult Sinusitis: Appropriate Choice of Antibiotic: Amoxicillin With or Without Clavulanate Prescribed for Patients with Acute Bacterial Sinusitis (Appropriate Use)</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of acute bacterial sinusitis that were prescribed amoxicillin, with or without clavulanate, as a first line antibiotic at the time of diagnosis</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -1922,7 +1922,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Otolaryngology-Head and Neck Surgery</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>allergyImmunology</measureSets>
     <measureSets>internalMedicine</measureSets>
     <measureSets>otolaryngology</measureSets>
@@ -1932,7 +1932,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Adult Sinusitis: Computerized Tomography (CT) for Acute Sinusitis (Overuse)</title>
     <description>Percentage of patients aged 18 years and older, with a diagnosis of acute sinusitis who had a computerized tomography (CT) scan of the paranasal sinuses ordered at the time of diagnosis or received within 28 days after date of diagnosis</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -1946,7 +1946,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Otolaryngology-Head and Neck Surgery</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>allergyImmunology</measureSets>
     <measureSets>internalMedicine</measureSets>
     <measureSets>otolaryngology</measureSets>
@@ -1956,7 +1956,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Adult Sinusitis: More than One Computerized Tomography (CT) Scan Within 90 Days for Chronic Sinusitis (Overuse)</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of chronic sinusitis who had more than one CT scan of the paranasal sinuses ordered or received within 90 days after the date of diagnosis</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -1970,7 +1970,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Otolaryngology-Head and Neck Surgery</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>allergyImmunology</measureSets>
     <measureSets>internalMedicine</measureSets>
     <measureSets>otolaryngology</measureSets>
@@ -1980,7 +1980,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Age Appropriate Screening Colonoscopy</title>
     <description>The percentage of patients greater than 85 years of age who received a screening colonoscopy from January 1 to December 31</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -1994,14 +1994,14 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Gastroenterological Association</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>gastroenterology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Age-Related Macular Degeneration (AMD): Counseling on Antioxidant Supplement</title>
     <description>Percentage of patients aged 50 years and older with a diagnosis of age-related macular degeneration (AMD) or their caregiver(s) who were counseled within 12 months on the benefits and/or risks of the Age-Related Eye Disease Study  (AREDS) formulation for preventing progression of AMD</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2015,15 +2015,15 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Ophthalmology</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>ophthalmology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Age-Related Macular Degeneration (AMD): Dilated Macular Examination</title>
     <description>Percentage of patients aged 50 years and older with a diagnosis of age-related macular degeneration (AMD) who had a dilated macular examination performed which included documentation of the presence or absence of macular thickening or hemorrhage AND the level of macular degeneration severity during one or more office visits within 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2037,15 +2037,15 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Ophthalmology</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>ophthalmology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>All-cause Hospital Readmission</title>
     <description>The 30-day All-Cause Hospital Readmission measure is a risk-standardized readmission rate for beneficiaries age 65 or older who were hospitalized at a short-stay acute care hospital and experienced an unplanned readmission for any cause to an acute care hospital within 30 days of discharge.</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -2059,13 +2059,13 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Yale University</primarySteward>
-    <methods>administrativeClaims</methods>
+    <submissionMethods>administrativeClaims</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Amyotrophic Lateral Sclerosis (ALS) Patient Care Preferences</title>
     <description>Percentage of patients diagnosed with Amyotrophic Lateral Sclerosis (ALS) who were offered assistance in planning for end of life issues (e.g., advance directives, invasive ventilation, hospice) at least once annually</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -2079,14 +2079,14 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Neurology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>neurology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Anastomotic Leak Intervention</title>
     <description>Percentage of patients aged 18 years and older who required an anastomotic leak intervention following gastric bypass or colectomy surgery</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -2100,14 +2100,14 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalSurgery</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Anesthesiology Smoking Abstinence</title>
     <description>The percentage of current smokers who abstain from cigarettes prior to anesthesia on the day of elective surgery or procedure</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2121,14 +2121,14 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Anesthesiologists</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>anesthesiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Annual Hepatitis C Virus (HCV) Screening for Patients who are Active Injection Drug Users</title>
     <description>Percentage of patients, regardless of age, who are active injection drug users who received screening for HCV infection within the 12 month reporting period</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2142,7 +2142,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
   </measure>
@@ -2150,7 +2150,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Anti-Depressant Medication Management</title>
     <description>Percentage of patients 18 years of age and older who were treated with antidepressant medication, had a diagnosis of major depression, and who remained on an antidepressant medication treatment. Two rates are reported. 
 a. Percentage of patients who remained on an antidepressant medication for at least 84 days (12 weeks). 
@@ -2167,7 +2167,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>mentalBehavioralHealth</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
@@ -2176,7 +2176,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Appropriate Assessment of Retrievable Inferior Vena Cava (IVC) Filters for Removal</title>
     <description>Percentage of patients in whom a retrievable IVC filter is placed who, within 3 months post-placement, have a documented assessment for the appropriateness of continued filtration, device removal or the inability to contact the patient with at least two attempts</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2190,13 +2190,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society of Interventional Radiology </primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Appropriate Follow-up Imaging for Incidental Abdominal Lesions</title>
     <description>Percentage of final reports for abdominal imaging studies for asymptomatic patients aged 18 years and older with one or more of the following noted incidentally with follow-up imaging recommended:
 &lt;br/&gt;&lt;ul&gt;&lt;li&gt; Liver lesion &lt;= 0.5 cm
@@ -2216,15 +2216,15 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Radiology</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>diagnosticRadiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Appropriate Follow-up Imaging for Incidental Thyroid Nodules in Patients</title>
     <description>Percentage of final reports for computed tomography (CT), CT angiography (CTA) or magnetic resonance imaging (MRI) or magnetic resonance angiogram (MRA) studies of the chest or neck or ultrasound of the neck for patients aged 18 years and older with no known thyroid disease with a thyroid nodule &lt; 1.0 cm noted incidentally with follow-up imaging recommended</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2238,15 +2238,15 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Radiology</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>diagnosticRadiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients</title>
     <description>Percentage of patients aged 50 to 75 years of age receiving a screening colonoscopy without biopsy or polypectomy who had a recommended follow-up interval of at least 10 years for repeat colonoscopy documented in their colonoscopy report</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -2260,15 +2260,15 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Gastroenterological Association</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>gastroenterology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Appropriate Testing for Children with Pharyngitis</title>
     <description>Percentage of children 3-18 years of age who were diagnosed with pharyngitis, ordered an antibiotic and received a group A streptococcus (strep) test for the episode</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -2282,8 +2282,8 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>ehr</methods>
-    <methods>registry</methods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>emergencyMedicine</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
     <measureSets>pediatrics</measureSets>
@@ -2292,7 +2292,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Appropriate Treatment for Children with Upper Respiratory Infection (URI)</title>
     <description>Percentage of children 3 months-18 years of age who were diagnosed with upper respiratory infection (URI) and were not dispensed an antibiotic prescription on or three days after the episode</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -2306,8 +2306,8 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>ehr</methods>
-    <methods>registry</methods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
     <measureSets>pediatrics</measureSets>
   </measure>
@@ -2315,7 +2315,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Appropriate Treatment of Methicillin-Sensitive Staphylococcus Aureus (MSSA) Bacteremia</title>
     <description>Percentage of patients with sepsis due to MSSA bacteremia who received beta-lactam antibiotic (e.g. nafcillin, oxacillin or cefazolin) as definitive therapy</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2329,15 +2329,15 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Infectious Diseases Society of America</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>hospitalists</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Appropriate Workup Prior to Endometrial Ablation</title>
     <description>Percentage of women, aged 18 years and older, who undergo   endometrial sampling or hysteroscopy with biopsy  before undergoing an endometrial ablation</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -2351,14 +2351,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>obstetricsGynecology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Atrial Fibrillation and Atrial Flutter: Chronic Anticoagulation Therapy</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of nonvalvular atrial fibrillation (AF) or atrial flutter whose assessment of the specified thromboembolic risk factors indicate one or more high-risk factors or more than one moderate risk factor, as determined by CHADS2 risk stratification, who are prescribed warfarin OR another oral anticoagulant drug that is FDA approved for the prevention of thromboembolism</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2372,8 +2372,8 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Cardiology</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>cardiology</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
@@ -2382,7 +2382,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Avoidance of Antibiotic Treatment in Adults With Acute Bronchitis</title>
     <description>The percentage of adults 18-64 years of age with a diagnosis of acute bronchitis who were not dispensed an antibiotic prescription</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -2396,7 +2396,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>emergencyMedicine</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
@@ -2405,7 +2405,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Barrett's Esophagus</title>
     <description>Percentage of esophageal biopsy reports that document the presence of Barrett's mucosa that also include a statement about dysplasia</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2419,15 +2419,15 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>College of American Pathologists</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>pathology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Basal Cell Carcinoma (BCC)/Squamous Cell Carcinoma: Biopsy Reporting Time - Pathologist to Clinician</title>
     <description>Percentage of biopsies with a diagnosis of cutaneous Basal Cell Carcinoma (BCC) and Squamous Cell Carcinoma (SCC) (including in situ disease) in which the pathologist communicates results to the clinician within 7 days of  biopsy date</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -2441,13 +2441,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Dermatology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Biopsy Follow-Up</title>
     <description>Percentage of new patients whose biopsy results have been reviewed and communicated to the primary care/referring physician and patient by the performing physician</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -2461,7 +2461,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Dermatology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>dermatology</measureSets>
     <measureSets>interventionalRadiology</measureSets>
     <measureSets>obstetricsGynecology</measureSets>
@@ -2471,7 +2471,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Bipolar Disorder and Major Depression: Appraisal for alcohol or chemical substance use</title>
     <description>Percentage of patients with depression or bipolar disorder with evidence of an initial assessment that includes an appraisal for alcohol or chemical substance use</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2485,13 +2485,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Center for Quality Assessment and Improvement in Mental Health</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Breast Cancer Resection Pathology Reporting: pT Category (Primary Tumor) and pN Category (Regional Lymph Nodes) with Histologic Grade</title>
     <description>Percentage of breast cancer resection pathology reports that include the pT category (primary tumor), the pN category (regional lymph nodes), and the histologic grade</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2505,15 +2505,15 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>College of American Pathologists</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>pathology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Breast Cancer Screening</title>
     <description>Percentage of women 50-74 years of age who had a mammogram to screen for breast cancer.</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2527,10 +2527,10 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>claims</methods>
-    <methods>ehr</methods>
-    <methods>cmsWebInterface</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>cmsWebInterface</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>obstetricsGynecology</measureSets>
     <measureSets>preventiveMedicine</measureSets>
@@ -2540,7 +2540,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>CAHPS for PQRS Clinician/Group Survey</title>
     <description>&lt;br/&gt;&lt;ul&gt;&lt;li&gt; Getting timely care, appointments, and information;
 &lt;/li&gt;&lt;li&gt; How well providers Communicate;
@@ -2565,14 +2565,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Agency for Healthcare Research &amp; Quality</primarySteward>
-    <methods>csv</methods>
+    <submissionMethods>csv</submissionMethods>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Cardiac Rehabilitation Patient Referral from an Outpatient Setting</title>
     <description>Percentage of patients evaluated in an outpatient setting who within the previous 12 months have experienced an acute myocardial infarction (MI), coronary artery bypass graft (CABG) surgery, a percutaneous coronary intervention (PCI), cardiac valve surgery, or cardiac transplantation, or who have chronic stable angina (CSA) and have not already participated in an early outpatient cardiac rehabilitation/secondary prevention (CR) program for the qualifying event/diagnosis who were referred to a CR program</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -2586,13 +2586,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Cardiology Foundation</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low Risk Surgery Patients</title>
     <description>Percentage of stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), or cardiac magnetic resonance (CMR) performed in low risk surgery patients 18 years or older for preoperative evaluation during the 12-month reporting period</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -2606,14 +2606,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Cardiology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>cardiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Routine Testing After Percutaneous Coronary Intervention (PCI)</title>
     <description>Percentage of all stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), and cardiovascular magnetic resonance (CMR) performed in patients aged 18 years and older routinely after percutaneous coronary intervention (PCI), with reference to timing of test after PCI and symptom status</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -2627,14 +2627,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Cardiology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>cardiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Testing in Asymptomatic, Low-Risk Patients</title>
     <description>Percentage of all stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), and cardiovascular magnetic resonance (CMR) performed in asymptomatic, low coronary heart disease (CHD) risk patients 18 years and older for initial detection and risk assessment</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -2648,14 +2648,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Cardiology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>cardiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Care Plan</title>
     <description>Percentage of patients aged 65 years and older who have an advance care plan or surrogate decision maker documented in the medical record or documentation in the medical record that an advance care plan was discussed but the patient did not wish or was not able to name a surrogate decision maker or provide an advance care plan</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -2669,8 +2669,8 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>cardiology</measureSets>
     <measureSets>emergencyMedicine</measureSets>
@@ -2697,7 +2697,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Cataracts: 20/40 or Better Visual Acuity within 90 Days Following Cataract Surgery</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of uncomplicated cataract who had cataract surgery and no significant ocular conditions impacting the visual outcome of surgery and had best-corrected visual acuity of 20/40 or better (distance or near) achieved within 90 days following the cataract surgery</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2711,15 +2711,15 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
-    <methods>ehr</methods>
-    <methods>registry</methods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>ophthalmology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Cataracts: Complications within 30 Days Following Cataract Surgery Requiring Additional Surgical Procedures</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of uncomplicated cataract who had cataract surgery and had any of a specified list of surgical procedures in the 30 days following cataract surgery which would indicate the occurrence of any of the following major complications: retained nuclear fragments, endophthalmitis, dislocated or wrong power IOL, retinal detachment, or wound dehiscence</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -2733,15 +2733,15 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
-    <methods>ehr</methods>
-    <methods>registry</methods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>ophthalmology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Cataracts: Improvement in Patient's Visual Function within 90 Days Following Cataract Surgery</title>
     <description>Percentage of patients aged 18 years and older who had cataract surgery and had improvement in visual function achieved within 90 days following the cataract surgery, based on completing a pre-operative and post-operative visual function survey</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -2755,14 +2755,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Ophthalmology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>ophthalmology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Cataracts: Patient Satisfaction within 90 Days Following Cataract Surgery</title>
     <description>Percentage of patients aged 18 years and older  who had cataract surgery and were satisfied with their care within 90 days following the cataract surgery, based on completion of the Consumer Assessment of Healthcare Providers and Systems Surgical Care Survey</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -2776,14 +2776,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Ophthalmology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>ophthalmology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Cataract Surgery: Difference Between Planned and Final Refraction</title>
     <description>Percentage of patients aged 18 years and older who had cataract surgery performed and who achieved a final refraction within +/- 1.0 diopters of their planned (target) refraction</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2797,14 +2797,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Ophthalmology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>ophthalmology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Cataract Surgery with Intra-Operative Complications (Unplanned Rupture of Posterior Capsule Requiring Unplanned Vitrectomy)</title>
     <description>Percentage of patients aged 18 years and older who had cataract surgery performed and had an unplanned rupture of the posterior capsule requiring vitrectomy</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -2818,14 +2818,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Ophthalmology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>ophthalmology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Cervical Cancer Screening</title>
     <description>Percentage of women 21-64 years of age who were screened for cervical cancer using either of the following criteria:
 *  Women age 21-64 who had cervical cytology performed every 3 years
@@ -2842,7 +2842,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
     <measureSets>obstetricsGynecology</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
   </measure>
@@ -2850,7 +2850,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Child and Adolescent Major Depressive Disorder (MDD): Suicide Risk Assessment</title>
     <description>Percentage of patient visits for those patients aged 6 through 17 years with a diagnosis of major depressive disorder with an assessment for suicide risk
 </description>
@@ -2865,7 +2865,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
     <measureSets>mentalBehavioralHealth</measureSets>
     <measureSets>pediatrics</measureSets>
   </measure>
@@ -2873,7 +2873,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Childhood Immunization Status</title>
     <description>Percentage of children 2 years of age who had four diphtheria, tetanus and acellular pertussis (DTaP); three polio (IPV), one measles, mumps and rubella (MMR); three H influenza type B (HiB); three hepatitis B (Hep B); one chicken pox (VZV); four pneumococcal conjugate (PCV); one hepatitis A (Hep A); two or three rotavirus (RV); and two influenza (flu) vaccines by their second birthday</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -2887,14 +2887,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
     <measureSets>pediatrics</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Children Who Have Dental Decay or Cavities</title>
     <description>Percentage of children, age 0-20 years, who have had tooth decay or cavities during the measurement period</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -2908,13 +2908,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Chlamydia Screening and Follow Up</title>
     <description>The percentage of female adolescents 16 years of age who had a chlamydia screening test with proper follow-up during the measurement period</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -2928,14 +2928,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>obstetricsGynecology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Chlamydia Screening for Women</title>
     <description>Percentage of women 16-24 years of age who were identified as sexually active and who had at least one test for chlamydia during the measurement period</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -2949,7 +2949,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
     <measureSets>obstetricsGynecology</measureSets>
     <measureSets>pediatrics</measureSets>
   </measure>
@@ -2957,7 +2957,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Chronic Obstructive Pulmonary Disease (COPD): Long-Acting Inhaled Bronchodilator Therapy</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of COPD (FEV1/FVC &lt; 70%) and who have an FEV1 less than 60% predicted and have symptoms who were prescribed an long-acting inhaled bronchodilator</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2971,14 +2971,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Thoracic Society</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Chronic Obstructive Pulmonary Disease (COPD): Spirometry Evaluation</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of COPD who had spirometry results documented</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2992,14 +2992,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Thoracic Society</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Clinical Outcome Post Endovascular Stroke Treatment</title>
     <description>Percentage of patients with a mRs score of 0 to 2 at 90 days following endovascular stroke intervention</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3013,13 +3013,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society of Interventional Radiology </primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Closing the Referral Loop: Receipt of Specialist Report</title>
     <description>Percentage of patients with referrals, regardless of age, for which the referring provider receives a report from the provider to whom the patient was referred</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -3033,7 +3033,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
     <measureSets>allergyImmunology</measureSets>
     <measureSets>cardiology</measureSets>
     <measureSets>dermatology</measureSets>
@@ -3060,7 +3060,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Colonoscopy Interval for Patients with a History of Adenomatous Polyps
 - Avoidance of Inappropriate Use</title>
     <description>Percentage of patients aged 18 years and older receiving a surveillance colonoscopy, with a history of a prior adenomatous polyp(s) in previous colonoscopy findings, which had an interval of 3 or more years since their last colonoscopy</description>
@@ -3075,15 +3075,15 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Gastroenterological Association</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>gastroenterology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Colorectal Cancer Resection Pathology Reporting: pT Category (Primary Tumor) and pN Category (Regional Lymph Nodes) with Histologic Grade</title>
     <description>Percentage of colon and rectum cancer resection pathology reports that include the pT category (primary tumor), the pN category (regional lymph nodes) and the histologic grade</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3097,15 +3097,15 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>College of American Pathologists</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>pathology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Colorectal Cancer Screening</title>
     <description>Percentage of adults 50-75 years of age who had appropriate screening for colorectal cancer.</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3119,10 +3119,10 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>claims</methods>
-    <methods>ehr</methods>
-    <methods>cmsWebInterface</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>cmsWebInterface</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
   </measure>
@@ -3130,7 +3130,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Communication with the Physician or Other Clinician Managing On-going Care Post-Fracture for Men and Women Aged 50 Years and Older</title>
     <description>Percentage of patients aged 50 years and older treated for a fracture with documentation of communication, between the physician treating the fracture and the physician or other clinician managing the patient's on-going care, that a fracture occurred and that the patient was or should be considered for osteoporosis treatment or testing. This measure is reported by the physician who treats the fracture and who therefore is held accountable for the communication</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -3144,15 +3144,15 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>preventiveMedicine</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Controlling High Blood Pressure</title>
     <description>Percentage of patients 18-85 years of age who had a diagnosis of hypertension and whose blood pressure was adequately controlled (&lt;140/90mmHg) during the measurement period</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3166,10 +3166,10 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>claims</methods>
-    <methods>ehr</methods>
-    <methods>cmsWebInterface</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>cmsWebInterface</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>cardiology</measureSets>
     <measureSets>obstetricsGynecology</measureSets>
@@ -3182,7 +3182,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Coronary Artery Bypass Graft (CABG): Deep Sternal Wound Infection Rate</title>
     <description>Percentage of patients aged 18 years and older undergoing isolated CABG surgery who, within 30 days postoperatively, develop deep sternal wound infection involving muscle, bone, and/or mediastinum requiring operative intervention</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3196,14 +3196,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society of Thoracic Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>thoracicSurgery</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Coronary Artery Bypass Graft (CABG): Postoperative Renal Failure</title>
     <description>Percentage of patients aged 18 years and older undergoing isolated CABG surgery (without pre-existing renal failure) who develop postoperative renal failure or require dialysis</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3217,14 +3217,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society of Thoracic Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>thoracicSurgery</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Coronary Artery Bypass Graft (CABG): Preoperative Beta-Blocker in Patients with Isolated CABG Surgery</title>
     <description>Percentage of isolated Coronary Artery Bypass Graft (CABG) surgeries for patients aged 18 years and older who received a beta-blocker within 24 hours prior to surgical incision</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3238,14 +3238,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>anesthesiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Coronary Artery Bypass Graft (CABG): Prolonged Intubation</title>
     <description>Percentage of patients aged 18 years and older undergoing isolated CABG surgery who require postoperative intubation &gt; 24 hours</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3259,14 +3259,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society of Thoracic Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>thoracicSurgery</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Coronary Artery Bypass Graft (CABG): Stroke</title>
     <description>Percentage of patients aged 18 years and older undergoing isolated CABG surgery who have a postoperative stroke (i.e., any confirmed neurological deficit of abrupt onset caused by a disturbance in blood supply to the brain) that did not resolve within 24 hours</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3280,14 +3280,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society of Thoracic Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>thoracicSurgery</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Coronary Artery Bypass Graft (CABG): Surgical Re-Exploration</title>
     <description>Percentage of patients aged 18 years and older undergoing isolated CABG surgery who require a return to the operating room (OR) during the current hospitalization for mediastinal bleeding with or without tamponade, graft occlusion, valve dysfunction, or other cardiac reason</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3301,14 +3301,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society of Thoracic Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>thoracicSurgery</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Coronary Artery Bypass Graft (CABG): Use of Internal Mammary Artery (IMA) in Patients with Isolated CABG Surgery</title>
     <description>Percentage of patients aged 18 years and older undergoing isolated CABG surgery who received an IMA graft</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3322,13 +3322,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society of Thoracic Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Coronary Artery Disease (CAD): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy - Diabetes or Left Ventricular Systolic Dysfunction (LVEF &lt; 40%)</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease seen within a 12 month period who also have diabetes OR a current or prior Left Ventricular Ejection Fraction (LVEF) &lt; 40% who were prescribed ACE inhibitor or ARB therapy</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3342,14 +3342,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Heart Association</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>cardiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Coronary Artery Disease (CAD): Antiplatelet Therapy</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease (CAD) seen within a 12 month period who were prescribed aspirin or clopidogrel</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3363,14 +3363,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Heart Association</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>cardiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Coronary Artery Disease (CAD): Beta-Blocker Therapy-Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF &lt;40%)</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease seen within a 12 month period who also have a prior MI or a current or prior LVEF &lt;40% who were prescribed beta-blocker therapy</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3384,8 +3384,8 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
-    <methods>ehr</methods>
-    <methods>registry</methods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>cardiology</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
   </measure>
@@ -3393,7 +3393,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Dementia: Caregiver Education and Support</title>
     <description>Percentage of patients, regardless of age, with a diagnosis of dementia whose caregiver(s) were provided with education on dementia disease management and health behavior changes AND referred to additional resources for support within a 12 month period</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -3407,7 +3407,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Neurology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>neurology</measureSets>
     <measureSets>mentalBehavioralHealth</measureSets>
   </measure>
@@ -3415,7 +3415,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Dementia: Cognitive Assessment</title>
     <description>Percentage of patients, regardless of age, with a diagnosis of dementia for whom an assessment of cognition is performed and the results reviewed at least once within a 12 month period</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3429,7 +3429,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
     <measureSets>neurology</measureSets>
     <measureSets>mentalBehavioralHealth</measureSets>
   </measure>
@@ -3437,7 +3437,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Dementia: Counseling Regarding Safety Concerns</title>
     <description>Percentage of patients, regardless of age, with a diagnosis of dementia or their caregiver(s) who were counseled or referred for counseling regarding safety concerns within a 12 month period</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -3451,7 +3451,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Neurology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>neurology</measureSets>
     <measureSets>mentalBehavioralHealth</measureSets>
   </measure>
@@ -3459,7 +3459,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Dementia: Functional Status Assessment</title>
     <description>Percentage of patients, regardless of age, with a diagnosis of dementia for whom an assessment of functional status is performed and the results reviewed at least once within a 12 month period</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3473,7 +3473,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Neurology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>neurology</measureSets>
     <measureSets>mentalBehavioralHealth</measureSets>
   </measure>
@@ -3481,7 +3481,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Dementia: Management of Neuropsychiatric Symptoms</title>
     <description>Percentage of patients, regardless of age, with a diagnosis of dementia who have one or more neuropsychiatric symptoms who received or were recommended to receive an intervention for neuropsychiatric symptoms within a 12 month period</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3495,7 +3495,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Neurology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>neurology</measureSets>
     <measureSets>mentalBehavioralHealth</measureSets>
   </measure>
@@ -3503,7 +3503,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Dementia: Neuropsychiatric Symptom Assessment</title>
     <description>Percentage of patients, regardless of age, with a diagnosis of dementia and for whom an assessment of neuropsychiatric symptoms is performed and results reviewed at least once in a 12 month period</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3517,7 +3517,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Neurology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>neurology</measureSets>
     <measureSets>mentalBehavioralHealth</measureSets>
   </measure>
@@ -3525,7 +3525,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Depression Remission at Six Months</title>
     <description>Adult patients age 18 years and older with major depression or dysthymia and an initial PHQ-9 score &gt; 9 who demonstrate remission at six months defined as a PHQ-9 score less than 5. This measure applies to both patients with newly diagnosed and existing depression whose current PHQ-9 score indicates a need for treatment. This measure additionally promotes ongoing contact between the patient and provider as patients who do not have a follow-up PHQ-9 score at six months (+/- 30 days) are also included in the denominator</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3539,14 +3539,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Minnesota Community Measurement</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>mentalBehavioralHealth</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Depression Remission at Twelve Months</title>
     <description>Patients age 18 and older with major depression or dysthymia and an initial Patient Health Questionnaire (PHQ-9) score greater than nine who demonstrate remission at twelve months (+/- 30 days after an index visit) defined as a PHQ-9 score less than five. This measure applies to both patients with newly diagnosed and existing depression whose current PHQ-9 score indicates a need for treatment.</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3560,9 +3560,9 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Minnesota Community Measurement</primarySteward>
-    <methods>ehr</methods>
-    <methods>cmsWebInterface</methods>
-    <methods>registry</methods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>cmsWebInterface</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>mentalBehavioralHealth</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
   </measure>
@@ -3570,7 +3570,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Depression Utilization of the PHQ-9 Tool</title>
     <description>Patients age 18 and older with the diagnosis of major depression or dysthymia who have a Patient Health Questionnaire (PHQ-9) tool administered at least once during a 4-month period in which there was a qualifying visit</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3584,14 +3584,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Minnesota Community Measurement</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
     <measureSets>mentalBehavioralHealth</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Diabetes: Eye Exam</title>
     <description>Percentage of patients 18-75 years of age with diabetes who had a retinal or dilated eye exam by an eye care professional during the measurement period or a negative retinal exam (no evidence of retinopathy) in the 12 months prior to the measurement period</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3605,10 +3605,10 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>claims</methods>
-    <methods>ehr</methods>
-    <methods>cmsWebInterface</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>cmsWebInterface</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>ophthalmology</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
@@ -3617,7 +3617,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Diabetes: Foot Exam</title>
     <description>The percentage of patients 18-75 years of age with diabetes (type 1 and type 2) who received a foot exam (visual inspection and sensory exam with mono filament and a pulse exam) during the measurement year</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3631,7 +3631,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
   </measure>
@@ -3639,7 +3639,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt;9%)</title>
     <description>Percentage of patients 18-75 years of age with diabetes who had hemoglobin A1c &gt; 9.0% during the measurement period</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3653,10 +3653,10 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>claims</methods>
-    <methods>ehr</methods>
-    <methods>cmsWebInterface</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>cmsWebInterface</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>preventiveMedicine</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
@@ -3665,7 +3665,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Diabetes: Medical Attention for Nephropathy</title>
     <description>The percentage of patients 18-75 years of age with diabetes who had a nephropathy screening test or evidence of nephropathy during the measurement period.</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3679,15 +3679,15 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>ehr</methods>
-    <methods>registry</methods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Diabetes Mellitus: Diabetic Foot and Ankle Care, Peripheral Neuropathy - Neurological Evaluation</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of diabetes mellitus who had a neurological examination of their lower extremities within 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3701,13 +3701,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Podiatric Medical Association</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Diabetes Mellitus: Diabetic Foot and Ankle Care, Ulcer Prevention - Evaluation of Footwear</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of diabetes mellitus who were evaluated for proper footwear and sizing</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3721,13 +3721,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Podiatric Medical Association</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of diabetic retinopathy who had a dilated macular or fundus exam performed with documented communication to the physician who manages the ongoing care of the patient with diabetes mellitus regarding the findings of the macular or fundus exam at least once within 12 months</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -3741,16 +3741,16 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
-    <methods>claims</methods>
-    <methods>ehr</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>ophthalmology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Diabetic Retinopathy: Documentation of Presence or Absence of Macular Edema and Level of Severity of Retinopathy</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of diabetic retinopathy who had a dilated macular or fundus exam performed which included documentation of the level of severity of retinopathy and the presence or absence of macular edema during one or more office visits within 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3764,14 +3764,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
     <measureSets>ophthalmology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Documentation of Current Medications in the Medical Record</title>
     <description>Percentage of visits for patients aged 18 years and older for which the eligible professional attests to documenting a list of current medications using all immediate resources available on the date of the encounter.  This list must include ALL known prescriptions, over-the-counters, herbals, and vitamin/mineral/dietary (nutritional) supplements AND must contain the medications' name, dosage, frequency and route of administration.</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -3785,9 +3785,9 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
-    <methods>claims</methods>
-    <methods>ehr</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>allergyImmunology</measureSets>
     <measureSets>internalMedicine</measureSets>
     <measureSets>anesthesiology</measureSets>
@@ -3817,7 +3817,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Documentation of Signed Opioid Treatment Agreement</title>
     <description>All patients 18 and older prescribed opiates for longer than six weeks duration who signed an opioid treatment agreement at least once during Opioid Therapy documented in the medical record.</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3831,7 +3831,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Neurology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>neurology</measureSets>
     <measureSets>physicalMedicine</measureSets>
@@ -3841,7 +3841,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Door to Puncture Time for Endovascular Stroke Treatment</title>
     <description>Percentage of patients undergoing endovascular stroke treatment who have a door to puncture time of less than two hours</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3855,13 +3855,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society of Interventional Radiology </primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Elder Maltreatment Screen and Follow-Up Plan</title>
     <description>Percentage of patients aged 65 years and older with a documented elder maltreatment screen using an Elder Maltreatment Screening tool on the date of encounter AND a documented follow-up plan on the date of the positive screen</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -3875,8 +3875,8 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>mentalBehavioralHealth</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
@@ -3885,7 +3885,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older</title>
     <description>Percentage of emergency department visits for patients aged 18 years and older who presented within 24 hours of a minor blunt head trauma with a Glasgow Coma Scale (GCS) score of 15 and who had a head CT for trauma ordered by an emergency care provider who have an indication for a head CT</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -3899,15 +3899,15 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Emergency Physicians</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>emergencyMedicine</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years</title>
     <description>Percentage of emergency department visits for patients aged 2 through 17 years who presented within 24 hours of a minor blunt head trauma with a Glasgow Coma Scale (GCS) score of 15 and who had a head CT for trauma ordered by an emergency care provider who are classified as low risk according to the Pediatric Emergency Care Applied Research Network (PECARN) prediction rules for traumatic brain injury</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -3921,15 +3921,15 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Emergency Physicians</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>emergencyMedicine</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Epilepsy: Counseling for Women of Childbearing Potential with Epilepsy</title>
     <description>All female patients of childbearing potential (12 - 44 years old) diagnosed with epilepsy who were counseled or referred for counseling for how epilepsy and its treatment may affect contraception OR pregnancy at least once a year</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3943,15 +3943,15 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Neurology</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>neurology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Evaluation or Interview for Risk of Opioid Misuse</title>
     <description>All patients 18 and older prescribed opiates for longer than six weeks duration evaluated for risk of opioid misuse using a brief validated instrument (e.g. Opioid Risk Tool, SOAPP-R) or patient interview documented at least once during Opioid Therapy in the medical record</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3965,7 +3965,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Neurology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>neurology</measureSets>
     <measureSets>physicalMedicine</measureSets>
@@ -3975,7 +3975,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Falls: Plan of Care</title>
     <description>Percentage of patients aged 65 years and older with a history of falls that had a plan of care for falls documented within 12 months</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -3989,8 +3989,8 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
   </measure>
@@ -3998,7 +3998,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Falls: Risk Assessment</title>
     <description>Percentage of patients aged 65 years and older with a history of falls that had a risk assessment for falls completed within 12 months</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -4012,8 +4012,8 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
   </measure>
@@ -4021,7 +4021,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Falls: Screening for Future Fall Risk</title>
     <description>Percentage of patients 65 years of age and older who were screened for future fall risk during the measurement period.</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -4035,14 +4035,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>ehr</methods>
-    <methods>cmsWebInterface</methods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>cmsWebInterface</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Follow-Up After Hospitalization for Mental Illness (FUH)</title>
     <description>The percentage of discharges for patients 6 years of age and older who were hospitalized for treatment of selected mental illness diagnoses and who had an outpatient visit, an intensive outpatient encounter or partial hospitalization with a mental health practitioner. Two rates are reported:
 &lt;br/&gt;&lt;ul&gt;&lt;li&gt; The percentage of discharges for which the patient received follow-up within 30 days of discharge.
@@ -4060,7 +4060,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>mentalBehavioralHealth</measureSets>
     <measureSets>pediatrics</measureSets>
   </measure>
@@ -4068,7 +4068,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Functional Outcome Assessment</title>
     <description>Percentage of visits for patients aged 18 years and older with documentation of a current functional outcome assessment using a standardized functional outcome assessment tool on the date of the encounter AND documentation of a care plan based on identified functional outcome deficiencies on the date of the identified deficiencies</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4082,15 +4082,15 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>physicalMedicine</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Functional Status Assessment for Total Hip Replacement</title>
     <description>Percentage of patients 18 years of age and older with primary total hip arthroplasty (THA) who completed baseline and follow-up patient-reported functional status assessments</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -4104,14 +4104,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
     <measureSets>orthopedicSurgery</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Functional Status Assessment for Total Knee Replacement</title>
     <description>Percentage of patients 18 years of age and older with primary total knee arthroplasty (TKA) who completed baseline and follow-up patient-reported functional status assessments</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -4125,14 +4125,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
     <measureSets>orthopedicSurgery</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Functional Status Assessments for Congestive Heart Failure</title>
     <description>Percentage of patients 65 years of age and older with congestive  heart failure who completed initial and follow-up patient-reported functional status assessments</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -4146,13 +4146,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Functional Status Change for Patients with Elbow, Wrist or Hand Impairments</title>
     <description>A self-report outcome measure of functional status (FS) for patients 14 years+ with elbow, wrist or hand impairments. The change in FS assessed using FOTO (elbow, wrist and hand) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS  outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4166,13 +4166,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Focus on Therapeutic Outcomes, Inc.</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Functional Status Change for Patients with Foot or Ankle Impairments</title>
     <description>A self-report measure of change in functional status (FS) for patients 14 years+ with foot and ankle impairments. The change in functional status (FS) assessed using FOTO's (foot and ankle) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4186,13 +4186,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Focus on Therapeutic Outcomes, Inc.</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Functional Status Change for Patients with General Orthopaedic Impairments</title>
     <description>A self-report outcome measure of functional status (FS) for patients 14 years+ with general orthopaedic impairments (neck, cranium, mandible, thoracic spine, ribs or other general orthopaedic impairment). The change in FS assessed using FOTO (general orthopaedic) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level by to assess quality</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4206,13 +4206,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Focus on Therapeutic Outcomes, Inc.</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Functional Status Change for Patients with Hip Impairments</title>
     <description>A self-report measure of change in functional status (FS) for patients 14 years+ with hip impairments. The change in functional status (FS) assessed using FOTO's (hip) PROM (patient- reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4226,13 +4226,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Focus on Therapeutic Outcomes, Inc.</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Functional Status Change for Patients with Knee Impairments</title>
     <description>A self-report measure of change in functional status for patients 14 year+ with knee impairments. The change in functional status (FS) assessed using FOTO's (knee ) PROM (patient-reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4246,13 +4246,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Focus on Therapeutic Outcomes, Inc.</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Functional Status Change for Patients with Lumbar Impairments</title>
     <description>A self-report outcome measure of change in functional status for patients 14 years+ with lumbar impairments. The change in functional status (FS) assessed using FOTO (lumbar) PROM (patient reported outcome measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level by to assess quality</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4266,13 +4266,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Focus on Therapeutic Outcomes, Inc.</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Functional Status Change for Patients with Shoulder Impairments</title>
     <description>A self-report outcome measure of change in functional status (FS) for patients 14 years+ with shoulder impairments. The change in functional status (FS) assessed using FOTO's (shoulder) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4286,13 +4286,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Focus on Therapeutic Outcomes, Inc.</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy for Left Ventricular Systolic Dysfunction (LVSD)</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of heart failure (HF) with a current or prior left ventricular ejection fraction (LVEF) &lt; 40% who were prescribed ACE inhibitor or ARB therapy either within a 12 month period when seen in the outpatient setting OR at each hospital discharge</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4306,8 +4306,8 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
-    <methods>ehr</methods>
-    <methods>registry</methods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>cardiology</measureSets>
     <measureSets>hospitalists</measureSets>
@@ -4317,7 +4317,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Heart Failure (HF): Beta-Blocker Therapy for Left Ventricular Systolic Dysfunction (LVSD)</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of heart failure (HF) with a current or prior left ventricular ejection fraction (LVEF) &lt; 40% who were prescribed beta-blocker therapy either within a 12 month period when seen in the outpatient setting OR at each hospital discharge</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4331,8 +4331,8 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
-    <methods>ehr</methods>
-    <methods>registry</methods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>cardiology</measureSets>
     <measureSets>hospitalists</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
@@ -4341,7 +4341,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Hematology: Chronic Lymphocytic Leukemia (CLL): Baseline Flow Cytometry</title>
     <description>Percentage of patients aged 18 years and older, seen within a 12 month reporting period, with a diagnosis of chronic lymphocytic leukemia (CLL) made at any time during or prior to the reporting period who had baseline flow cytometry studies performed and documented in the chart</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4355,13 +4355,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Hematology: Multiple Myeloma: Treatment with Bisphosphonates</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of multiple myeloma, not in remission, who were prescribed or received intravenous bisphosphonate therapy within the 12 month reporting period</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4375,13 +4375,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Hematology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Hematology: Myelodysplastic Syndrome (MDS) and Acute Leukemias: Baseline Cytogenetic Testing Performed on Bone Marrow</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of myelodysplastic syndrome (MDS) or an acute leukemia who had baseline cytogenetic testing performed on bone marrow</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4395,13 +4395,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Hematology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Hematology: Myelodysplastic Syndrome (MDS): Documentation of Iron Stores in Patients Receiving Erythropoietin Therapy</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of myelodysplastic syndrome (MDS) who are receiving erythropoietin therapy with documentation of iron stores within 60 days prior to initiating erythropoietin therapy</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4415,13 +4415,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Hematology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Hepatitis C: Discussion and Shared Decision Making Surrounding Treatment Options</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of hepatitis C with whom a physician or other qualified healthcare professional reviewed the range of treatment options appropriate to their genotype and demonstrated a shared decision making approach with the patient. To meet the measure, there must be documentation in the patient record of a discussion between the physician or other qualified healthcare professional and the patient that includes all of the following: treatment choices appropriate to genotype, risks and benefits, evidence of effectiveness, and patient preferences toward treatment
 </description>
@@ -4436,14 +4436,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Gastroenterological Association</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>gastroenterology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Hepatitis C: Screening for Hepatocellular Carcinoma (HCC) in Patients with Cirrhosis</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of chronic hepatitis C cirrhosis who underwent imaging with either ultrasound, contrast enhanced CT or MRI for hepatocellular carcinoma (HCC) at least once within the 12 month reporting period</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4457,7 +4457,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Gastroenterological Association</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>gastroenterology</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
@@ -4466,7 +4466,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>HER2 Negative or Undocumented Breast Cancer Patients Spared Treatment with HER2-Targeted Therapies</title>
     <description>Proportion of female patients (aged 18 years and older) with breast cancer who are human epidermal growth factor receptor 2 (HER2)/neu negative who are not administered HER2-targeted therapies</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -4480,14 +4480,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Clinical Oncology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalOncology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>HIV/AIDS: Pneumocystis Jiroveci Pneumonia (PCP) Prophylaxis</title>
     <description>Percentage of patients aged 6 weeks and older with a diagnosis of HIV/AIDS who were prescribed Pneumocystis jiroveci pneumonia (PCP) prophylaxis</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4501,7 +4501,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
     <measureSets>allergyImmunology</measureSets>
     <measureSets>pediatrics</measureSets>
   </measure>
@@ -4509,7 +4509,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>HIV/AIDS: Sexually Transmitted Disease Screening for Chlamydia, Gonorrhea, and Syphilis</title>
     <description>Percentage of patients aged 13 years and older with a diagnosis of HIV/AIDS for whom chlamydia, gonorrhea, and syphilis screenings were performed at least once since the diagnosis of HIV infection</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4523,14 +4523,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>pediatrics</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>HIV Medical Visit Frequency</title>
     <description>Percentage of patients, regardless of age with a diagnosis of HIV who had at least one medical visit in each 6 month period of the 24 month measurement period, with a minimum of 60 days between medical visits</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -4544,13 +4544,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Health Resources and Services Administration</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>HIV Viral Load Suppression</title>
     <description>The percentage of patients, regardless of age, with a diagnosis of HIV with a HIV viral load less than 200 copies/mL at last HIV viral load test during the measurement year</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4564,14 +4564,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Health Resources and Services Administration</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>HRS-12: Cardiac Tamponade and/or Pericardiocentesis Following Atrial Fibrillation Ablation</title>
     <description>Rate of cardiac tamponade and/or pericardiocentesis following atrial fibrillation ablation This measure is reported as four rates stratified by age and gender:
 &lt;br/&gt;&lt;ul&gt;&lt;li&gt; Reporting Age Criteria 1: Females 18-64years of age
@@ -4590,14 +4590,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>The Heart Rhythm Society</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>electrophysiologyCardiacSpecialist</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>HRS-3: Implantable Cardioverter-Defibrillator (ICD) Complications Rate</title>
     <description>Patients with physician-specific risk-standardized rates of procedural complications following the first time implantation of an ICD</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -4611,14 +4611,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>The Heart Rhythm Society</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>electrophysiologyCardiacSpecialist</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>HRS-9: Infection within 180 Days of Cardiac Implantable Electronic Device (CIED) Implantation, Replacement, or Revision</title>
     <description>Infection rate following CIED device implantation, replacement, or revision
 </description>
@@ -4633,14 +4633,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>The Heart Rhythm Society</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>electrophysiologyCardiacSpecialist</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Hypertension: Improvement in Blood Pressure</title>
     <description>Percentage of patients aged 18-85 years of age with a diagnosis of hypertension whose blood pressure improved during the measurement period.</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4654,13 +4654,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Image Confirmation of Successful Excision of Image-Localized Breast Lesion</title>
     <description>Image confirmation of lesion(s) targeted for image guided excisional biopsy or image guided partial mastectomy in patients with nonpalpable, image-detected breast lesion(s). Lesions may include: microcalcifications, mammographic or sonographic mass or architectural distortion, focal suspicious abnormalities on magnetic resonance imaging (MRI) or other breast imaging amenable to localization such as positron emission tomography (PET) mammography, or a biopsy marker demarcating site of confirmed pathology as established by previous core biopsy</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -4674,13 +4674,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Breast Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Immunizations for Adolescents</title>
     <description>The percentage of adolescents 13 years of age who had the recommended immunizations by their 13th birthday</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -4694,7 +4694,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
     <measureSets>pediatrics</measureSets>
   </measure>
@@ -4702,7 +4702,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Inflammatory Bowel Disease (IBD): Assessment of Hepatitis B Virus (HBV) Status Before Initiating Anti-TNF (Tumor Necrosis Factor) Therapy</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of inflammatory bowel disease (IBD) who had Hepatitis B Virus (HBV) status assessed and results interpreted within one year prior to receiving a first course of anti-TNF (tumor necrosis factor) therapy</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4716,14 +4716,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Gastroenterological Association</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>gastroenterology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Inflammatory Bowel Disease (IBD): Preventive Care: Corticosteroid Related Iatrogenic Injury - Bone Loss Assessment</title>
     <description>Percentage of patients aged 18 years and older with an inflammatory bowel disease encounter who were prescribed prednisone equivalents greater than or equal to 10 mg/day for 60 or greater consecutive days or a single prescription equating to 600 mg prednisone or greater for all fills and were documented for risk of bone loss once during the reporting year or the previous calendar year</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4737,14 +4737,14 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Gastroenterological Association</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>gastroenterology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Initiation and Engagement of Alcohol and Other Drug Dependence Treatment</title>
     <description>Percentage of patients 13 years of age and older with a new episode of alcohol and other drug (AOD) dependence who received the following. Two rates are reported.
 a. Percentage of patients who initiated treatment within 14 days of the diagnosis.
@@ -4761,13 +4761,13 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Ischemic Vascular Disease (IVD) All or None Outcome Measure (Optimal Control)</title>
     <description>The IVD All-or-None Measure is one outcome measure (optimal control). The measure contains four goals. All four goals within a measure must be reached in order to meet that measure. The numerator for the all-or-none measure should be collected from the organization's total IVD denominator. All-or-None Outcome Measure (Optimal Control) - Using the IVD denominator optimal results include: 
 &lt;br/&gt;&lt;ul&gt;&lt;li&gt; Most recent blood pressure (BP) measurement is less than 140/90 mm Hg -- And 
@@ -4786,13 +4786,13 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Wisconsin Collaborative for Healthcare Quality</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Ischemic Vascular Disease (IVD): Use of Aspirin or Another Antiplatelet</title>
     <description>Percentage of patients 18 years of age and older who were diagnosed with acute myocardial infarction (AMI), coronary artery bypass graft (CABG) or percutaneous coronary interventions (PCI) in the 12 months prior to the measurement period, or who had an active diagnosis of ischemic vascular disease (IVD) during the measurement period, and who had documentation of use of aspirin or another antiplatelet during the measurement period.</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4806,10 +4806,10 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>claims</methods>
-    <methods>ehr</methods>
-    <methods>cmsWebInterface</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>cmsWebInterface</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>cardiology</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
@@ -4818,7 +4818,7 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>KRAS Gene Mutation Testing Performed for Patients with Metastatic Colorectal Cancer who receive Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibody Therapy</title>
     <description>Percentage of adult patients (aged 18 or over) with metastatic colorectal cancer who receive anti-epidermal growth factor receptor monoclonal antibody therapy for whom KRAS gene mutation testing was performed</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4832,14 +4832,14 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Clinical Oncology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalOncology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Lung Cancer Reporting (Biopsy/Cytology Specimens)</title>
     <description>Pathology reports based on biopsy and/or cytology specimens with a diagnosis of primary non-small cell lung cancer classified into specific histologic type or classified as NSCLC-NOS with an explanation included in the pathology report</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4853,15 +4853,15 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>College of American Pathologists</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>pathology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Lung Cancer Reporting (Resection Specimens)</title>
     <description>Pathology reports based on resection specimens with a diagnosis of primary lung carcinoma that include the pT category, pN category and for non-small cell lung cancer, histologic type</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4875,15 +4875,15 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>College of American Pathologists</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>pathology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Maternal Depression Screening</title>
     <description>The percentage of children who turned 6 months of age during the measurement year, who had a face-to-face visit between the clinician and the child during child's first 6 months, and who had a maternal depression screening for the mother at least once between 0 and 6 months of life.
 </description>
@@ -4898,13 +4898,13 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Maternity Care: Elective Delivery or Early Induction Without Medical Indication at &gt;= 37 and &lt; 39 Weeks (Overuse)</title>
     <description>Percentage of patients, regardless of age, who gave birth during a 12-month period who delivered a live singleton at
 &gt;= 37 and &lt; 39 weeks of gestation completed who had elective deliveries or early inductions without medical indication
@@ -4920,13 +4920,13 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Maternity Care: Post-Partum Follow-Up and Care Coordination</title>
     <description>Percentage of patients, regardless of age, who gave birth during a 12-month period who were seen for post-partum care within 8 weeks of giving birth who received a breast feeding evaluation and education, post-partum depression screening, post-partum glucose screening for gestational diabetes patients, and family and contraceptive planning</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4940,13 +4940,13 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Medication Management for People with Asthma</title>
     <description>The percentage of patients 5-64 years of age during the measurement year who were identified as having persistent asthma and were dispensed appropriate medications that they remained on for at least 75% of their treatment period</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -4960,7 +4960,7 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>allergyImmunology</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
     <measureSets>pediatrics</measureSets>
@@ -4969,7 +4969,7 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Medication Reconciliation Post-Discharge</title>
     <description>The percentage of discharges from any inpatient facility (e.g. hospital, skilled nursing facility, or rehabilitation facility) for patients 18 years and older of age seen within 30 days following discharge in the office by the physician, prescribing practitioner, registered nurse, or clinical pharmacist providing on-going care for whom the discharge medication list was reconciled with the current medication list in the outpatient medical record.
 This measure is reported as three rates stratified by age group:
@@ -4988,15 +4988,15 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>claims</methods>
-    <methods>cmsWebInterface</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>cmsWebInterface</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Melanoma: Continuity of Care - Recall System</title>
     <description>Percentage of patients, regardless of age, with a current diagnosis of melanoma or a history of melanoma whose information was entered, at least once within a 12 month period, into a recall system that includes:
 &lt;br/&gt;&lt;ul&gt;&lt;li&gt; A target date for the next complete physical skin exam, AND
@@ -5013,14 +5013,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Dermatology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>dermatology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Melanoma: Coordination of Care</title>
     <description>Percentage of patient visits, regardless of age, with a new occurrence of melanoma who have a treatment plan documented in the chart that was communicated to the physician(s) providing continuing care within one month of diagnosis</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -5034,14 +5034,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Dermatology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>dermatology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Melanoma: Overutilization of Imaging Studies in Melanoma</title>
     <description>Percentage of patients, regardless of age, with a current diagnosis of Stage 0 through IIC melanoma or a history of melanoma of any stage, without signs or symptoms suggesting systemic spread, seen for an office visit during the one-year measurement period, for whom no diagnostic imaging studies were ordered</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -5055,14 +5055,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Dermatology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>dermatology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Melanoma Reporting</title>
     <description>Pathology reports for primary malignant cutaneous melanoma that include the pT category and a statement on thickness and ulceration and for pT1, mitotic rate</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -5076,15 +5076,15 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>College of American Pathologists</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>pathology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Non-Recommended Cervical Cancer Screening in Adolescent Females</title>
     <description>The percentage of adolescent females 16-20 years of age who were screened unnecessarily for cervical cancer</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -5098,7 +5098,7 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>obstetricsGynecology</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
   </measure>
@@ -5106,7 +5106,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Nuclear Medicine: Correlation with Existing Imaging Studies for All Patients Undergoing Bone Scintigraphy</title>
     <description>Percentage of final reports for all patients, regardless of age, undergoing bone scintigraphy that include physician documentation of correlation with existing relevant imaging studies (e.g., x-ray, MRI, CT, etc.) that were performed</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -5120,15 +5120,15 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society of Nuclear Medicine and Molecular Imaging</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>diagnosticRadiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Oncology: Medical and Radiation - Pain Intensity Quantified</title>
     <description>Percentage of patient visits, regardless of patient age, with a diagnosis of cancer currently receiving chemotherapy or radiation therapy in which pain intensity is quantified</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -5142,8 +5142,8 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
-    <methods>ehr</methods>
-    <methods>registry</methods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalOncology</measureSets>
     <measureSets>radiationOncology</measureSets>
   </measure>
@@ -5151,7 +5151,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Oncology: Medical and Radiation - Plan of Care for Pain</title>
     <description>Percentage of visits for patients, regardless of age, with a diagnosis of cancer currently receiving chemotherapy or radiation therapy who report having pain with a documented plan of care to address pain</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -5165,14 +5165,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Clinical Oncology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>radiationOncology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Oncology: Radiation Dose Limits to Normal Tissues</title>
     <description>Percentage of patients, regardless of age, with a diagnosis of breast, rectal, pancreatic or lung cancer receiving 3D conformal radiation therapy who had documentation in medical record that radiation dose limits to normal tissues were established prior to the initiation of a course of 3D conformal radiation for a minimum of two tissues</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -5186,15 +5186,15 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society for Radiation Oncology</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>radiationOncology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>One-Time Screening for Hepatitis C Virus (HCV) for Patients at Risk</title>
     <description>Percentage of patients aged 18 years and older with one or more of the following: a history of injection drug use, receipt of a blood transfusion prior to 1992, receiving maintenance hemodialysis, OR birthdate in the years 1945-1965 who received one-time screening for hepatitis C virus (HCV) infection</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5208,7 +5208,7 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
   </measure>
@@ -5216,7 +5216,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Operative Mortality Stratified by the Five STS-EACTS Mortality Categories</title>
     <description>Percent of patients undergoing index pediatric and/or congenital heart surgery who die, including both 1) all deaths occurring during the hospitalization in which the procedure was performed, even if after 30 days (including patients transferred to other acute care facilities), and 2) those deaths occurring after discharge from the hospital, but within 30 days of the procedure, stratified by the five STAT Mortality Levels, a multi-institutional validated complexity stratification tool</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -5230,13 +5230,13 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society of Thoracic Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Opioid Therapy Follow-up Evaluation</title>
     <description>All patients 18 and older prescribed opiates for longer than six weeks duration who had a follow-up evaluation conducted at least every three months during Opioid Therapy documented in the medical record</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5250,7 +5250,7 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Neurology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>neurology</measureSets>
     <measureSets>physicalMedicine</measureSets>
@@ -5260,7 +5260,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Optimal Asthma Control</title>
     <description>Composite measure of the percentage of pediatric and adult patients whose asthma is well-controlled as demonstrated by one of three age appropriate patient reported outcome tools and not at risk for exacerbation</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5274,7 +5274,7 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Minnesota Community Measurement</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>allergyImmunology</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
   </measure>
@@ -5282,7 +5282,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Optimizing Patient Exposure to Ionizing Radiation: Appropriateness: Follow-up CT Imaging for Incidentally Detected Pulmonary Nodules According to Recommended Guidelines</title>
     <description>Percentage of final reports for computed tomography (CT) imaging studies of the thorax for patients aged 18 years and older with documented follow-up recommendations for incidentally detected pulmonary nodules (e.g., follow-up CT imaging studies needed or that no follow-up is needed) based at a minimum on nodule size AND patient risk factors</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -5296,14 +5296,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Radiology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>diagnosticRadiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Optimizing Patient Exposure to Ionizing Radiation: Computed Tomography (CT) Images Available for Patient Follow-up and Comparison Purposes</title>
     <description>Percentage of final reports for computed tomography (CT) studies performed for all patients, regardless of age, which document that Digital Imaging and Communications in Medicine (DICOM) format image data are available to non-affiliated external healthcare facilities or entities on a secure, media free, reciprocally searchable basis with patient authorization for at least a 12-month period after the study</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -5317,14 +5317,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Radiology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>diagnosticRadiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Optimizing Patient Exposure to Ionizing Radiation: Count of Potential High Dose Radiation Imaging Studies: Computed Tomography (CT) and Cardiac Nuclear Medicine Studies</title>
     <description>Percentage of computed tomography (CT) and cardiac nuclear medicine (myocardial perfusion studies) imaging reports for all patients, regardless of age, that document a count of known previous CT (any type of CT) and cardiac nuclear medicine (myocardial perfusion) studies that the patient has received in the 12-month period prior to the current study</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -5338,14 +5338,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Radiology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>diagnosticRadiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Optimizing Patient Exposure to Ionizing Radiation: Reporting to a Radiation Dose Index Registry</title>
     <description>Percentage of total computed tomography (CT) studies performed for all patients, regardless of age, that are reported to a radiation dose index registry that is capable of collecting at a minimum selected data elements</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -5359,14 +5359,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Radiology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>diagnosticRadiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Optimizing Patient Exposure to Ionizing Radiation: Search for Prior Computed Tomography (CT) Studies Through a Secure, Authorized, Media-Free, Shared Archive</title>
     <description>Percentage of final reports of computed tomography (CT) studies performed for all patients, regardless of age, which document that a search for Digital Imaging and Communications in Medicine (DICOM) format images was conducted for prior patient CT imaging studies completed at non-affiliated external healthcare facilities or entities within the past 12-months and are available through a secure, authorized, media-free, shared archive prior to an imaging study being performed</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -5380,14 +5380,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Radiology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>diagnosticRadiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Optimizing Patient Exposure to Ionizing Radiation: Utilization of a Standardized Nomenclature for Computed Tomography (CT) Imaging Description</title>
     <description>Percentage of computed tomography (CT) imaging reports for all patients, regardless of age, with the imaging study named according to a standardized nomenclature and the standardized nomenclature is used in institution's computer systems</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -5401,14 +5401,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Radiology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>diagnosticRadiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Osteoarthritis (OA): Function and Pain Assessment</title>
     <description>Percentage of patient visits for patients aged 21 years and older with a diagnosis of osteoarthritis (OA) with assessment for function and pain</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -5422,8 +5422,8 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Orthopedic Surgeons</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>orthopedicSurgery</measureSets>
     <measureSets>physicalMedicine</measureSets>
@@ -5434,7 +5434,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Osteoporosis Management in Women Who Had a Fracture</title>
     <description>The percentage of women age 50-85 who suffered a fracture and who either had a bone mineral density test or received a prescription for a drug to treat osteoporosis in the six months after the fracture</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5448,8 +5448,8 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>obstetricsGynecology</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
@@ -5458,7 +5458,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Overuse Of Neuroimaging For Patients With Primary Headache And A Normal Neurological Examination</title>
     <description>Percentage of patients with a diagnosis of primary headache disorder whom advanced brain imaging was not ordered</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -5472,15 +5472,15 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Neurology</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>neurology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Pain Assessment and Follow-Up</title>
     <description>Percentage of visits for patients aged 18 years and older with documentation of a pain assessment using a standardized tool(s) on each visit AND documentation of a follow-up plan when pain is present</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -5494,15 +5494,15 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>physicalMedicine</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Pain Brought Under Control Within 48 Hours</title>
     <description>Patients aged 18 and older who report being uncomfortable because of pain at the initial assessment (after admission to palliative care services) that report pain was brought to a comfortable level within 48 hours</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -5516,14 +5516,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Hospice and Palliative Care Organization</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Parkinson's Disease: Cognitive Impairment or Dysfunction Assessment</title>
     <description>All patients with a diagnosis of Parkinson's disease who were assessed for cognitive impairment or dysfunction  in the last 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5537,14 +5537,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Neurology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>neurology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Parkinson's Disease: Parkinson's Disease Medical and Surgical Treatment Options Reviewed</title>
     <description>All patients with a diagnosis of Parkinson's disease (or caregiver(s), as appropriate) who had the Parkinson's disease treatment options (e.g., non-pharmacological treatment, pharmacological treatment, or surgical treatment) reviewed at least annually</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -5558,14 +5558,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Neurology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>neurology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Parkinson's Disease: Psychiatric Symptoms Assessment for Patients with Parkinson's Disease</title>
     <description>All patients with a diagnosis of Parkinson's disease who were assessed for psychiatric symptoms (e.g., psychosis, depression, anxiety disorder, apathy, or impulse control disorder) in the last 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5579,14 +5579,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Neurology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>neurology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Parkinson's Disease: Rehabilitative Therapy Options</title>
     <description>All patients with a diagnosis of Parkinson's Disease (or caregiver(s), as appropriate) who had rehabilitative therapy options (e.g., physical, occupational, or speech therapy) discussed  in the last 12 months</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -5600,14 +5600,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Neurology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>neurology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Patient-Centered Surgical Risk Assessment and Communication</title>
     <description>Percentage of patients who underwent a non-emergency surgery who had their personalized risks of postoperative complications assessed by their surgical team prior to surgery using a clinical data-based, patient-specific risk calculator and who received personal discussion of those risks with the surgeon</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -5621,7 +5621,7 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalSurgery</measureSets>
     <measureSets>orthopedicSurgery</measureSets>
     <measureSets>otolaryngology</measureSets>
@@ -5633,7 +5633,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Patients with Metastatic Colorectal Cancer and KRAS Gene Mutation Spared Treatment with Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibodies</title>
     <description>Percentage of adult patients (aged 18 or over) with metastatic colorectal cancer and KRAS gene mutation spared treatment with anti-EGFR monoclonal antibodies</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -5647,14 +5647,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Clinical Oncology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalOncology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Pediatric Kidney Disease: Adequacy of Volume Management</title>
     <description>Percentage of calendar months within a 12-month period during which patients aged 17 years and younger with a diagnosis of End Stage Renal Disease (ESRD) undergoing maintenance hemodialysis in an outpatient dialysis facility have an assessment of the adequacy of volume management from a nephrologist</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5668,13 +5668,13 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Renal Physicians Association</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Pediatric Kidney Disease: ESRD Patients Receiving Dialysis: Hemoglobin Level &lt; 10 g/dL</title>
     <description>Percentage of calendar months within a 12-month period during which patients aged 17 years and younger with a diagnosis of End Stage Renal Disease (ESRD) receiving hemodialysis or peritoneal dialysis have a hemoglobin level &lt; 10 g/dL</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5688,13 +5688,13 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Renal Physicians Association</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Pelvic Organ Prolapse: Preoperative Assessment of Occult Stress Urinary Incontinence</title>
     <description>Percentage of patients undergoing appropriate preoperative evaluation of stress urinary incontinence prior to pelvic organ prolapse surgery per ACOG/AUGS/AUA guidelines</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5708,13 +5708,13 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Urogynecologic Society</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Pelvic Organ Prolapse: Preoperative Screening for Uterine Malignancy</title>
     <description>Percentage of patients who are screened for uterine malignancy prior to vaginal closure or obliterative surgery for pelvic organ prolapse</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -5728,14 +5728,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Urogynecologic Society</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Performing Cystoscopy at the Time of Hysterectomy for Pelvic Organ Prolapse to Detect Lower Urinary Tract Injury</title>
     <description>Percentage of patients who undergo cystoscopy to evaluate for lower urinary tract injury at the time of hysterectomy for pelvic organ prolapse</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -5749,15 +5749,15 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Urogynecologic Society</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>obstetricsGynecology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Perioperative Anti-platelet Therapy for Patients Undergoing Carotid Endarterectomy</title>
     <description>Percentage of patients undergoing carotid endarterectomy (CEA) who are taking an anti-platelet agent within 48 hours prior to surgery and are prescribed this medication at hospital discharge following surgery</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5771,14 +5771,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society for Vascular Surgeons</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Perioperative Care: Selection of Prophylactic Antibiotic - First OR Second Generation Cephalosporin</title>
     <description>Percentage of surgical patients aged 18 years and older undergoing procedures with the indications for a first OR second generation cephalosporin prophylactic antibiotic who had an order for a first OR second generation cephalosporin for antimicrobial prophylaxis</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -5792,8 +5792,8 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Plastic Surgeons</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalSurgery</measureSets>
     <measureSets>orthopedicSurgery</measureSets>
     <measureSets>otolaryngology</measureSets>
@@ -5804,7 +5804,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Perioperative Care: Venous Thromboembolism (VTE) Prophylaxis (When Indicated in ALL Patients)</title>
     <description>Percentage of surgical patients aged 18 years and older undergoing procedures for which venous thromboembolism (VTE) prophylaxis is indicated in all patients, who had an order for Low Molecular Weight Heparin (LMWH), Low- Dose Unfractionated Heparin (LDUH), adjusted-dose warfarin, fondaparinux or mechanical prophylaxis to be given within 24 hours prior to incision time or within 24 hours after surgery end time</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -5818,8 +5818,8 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Plastic Surgeons</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalSurgery</measureSets>
     <measureSets>orthopedicSurgery</measureSets>
     <measureSets>otolaryngology</measureSets>
@@ -5830,7 +5830,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Perioperative Temperature Management</title>
     <description>Percentage of patients, regardless of age, who undergo surgical or therapeutic procedures under general or neuraxial anesthesia of 60 minutes duration or longer for whom at least one body temperature greater than or equal to 35.5 degrees Celsius (or 95.9 degrees Fahrenheit) was recorded within the 30 minutes immediately before or the 15 minutes immediately after anesthesia end time</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -5844,14 +5844,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Anesthesiologists</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>anesthesiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Persistence of Beta-Blocker Treatment After a Heart Attack</title>
     <description>The percentage of patients 18 years of age and older during the measurement year who were hospitalized and discharged from July 1 of the year prior to the measurement year to June 30 of the measurement year with a diagnosis of acute myocardial infarction (AMI) and who were prescribed persistent beta-blocker treatment for six months after discharge</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5865,14 +5865,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Photodocumentation of Cecal Intubation</title>
     <description>The rate of screening and surveillance colonoscopies for which photodocumentation of landmarks of cecal intubation is performed to establish a complete examination</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5886,14 +5886,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society for Gastrointestinal Endoscopy</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Pneumococcal Vaccination Status for Older Adults</title>
     <description>Percentage of patients 65 years of age and older who have ever received a pneumococcal vaccine.</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -5907,10 +5907,10 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>claims</methods>
-    <methods>ehr</methods>
-    <methods>cmsWebInterface</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>cmsWebInterface</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>allergyImmunology</measureSets>
     <measureSets>preventiveMedicine</measureSets>
   </measure>
@@ -5918,7 +5918,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Post-Anesthetic Transfer of Care Measure: Procedure Room to a Post Anesthesia Care Unit (PACU)</title>
     <description>Percentage of patients, regardless of age, who are under the care of an anesthesia practitioner and are admitted to a PACU in which a post-anesthetic formal transfer of care protocol or checklist which includes the key transfer of care elements is utilized</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -5932,14 +5932,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Anesthesiologists</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>anesthesiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Post-Anesthetic Transfer of Care: Use of Checklist or Protocol for Direct Transfer of Care from Procedure Room to Intensive Care Unit (ICU)</title>
     <description>Percentage of patients, regardless of age, who undergo a procedure under anesthesia and are admitted to an Intensive Care Unit (ICU) directly from the anesthetizing location, who have a documented use of a checklist or protocol for the transfer of care from the responsible anesthesia practitioner to the responsible ICU team or team member</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -5953,14 +5953,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Anesthesiologists</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>anesthesiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Pregnant women that had HBsAg testing</title>
     <description>This measure identifies pregnant women who had a HBsAg (hepatitis B) test during their pregnancy</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5974,13 +5974,13 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>OptumInsight</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Preoperative Diagnosis of Breast Cancer</title>
     <description>The percent of patients undergoing breast cancer operations who obtained the diagnosis of breast cancer preoperatively by a minimally invasive biopsy method</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5994,13 +5994,13 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Breast Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Prevention of Central Venous Catheter (CVC) - Related Bloodstream Infections</title>
     <description>Percentage of patients, regardless of age, who undergo central venous catheter (CVC) insertion for whom CVC was inserted with all elements of maximal sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound techniques followed</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6014,8 +6014,8 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Anesthesiologists</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>anesthesiology</measureSets>
     <measureSets>hospitalists</measureSets>
   </measure>
@@ -6023,7 +6023,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Prevention of Post-Operative Nausea and Vomiting (PONV) - Combination Therapy</title>
     <description>Percentage of patients, aged 18 years and older, who undergo a procedure under an inhalational general anesthetic, AND who have three or more risk factors for post-operative nausea and vomiting (PONV), who receive combination therapy consisting of at least two prophylactic pharmacologic antiemetic agents of different classes preoperatively or intraoperatively</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6037,14 +6037,14 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Anesthesiologists</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>anesthesiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan</title>
     <description>Percentage of patients aged 18 years and older with a BMI documented during the current encounter or during the previous six months AND with a BMI outside of normal parameters, a follow-up plan is documented during the encounter or during the previous six months of the current encounter  
 
@@ -6060,10 +6060,10 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
-    <methods>claims</methods>
-    <methods>ehr</methods>
-    <methods>cmsWebInterface</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>cmsWebInterface</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>cardiology</measureSets>
     <measureSets>gastroenterology</measureSets>
@@ -6085,7 +6085,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Preventive Care and Screening: Influenza Immunization</title>
     <description>Percentage of patients aged 6 months and older seen for a visit between October 1 and March 31 who received an influenza immunization OR who reported previous receipt of an influenza immunization</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -6099,10 +6099,10 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
-    <methods>claims</methods>
-    <methods>ehr</methods>
-    <methods>cmsWebInterface</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>cmsWebInterface</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>allergyImmunology</measureSets>
     <measureSets>internalMedicine</measureSets>
     <measureSets>obstetricsGynecology</measureSets>
@@ -6114,7 +6114,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Preventive Care and Screening: Screening for Clinical Depression and Follow-Up Plan</title>
     <description>Percentage of patients aged 12 years and older screened for depression on the date of the encounter using an age appropriate standardized depression screening tool AND if positive, a follow-up plan is documented on the date of the positive screen</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -6128,10 +6128,10 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
-    <methods>claims</methods>
-    <methods>ehr</methods>
-    <methods>cmsWebInterface</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>cmsWebInterface</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>mentalBehavioralHealth</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
@@ -6141,7 +6141,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented</title>
     <description>Percentage of patients aged 18 years and older seen during the reporting period who were screened for high blood pressure AND a recommended follow-up plan is documented based on the current blood pressure (BP) reading as indicated</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -6155,9 +6155,9 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
-    <methods>claims</methods>
-    <methods>ehr</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>allergyImmunology</measureSets>
     <measureSets>internalMedicine</measureSets>
     <measureSets>anesthesiology</measureSets>
@@ -6187,7 +6187,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention</title>
     <description>Percentage of patients aged 18 years and older who were screened for tobacco use one or more times within 24 months AND who received cessation counseling intervention if identified as a tobacco user</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -6201,10 +6201,10 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
-    <methods>claims</methods>
-    <methods>ehr</methods>
-    <methods>cmsWebInterface</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>cmsWebInterface</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>allergyImmunology</measureSets>
     <measureSets>internalMedicine</measureSets>
     <measureSets>cardiology</measureSets>
@@ -6233,7 +6233,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Preventive Care and Screening: Unhealthy Alcohol Use: Screening &amp; Brief Counseling</title>
     <description>Percentage of patients aged 18 years and older who were screened for unhealthy alcohol use using a systematic screening method at least once within the last 24 months AND who received brief counseling if identified as an unhealthy alcohol user</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -6247,7 +6247,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>cardiology</measureSets>
     <measureSets>emergencyMedicine</measureSets>
@@ -6266,7 +6266,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Primary Caries Prevention Intervention as Offered by Primary Care Providers, including Dentists</title>
     <description>Percentage of children, age 0-20 years, who received a fluoride varnish application during the measurement period.</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6280,14 +6280,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
     <measureSets>pediatrics</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of primary open-angle glaucoma (POAG) who have an optic nerve head evaluation during one or more office visits within 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6301,16 +6301,16 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
-    <methods>claims</methods>
-    <methods>ehr</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>ophthalmology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of primary open-angle glaucoma (POAG) whose glaucoma treatment has not failed (the most recent IOP was reduced by at least 15% from the pre-intervention level) OR if the most recent IOP was not reduced by at least 15% from the pre-intervention level, a plan of care was documented within 12 months</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -6324,15 +6324,15 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Ophthalmology</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>ophthalmology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Proportion Admitted to Hospice for less than 3 days</title>
     <description>Proportion of patients who died from cancer, and admitted to hospice and spent less than 3 days there</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6346,14 +6346,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Clinical Oncology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalOncology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Proportion Admitted to the Intensive Care Unit (ICU) in the Last 30 Days of Life</title>
     <description>Proportion of patients who died from cancer admitted to the ICU in the last 30 days of life</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6367,14 +6367,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Clinical Oncology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalOncology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Proportion Not Admitted To Hospice</title>
     <description>Proportion  of patients who died from cancer not admitted to hospice</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6388,14 +6388,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Clinical Oncology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalOncology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Proportion of Patients Sustaining a Bladder Injury at the Time of any Pelvic Organ Prolapse Repair</title>
     <description>Percentage of patients undergoing any surgery to repair pelvic organ prolapse who sustains an injury to the bladder recognized either during or within 1 month after surgery</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6409,14 +6409,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Urogynecologic Society</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>obstetricsGynecology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Proportion of Patients Sustaining a Bowel Injury at the time of any Pelvic Organ Prolapse Repair</title>
     <description>Percentage of patients undergoing surgical repair of pelvic organ prolapse that is complicated by a bowel injury at the time of index surgery that is recognized intraoperatively or within 1 month after surgery</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6430,14 +6430,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Urogynecologic Society</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>obstetricsGynecology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Proportion of Patients Sustaining a Ureter Injury at the Time of any Pelvic Organ Prolapse Repair</title>
     <description>Percentage of patients undergoing pelvic organ prolapse repairs who sustain an injury to the ureter recognized either during or within 1 month after surgery</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6451,14 +6451,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Urogynecologic Society</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>obstetricsGynecology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Proportion of Patients who Died from Cancer with more than One Emergency Department Visit in the Last 30 Days of Life</title>
     <description>Proportion of patients who died from cancer with more than one emergency department visit in the last 30 days of life</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6472,14 +6472,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Clinical Oncology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalOncology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Proportion Receiving Chemotherapy in the Last 14 Days of Life</title>
     <description>Proportion of patients who died from cancer receiving chemotherapy in the last 14 days of life</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6493,14 +6493,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Clinical Oncology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalOncology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Prostate Cancer: Adjuvant Hormonal Therapy for High Risk or Very High Risk Prostate Cancer</title>
     <description>Percentage of patients, regardless of age, with a diagnosis of prostate cancer at high or very high risk of recurrence receiving external beam radiotherapy to the prostate who were prescribed adjuvant hormonal therapy (GnRH [gonadotropin-releasing hormone] agonist or antagonist)</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6514,14 +6514,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Urological Association Education and Research</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>urology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients</title>
     <description>Percentage of patients, regardless of age, with a diagnosis of prostate cancer at low (or very low) risk of recurrence receiving interstitial prostate brachytherapy, OR external beam radiotherapy to the prostate, OR radical prostatectomy, OR cryotherapy who did not have a bone scan performed at any time since diagnosis of prostate cancer</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -6535,8 +6535,8 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
-    <methods>ehr</methods>
-    <methods>registry</methods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalOncology</measureSets>
     <measureSets>radiationOncology</measureSets>
     <measureSets>urology</measureSets>
@@ -6545,7 +6545,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Psoriasis: Clinical Response to Oral Systemic or Biologic Medications</title>
     <description>Percentage of psoriasis patients receiving oral systemic or biologic therapy who meet minimal physician-or patient- reported disease activity levels. It is implied that establishment and maintenance of an established minimum level of disease control as measured by physician-and/or patient-reported outcomes will increase patient satisfaction with and adherence to treatment</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -6559,15 +6559,15 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Dermatology</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>dermatology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Quality of Life Assessment For Patients With Primary Headache Disorders</title>
     <description>Percentage of patients with a diagnosis of primary headache disorder whose health related quality of life (HRQoL) was assessed with a tool(s) during at least two visits during the 12 month measurement period AND whose health related quality of life score stayed the same or improved</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6581,15 +6581,15 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Neurology</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>neurology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Quantitative Immunohistochemical (IHC) Evaluation of Human Epidermal Growth Factor Receptor 2 Testing (HER2) for Breast Cancer Patients</title>
     <description>This is a measure based on whether quantitative evaluation of Human Epidermal Growth Factor Receptor 2 Testing (HER2) by immunohistochemistry (IHC) uses the system recommended in the current ASCO/CAP Guidelines for Human Epidermal Growth Factor Receptor 2 Testing in breast cancer</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6603,15 +6603,15 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>College of American Pathologists</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>pathology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Radiation Consideration for Adult CT: Utilization of Dose Lowering Techniques</title>
     <description>Percentage of final reports for patients aged 18 years and older undergoing CT with documentation that one or more of the following dose reduction techniques were used:
 &lt;br/&gt;&lt;ul&gt;&lt;li&gt; Automated exposure control
@@ -6630,15 +6630,15 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Radiology</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>diagnosticRadiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Radical Prostatectomy Pathology Reporting</title>
     <description>Percentage of radical prostatectomy pathology reports that include the pT category, the pN category, the Gleason score and a statement about margin status</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6652,8 +6652,8 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>College of American Pathologists</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalOncology</measureSets>
     <measureSets>pathology</measureSets>
   </measure>
@@ -6661,7 +6661,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Radiology: Exposure Dose or Time Reported for Procedures Using Fluoroscopy</title>
     <description>Final reports for procedures using fluoroscopy that document radiation exposure indices, or exposure time and number of fluorographic images (if radiation exposure indices are not available)</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6675,15 +6675,15 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Radiology</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>diagnosticRadiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Radiology: Inappropriate Use of "Probably Benign" Assessment Category in Screening Mammograms</title>
     <description>Percentage of final reports for screening mammograms that are classified as "probably benign"</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -6697,15 +6697,15 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Radiology</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>diagnosticRadiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Radiology: Reminder System for Screening Mammograms</title>
     <description>Percentage of patients undergoing a screening mammogram whose information is entered into a reminder system with a target due date for the next mammogram</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -6719,15 +6719,15 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Radiology</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>diagnosticRadiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Radiology: Stenosis Measurement in Carotid Imaging Reports</title>
     <description>Percentage of final reports for carotid imaging studies (neck magnetic resonance angiography [MRA], neck computed tomography angiography [CTA], neck duplex ultrasound, carotid angiogram) performed that include direct or indirect reference to measurements of distal internal carotid diameter as the denominator for stenosis measurement</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6741,15 +6741,15 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Radiology</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>diagnosticRadiology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Rate of Carotid Artery Stenting (CAS) for Asymptomatic Patients, Without Major Complications (Discharged to Home by Post-Operative Day #2)</title>
     <description>Percent of asymptomatic patients undergoing CAS who are discharged to home no later than post-operative day #2</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6763,7 +6763,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society for Vascular Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>interventionalRadiology</measureSets>
     <measureSets>vascularSurgery</measureSets>
   </measure>
@@ -6771,7 +6771,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Rate of Carotid Endarterectomy (CEA) for Asymptomatic Patients, without Major Complications (Discharged to Home by Post-Operative Day #2)</title>
     <description>Percent of asymptomatic patients undergoing CEA who are discharged to home no later than post-operative day #2</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6785,14 +6785,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society for Vascular Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>vascularSurgery</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) Who Die While in Hospital</title>
     <description>Percent of patients undergoing endovascular repair of small or moderate infrarenal abdominal aortic aneurysms (AAA) that die while in the hospital</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6806,14 +6806,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society for Vascular Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>vascularSurgery</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post Operative Day #2)</title>
     <description>Percent of patients undergoing endovascular repair of small or moderate non-ruptured infrarenal abdominal aortic aneurysms (AAA) that do not experience a major complication (discharged to home no later than post-operative day #2)</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6827,7 +6827,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society for Vascular Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>interventionalRadiology</measureSets>
     <measureSets>vascularSurgery</measureSets>
   </measure>
@@ -6835,7 +6835,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Rate of Open Repair of Small or Moderate Abdominal Aortic Aneurysms (AAA) Where Patients Are Discharged Alive</title>
     <description>Percentage of patients undergoing open repair of small or moderate abdominal aortic aneurysms (AAA) who are discharged alive</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6849,13 +6849,13 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society for Vascular Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Rate of Open Repair of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post-Operative Day #7)</title>
     <description>Percent of patients undergoing open repair of small or moderate sized non-ruptured infrarenal abdominal aortic aneurysms who do not experience a major complication (discharge to home no later than post-operative day #7)</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6869,14 +6869,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society for Vascular Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>vascularSurgery</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Rate of Postoperative Stroke or Death in Asymptomatic Patients Undergoing Carotid Artery Stenting (CAS)</title>
     <description>Percent of asymptomatic patients undergoing CAS who experience stroke or death following surgery while in the hospital</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6890,7 +6890,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society for Vascular Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>interventionalRadiology</measureSets>
     <measureSets>vascularSurgery</measureSets>
   </measure>
@@ -6898,7 +6898,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Rate of Postoperative Stroke or Death in Asymptomatic Patients Undergoing Carotid Endarterectomy (CEA)</title>
     <description>Percent of asymptomatic patients undergoing CEA who experience stroke or death following surgery while in the hospital</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6912,13 +6912,13 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society for Vascular Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Rate of Surgical Conversion from Lower Extremity Endovascular Revascularization Procedure</title>
     <description>Inpatients assigned to endovascular treatment for obstructive arterial disease, the percent of patients who undergo unplanned major amputation or surgical bypass within 48 hours of the index procedure</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6932,14 +6932,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society of Interventional Radiology </primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Referral for Otologic Evaluation for Patients with Acute or Chronic Dizziness</title>
     <description>Percentage of patients aged birth and older referred to a physician (preferably a physician specially trained in disorders of the ear) for an otologic evaluation subsequent to an audiologic evaluation after presenting with acute or chronic dizziness</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -6953,14 +6953,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Audiology Quality Consortium</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Rheumatoid Arthritis (RA): Assessment and Classification of Disease Prognosis</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have an assessment and classification of disease prognosis at least once within 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6974,7 +6974,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Rheumatology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>orthopedicSurgery</measureSets>
     <measureSets>rheumatology</measureSets>
   </measure>
@@ -6982,7 +6982,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Rheumatoid Arthritis (RA): Functional Status Assessment</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) for whom a functional status assessment was performed at least once within 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6996,7 +6996,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Rheumatology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>orthopedicSurgery</measureSets>
     <measureSets>rheumatology</measureSets>
   </measure>
@@ -7004,7 +7004,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Rheumatoid Arthritis (RA): Glucocorticoid Management</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have been assessed for glucocorticoid use and, for those on prolonged doses of prednisone &gt;= 10 mg daily (or equivalent) with improvement or no change in disease activity, documentation of glucocorticoid management plan within 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7018,7 +7018,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Rheumatology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>orthopedicSurgery</measureSets>
     <measureSets>rheumatology</measureSets>
   </measure>
@@ -7026,7 +7026,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Rheumatoid Arthritis (RA): Periodic Assessment of Disease Activity</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have an assessment and classification of disease activity within 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7040,14 +7040,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Rheumatology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>rheumatology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Rheumatoid Arthritis (RA): Tuberculosis Screening</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have documentation of a tuberculosis (TB) screening performed and results interpreted within 6 months prior to receiving a first course of therapy using a biologic disease-modifying anti-rheumatic drug (DMARD)</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7061,14 +7061,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Rheumatology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>rheumatology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Rh Immunoglobulin (Rhogam) for Rh-Negative Pregnant Women at Risk of Fetal Blood Exposure</title>
     <description>Percentage of Rh-negative pregnant women aged 14-50 years at risk of fetal blood exposure who receive Rh- Immunoglobulin (Rhogam) in the emergency department (ED)</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7082,15 +7082,15 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Emergency Physicians</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>emergencyMedicine</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Risk-Adjusted Operative Mortality for Coronary Artery Bypass Graft (CABG)</title>
     <description>Percent of patients aged 18 years and older undergoing isolated CABG who die, including both all deaths occurring during the hospitalization in which the CABG was performed, even if after 30 days, and those deaths occurring after discharge from the hospital, but within 30 days of the procedure</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7104,13 +7104,13 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society of Thoracic Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Screening Colonoscopy Adenoma Detection Rate</title>
     <description>The percentage of patients age 50 years or older with at least one conventional adenoma or colorectal cancer detected during screening colonoscopy</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7124,14 +7124,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society for Gastrointestinal Endoscopy</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>gastroenterology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Screening for Osteoporosis for Women Aged 65-85 Years of Age</title>
     <description>Percentage of female patients aged 65-85 years of age who ever had a central dual-energy X-ray absorptiometry (DXA) to check for osteoporosis</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7145,15 +7145,15 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>preventiveMedicine</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Sentinel Lymph Node Biopsy for Invasive Breast Cancer</title>
     <description>The percentage of clinically node negative (clinical stage T1N0M0 or T2N0M0) breast cancer patients who undergo a sentinel lymph node (SLN) procedure</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7167,13 +7167,13 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Breast Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Sleep Apnea: Assessment of Adherence to Positive Airway Pressure Therapy</title>
     <description>Percentage of visits for patients aged 18 years and older with a diagnosis of obstructive sleep apnea who were prescribed positive airway pressure therapy who had documentation that adherence to positive airway pressure therapy was objectively measured</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7187,13 +7187,13 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Sleep Medicine</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Sleep Apnea: Assessment of Sleep Symptoms</title>
     <description>Percentage of visits for patients aged 18 years and older with a diagnosis of obstructive sleep apnea that includes documentation of an assessment of sleep symptoms, including presence or absence of snoring and daytime sleepiness</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7207,13 +7207,13 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Sleep Medicine</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Sleep Apnea: Positive Airway Pressure Therapy Prescribed</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of moderate or severe obstructive sleep apnea who were prescribed positive airway pressure therapy</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7227,13 +7227,13 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Sleep Medicine</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Sleep Apnea: Severity Assessment at Initial Diagnosis</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of obstructive sleep apnea who had an apnea hypopnea index (AHI) or a respiratory disturbance index (RDI) measured at the time of initial diagnosis</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7247,13 +7247,13 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Sleep Medicine</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Statin Therapy at Discharge after Lower Extremity Bypass (LEB)</title>
     <description>Percentage of patients aged 18 years and older undergoing infra-inguinal lower extremity bypass who are prescribed a statin medication at discharge</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7267,13 +7267,13 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society for Vascular Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Statin Therapy for the Prevention and Treatment of Cardiovascular Disease</title>
     <description>Percentage of the following patients-all considered at high risk of cardiovascular events-who were prescribed or were on statin therapy during the measurement period:
 &lt;br/&gt;&lt;ul&gt;&lt;li&gt; Adults aged &gt;= 21 years who were previously diagnosed with or currently have an active diagnosis of clinical atherosclerotic cardiovascular disease (ASCVD); OR
@@ -7292,8 +7292,8 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
-    <methods>cmsWebInterface</methods>
-    <methods>registry</methods>
+    <submissionMethods>cmsWebInterface</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>cardiology</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
@@ -7302,7 +7302,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Stroke and Stroke Rehabilitation: Discharged on Antithrombotic Therapy</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of ischemic stroke or transient ischemic attack (TIA) who were prescribed antithrombotic therapy at discharge</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7316,8 +7316,8 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Neurology</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>hospitalists</measureSets>
     <measureSets>neurology</measureSets>
   </measure>
@@ -7325,7 +7325,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Stroke and Stroke Rehabilitation: Thrombolytic Therapy</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of acute ischemic stroke who arrive at the hospital within two hours of time last known well and for whom IV t-PA was initiated within three hours of time last known well</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7339,13 +7339,13 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Heart Association</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Surgical Site Infection (SSI)</title>
     <description>Percentage of patients aged 18 years and older who had a surgical site infection (SSI)</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7359,7 +7359,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalSurgery</measureSets>
     <measureSets>otolaryngology</measureSets>
     <measureSets>vascularSurgery</measureSets>
@@ -7369,7 +7369,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Tobacco Use and Help with Quitting Among Adolescents</title>
     <description>The percentage of adolescents 12 to 20 years of age with a primary care visit during the measurement year for whom tobacco use status was documented and received help with quitting if identified as a tobacco user</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -7383,7 +7383,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>allergyImmunology</measureSets>
     <measureSets>internalMedicine</measureSets>
     <measureSets>cardiology</measureSets>
@@ -7413,7 +7413,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Total Knee Replacement: Identification of Implanted Prosthesis in Operative Report</title>
     <description>Percentage of patients regardless of age  undergoing a total knee replacement whose operative report identifies the prosthetic implant specifications including the prosthetic implant manufacturer, the brand name of the prosthetic implant and the size of each prosthetic implant</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -7427,14 +7427,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Association of Hip and Knee Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>orthopedicSurgery</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Total Knee Replacement: Preoperative Antibiotic Infusion with Proximal Tourniquet</title>
     <description>Percentage of patients regardless of age undergoing a total knee replacement who had the prophylactic antibiotic completely infused prior to the inflation of the proximal tourniquet</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -7448,14 +7448,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Association of Hip and Knee Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>orthopedicSurgery</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Total Knee Replacement: Shared Decision-Making: Trial of Conservative (Non-surgical) Therapy</title>
     <description>Percentage of patients regardless of age undergoing a total knee replacement with documented shared decision-making with discussion of conservative (non-surgical) therapy (e.g., non-steroidal anti-inflammatory drug (NSAIDs), analgesics, weight loss, exercise, injections) prior to the procedure</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -7469,14 +7469,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Association of Hip and Knee Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>orthopedicSurgery</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Total Knee Replacement: Venous Thromboembolic and Cardiovascular Risk Evaluation</title>
     <description>Percentage of patients regardless of age undergoing a total knee replacement who are evaluated for the presence or absence of venous thromboembolic and cardiovascular risk factors within 30 days prior to the procedure (e.g. history of Deep Vein Thrombosis (DVT), Pulmonary Embolism (PE), Myocardial Infarction (MI), Arrhythmia and Stroke)</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -7490,14 +7490,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Association of Hip and Knee Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>orthopedicSurgery</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Trastuzumab Received By Patients With AJCC Stage I (T1c) -  III And HER2 Positive Breast Cancer Receiving Adjuvant Chemotherapy</title>
     <description>Proportion of female patients (aged 18 years and older) with AJCC stage I (T1c) - III, human epidermal growth factor receptor 2 (HER2) positive breast cancer receiving adjuvant chemotherapy who are also receiving trastuzumab</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -7511,14 +7511,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Society of Clinical Oncology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalOncology</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Tuberculosis (TB) Prevention for Psoriasis, Psoriatic Arthritis and Rheumatoid Arthritis Patients on a Biological Immune Response Modifier</title>
     <description>Percentage of patients whose providers are ensuring active tuberculosis prevention either through yearly negative standard tuberculosis screening tests or are reviewing the patient's history to determine if they have had appropriate management for a recent or prior positive test</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7532,7 +7532,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American Academy of Dermatology</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>dermatology</measureSets>
     <measureSets>rheumatology</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
@@ -7541,7 +7541,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Ultrasound Determination of Pregnancy Location for Pregnant Patients with Abdominal Pain</title>
     <description>Percentage of pregnant female patients aged 14 to 50 who present to the emergency department (ED) with a chief complaint of abdominal pain or vaginal bleeding who receive a trans-abdominal or trans-vaginal ultrasound to determine pregnancy location</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7555,15 +7555,15 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Emergency Physicians</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>emergencyMedicine</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Unplanned Hospital Readmission within 30 Days of Principal Procedure</title>
     <description>Percentage of patients aged 18 years and older who had an unplanned hospital readmission within 30 days of principal procedure</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7577,14 +7577,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalSurgery</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Unplanned Reoperation within the 30 Day Postoperative Period</title>
     <description>Percentage of patients aged 18 years and older who had any unplanned reoperation within the 30 day postoperative period</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -7598,14 +7598,14 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>American College of Surgeons</primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>generalSurgery</measureSets>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Urinary Incontinence: Assessment of Presence or Absence of Urinary Incontinence in Women Aged 65 Years and Older</title>
     <description>Percentage of female patients aged 65 years and older who were assessed for the presence or absence of urinary incontinence within 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7619,8 +7619,8 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>obstetricsGynecology</measureSets>
     <measureSets>preventiveMedicine</measureSets>
     <measureSets>urology</measureSets>
@@ -7629,7 +7629,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Years and Older</title>
     <description>Percentage of female patients aged 65 years and older with a diagnosis of urinary incontinence with a documented plan of care for urinary incontinence at least once within 12 months</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -7643,8 +7643,8 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>claims</methods>
-    <methods>registry</methods>
+    <submissionMethods>claims</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
     <measureSets>internalMedicine</measureSets>
     <measureSets>obstetricsGynecology</measureSets>
     <measureSets>urology</measureSets>
@@ -7654,7 +7654,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Use of High-Risk Medications in the Elderly</title>
     <description>Percentage of patients 66 years of age and older who were ordered high-risk medications. Two rates are reported.
 a. Percentage of patients who were ordered at least one high-risk medication. 
@@ -7670,14 +7670,14 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>ehr</methods>
-    <methods>registry</methods>
+    <submissionMethods>ehr</submissionMethods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Use of Imaging Studies for Low Back Pain</title>
     <description>Percentage of patients 18-50 years of age with a diagnosis of low back pain who did not have an imaging study (plain X-ray, MRI, CT scan) within 28 days of the diagnosis.</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -7691,7 +7691,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
     <measureSets>orthopedicSurgery</measureSets>
     <measureSets>physicalMedicine</measureSets>
     <measureSets>generalPracticeFamilyMedicine</measureSets>
@@ -7700,7 +7700,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Varicose Vein Treatment with Saphenous Ablation: Outcome Survey</title>
     <description>Percentage of patients treated for varicose veins (CEAP C2-S) who are treated with saphenous ablation (with or without adjunctive tributary treatment) that report an improvement on a disease specific patient reported outcome survey instrument after treatment</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7714,13 +7714,13 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Society of Interventional Radiology </primarySteward>
-    <methods>registry</methods>
+    <submissionMethods>registry</submissionMethods>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRatio</metricType>
+    <metricType>performanceRate</metricType>
     <title>Weight Assessment and Counseling for Nutrition and Physical Activity for Children and Adolescents</title>
     <description>Percentage of patients 3-17 years of age who had an outpatient visit with a Primary Care Physician (PCP) or Obstetrician/Gynecologist (OB/GYN) and who had evidence of the following during the measurement period. Three rates are reported.
 
@@ -7738,7 +7738,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <isInverse>false</isInverse>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
-    <methods>ehr</methods>
+    <submissionMethods>ehr</submissionMethods>
     <measureSets>pediatrics</measureSets>
   </measure>
 </measures>

--- a/measures/measures-schema.yaml
+++ b/measures/measures-schema.yaml
@@ -11,7 +11,7 @@ definitions:
       title: { type: string }
       description: { type: string }
       category: { enum: [ia, quality, aci, cost] }
-      metricType: { enum: [boolean, proportion, performanceRatio, multiPerformanceRatio, continuous] }
+      metricType: { enum: [boolean, proportion, performanceRate, continuous] }
       firstPerformanceYear: { type: integer }
       lastPerformanceYear: { type: [integer, 'null'] }
       measureSets:
@@ -63,7 +63,7 @@ definitions:
         # TODO (Mari): This will be enumerated
         items: { type: string }
       primarySteward: { type: string }
-      methods:
+      submissionMethods:
         type: array
         items: { $ref: #/definitions/methods }
     required: [nationalQualityCode, measureType, eMeasureId, nqfEMeasureId, nqfId, qualityId, isHighPriority, isInverse, overallAlgorithm, strata, primarySteward, measureSets]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/qpp-measures-data",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/util/convert-qpp-to-measures.js
+++ b/util/convert-qpp-to-measures.js
@@ -93,7 +93,7 @@ process.stdin.on('end', () => {
  *    nqf_num               | nqfId
  *    qlty_id               | qualityId
  *    high_prrty_msr_sw     | isHighPriority
- *    submission_method     | methods
+ *    submission_method     | submissionMethods
  *    speciality_list       | measureSets
  *    prmry_msr_stwrd_name  | primarySteward
  *    N/A                   | metricType
@@ -169,7 +169,7 @@ function parseQpp(json) {
       } else if (j === 'prmry_msr_stwrd_name') {
         obj.primarySteward = measure[j];
       } else if (j === 'submission_method') {
-        obj.methods = _.map(measure[j], function(method) {
+        obj.submissionMethods = _.map(measure[j], function(method) {
           return formatString(method);
         });
       } else if (j === 'speciality_list') {
@@ -180,7 +180,7 @@ function parseQpp(json) {
         // TODO (Mari): These will need to be populated via another mechanism
         // outside of the API (similar to CEHRT eligible IA measures)
         obj.isInverse = false;
-        obj.metricType = 'performanceRatio';
+        obj.metricType = 'performanceRate';
         obj.overallAlgorithm = 'simpleAverage';
         obj.strata = [];
       }


### PR DESCRIPTION
- Changes the default `metricType` for quality measures to `performanceRate`
- Changes the `methods` field to `submissionMethods`
- Bumps the version of 0.0.18

Testing
`cat measures/measures-data.json | node util/validate-data.js measures`

Reviewers: @gabesmed @abarciauskas-bgse 