### PR TITLE
Update qcdr to registry for benchmark data

### DIFF
--- a/benchmarks/2017.json
+++ b/benchmarks/2017.json
@@ -37,7 +37,7 @@
     "measureId": "CMS122v50059001",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       83.1,
@@ -71,7 +71,7 @@
     "measureId": "0392100",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       83.96,
@@ -88,7 +88,7 @@
     "measureId": "CMS129v60389102",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       42.12,
@@ -105,7 +105,7 @@
     "measureId": "0390104",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       77.31,
@@ -156,7 +156,7 @@
     "measureId": "109",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       5.16,
@@ -207,7 +207,7 @@
     "measureId": "CMS147v60041110",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       11.57,
@@ -258,7 +258,7 @@
     "measureId": "CMS127v50043111",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       12.24,
@@ -309,7 +309,7 @@
     "measureId": "CMS125v52372112",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       14.49,
@@ -360,7 +360,7 @@
     "measureId": "CMS130v50034113",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       10.08,
@@ -377,7 +377,7 @@
     "measureId": "0058116",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       23.19,
@@ -428,7 +428,7 @@
     "measureId": "CMS131v50055117",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       69.39,
@@ -445,7 +445,7 @@
     "measureId": "0066118",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       71.03,
@@ -496,7 +496,7 @@
     "measureId": "CMS134v50062119",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       66.24,
@@ -547,7 +547,7 @@
     "measureId": "CMS143v50086012",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       95.07,
@@ -564,7 +564,7 @@
     "measureId": "122",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       60.62,
@@ -581,7 +581,7 @@
     "measureId": "0417126",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       10.34,
@@ -598,7 +598,7 @@
     "measureId": "0416127",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       4.26,
@@ -649,7 +649,7 @@
     "measureId": "CMS69v50421128",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       39.8,
@@ -700,7 +700,7 @@
     "measureId": "CMS68v60419130",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       61.27,
@@ -734,7 +734,7 @@
     "measureId": "0420131",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       8.91,
@@ -785,7 +785,7 @@
     "measureId": "CMS2v60418134",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       2.01,
@@ -802,7 +802,7 @@
     "measureId": "0650137",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       53.73,
@@ -819,7 +819,7 @@
     "measureId": "138",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       35.19,
@@ -853,7 +853,7 @@
     "measureId": "0087014",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       31.01,
@@ -887,7 +887,7 @@
     "measureId": "0566140",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       32.26,
@@ -921,7 +921,7 @@
     "measureId": "0563141",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       78.95,
@@ -955,7 +955,7 @@
     "measureId": "CMS157v50384143",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       35.53,
@@ -972,7 +972,7 @@
     "measureId": "0383144",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       33.64,
@@ -1006,7 +1006,7 @@
     "measureId": "145",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       67.86,
@@ -1040,7 +1040,7 @@
     "measureId": "0508146",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       4.77,
@@ -1074,7 +1074,7 @@
     "measureId": "147",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       59.52,
@@ -1108,7 +1108,7 @@
     "measureId": "0101154",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       7.81,
@@ -1142,7 +1142,7 @@
     "measureId": "0101155",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       20,
@@ -1159,7 +1159,7 @@
     "measureId": "0382156",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       93.1,
@@ -1210,7 +1210,7 @@
     "measureId": "CMS123v50056163",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       6.14,
@@ -1227,7 +1227,7 @@
     "measureId": "0129164",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       12.16,
@@ -1244,7 +1244,7 @@
     "measureId": "0130165",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       0,
@@ -1261,7 +1261,7 @@
     "measureId": "0131166",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       2.41,
@@ -1278,7 +1278,7 @@
     "measureId": "0114167",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       3.7,
@@ -1295,7 +1295,7 @@
     "measureId": "0115168",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       3.6,
@@ -1312,7 +1312,7 @@
     "measureId": "178",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       27.99,
@@ -1363,7 +1363,7 @@
     "measureId": "181",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       28.8,
@@ -1397,7 +1397,7 @@
     "measureId": "2624182",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       94.35,
@@ -1431,7 +1431,7 @@
     "measureId": "0659185",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       81.08,
@@ -1448,7 +1448,7 @@
     "measureId": "187",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       14.55,
@@ -1499,7 +1499,7 @@
     "measureId": "CMS142v50089019",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       36.21,
@@ -1533,7 +1533,7 @@
     "measureId": "CMS133v50565191",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       42.89,
@@ -1567,7 +1567,7 @@
     "measureId": "CMS132v50564192",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       1.6,
@@ -1601,7 +1601,7 @@
     "measureId": "0507195",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       82.98,
@@ -1652,7 +1652,7 @@
     "measureId": "CMS164v50068204",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       68.03,
@@ -1686,7 +1686,7 @@
     "measureId": "0268021",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       91.17,
@@ -1703,7 +1703,7 @@
     "measureId": "0562224",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       100,
@@ -1737,7 +1737,7 @@
     "measureId": "0509225",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       99.89,
@@ -1788,7 +1788,7 @@
     "measureId": "CMS138v50028226",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       76.67,
@@ -1822,7 +1822,7 @@
     "measureId": "0239023",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       89.74,
@@ -1873,7 +1873,7 @@
     "measureId": "CMS165v50018236",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       51,
@@ -1907,7 +1907,7 @@
     "measureId": "CMS156v50022238",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       20,
@@ -1958,7 +1958,7 @@
     "measureId": "0045024",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       8,
@@ -2009,7 +2009,7 @@
     "measureId": "1854249",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       100,
@@ -2060,7 +2060,7 @@
     "measureId": "1855251",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       100,
@@ -2077,7 +2077,7 @@
     "measureId": "262",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       100,
@@ -2094,7 +2094,7 @@
     "measureId": "263",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       97.95,
@@ -2111,7 +2111,7 @@
     "measureId": "264",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       97.01,
@@ -2128,7 +2128,7 @@
     "measureId": "265",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       24.44,
@@ -2162,7 +2162,7 @@
     "measureId": "1536303",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       5.76,
@@ -2179,7 +2179,7 @@
     "measureId": "304",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       5.32,
@@ -2230,7 +2230,7 @@
     "measureId": "CMS124v50032309",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       28.95,
@@ -2264,7 +2264,7 @@
     "measureId": "CMS153v50033310",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       6.06,
@@ -2298,7 +2298,7 @@
     "measureId": "CMS166v60052312",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       55,
@@ -2349,7 +2349,7 @@
     "measureId": "CMS22v5317",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       24.74,
@@ -2383,7 +2383,7 @@
     "measureId": "CMS139v50101318",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       0.11,
@@ -2417,7 +2417,7 @@
     "measureId": "032",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       27.17,
@@ -2451,7 +2451,7 @@
     "measureId": "0658320",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       81.82,
@@ -2468,7 +2468,7 @@
     "measureId": "322",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       2.67,
@@ -2485,7 +2485,7 @@
     "measureId": "323",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       1,
@@ -2502,7 +2502,7 @@
     "measureId": "324",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       3.38,
@@ -2519,7 +2519,7 @@
     "measureId": "325",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       91.3,
@@ -2553,7 +2553,7 @@
     "measureId": "1525326",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       20,
@@ -2570,7 +2570,7 @@
     "measureId": "331",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       89.07,
@@ -2587,7 +2587,7 @@
     "measureId": "332",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       44.39,
@@ -2604,7 +2604,7 @@
     "measureId": "333",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       2.13,
@@ -2621,7 +2621,7 @@
     "measureId": "334",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       2.25,
@@ -2638,7 +2638,7 @@
     "measureId": "337",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       6.82,
@@ -2655,7 +2655,7 @@
     "measureId": "343",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       29.63,
@@ -2672,7 +2672,7 @@
     "measureId": "358",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       8.47,
@@ -2689,7 +2689,7 @@
     "measureId": "359",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       100,
@@ -2706,7 +2706,7 @@
     "measureId": "362",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       100,
@@ -2723,7 +2723,7 @@
     "measureId": "363",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       100,
@@ -2757,7 +2757,7 @@
     "measureId": "CMS160v50712371",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       0.27,
@@ -2791,7 +2791,7 @@
     "measureId": "CMS65v6373",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       2.39,
@@ -2893,7 +2893,7 @@
     "measureId": "1879383",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       34.78,
@@ -2910,7 +2910,7 @@
     "measureId": "388",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       100,
       0.26,
@@ -2927,7 +2927,7 @@
     "measureId": "389",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       66.67,
@@ -2961,7 +2961,7 @@
     "measureId": "0046039",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       13.39,
@@ -2978,7 +2978,7 @@
     "measureId": "0576391",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       3.81,
@@ -3012,7 +3012,7 @@
     "measureId": "395",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       93.75,
@@ -3046,7 +3046,7 @@
     "measureId": "397",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       47.22,
@@ -3063,7 +3063,7 @@
     "measureId": "400",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       1.19,
@@ -3080,7 +3080,7 @@
     "measureId": "402",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       74.1,
@@ -3097,7 +3097,7 @@
     "measureId": "0134043",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       98.17,
@@ -3131,7 +3131,7 @@
     "measureId": "0236044",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       91.14,
@@ -3165,7 +3165,7 @@
     "measureId": "0097046",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       91.97,
@@ -3199,7 +3199,7 @@
     "measureId": "0326047",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       16.52,
@@ -3233,7 +3233,7 @@
     "measureId": "048",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       16.31,
@@ -3267,7 +3267,7 @@
     "measureId": "CMS135v500812907005",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       75.86,
@@ -3301,7 +3301,7 @@
     "measureId": "050",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       73.48,
@@ -3335,7 +3335,7 @@
     "measureId": "0091051",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       50.53,
@@ -3369,7 +3369,7 @@
     "measureId": "0102052",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       95.24,
@@ -3386,7 +3386,7 @@
     "measureId": "0067006",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       76.92,
@@ -3420,7 +3420,7 @@
     "measureId": "CMS154v50069065",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       67.74,
@@ -3454,7 +3454,7 @@
     "measureId": "0377067",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       95,
@@ -3488,7 +3488,7 @@
     "measureId": "CMS145v50070007",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       74.51,
@@ -3505,7 +3505,7 @@
     "measureId": "0379070",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       86.52,
@@ -3539,7 +3539,7 @@
     "measureId": "076",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       89.66,
@@ -3573,7 +3573,7 @@
     "measureId": "CMS144v500832908008",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       75.68,
@@ -3624,7 +3624,7 @@
     "measureId": "0653091",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       60.47,
@@ -3658,7 +3658,7 @@
     "measureId": "0654093",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       73.91,
@@ -3692,7 +3692,7 @@
     "measureId": "0391099",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "qcdrOrQualifiedRegistry",
+    "submissionMethod": "registry",
     "deciles": [
       0,
       97.62,

--- a/benchmarks/benchmarks-schema.yaml
+++ b/benchmarks/benchmarks-schema.yaml
@@ -24,5 +24,5 @@ definitions:
         minItems: 9
         maxItems: 9
       submissionMethod:
-        enum: [claims, registry, qcdrOrQualifiedRegistry, cmsWebInterface, administrativeClaims, ehr, cmsApprovedCahpsVendor]
+        enum: [claims, registry, cmsWebInterface, administrativeClaims, ehr, cmsApprovedCahpsVendor]
     required: [measureId, performanceYear, benchmarkYear, submissionMethod, deciles]

--- a/test/util/format-benchmark-record-spec.js
+++ b/test/util/format-benchmark-record-spec.js
@@ -249,7 +249,7 @@ describe('formatBenchmarkRecord', function() {
         it('should return the correct benchmark object', function() {
           expect(benchmark).to.exist;
           expect(benchmark.measureId, 'measureId').to.equal('CMS122v50059001');
-          expect(benchmark.submissionMethod, 'submissionMethod').to.equal('qcdrOrQualifiedRegistry');
+          expect(benchmark.submissionMethod, 'submissionMethod').to.equal('registry');
           expect(benchmark.benchmarkYear, 'benchmarkYear').to.equal(2016);
           expect(benchmark.performanceYear, 'performanceYear').to.equal(2018);
           expect(benchmark.deciles).to.eql([0, 0, 0, 0, 0, 0, 0, 0, 0]);
@@ -306,7 +306,7 @@ describe('formatBenchmarkRecord', function() {
         it('should return the correct benchmark object', function() {
           expect(benchmark).to.exist;
           expect(benchmark.measureId, 'measureId').to.equal('CMS122v50059001');
-          expect(benchmark.submissionMethod, 'submissionMethod').to.equal('qcdrOrQualifiedRegistry');
+          expect(benchmark.submissionMethod, 'submissionMethod').to.equal('registry');
           expect(benchmark.benchmarkYear, 'benchmarkYear').to.equal(2016);
           expect(benchmark.performanceYear, 'performanceYear').to.equal(2018);
           expect(benchmark.deciles).to.eql([100, 0.13, 0.12, 0.12, 0.12, 0, 0, 0, 0]);

--- a/util/format-benchmark-record.js
+++ b/util/format-benchmark-record.js
@@ -14,7 +14,7 @@ var measures = require('./../measures/measures-data.json');
 var SUBMISSION_METHOD_MAP = {
   'claims': 'claims',
   'registry': 'registry',
-  'registry/qcdr': 'qcdrOrQualifiedRegistry',
+  'registry/qcdr': 'registry',
   'cmswebinterface': 'cmsWebInterface',
   'administrativeclaims': 'administrativeClaims',
   'ehr': 'ehr',


### PR DESCRIPTION
https://jira.cms.gov/browse/QPPA-491

Updates `qcdrOrQualifiedRegistry` to `registry` - practically speaking they are the same. 

Testing
`npm run test` passes
`cat benchmarks/2017.json | node scripts/validate-data.js benchmarks` passes
