### PR TITLE
Update metricType and overallAlgorithm

### DIFF
--- a/measures/measures-data.json
+++ b/measures/measures-data.json
@@ -1603,7 +1603,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Acute Otitis Externa (AOE): Systemic Antimicrobial Therapy - Avoidance of Inappropriate Use",
     "description": "Percentage of patients aged 2 years and older with a diagnosis of AOE who were not prescribed systemic antimicrobial therapy",
     "nationalQualityCode": "ECR",
@@ -1615,7 +1615,6 @@
     "qualityId": "093",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 2 years and older with a diagnosis of AOE who were not prescribed systemic antimicrobial therapy",
@@ -1638,7 +1637,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Acute Otitis Externa (AOE): Topical Therapy",
     "description": "Percentage of patients aged 2 years and older with a diagnosis of AOE who were prescribed topical preparations",
     "nationalQualityCode": "ECC",
@@ -1650,7 +1649,6 @@
     "qualityId": "091",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 2 years and older with a diagnosis of AOE who were prescribed topical preparations",
@@ -1672,7 +1670,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "ADHD: Follow-Up Care for Children Prescribed Attention-Deficit/Hyperactivity Disorder (ADHD) Medication",
     "description": "Percentage of children 6-12 years of age and newly dispensed a medication for attention-deficit/hyperactivity disorder (ADHD) who had appropriate follow-up care.  Two rates are reported.  \na. Percentage of children who had one follow-up visit with a practitioner with prescribing authority during the 30-Day Initiation Phase.\nb. Percentage of children who remained on ADHD medication for at least 210 days and who, in addition to the visit in the Initiation Phase, had at least two additional follow-up visits with a practitioner within 270 days (9 months) after the Initiation Phase ended.\n",
     "nationalQualityCode": "ECC",
@@ -1684,7 +1682,6 @@
     "qualityId": "366",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
@@ -1699,7 +1696,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Adherence to Antipsychotic Medications For Individuals with Schizophrenia",
     "description": "Percentage of individuals at least 18 years of age as of the beginning of the measurement period with schizophrenia or schizoaffective disorder who had at least two prescriptions filled for any antipsychotic medication and who had a Proportion of Days Covered (PDC) of at least 0.8 for antipsychotic medications during the measurement period (12 consecutive months)",
     "nationalQualityCode": "PS",
@@ -1711,7 +1708,6 @@
     "qualityId": "383",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of individuals at least 18 years of age as of the beginning of the measurement period with schizophrenia or schizoaffective disorder who had at least two prescriptions filled for any antipsychotic medication and who had a Proportion of Days Covered (PDC) of at least 0.8 for antipsychotic medications during the measurement period (12 consecutive months)",
@@ -1730,7 +1726,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "multiPerformanceRate",
     "title": "Adult Kidney Disease: Blood Pressure Management",
     "description": "Percentage of patient visits for those patients aged 18 years and older with a diagnosis of chronic kidney disease (CKD) (stage 3, 4, or 5, not receiving Renal Replacement Therapy [RRT]) with a blood pressure < 140/90 mmHg OR >= 140/90 mmHg with a documented plan of care",
     "nationalQualityCode": "ECC",
@@ -1742,7 +1738,6 @@
     "qualityId": "122",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "weightedAverage",
     "strata": [
       {
         "description": "Percentage of patient visits with blood pressure results < 140/90 mmHg",
@@ -1761,13 +1756,14 @@
     "submissionMethods": [
       "registry"
     ],
-    "measureSets": []
+    "measureSets": [],
+    "overallAlgorithm": "weightedAverage"
   },
   {
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Adult Kidney Disease: Catheter Use at Initiation of Hemodialysis",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of End Stage Renal Disease (ESRD) who initiate maintenance hemodialysis during the measurement period, whose mode of vascular access is a catheter at the time maintenance hemodialysis is initiated",
     "nationalQualityCode": "ECC",
@@ -1779,7 +1775,6 @@
     "qualityId": "329",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of End Stage Renal Disease (ESRD) who initiate maintenance hemodialysis during the measurement period, whose mode of vascular access is a catheter at the time maintenance hemodialysis is initiated",
@@ -1796,7 +1791,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Adult Kidney Disease: Catheter Use for Greater Than or Equal to 90 Days",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of End Stage Renal Disease (ESRD) receiving maintenance hemodialysis for greater than or equal to 90 days whose mode of vascular access is a catheter",
     "nationalQualityCode": "PS",
@@ -1808,7 +1803,6 @@
     "qualityId": "330",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of End Stage Renal Disease (ESRD) receiving maintenance hemodialysis for greater than or equal to 90 days whose mode of vascular access is a catheter",
@@ -1825,7 +1819,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Adult Kidney Disease: Referral to Hospice",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of ESRD who withdraw from hemodialysis or peritoneal dialysis who are referred to hospice care",
     "nationalQualityCode": "PCCEO",
@@ -1837,7 +1831,6 @@
     "qualityId": "403",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of ESRD who withdraw from hemodialysis or peritoneal dialysis who are referred to hospice care",
@@ -1854,7 +1847,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Adult Major Depressive Disorder (MDD): Coordination of Care of Patients with Specific Comorbid Conditions",
     "description": "Percentage of medical records of patients aged 18 years and older with a diagnosis of major depressive disorder (MDD) and a specific diagnosed comorbid condition (diabetes, coronary artery disease, ischemic stroke, intracranial hemorrhage, chronic kidney disease [stages 4 or 5], End Stage Renal Disease [ESRD] or congestive heart failure) being treated by another clinician with communication to the clinician treating the comorbid condition",
     "nationalQualityCode": "CCC",
@@ -1866,7 +1859,6 @@
     "qualityId": "325",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of medical records of patients aged 18 years and older with a diagnosis of major depressive disorder (MDD) and a specific diagnosed comorbid condition (diabetes, coronary artery disease, ischemic stroke, intracranial hemorrhage, chronic kidney disease [stages 4 or 5], End Stage Renal Disease [ESRD] or congestive heart failure) being treated by another clinician with communication to the clinician treating the comorbid condition",
@@ -1885,7 +1877,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Adult Major Depressive Disorder (MDD): Suicide Risk Assessment",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of major depressive disorder (MDD) with a suicide risk assessment completed during the visit in which a new diagnosis or recurrent episode was identified",
     "nationalQualityCode": "ECC",
@@ -1897,7 +1889,6 @@
     "qualityId": "107",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
     "submissionMethods": [
@@ -1909,7 +1900,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Adult Primary Rhegmatogenous Retinal Detachment Surgery: No Return to the Operating Room Within 90 Days of Surgery",
     "description": "Patients aged 18 years and older who had surgery for primary rhegmatogenous retinal detachment who did not require a return to the operating room within 90 days of surgery",
     "nationalQualityCode": "ECC",
@@ -1921,7 +1912,6 @@
     "qualityId": "384",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Patients aged 18 years and older who had surgery for primary rhegmatogenous retinal detachment who did not require a return to the operating room within 90 days of surgery",
@@ -1940,7 +1930,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Adult Primary Rhegmatogenous Retinal Detachment Surgery: Visual Acuity Improvement Within 90 Days of Surgery",
     "description": "Patients aged 18 years and older who had surgery for primary rhegmatogenous retinal detachment and achieved an improvement in their visual acuity, from their preoperative level, within 90 days of surgery in the operative eye",
     "nationalQualityCode": "ECC",
@@ -1952,7 +1942,6 @@
     "qualityId": "385",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Patients aged 18 years and older who had surgery for primary rhegmatogenous retinal detachment and achieved an improvement in their visual acuity, from their preoperative level, within 90 days of surgery in the operative eye",
@@ -1971,7 +1960,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Adult Sinusitis: Antibiotic Prescribed for Acute Sinusitis (Overuse)",
     "description": "Percentage of patients, aged 18 years and older, with a diagnosis of acute sinusitis who were prescribed an antibiotic within 10 days after onset of symptoms",
     "nationalQualityCode": "ECR",
@@ -1983,7 +1972,6 @@
     "qualityId": "331",
     "isHighPriority": true,
     "isInverse": true,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients, aged 18 years and older, with a diagnosis of acute sinusitis who were prescribed an antibiotic within 10 days after onset of symptoms",
@@ -2005,7 +1993,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Adult Sinusitis: Appropriate Choice of Antibiotic: Amoxicillin With or Without Clavulanate Prescribed for Patients with Acute Bacterial Sinusitis (Appropriate Use)",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of acute bacterial sinusitis that were prescribed amoxicillin, with or without clavulanate, as a first line antibiotic at the time of diagnosis",
     "nationalQualityCode": "ECR",
@@ -2017,7 +2005,6 @@
     "qualityId": "332",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of acute bacterial sinusitis that were prescribed amoxicillin, with or without clavulanate, as a first line antibiotic at the time of diagnosis",
@@ -2039,7 +2026,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Adult Sinusitis: Computerized Tomography (CT) for Acute Sinusitis (Overuse)",
     "description": "Percentage of patients aged 18 years and older, with a diagnosis of acute sinusitis who had a computerized tomography (CT) scan of the paranasal sinuses ordered at the time of diagnosis or received within 28 days after date of diagnosis",
     "nationalQualityCode": "ECR",
@@ -2051,7 +2038,6 @@
     "qualityId": "333",
     "isHighPriority": true,
     "isInverse": true,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older, with a diagnosis of acute sinusitis who had a computerized tomography (CT) scan of the paranasal sinuses ordered at the time of diagnosis or received within 28 days after date of diagnosis",
@@ -2073,7 +2059,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Adult Sinusitis: More than One Computerized Tomography (CT) Scan Within 90 Days for Chronic Sinusitis (Overuse)",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of chronic sinusitis who had more than one CT scan of the paranasal sinuses ordered or received within 90 days after the date of diagnosis",
     "nationalQualityCode": "ECR",
@@ -2085,7 +2071,6 @@
     "qualityId": "334",
     "isHighPriority": true,
     "isInverse": true,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of chronic sinusitis who had more than one CT scan of the paranasal sinuses ordered or received within 90 days after date of diagnosis",
@@ -2107,7 +2092,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Age Appropriate Screening Colonoscopy",
     "description": "The percentage of patients greater than 85 years of age who received a screening colonoscopy from January 1 to December 31",
     "nationalQualityCode": "ECR",
@@ -2119,7 +2104,6 @@
     "qualityId": "439",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "The percentage of patients greater than 85 years of age who received a screening colonoscopy from January 1 to December 31",
@@ -2138,7 +2122,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Age-Related Macular Degeneration (AMD): Counseling on Antioxidant Supplement",
     "description": "Percentage of patients aged 50 years and older with a diagnosis of age-related macular degeneration (AMD) or their caregiver(s) who were counseled within 12 months on the benefits and/or risks of the Age-Related Eye Disease Study  (AREDS) formulation for preventing progression of AMD",
     "nationalQualityCode": "ECC",
@@ -2150,7 +2134,6 @@
     "qualityId": "140",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 50 years and older with a diagnosis of age-related macular degeneration (AMD) or their caregiver(s) who were counseled within 12 months on the benefits and/or risks of the Age-Related Eye Disease Study (AREDS) formulation for preventing progression of AMD",
@@ -2170,7 +2153,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Age-Related Macular Degeneration (AMD): Dilated Macular Examination",
     "description": "Percentage of patients aged 50 years and older with a diagnosis of age-related macular degeneration (AMD) who had a dilated macular examination performed which included documentation of the presence or absence of macular thickening or hemorrhage AND the level of macular degeneration severity during one or more office visits within 12 months",
     "nationalQualityCode": "ECC",
@@ -2182,7 +2165,6 @@
     "qualityId": "014",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 50 years and older with a diagnosis of age-related macular degeneration (AMD) who had a dilated macular examination performed which included documentation of the presence or absence of macular thickening or hemorrhage the level of macular degeneration severity during one or more office visits within 12 months",
@@ -2202,7 +2184,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "All-cause Hospital Readmission",
     "description": "The 30-day All-Cause Hospital Readmission measure is a risk-standardized readmission rate for beneficiaries age 65 or older who were hospitalized at a short-stay acute care hospital and experienced an unplanned readmission for any cause to an acute care hospital within 30 days of discharge.",
     "nationalQualityCode": "CCC",
@@ -2214,7 +2196,6 @@
     "qualityId": "458",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Yale University",
     "submissionMethods": [
@@ -2226,7 +2207,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Amyotrophic Lateral Sclerosis (ALS) Patient Care Preferences",
     "description": "Percentage of patients diagnosed with Amyotrophic Lateral Sclerosis (ALS) who were offered assistance in planning for end of life issues (e.g., advance directives, invasive ventilation, hospice) at least once annually",
     "nationalQualityCode": "PCCEO",
@@ -2238,7 +2219,6 @@
     "qualityId": "386",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients diagnosed with Amyotrophic Lateral Sclerosis (ALS) who were offered assistance in planning for end of life issues (e.g., advance directives, invasive ventilation, hospice) at least once annually",
@@ -2257,7 +2237,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Anastomotic Leak Intervention",
     "description": "Percentage of patients aged 18 years and older who required an anastomotic leak intervention following gastric bypass or colectomy surgery",
     "nationalQualityCode": "PS",
@@ -2269,7 +2249,6 @@
     "qualityId": "354",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older who required an anastomotic leak intervention following gastric bypass or colectomy surgery",
@@ -2288,7 +2267,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Anesthesiology Smoking Abstinence",
     "description": "The percentage of current smokers who abstain from cigarettes prior to anesthesia on the day of elective surgery or procedure",
     "nationalQualityCode": "ECC",
@@ -2300,7 +2279,6 @@
     "qualityId": "404",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "The percentage of current smokers who abstain from cigarettes prior to anesthesia on the day of elective surgery or procedure",
@@ -2319,7 +2297,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Annual Hepatitis C Virus (HCV) Screening for Patients who are Active Injection Drug Users",
     "description": "Percentage of patients, regardless of age, who are active injection drug users who received screening for HCV infection within the 12 month reporting period",
     "nationalQualityCode": "ECC",
@@ -2331,7 +2309,6 @@
     "qualityId": "387",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients, regardless of age, who are active injection drug users who received screening for HCV infection within the 12 month reporting period",
@@ -2351,7 +2328,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Anti-Depressant Medication Management",
     "description": "Percentage of patients 18 years of age and older who were treated with antidepressant medication, had a diagnosis of major depression, and who remained on an antidepressant medication treatment. Two rates are reported. \na. Percentage of patients who remained on an antidepressant medication for at least 84 days (12 weeks). \nb. Percentage of patients who remained on an antidepressant medication for at least 180 days (6 months).\n",
     "nationalQualityCode": "ECC",
@@ -2363,7 +2340,6 @@
     "qualityId": "009",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
@@ -2379,7 +2355,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Appropriate Assessment of Retrievable Inferior Vena Cava (IVC) Filters for Removal",
     "description": "Percentage of patients in whom a retrievable IVC filter is placed who, within 3 months post-placement, have a documented assessment for the appropriateness of continued filtration, device removal or the inability to contact the patient with at least two attempts",
     "nationalQualityCode": "ECC",
@@ -2391,7 +2367,6 @@
     "qualityId": "421",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients in whom a retrievable IVC filter is placed who, within 3 months post-placement, have a documented assessment for the appropriateness of continued filtration, device removal or the inability to contact the patient with at least two attempts",
@@ -2408,7 +2383,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Appropriate Follow-up Imaging for Incidental Abdominal Lesions",
     "description": "Percentage of final reports for abdominal imaging studies for asymptomatic patients aged 18 years and older with one or more of the following noted incidentally with follow-up imaging recommended:\n<br/><ul><li> Liver lesion <= 0.5 cm\n</li><li> Cystic kidney lesion < 1.0 cm\n</li><li> Adrenal lesion <= 1.0 cm\n\n\n</li></ul>",
     "nationalQualityCode": "ECC",
@@ -2420,7 +2395,6 @@
     "qualityId": "405",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of final reports for abdominal imaging studies for asymptomatic patients aged 18 years and older with one or more of the following noted incidentally with follow‐up imaging recommended: • Liver lesion ≤ 0.5 cm • Cystic kidney lesion < 1.0 cm • Adrenal lesion ≤ 1.0 cm",
@@ -2440,7 +2414,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Appropriate Follow-up Imaging for Incidental Thyroid Nodules in Patients",
     "description": "Percentage of final reports for computed tomography (CT), CT angiography (CTA) or magnetic resonance imaging (MRI) or magnetic resonance angiogram (MRA) studies of the chest or neck or ultrasound of the neck for patients aged 18 years and older with no known thyroid disease with a thyroid nodule < 1.0 cm noted incidentally with follow-up imaging recommended",
     "nationalQualityCode": "ECC",
@@ -2452,7 +2426,6 @@
     "qualityId": "406",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of final reports for computed tomography (CT), CT angiography (CTA) or magnetic resonance imaging (MRI) or magnetic resonance angiogram (MRA) studies of the chest or neck or ultrasound of the neck for patients aged 18 years and older with no known thyroid disease with a thyroid nodule < 1.0 cm noted incidentally with follow-up imaging recommended",
@@ -2472,7 +2445,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients",
     "description": "Percentage of patients aged 50 to 75 years of age receiving a screening colonoscopy without biopsy or polypectomy who had a recommended follow-up interval of at least 10 years for repeat colonoscopy documented in their colonoscopy report",
     "nationalQualityCode": "CCC",
@@ -2484,7 +2457,6 @@
     "qualityId": "320",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 50 to 75 years of age receiving a screening colonoscopy without biopsy or polypectomy who had a recommended follow-up interval of at least 10 years for repeat colonoscopy documented in their colonoscopy report",
@@ -2504,7 +2476,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Appropriate Testing for Children with Pharyngitis",
     "description": "Percentage of children 3-18 years of age who were diagnosed with pharyngitis, ordered an antibiotic and received a group A streptococcus (strep) test for the episode",
     "nationalQualityCode": "ECR",
@@ -2516,7 +2488,6 @@
     "qualityId": "066",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of children 3-18 years of age who were diagnosed with pharyngitis, ordered an antibiotic and received a group A streptococcus (strep) test for the episode",
@@ -2538,7 +2509,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Appropriate Treatment for Children with Upper Respiratory Infection (URI)",
     "description": "Percentage of children 3 months-18 years of age who were diagnosed with upper respiratory infection (URI) and were not dispensed an antibiotic prescription on or three days after the episode",
     "nationalQualityCode": "ECR",
@@ -2550,7 +2521,6 @@
     "qualityId": "065",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of children 3 months - 18 years of age who were diagnosed with upper respiratory infection (URI) and were not dispensed an antibiotic prescription on or three days after the episode",
@@ -2571,7 +2541,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Appropriate Treatment of Methicillin-Sensitive Staphylococcus Aureus (MSSA) Bacteremia",
     "description": "Percentage of patients with sepsis due to MSSA bacteremia who received beta-lactam antibiotic (e.g. nafcillin, oxacillin or cefazolin) as definitive therapy",
     "nationalQualityCode": "ECC",
@@ -2583,7 +2553,6 @@
     "qualityId": "407",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients with sepsis due to MSSA bacteremia who received beta-lactam antibiotic (e.g. nafcillin, oxacillin or cefazolin) as definitive therapy",
@@ -2603,7 +2572,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Appropriate Workup Prior to Endometrial Ablation",
     "description": "Percentage of women, aged 18 years and older, who undergo   endometrial sampling or hysteroscopy with biopsy  before undergoing an endometrial ablation",
     "nationalQualityCode": "PS",
@@ -2615,7 +2584,6 @@
     "qualityId": "448",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of women, aged 18 years and older, who undergo endometrial sampling or hysteroscopy with biopsy and results documented before undergoing an endometrial ablation",
@@ -2634,7 +2602,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Atrial Fibrillation and Atrial Flutter: Chronic Anticoagulation Therapy",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of nonvalvular atrial fibrillation (AF) or atrial flutter whose assessment of the specified thromboembolic risk factors indicate one or more high-risk factors or more than one moderate risk factor, as determined by CHADS2 risk stratification, who are prescribed warfarin OR another oral anticoagulant drug that is FDA approved for the prevention of thromboembolism",
     "nationalQualityCode": "ECC",
@@ -2646,7 +2614,6 @@
     "qualityId": "326",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of nonvalvular atrial fibrillation (AF) or atrial flutter whose assessment of the specified thromboembolic risk factors indicate one or more high-risk factors or more than one moderate risk factor, as determined by CHADS2 risk stratification, who are prescribed warfarin another oral anticoagulant drug that is FDA approved for the prevention of thromboembolism",
@@ -2668,7 +2635,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Avoidance of Antibiotic Treatment in Adults With Acute Bronchitis",
     "description": "The percentage of adults 18-64 years of age with a diagnosis of acute bronchitis who were not dispensed an antibiotic prescription",
     "nationalQualityCode": "ECR",
@@ -2680,7 +2647,6 @@
     "qualityId": "116",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "The percentage of adults 18–64 years of age with a diagnosis of acute bronchitis who were not dispensed an antibiotic prescription",
@@ -2701,7 +2667,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Barrett's Esophagus",
     "description": "Percentage of esophageal biopsy reports that document the presence of Barrett's mucosa that also include a statement about dysplasia",
     "nationalQualityCode": "ECC",
@@ -2713,7 +2679,6 @@
     "qualityId": "249",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of esophageal biopsy reports that document the presence of Barrett’s mucosa that also include a statement about dysplasia",
@@ -2733,7 +2698,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Basal Cell Carcinoma (BCC)/Squamous Cell Carcinoma: Biopsy Reporting Time - Pathologist to Clinician",
     "description": "Percentage of biopsies with a diagnosis of cutaneous Basal Cell Carcinoma (BCC) and Squamous Cell Carcinoma (SCC) (including in situ disease) in which the pathologist communicates results to the clinician within 7 days of  biopsy date",
     "nationalQualityCode": "CCC",
@@ -2745,7 +2710,6 @@
     "qualityId": "440",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of biopsies with a diagnosis of cutaneous Basal Cell Carcinoma (BCC) and Squamous Cell Carcinoma (SCC) (including in situ disease) in which the pathologist communicates results to the clinician within 7 days of biopsy date",
@@ -2762,7 +2726,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Biopsy Follow-Up",
     "description": "Percentage of new patients whose biopsy results have been reviewed and communicated to the primary care/referring physician and patient by the performing physician",
     "nationalQualityCode": "CCC",
@@ -2774,7 +2738,6 @@
     "qualityId": "265",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of new patients whose biopsy results have been reviewed and communicated to the primary care/referring physician and patient by the performing physician",
@@ -2796,7 +2759,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Bipolar Disorder and Major Depression: Appraisal for alcohol or chemical substance use",
     "description": "Percentage of patients with depression or bipolar disorder with evidence of an initial assessment that includes an appraisal for alcohol or chemical substance use",
     "nationalQualityCode": "ECC",
@@ -2808,7 +2771,6 @@
     "qualityId": "367",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Center for Quality Assessment and Improvement in Mental Health",
     "submissionMethods": [
@@ -2820,7 +2782,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Breast Cancer Resection Pathology Reporting: pT Category (Primary Tumor) and pN Category (Regional Lymph Nodes) with Histologic Grade",
     "description": "Percentage of breast cancer resection pathology reports that include the pT category (primary tumor), the pN category (regional lymph nodes), and the histologic grade",
     "nationalQualityCode": "ECC",
@@ -2832,7 +2794,6 @@
     "qualityId": "099",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of breast cancer resection pathology reports that include the pT category (primary tumor), the pN category (regional lymph nodes), and the histologic grade",
@@ -2852,7 +2813,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Breast Cancer Screening",
     "description": "Percentage of women 50-74 years of age who had a mammogram to screen for breast cancer.",
     "nationalQualityCode": "ECC",
@@ -2864,7 +2825,6 @@
     "qualityId": "112",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of women 50 - 74 years of age who had a mammogram to screen for breast cancer",
@@ -2889,7 +2849,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "CAHPS for MIPS Clinician/Group Survey",
     "description": "<br/><ul><li> Getting timely care, appointments, and information;\n</li><li> How well providers Communicate;\n</li><li> Patient's Rating of Provider;\n</li><li> Access to Specialists;\n</li><li> Health Promotion & Education;\n</li><li> Shared Decision Making;\n</li><li> Health Status/Functional Status;\n</li><li> Courteous and Helpful Office Staff;\n</li><li> Care Coordination;\n</li><li> Between Visit Communication;\n</li><li> Helping Your to Take Medication as Directed; and\n</li><li> Stewardship of Patient Resources</li></ul>",
     "nationalQualityCode": "PCCEO",
@@ -2901,7 +2861,6 @@
     "qualityId": "321",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Agency for Healthcare Research & Quality",
     "submissionMethods": [
@@ -2915,7 +2874,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Cardiac Rehabilitation Patient Referral from an Outpatient Setting",
     "description": "Percentage of patients evaluated in an outpatient setting who within the previous 12 months have experienced an acute myocardial infarction (MI), coronary artery bypass graft (CABG) surgery, a percutaneous coronary intervention (PCI), cardiac valve surgery, or cardiac transplantation, or who have chronic stable angina (CSA) and have not already participated in an early outpatient cardiac rehabilitation/secondary prevention (CR) program for the qualifying event/diagnosis who were referred to a CR program",
     "nationalQualityCode": "CCC",
@@ -2927,7 +2886,6 @@
     "qualityId": "243",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients evaluated in an outpatient setting who within the previous 12 months have experienced an acute myocardial infarction (MI), coronary artery bypass graft (CABG) surgery, a percutaneous coronary intervention (PCI), cardiac valve surgery, or cardiac transplantation, or who have chronic stable angina (CSA) and have not already participated in an early outpatient cardiac rehabilitation/secondary prevention (CR) program for the qualifying event/diagnosis who were referred to a CR program Definition: Referral - A referral is defined as an official communication between the health care provider and the patient to recommend and carry out a referral order to an outpatient CR program. This includes the provision of all necessary information to the patient that will allow the patient to enroll in an outpatient CR program. This also includes a written or electronic communication between the healthcare provider or healthcare system and the cardiac rehabilitation program that includes the patient's enrollment information for the program. A hospital discharge summary or office note may potentially be formatted to include the necessary patient information to communicate to the CR program (the patient’s cardiovascular history, testing, and treatments, for instance). According to standards of practice for cardiac rehabilitation programs, care coordination communications are sent to the referring provider, including any issues regarding treatment changes, adverse treatment responses, or new non-emergency condition (new symptoms, patient care questions, etc.) that need attention by the referring provider. These communications also include a progress report once the patient has completed the program. All communications must maintain an appropriate level of confidentiality as outlined by the 1996 Health Insurance Portability and Accountability Act (HIPAA). Note: A patient with a qualifying diagnosis should have a referral to CR within the subsequent 12 months. In the event that the patient has a second (recurrent) qualifying event before the original 12 month “referral” period has ended, a new 12 month “referral” period for CR referral starts at the time of the second qualifying event, since the patient again becomes eligible for CR at that time.",
@@ -2944,7 +2902,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low Risk Surgery Patients",
     "description": "Percentage of stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), or cardiac magnetic resonance (CMR) performed in low risk surgery patients 18 years or older for preoperative evaluation during the 12-month reporting period",
     "nationalQualityCode": "ECR",
@@ -2956,7 +2914,6 @@
     "qualityId": "322",
     "isHighPriority": true,
     "isInverse": true,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), or cardiac magnetic resonance (CMR) performed in low risk surgery patients 18 years or older for preoperative evaluation during the 12-month reporting period",
@@ -2975,7 +2932,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Routine Testing After Percutaneous Coronary Intervention (PCI)",
     "description": "Percentage of all stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), and cardiovascular magnetic resonance (CMR) performed in patients aged 18 years and older routinely after percutaneous coronary intervention (PCI), with reference to timing of test after PCI and symptom status",
     "nationalQualityCode": "ECR",
@@ -2987,7 +2944,6 @@
     "qualityId": "323",
     "isHighPriority": true,
     "isInverse": true,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of all stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), and cardiovascular magnetic resonance (CMR) performed in patients aged 18 years and older routinely after percutaneous coronary intervention (PCI), with reference to timing of test after PCI and symptom status",
@@ -3006,7 +2962,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Testing in Asymptomatic, Low-Risk Patients",
     "description": "Percentage of all stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), and cardiovascular magnetic resonance (CMR) performed in asymptomatic, low coronary heart disease (CHD) risk patients 18 years and older for initial detection and risk assessment",
     "nationalQualityCode": "ECR",
@@ -3018,7 +2974,6 @@
     "qualityId": "324",
     "isHighPriority": true,
     "isInverse": true,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of all stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), and cardiovascular magnetic resonance (CMR) performed in asymptomatic, low coronary heart disease (CHD) risk patients 18 years and older for initial detection and risk assessment",
@@ -3037,7 +2992,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Care Plan",
     "description": "Percentage of patients aged 65 years and older who have an advance care plan or surrogate decision maker documented in the medical record or documentation in the medical record that an advance care plan was discussed but the patient did not wish or was not able to name a surrogate decision maker or provide an advance care plan",
     "nationalQualityCode": "CCC",
@@ -3049,7 +3004,6 @@
     "qualityId": "047",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 65 years and older who have an advance care plan or surrogate decision maker documented in the medical record or documentation in the medical record that an advance care plan was discussed but the patient did not wish or was not able to name a surrogate decision maker or provide an advance care plan",
@@ -3089,7 +3043,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Cataracts: 20/40 or Better Visual Acuity within 90 Days Following Cataract Surgery",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of uncomplicated cataract who had cataract surgery and no significant ocular conditions impacting the visual outcome of surgery and had best-corrected visual acuity of 20/40 or better (distance or near) achieved within 90 days following the cataract surgery",
     "nationalQualityCode": "ECC",
@@ -3101,7 +3055,6 @@
     "qualityId": "191",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of uncomplicated cataract who had cataract surgery and no significant ocular conditions impacting the visual outcome of surgery and had best-corrected visual acuity of 20/40 or better (distance or near) achieved within 90 days following the cataract surgery",
@@ -3121,7 +3074,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Cataracts: Complications within 30 Days Following Cataract Surgery Requiring Additional Surgical Procedures",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of uncomplicated cataract who had cataract surgery and had any of a specified list of surgical procedures in the 30 days following cataract surgery which would indicate the occurrence of any of the following major complications: retained nuclear fragments, endophthalmitis, dislocated or wrong power IOL, retinal detachment, or wound dehiscence",
     "nationalQualityCode": "PS",
@@ -3133,7 +3086,6 @@
     "qualityId": "192",
     "isHighPriority": true,
     "isInverse": true,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of uncomplicated cataract who had cataract surgery and had any of a specified list of surgical procedures in the 30 days following cataract surgery which would indicate the occurrence of any of the following major complications: retained nuclear fragments, endophthalmitis, dislocated or wrong power IOL, retinal detachment, or wound dehiscence",
@@ -3153,7 +3105,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Cataracts: Improvement in Patient's Visual Function within 90 Days Following Cataract Surgery",
     "description": "Percentage of patients aged 18 years and older who had cataract surgery and had improvement in visual function achieved within 90 days following the cataract surgery, based on completing a pre-operative and post-operative visual function survey",
     "nationalQualityCode": "PCCEO",
@@ -3165,7 +3117,6 @@
     "qualityId": "303",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older who had cataract surgery and had improvement in visual function achieved within 90 days following the cataract surgery, based on completing a pre-operative and post-operative visual function survey",
@@ -3184,7 +3135,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Cataracts: Patient Satisfaction within 90 Days Following Cataract Surgery",
     "description": "Percentage of patients aged 18 years and older  who had cataract surgery and were satisfied with their care within 90 days following the cataract surgery, based on completion of the Consumer Assessment of Healthcare Providers and Systems Surgical Care Survey",
     "nationalQualityCode": "PCCEO",
@@ -3196,7 +3147,6 @@
     "qualityId": "304",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older who had cataract surgery and were satisfied with their care within 90 days following the cataract surgery, based on completion of the Consumer Assessment of Healthcare Providers and Systems Surgical Care Survey",
@@ -3215,7 +3165,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Cataract Surgery: Difference Between Planned and Final Refraction",
     "description": "Percentage of patients aged 18 years and older who had cataract surgery performed and who achieved a final refraction within +/- 1.0 diopters of their planned (target) refraction",
     "nationalQualityCode": "ECC",
@@ -3227,7 +3177,6 @@
     "qualityId": "389",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older who had cataract surgery performed and who achieved a final refraction within +/- 1.0 diopters of their planned (target) refraction",
@@ -3246,7 +3195,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Cataract Surgery with Intra-Operative Complications (Unplanned Rupture of Posterior Capsule Requiring Unplanned Vitrectomy)",
     "description": "Percentage of patients aged 18 years and older who had cataract surgery performed and had an unplanned rupture of the posterior capsule requiring vitrectomy",
     "nationalQualityCode": "PS",
@@ -3258,7 +3207,6 @@
     "qualityId": "388",
     "isHighPriority": true,
     "isInverse": true,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older who had cataract surgery performed and had an unplanned rupture of the posterior capsule requiring vitrectomy",
@@ -3277,7 +3225,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Cervical Cancer Screening",
     "description": "Percentage of women 21-64 years of age who were screened for cervical cancer using either of the following criteria:\n*  Women age 21-64 who had cervical cytology performed every 3 years\n*  Women age 30-64 who had cervical cytology/human papillomavirus (HPV) co-testing performed every 5 years\n",
     "nationalQualityCode": "ECC",
@@ -3289,7 +3237,6 @@
     "qualityId": "309",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
@@ -3304,7 +3251,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Child and Adolescent Major Depressive Disorder (MDD): Suicide Risk Assessment",
     "description": "Percentage of patient visits for those patients aged 6 through 17 years with a diagnosis of major depressive disorder with an assessment for suicide risk\n",
     "nationalQualityCode": "PS",
@@ -3316,7 +3263,6 @@
     "qualityId": "382",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
     "submissionMethods": [
@@ -3331,7 +3277,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Childhood Immunization Status",
     "description": "Percentage of children 2 years of age who had four diphtheria, tetanus and acellular pertussis (DTaP); three polio (IPV), one measles, mumps and rubella (MMR); three H influenza type B (HiB); three hepatitis B (Hep B); one chicken pox (VZV); four pneumococcal conjugate (PCV); one hepatitis A (Hep A); two or three rotavirus (RV); and two influenza (flu) vaccines by their second birthday",
     "nationalQualityCode": "CPH",
@@ -3343,7 +3289,6 @@
     "qualityId": "240",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
@@ -3357,7 +3302,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Children Who Have Dental Decay or Cavities",
     "description": "Percentage of children, age 0-20 years, who have had tooth decay or cavities during the measurement period",
     "nationalQualityCode": "CPH",
@@ -3369,7 +3314,6 @@
     "qualityId": "378",
     "isHighPriority": true,
     "isInverse": true,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
@@ -3381,7 +3325,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Chlamydia Screening and Follow Up",
     "description": "The percentage of female adolescents 16 years of age who had a chlamydia screening test with proper follow-up during the measurement period",
     "nationalQualityCode": "CPH",
@@ -3393,7 +3337,6 @@
     "qualityId": "447",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "The percentage of female adolescents 16 years of age who had a chlamydia screening test with proper follow-up during the measurement period",
@@ -3412,7 +3355,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Chlamydia Screening for Women",
     "description": "Percentage of women 16-24 years of age who were identified as sexually active and who had at least one test for chlamydia during the measurement period",
     "nationalQualityCode": "CPH",
@@ -3424,7 +3367,6 @@
     "qualityId": "310",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
@@ -3439,7 +3381,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Chronic Obstructive Pulmonary Disease (COPD): Long-Acting Inhaled Bronchodilator Therapy",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of COPD (FEV1/FVC < 70%) and who have an FEV1 less than 60% predicted and have symptoms who were prescribed an long-acting inhaled bronchodilator",
     "nationalQualityCode": "ECC",
@@ -3451,7 +3393,6 @@
     "qualityId": "052",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of COPD (FEV1/FVC < 70%) and who have an FEV1 less than 60% predicted and have symptoms who were prescribed a long-acting inhaled bronchodilator",
@@ -3469,7 +3410,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Chronic Obstructive Pulmonary Disease (COPD): Spirometry Evaluation",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of COPD who had spirometry results documented",
     "nationalQualityCode": "ECC",
@@ -3481,7 +3422,6 @@
     "qualityId": "051",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of COPD who had spirometry results documented",
@@ -3499,7 +3439,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Clinical Outcome Post Endovascular Stroke Treatment",
     "description": "Percentage of patients with a mRs score of 0 to 2 at 90 days following endovascular stroke intervention",
     "nationalQualityCode": "ECC",
@@ -3511,7 +3451,6 @@
     "qualityId": "409",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients with a mRs score of 0 to 2 at 90 days following endovascular stroke intervention",
@@ -3528,7 +3467,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Closing the Referral Loop: Receipt of Specialist Report",
     "description": "Percentage of patients with referrals, regardless of age, for which the referring provider receives a report from the provider to whom the patient was referred",
     "nationalQualityCode": "CCC",
@@ -3540,7 +3479,6 @@
     "qualityId": "374",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
@@ -3574,7 +3512,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Colonoscopy Interval for Patients with a History of Adenomatous Polyps\n- Avoidance of Inappropriate Use",
     "description": "Percentage of patients aged 18 years and older receiving a surveillance colonoscopy, with a history of a prior adenomatous polyp(s) in previous colonoscopy findings, which had an interval of 3 or more years since their last colonoscopy",
     "nationalQualityCode": "CCC",
@@ -3586,7 +3524,6 @@
     "qualityId": "185",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older receiving a surveillance colonoscopy, with a history of a prior adenomatous polyp(s) in previous colonoscopy findings, which had an interval of 3 or more years since their last colonoscopy",
@@ -3606,7 +3543,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Colorectal Cancer Resection Pathology Reporting: pT Category (Primary Tumor) and pN Category (Regional Lymph Nodes) with Histologic Grade",
     "description": "Percentage of colon and rectum cancer resection pathology reports that include the pT category (primary tumor), the pN category (regional lymph nodes) and the histologic grade",
     "nationalQualityCode": "ECC",
@@ -3618,7 +3555,6 @@
     "qualityId": "100",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of colon and rectum cancer resection pathology reports that include the pT category (primary tumor), the pN category (regional lymph nodes) and the histologic grade",
@@ -3638,7 +3574,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Colorectal Cancer Screening",
     "description": "Percentage of adults 50-75 years of age who had appropriate screening for colorectal cancer.",
     "nationalQualityCode": "ECC",
@@ -3650,7 +3586,6 @@
     "qualityId": "113",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients 50-75 years of age who had appropriate screening for colorectal cancer",
@@ -3673,7 +3608,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Communication with the Physician or Other Clinician Managing On-going Care Post-Fracture for Men and Women Aged 50 Years and Older",
     "description": "Percentage of patients aged 50 years and older treated for a fracture with documentation of communication, between the physician treating the fracture and the physician or other clinician managing the patient's on-going care, that a fracture occurred and that the patient was or should be considered for osteoporosis treatment or testing. This measure is reported by the physician who treats the fracture and who therefore is held accountable for the communication",
     "nationalQualityCode": "CCC",
@@ -3685,7 +3620,6 @@
     "qualityId": "024",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 50 years and older treated for a fracture with documentation of communication, between the physician treating the fracture and the physician or other clinician managing the patient’s on-going care, that a fracture occurred and that the patient was or should be considered for osteoporosis treatment or testing. This measure is reported by the physician who treats the fracture and who therefore is held accountable for the communication",
@@ -3705,7 +3639,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Controlling High Blood Pressure",
     "description": "Percentage of patients 18-85 years of age who had a diagnosis of hypertension and whose blood pressure was adequately controlled (<140/90mmHg) during the measurement period",
     "nationalQualityCode": "ECC",
@@ -3717,7 +3651,6 @@
     "qualityId": "236",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients 18 - 85 years of age who had a diagnosis of hypertension and whose blood pressure was adequately controlled (< 140/90 mmHg) during the measurement period",
@@ -3745,7 +3678,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Coronary Artery Bypass Graft (CABG): Deep Sternal Wound Infection Rate",
     "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery who, within 30 days postoperatively, develop deep sternal wound infection involving muscle, bone, and/or mediastinum requiring operative intervention",
     "nationalQualityCode": "ECC",
@@ -3757,7 +3690,6 @@
     "qualityId": "165",
     "isHighPriority": true,
     "isInverse": true,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery who, within 30 days postoperatively, develop deep sternal wound infection involving muscle, bone, and/or mediastinum requiring operative intervention",
@@ -3776,7 +3708,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Coronary Artery Bypass Graft (CABG): Postoperative Renal Failure",
     "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery (without pre-existing renal failure) who develop postoperative renal failure or require dialysis",
     "nationalQualityCode": "ECC",
@@ -3788,7 +3720,6 @@
     "qualityId": "167",
     "isHighPriority": true,
     "isInverse": true,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery (without pre-existing renal failure) who develop postoperative renal failure or require dialysis",
@@ -3807,7 +3738,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Coronary Artery Bypass Graft (CABG): Preoperative Beta-Blocker in Patients with Isolated CABG Surgery",
     "description": "Percentage of isolated Coronary Artery Bypass Graft (CABG) surgeries for patients aged 18 years and older who received a beta-blocker within 24 hours prior to surgical incision",
     "nationalQualityCode": "ECC",
@@ -3819,7 +3750,6 @@
     "qualityId": "044",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of isolated Coronary Artery Bypass Graft (CABG) surgeries for patients aged 18 years and older who received a beta-blocker within 24 hours prior to surgical incision",
@@ -3838,7 +3768,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Coronary Artery Bypass Graft (CABG): Prolonged Intubation",
     "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery who require postoperative intubation > 24 hours",
     "nationalQualityCode": "ECC",
@@ -3850,7 +3780,6 @@
     "qualityId": "164",
     "isHighPriority": true,
     "isInverse": true,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery who require postoperative intubation > 24 hours",
@@ -3869,7 +3798,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Coronary Artery Bypass Graft (CABG): Stroke",
     "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery who have a postoperative stroke (i.e., any confirmed neurological deficit of abrupt onset caused by a disturbance in blood supply to the brain) that did not resolve within 24 hours",
     "nationalQualityCode": "ECC",
@@ -3881,7 +3810,6 @@
     "qualityId": "166",
     "isHighPriority": true,
     "isInverse": true,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery who have a postoperative stroke (i.e., any confirmed neurological deficit of abrupt onset caused by a disturbance in blood supply to the brain) that did not resolve within 24 hours",
@@ -3900,7 +3828,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Coronary Artery Bypass Graft (CABG): Surgical Re-Exploration",
     "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery who require a return to the operating room (OR) during the current hospitalization for mediastinal bleeding with or without tamponade, graft occlusion, valve dysfunction, or other cardiac reason",
     "nationalQualityCode": "ECC",
@@ -3912,7 +3840,6 @@
     "qualityId": "168",
     "isHighPriority": true,
     "isInverse": true,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery who require a return to the operating room () during the current hospitalization for mediastinal bleeding with or without tamponade, graft occlusion, valve dysfunction, or other cardiac reason",
@@ -3931,7 +3858,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Coronary Artery Bypass Graft (CABG): Use of Internal Mammary Artery (IMA) in Patients with Isolated CABG Surgery",
     "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery who received an IMA graft",
     "nationalQualityCode": "ECC",
@@ -3943,7 +3870,6 @@
     "qualityId": "043",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery who received an IMA graft",
@@ -3960,7 +3886,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Coronary Artery Disease (CAD): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy - Diabetes or Left Ventricular Systolic Dysfunction (LVEF < 40%)",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease seen within a 12 month period who also have diabetes OR a current or prior Left Ventricular Ejection Fraction (LVEF) < 40% who were prescribed ACE inhibitor or ARB therapy",
     "nationalQualityCode": "ECC",
@@ -3972,7 +3898,6 @@
     "qualityId": "118",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease seen within a 12 month period who also have diabetes a current or prior Left Ventricular Ejection Fraction (LVEF) < 40% who were prescribed ACE inhibitor or ARB therapy",
@@ -3991,7 +3916,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Coronary Artery Disease (CAD): Antiplatelet Therapy",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease (CAD) seen within a 12 month period who were prescribed aspirin or clopidogrel",
     "nationalQualityCode": "ECC",
@@ -4003,7 +3928,6 @@
     "qualityId": "006",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease (CAD) seen within a 12 month period who were prescribed aspirin or clopidogrel",
@@ -4022,7 +3946,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "multiPerformanceRate",
     "title": "Coronary Artery Disease (CAD): Beta-Blocker Therapy-Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF <40%)",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease seen within a 12 month period who also have a prior MI or a current or prior LVEF <40% who were prescribed beta-blocker therapy",
     "nationalQualityCode": "ECC",
@@ -4034,7 +3958,6 @@
     "qualityId": "007",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "weightedAverage",
     "strata": [
       {
         "description": "Patients who are 18 years and older with a diagnosis of CAD or history of cardiac surgery who have a current or prior LVEF < 40%",
@@ -4053,13 +3976,14 @@
     "measureSets": [
       "cardiology",
       "generalPracticeFamilyMedicine"
-    ]
+    ],
+    "overallAlgorithm": "weightedAverage"
   },
   {
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Dementia: Caregiver Education and Support",
     "description": "Percentage of patients, regardless of age, with a diagnosis of dementia whose caregiver(s) were provided with education on dementia disease management and health behavior changes AND referred to additional resources for support within a 12 month period",
     "nationalQualityCode": "CCC",
@@ -4071,7 +3995,6 @@
     "qualityId": "288",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients, regardless of age, with a diagnosis of dementia whose caregiver(s) were provided with education on dementia disease management and health behavior changes referred to additional resources for support within a 12 month period",
@@ -4091,7 +4014,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Dementia: Cognitive Assessment",
     "description": "Percentage of patients, regardless of age, with a diagnosis of dementia for whom an assessment of cognition is performed and the results reviewed at least once within a 12 month period",
     "nationalQualityCode": "ECC",
@@ -4103,7 +4026,6 @@
     "qualityId": "281",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
     "submissionMethods": [
@@ -4118,7 +4040,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Dementia: Counseling Regarding Safety Concerns",
     "description": "Percentage of patients, regardless of age, with a diagnosis of dementia or their caregiver(s) who were counseled or referred for counseling regarding safety concerns within a 12 month period",
     "nationalQualityCode": "PS",
@@ -4130,7 +4052,6 @@
     "qualityId": "286",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients, regardless of age, with a diagnosis of dementia or their caregiver(s) who were counseled or referred for counseling regarding safety concerns within a 12 month period",
@@ -4150,7 +4071,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Dementia: Functional Status Assessment",
     "description": "Percentage of patients, regardless of age, with a diagnosis of dementia for whom an assessment of functional status is performed and the results reviewed at least once within a 12 month period",
     "nationalQualityCode": "ECC",
@@ -4162,7 +4083,6 @@
     "qualityId": "282",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients, regardless of age, with a diagnosis of dementia for whom an assessment of functional status is performed and the results reviewed at least once within a 12 month period",
@@ -4182,7 +4102,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Dementia: Management of Neuropsychiatric Symptoms",
     "description": "Percentage of patients, regardless of age, with a diagnosis of dementia who have one or more neuropsychiatric symptoms who received or were recommended to receive an intervention for neuropsychiatric symptoms within a 12 month period",
     "nationalQualityCode": "ECC",
@@ -4194,7 +4114,6 @@
     "qualityId": "284",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients, regardless of age, with a diagnosis of dementia who have one or more neuropsychiatric symptoms who received or were recommended to receive an intervention for neuropsychiatric symptoms within a 12 month period",
@@ -4214,7 +4133,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Dementia: Neuropsychiatric Symptom Assessment",
     "description": "Percentage of patients, regardless of age, with a diagnosis of dementia and for whom an assessment of neuropsychiatric symptoms is performed and results reviewed at least once in a 12 month period",
     "nationalQualityCode": "ECC",
@@ -4226,7 +4145,6 @@
     "qualityId": "283",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients, regardless of age, with a diagnosis of dementia and for whom an assessment of neuropsychiatric symptoms is performed and results reviewed at least once in a 12 month period",
@@ -4246,7 +4164,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Depression Remission at Six Months",
     "description": "Adult patients age 18 years and older with major depression or dysthymia and an initial PHQ-9 score > 9 who demonstrate remission at six months defined as a PHQ-9 score less than 5. This measure applies to both patients with newly diagnosed and existing depression whose current PHQ-9 score indicates a need for treatment. This measure additionally promotes ongoing contact between the patient and provider as patients who do not have a follow-up PHQ-9 score at six months (+/- 30 days) are also included in the denominator",
     "nationalQualityCode": "ECC",
@@ -4258,7 +4176,6 @@
     "qualityId": "411",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Adult patients age 18 years and older with major depression or dysthymia and an initial PHQ-9 score > 9 who demonstrate remission at six months defined as a PHQ-9 score less than 5. This measure applies to both patients with newly diagnosed and existing depression whose current PHQ-9 score indicates a need for treatment. This measure additionally promotes ongoing contact between the patient and provider as patients who do not have a follow-up PHQ-9 score at six months (+/- 30 days) are also included in the denominator",
@@ -4277,7 +4194,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Depression Remission at Twelve Months",
     "description": "Patients age 18 and older with major depression or dysthymia and an initial Patient Health Questionnaire (PHQ-9) score greater than nine who demonstrate remission at twelve months (+/- 30 days after an index visit) defined as a PHQ-9 score less than five. This measure applies to both patients with newly diagnosed and existing depression whose current PHQ-9 score indicates a need for treatment.",
     "nationalQualityCode": "ECC",
@@ -4289,7 +4206,6 @@
     "qualityId": "370",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Patients age 18 and older with major depression or dysthymia and an initial Patient Health Questionnaire (PHQ-9) score greater than nine who demonstrate remission at twelve months (+/- 30 days after an index visit) defined as a PHQ-9 score less than five. This measure applies to both patients with newly diagnosed and existing depression whose current PHQ-9 score indicates a need for treatment",
@@ -4311,7 +4227,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Depression Utilization of the PHQ-9 Tool",
     "description": "Patients age 18 and older with the diagnosis of major depression or dysthymia who have a Patient Health Questionnaire (PHQ-9) tool administered at least once during a 4-month period in which there was a qualifying visit",
     "nationalQualityCode": "ECC",
@@ -4323,7 +4239,6 @@
     "qualityId": "371",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Minnesota Community Measurement",
     "submissionMethods": [
@@ -4337,7 +4252,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Diabetes: Eye Exam",
     "description": "Percentage of patients 18-75 years of age with diabetes who had a retinal or dilated eye exam by an eye care professional during the measurement period or a negative retinal exam (no evidence of retinopathy) in the 12 months prior to the measurement period",
     "nationalQualityCode": "ECC",
@@ -4349,7 +4264,6 @@
     "qualityId": "117",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients 18 - 75 years of age with diabetes who had a retinal or dilated eye exam by an eye care professional during the measurement period or a negative retinal or dilated eye exam (no evidence of retinopathy) in the 12 months prior to the measurement period",
@@ -4373,7 +4287,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Diabetes: Foot Exam",
     "description": "The percentage of patients 18-75 years of age with diabetes (type 1 and type 2) who received a foot exam (visual inspection and sensory exam with mono filament and a pulse exam) during the measurement year",
     "nationalQualityCode": "ECC",
@@ -4385,7 +4299,6 @@
     "qualityId": "163",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
@@ -4400,7 +4313,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%)",
     "description": "Percentage of patients 18-75 years of age with diabetes who had hemoglobin A1c > 9.0% during the measurement period",
     "nationalQualityCode": "ECC",
@@ -4412,7 +4325,6 @@
     "qualityId": "001",
     "isHighPriority": true,
     "isInverse": true,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients 18-75 years of age with diabetes who had hemoglobin A1c > 9.0% during the measurement period",
@@ -4436,7 +4348,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Diabetes: Medical Attention for Nephropathy",
     "description": "The percentage of patients 18-75 years of age with diabetes who had a nephropathy screening test or evidence of nephropathy during the measurement period.",
     "nationalQualityCode": "ECC",
@@ -4448,7 +4360,6 @@
     "qualityId": "119",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "The percentage of patients 18-75 years of age with diabetes who had a nephropathy screening test or evidence of nephropathy during the measurement period",
@@ -4468,7 +4379,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Diabetes Mellitus: Diabetic Foot and Ankle Care, Peripheral Neuropathy - Neurological Evaluation",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of diabetes mellitus who had a neurological examination of their lower extremities within 12 months",
     "nationalQualityCode": "ECC",
@@ -4480,7 +4391,6 @@
     "qualityId": "126",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of diabetes mellitus who had a neurological examination of their lower extremities within 12 months",
@@ -4497,7 +4407,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Diabetes Mellitus: Diabetic Foot and Ankle Care, Ulcer Prevention - Evaluation of Footwear",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of diabetes mellitus who were evaluated for proper footwear and sizing",
     "nationalQualityCode": "ECC",
@@ -4509,7 +4419,6 @@
     "qualityId": "127",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of diabetes mellitus who were evaluated for proper footwear and sizing",
@@ -4526,7 +4435,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of diabetic retinopathy who had a dilated macular or fundus exam performed with documented communication to the physician who manages the ongoing care of the patient with diabetes mellitus regarding the findings of the macular or fundus exam at least once within 12 months",
     "nationalQualityCode": "CCC",
@@ -4538,7 +4447,6 @@
     "qualityId": "019",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of diabetic retinopathy who had a dilated macular or fundus exam performed with documented communication to the physician who manages the ongoing care of the patient with diabetes mellitus regarding the findings of the macular or fundus exam at least once within 12 months",
@@ -4559,7 +4467,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Diabetic Retinopathy: Documentation of Presence or Absence of Macular Edema and Level of Severity of Retinopathy",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of diabetic retinopathy who had a dilated macular or fundus exam performed which included documentation of the level of severity of retinopathy and the presence or absence of macular edema during one or more office visits within 12 months",
     "nationalQualityCode": "ECC",
@@ -4571,7 +4479,6 @@
     "qualityId": "018",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Physician Consortium for Performance Improvement",
     "submissionMethods": [
@@ -4585,7 +4492,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Documentation of Current Medications in the Medical Record",
     "description": "Percentage of visits for patients aged 18 years and older for which the eligible professional attests to documenting a list of current medications using all immediate resources available on the date of the encounter.  This list must include ALL known prescriptions, over-the-counters, herbals, and vitamin/mineral/dietary (nutritional) supplements AND must contain the medications' name, dosage, frequency and route of administration.",
     "nationalQualityCode": "PS",
@@ -4597,7 +4504,6 @@
     "qualityId": "130",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of visits for patients aged 18 years and older for which the eligible clinician attests to documenting a list of current medications using all immediate resources available on the date of the encounter. This list must include ALL known prescriptions, over-the-counters, herbals, and vitamin/mineral/dietary (nutritional) supplements must contain the medications’ name, dosage, frequency and route of administration",
@@ -4641,7 +4547,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Documentation of Signed Opioid Treatment Agreement",
     "description": "All patients 18 and older prescribed opiates for longer than six weeks duration who signed an opioid treatment agreement at least once during Opioid Therapy documented in the medical record.",
     "nationalQualityCode": "ECC",
@@ -4653,7 +4559,6 @@
     "qualityId": "412",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "All patients 18 and older prescribed opiates for longer than six weeks duration who signed an opioid treatment agreement at least once during Opioid Therapy documented in the medical record",
@@ -4675,7 +4580,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Door to Puncture Time for Endovascular Stroke Treatment",
     "description": "Percentage of patients undergoing endovascular stroke treatment who have a door to puncture time of less than two hours",
     "nationalQualityCode": "ECC",
@@ -4687,7 +4592,6 @@
     "qualityId": "413",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients undergoing endovascular stroke treatment who have a door to puncture time of less than two hours",
@@ -4704,7 +4608,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Elder Maltreatment Screen and Follow-Up Plan",
     "description": "Percentage of patients aged 65 years and older with a documented elder maltreatment screen using an Elder Maltreatment Screening tool on the date of encounter AND a documented follow-up plan on the date of the positive screen",
     "nationalQualityCode": "PS",
@@ -4716,7 +4620,6 @@
     "qualityId": "181",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 65 years and older with a documented elder maltreatment screen using an Elder Maltreatment Screening tool on the date of encounter a documented follow-up plan on the date of the positive screen",
@@ -4738,7 +4641,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older",
     "description": "Percentage of emergency department visits for patients aged 18 years and older who presented within 24 hours of a minor blunt head trauma with a Glasgow Coma Scale (GCS) score of 15 and who had a head CT for trauma ordered by an emergency care provider who have an indication for a head CT",
     "nationalQualityCode": "ECR",
@@ -4750,7 +4653,6 @@
     "qualityId": "415",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of emergency department visits for patients aged 18 years and older who presented within 24 hours of a minor blunt head trauma with a Glasgow Coma Scale (GCS) score of 15 and who had a head CT for trauma ordered by an emergency care provider who have an indication for a head CT",
@@ -4770,7 +4672,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years",
     "description": "Percentage of emergency department visits for patients aged 2 through 17 years who presented within 24 hours of a minor blunt head trauma with a Glasgow Coma Scale (GCS) score of 15 and who had a head CT for trauma ordered by an emergency care provider who are classified as low risk according to the Pediatric Emergency Care Applied Research Network (PECARN) prediction rules for traumatic brain injury",
     "nationalQualityCode": "ECR",
@@ -4782,7 +4684,6 @@
     "qualityId": "416",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of emergency department visits for patients aged 2 through 17 years who presented within 24 hours of a minor blunt head trauma with a Glasgow Coma Scale (GCS) score of 15 and who had a head CT for trauma ordered by an emergency care provider who are classified as low risk according to the Pediatric Emergency Care Applied Research Network (PECARN) prediction rules for traumatic brain injury",
@@ -4802,7 +4703,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Epilepsy: Counseling for Women of Childbearing Potential with Epilepsy",
     "description": "All female patients of childbearing potential (12 - 44 years old) diagnosed with epilepsy who were counseled or referred for counseling for how epilepsy and its treatment may affect contraception OR pregnancy at least once a year",
     "nationalQualityCode": "ECC",
@@ -4814,7 +4715,6 @@
     "qualityId": "268",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "All female patients of childbearing potential (12 - 44 years old) diagnosed with epilepsy who were counseled or referred for counseling for how epilepsy and its treatment may affect contraception pregnancy at least once a year",
@@ -4834,7 +4734,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Evaluation or Interview for Risk of Opioid Misuse",
     "description": "All patients 18 and older prescribed opiates for longer than six weeks duration evaluated for risk of opioid misuse using a brief validated instrument (e.g. Opioid Risk Tool, SOAPP-R) or patient interview documented at least once during Opioid Therapy in the medical record",
     "nationalQualityCode": "ECC",
@@ -4846,7 +4746,6 @@
     "qualityId": "414",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "All patients 18 and older prescribed opiates for longer than six weeks duration evaluated for risk of opioid misuse using a brief validated instrument (e.g. Opioid Risk Tool, SOAPP-R) or patient interview documented at least once during Opioid Therapy in the medical record",
@@ -4868,7 +4767,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Falls: Plan of Care",
     "description": "Percentage of patients aged 65 years and older with a history of falls that had a plan of care for falls documented within 12 months",
     "nationalQualityCode": "CCC",
@@ -4880,7 +4779,6 @@
     "qualityId": "155",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 65 years and older with a history of falls that had a plan of care for falls documented within 12 months",
@@ -4901,7 +4799,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Falls: Risk Assessment",
     "description": "Percentage of patients aged 65 years and older with a history of falls that had a risk assessment for falls completed within 12 months",
     "nationalQualityCode": "PS",
@@ -4913,7 +4811,6 @@
     "qualityId": "154",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 65 years and older with a history of falls that had a risk assessment for falls completed within 12 months",
@@ -4934,7 +4831,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Falls: Screening for Future Fall Risk",
     "description": "Percentage of patients 65 years of age and older who were screened for future fall risk during the measurement period.",
     "nationalQualityCode": "PS",
@@ -4946,7 +4843,6 @@
     "qualityId": "318",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
@@ -4959,7 +4855,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "multiPerformanceRate",
     "title": "Follow-Up After Hospitalization for Mental Illness (FUH)",
     "description": "The percentage of discharges for patients 6 years of age and older who were hospitalized for treatment of selected mental illness diagnoses and who had an outpatient visit, an intensive outpatient encounter or partial hospitalization with a mental health practitioner. Two rates are reported:\n<br/><ul><li> The percentage of discharges for which the patient received follow-up within 30 days of discharge.\n</li><li> The percentage of discharges for which the patient received follow-up within 7 days of discharge\n\n</li></ul>",
     "nationalQualityCode": "CCC",
@@ -4971,7 +4867,6 @@
     "qualityId": "391",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "The percentage of discharges for which the patient received follow-up within 30 days of discharge",
@@ -4989,13 +4884,14 @@
     "measureSets": [
       "mentalBehavioralHealth",
       "pediatrics"
-    ]
+    ],
+    "overallAlgorithm": "simpleAverage"
   },
   {
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Functional Outcome Assessment",
     "description": "Percentage of visits for patients aged 18 years and older with documentation of a current functional outcome assessment using a standardized functional outcome assessment tool on the date of the encounter AND documentation of a care plan based on identified functional outcome deficiencies on the date of the identified deficiencies",
     "nationalQualityCode": "CCC",
@@ -5007,7 +4903,6 @@
     "qualityId": "182",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of visits for patients aged 18 years and older with documentation of a current functional outcome assessment using a standardized functional outcome assessment tool on the date of the encounter documentation of a care plan based on identified functional outcome deficiencies on the date of the identified deficiencies",
@@ -5027,7 +4922,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Functional Status Assessment for Total Hip Replacement",
     "description": "Percentage of patients 18 years of age and older with primary total hip arthroplasty (THA) who completed baseline and follow-up patient-reported functional status assessments",
     "nationalQualityCode": "PCCEO",
@@ -5039,7 +4934,6 @@
     "qualityId": "376",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
@@ -5053,7 +4947,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Functional Status Assessment for Total Knee Replacement",
     "description": "Percentage of patients 18 years of age and older with primary total knee arthroplasty (TKA) who completed baseline and follow-up patient-reported functional status assessments",
     "nationalQualityCode": "PCCEO",
@@ -5065,7 +4959,6 @@
     "qualityId": "375",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
@@ -5079,7 +4972,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Functional Status Assessments for Congestive Heart Failure",
     "description": "Percentage of patients 65 years of age and older with congestive  heart failure who completed initial and follow-up patient-reported functional status assessments",
     "nationalQualityCode": "PCCEO",
@@ -5091,7 +4984,6 @@
     "qualityId": "377",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
@@ -5103,7 +4995,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Functional Status Change for Patients with Elbow, Wrist or Hand Impairments",
     "description": "A self-report outcome measure of functional status (FS) for patients 14 years+ with elbow, wrist or hand impairments. The change in FS assessed using FOTO (elbow, wrist and hand) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS  outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality",
     "nationalQualityCode": "CCC",
@@ -5115,7 +5007,6 @@
     "qualityId": "222",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "A self-report outcome measure of functional status (FS) for patients 14 years+ with elbow, wrist or hand impairments. The change in FS assessed using FOTO (elbow, wrist and hand) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality",
@@ -5132,7 +5023,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Functional Status Change for Patients with Foot or Ankle Impairments",
     "description": "A self-report measure of change in functional status (FS) for patients 14 years+ with foot and ankle impairments. The change in functional status (FS) assessed using FOTO's (foot and ankle) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality",
     "nationalQualityCode": "CCC",
@@ -5144,7 +5035,6 @@
     "qualityId": "219",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "A self-report measure of change in functional status (FS) for patients 14 years+ with foot and ankle impairments. The change in functional status (FS) assessed using FOTO’s (foot and ankle) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality",
@@ -5161,7 +5051,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Functional Status Change for Patients with General Orthopaedic Impairments",
     "description": "A self-report outcome measure of functional status (FS) for patients 14 years+ with general orthopaedic impairments (neck, cranium, mandible, thoracic spine, ribs or other general orthopaedic impairment). The change in FS assessed using FOTO (general orthopaedic) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level by to assess quality",
     "nationalQualityCode": "CCC",
@@ -5173,7 +5063,6 @@
     "qualityId": "223",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "A self-report outcome measure of functional status (FS) for patients 14 years+ with general orthopaedic impairments (neck, cranium, mandible, thoracic spine, ribs or other general orthopedic impairment). The change in FS assessed using FOTO (general orthopedic) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level by to assess quality",
@@ -5190,7 +5079,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Functional Status Change for Patients with Hip Impairments",
     "description": "A self-report measure of change in functional status (FS) for patients 14 years+ with hip impairments. The change in functional status (FS) assessed using FOTO's (hip) PROM (patient- reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality",
     "nationalQualityCode": "CCC",
@@ -5202,7 +5091,6 @@
     "qualityId": "218",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "A self-report measure of change in functional status (FS) for patients 14 years+ with hip impairments. The change in functional status (FS) assessed using FOTO’s (hip) PROM (patient- reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality",
@@ -5219,7 +5107,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Functional Status Change for Patients with Knee Impairments",
     "description": "A self-report measure of change in functional status for patients 14 year+ with knee impairments. The change in functional status (FS) assessed using FOTO's (knee ) PROM (patient-reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality",
     "nationalQualityCode": "CCC",
@@ -5231,7 +5119,6 @@
     "qualityId": "217",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "A self-report measure of change in functional status for patients 14 year+ with knee impairments. The change in functional status (FS) assessed using FOTO’s (knee) PROM (patient-reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality",
@@ -5248,7 +5135,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Functional Status Change for Patients with Lumbar Impairments",
     "description": "A self-report outcome measure of change in functional status for patients 14 years+ with lumbar impairments. The change in functional status (FS) assessed using FOTO (lumbar) PROM (patient reported outcome measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level by to assess quality",
     "nationalQualityCode": "CCC",
@@ -5260,7 +5147,6 @@
     "qualityId": "220",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "A self-report outcome measure of change in functional status for patients 14 years+ with lumbar impairments. The change in functional status (FS) assessed using FOTO (lumbar) PROM (patient reported outcome measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level by to assess quality",
@@ -5277,7 +5163,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Functional Status Change for Patients with Shoulder Impairments",
     "description": "A self-report outcome measure of change in functional status (FS) for patients 14 years+ with shoulder impairments. The change in functional status (FS) assessed using FOTO's (shoulder) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality",
     "nationalQualityCode": "CCC",
@@ -5289,7 +5175,6 @@
     "qualityId": "221",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "A self-report outcome measure of change in functional status (FS) for patients 14 years+ with shoulder impairments. The change in functional status (FS) assessed using FOTO’s (shoulder) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality",
@@ -5306,7 +5191,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy for Left Ventricular Systolic Dysfunction (LVSD)",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of heart failure (HF) with a current or prior left ventricular ejection fraction (LVEF) < 40% who were prescribed ACE inhibitor or ARB therapy either within a 12 month period when seen in the outpatient setting OR at each hospital discharge",
     "nationalQualityCode": "ECC",
@@ -5318,7 +5203,6 @@
     "qualityId": "005",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of heart failure (HF) with a current or prior left ventricular ejection fraction (LVEF) < 40% who were prescribed ACE inhibitor or ARB therapy either within a 12 month period when seen in the outpatient setting at each hospital discharge",
@@ -5341,7 +5225,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Heart Failure (HF): Beta-Blocker Therapy for Left Ventricular Systolic Dysfunction (LVSD)",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of heart failure (HF) with a current or prior left ventricular ejection fraction (LVEF) < 40% who were prescribed beta-blocker therapy either within a 12 month period when seen in the outpatient setting OR at each hospital discharge",
     "nationalQualityCode": "ECC",
@@ -5353,7 +5237,6 @@
     "qualityId": "008",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of heart failure (HF) with a current or prior left ventricular ejection fraction (LVEF) < 40% who were prescribed beta-blocker therapy either within a 12 month period when seen in the outpatient setting at each hospital discharge",
@@ -5375,7 +5258,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Hematology: Chronic Lymphocytic Leukemia (CLL): Baseline Flow Cytometry",
     "description": "Percentage of patients aged 18 years and older, seen within a 12 month reporting period, with a diagnosis of chronic lymphocytic leukemia (CLL) made at any time during or prior to the reporting period who had baseline flow cytometry studies performed and documented in the chart",
     "nationalQualityCode": "ECC",
@@ -5387,7 +5270,6 @@
     "qualityId": "070",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older, seen within a 12 month reporting period, with a diagnosis of chronic lymphocytic leukemia (CLL) made at any time during or prior to the reporting period who had baseline flow cytometry studies performed and documented in the chart",
@@ -5404,7 +5286,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Hematology: Multiple Myeloma: Treatment with Bisphosphonates",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of multiple myeloma, not in remission, who were prescribed or received intravenous bisphosphonate therapy within the 12 month reporting period",
     "nationalQualityCode": "ECC",
@@ -5416,7 +5298,6 @@
     "qualityId": "069",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of multiple myeloma, not in remission, who were prescribed or received intravenous bisphosphonate therapy within the 12 month reporting period.",
@@ -5433,7 +5314,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Hematology: Myelodysplastic Syndrome (MDS) and Acute Leukemias: Baseline Cytogenetic Testing Performed on Bone Marrow",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of myelodysplastic syndrome (MDS) or an acute leukemia who had baseline cytogenetic testing performed on bone marrow",
     "nationalQualityCode": "ECC",
@@ -5445,7 +5326,6 @@
     "qualityId": "067",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of myelodysplastic syndrome (MDS) or an acute leukemia who had baseline cytogenetic testing performed on bone marrow",
@@ -5462,7 +5342,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Hematology: Myelodysplastic Syndrome (MDS): Documentation of Iron Stores in Patients Receiving Erythropoietin Therapy",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of myelodysplastic syndrome (MDS) who are receiving erythropoietin therapy with documentation of iron stores within 60 days prior to initiating erythropoietin therapy",
     "nationalQualityCode": "ECC",
@@ -5474,7 +5354,6 @@
     "qualityId": "068",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of myelodysplastic syndrome (MDS) who are receiving erythropoietin therapy with documentation of iron stores within 60 days prior to initiating erythropoietin therapy",
@@ -5491,7 +5370,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Hepatitis C: Discussion and Shared Decision Making Surrounding Treatment Options",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of hepatitis C with whom a physician or other qualified healthcare professional reviewed the range of treatment options appropriate to their genotype and demonstrated a shared decision making approach with the patient. To meet the measure, there must be documentation in the patient record of a discussion between the physician or other qualified healthcare professional and the patient that includes all of the following: treatment choices appropriate to genotype, risks and benefits, evidence of effectiveness, and patient preferences toward treatment\n",
     "nationalQualityCode": "PCCEO",
@@ -5503,7 +5382,6 @@
     "qualityId": "390",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of hepatitis C with whom a physician or other qualified healthcare professional reviewed the range of treatment options appropriate to their genotype and demonstrated a shared decision making approach with the patient. To meet the measure, there must be documentation in the patient record of a discussion between the physician or other qualified healthcare professional and the patient that includes all of the following: treatment choices appropriate to genotype, risks and benefits, evidence of effectiveness, and patient preferences toward treatment",
@@ -5522,7 +5400,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Hepatitis C: Screening for Hepatocellular Carcinoma (HCC) in Patients with Cirrhosis",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of chronic hepatitis C cirrhosis who underwent imaging with either ultrasound, contrast enhanced CT or MRI for hepatocellular carcinoma (HCC) at least once within the 12 month reporting period",
     "nationalQualityCode": "ECC",
@@ -5534,7 +5412,6 @@
     "qualityId": "401",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of chronic hepatitis C cirrhosis who underwent imaging with either ultrasound, contrast enhanced CT or MRI for hepatocellular carcinoma (HCC) at least once within the 12 month reporting period",
@@ -5555,7 +5432,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "HER2 Negative or Undocumented Breast Cancer Patients Spared Treatment with HER2-Targeted Therapies",
     "description": "Proportion of female patients (aged 18 years and older) with breast cancer who are human epidermal growth factor receptor 2 (HER2)/neu negative who are not administered HER2-targeted therapies",
     "nationalQualityCode": "ECR",
@@ -5567,7 +5444,6 @@
     "qualityId": "449",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Proportion of female patients (aged 18 years and older) with breast cancer who are human epidermal growth factor receptor 2 (HER2)/neu negative who are not administered HER2-targeted therapies",
@@ -5586,7 +5462,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "HIV/AIDS: Pneumocystis Jiroveci Pneumonia (PCP) Prophylaxis",
     "description": "Percentage of patients aged 6 weeks and older with a diagnosis of HIV/AIDS who were prescribed Pneumocystis jiroveci pneumonia (PCP) prophylaxis",
     "nationalQualityCode": "ECC",
@@ -5598,7 +5474,6 @@
     "qualityId": "160",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
@@ -5613,7 +5488,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "HIV/AIDS: Sexually Transmitted Disease Screening for Chlamydia, Gonorrhea, and Syphilis",
     "description": "Percentage of patients aged 13 years and older with a diagnosis of HIV/AIDS for whom chlamydia, gonorrhea, and syphilis screenings were performed at least once since the diagnosis of HIV infection",
     "nationalQualityCode": "ECC",
@@ -5625,7 +5500,6 @@
     "qualityId": "205",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 13 years and older with a diagnosis of HIV/AIDS for whom chlamydia, gonorrhea, and syphilis screenings were performed at least once since the diagnosis of HIV infection",
@@ -5644,7 +5518,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "HIV Medical Visit Frequency",
     "description": "Percentage of patients, regardless of age with a diagnosis of HIV who had at least one medical visit in each 6 month period of the 24 month measurement period, with a minimum of 60 days between medical visits",
     "nationalQualityCode": "ECR",
@@ -5656,7 +5530,6 @@
     "qualityId": "340",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients, regardless of age with a diagnosis of HIV who had at least one medical visit in each 6 month period of the 24 month measurement period, with a minimum of 60 days between medical visits",
@@ -5673,7 +5546,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "HIV Viral Load Suppression",
     "description": "The percentage of patients, regardless of age, with a diagnosis of HIV with a HIV viral load less than 200 copies/mL at last HIV viral load test during the measurement year",
     "nationalQualityCode": "ECC",
@@ -5685,7 +5558,6 @@
     "qualityId": "338",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "The percentage of patients, regardless of age, with a diagnosis of HIV with a HIV viral load less than 200 copies/mL at last HIV viral load test during the measurement year",
@@ -5704,7 +5576,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "multiPerformanceRate",
     "title": "HRS-12: Cardiac Tamponade and/or Pericardiocentesis Following Atrial Fibrillation Ablation",
     "description": "Rate of cardiac tamponade and/or pericardiocentesis following atrial fibrillation ablation This measure is reported as four rates stratified by age and gender:\n<br/><ul><li> Reporting Age Criteria 1: Females 18-64years of age\n</li><li> Reporting Age Criteria 2: Males 18-64 years of age\n</li><li> Reporting Age Criteria 3: Females 65 years of age and older\n</li><li> Reporting Age Criteria 4: Males 65 years of age and older\n</li></ul>",
     "nationalQualityCode": "PS",
@@ -5716,7 +5588,6 @@
     "qualityId": "392",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "weightedAverage",
     "strata": [
       {
         "description": "Females 18-64 years of age",
@@ -5745,13 +5616,14 @@
     ],
     "measureSets": [
       "electrophysiologyCardiacSpecialist"
-    ]
+    ],
+    "overallAlgorithm": "weightedAverage"
   },
   {
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "multiPerformanceRate",
     "title": "HRS-3: Implantable Cardioverter-Defibrillator (ICD) Complications Rate",
     "description": "Patients with physician-specific risk-standardized rates of procedural complications following the first time implantation of an ICD",
     "nationalQualityCode": "PS",
@@ -5763,7 +5635,6 @@
     "qualityId": "348",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "weightedAverage",
     "strata": [
       {
         "description": "Patients with first time implants with one or more complications or mortality within 30 days",
@@ -5780,13 +5651,14 @@
     ],
     "measureSets": [
       "electrophysiologyCardiacSpecialist"
-    ]
+    ],
+    "overallAlgorithm": "weightedAverage"
   },
   {
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "HRS-9: Infection within 180 Days of Cardiac Implantable Electronic Device (CIED) Implantation, Replacement, or Revision",
     "description": "Infection rate following CIED device implantation, replacement, or revision\n",
     "nationalQualityCode": "PS",
@@ -5798,7 +5670,6 @@
     "qualityId": "393",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Infection rate following CIED device implantation, replacement, or revision",
@@ -5817,7 +5688,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Hypertension: Improvement in Blood Pressure",
     "description": "Percentage of patients aged 18-85 years of age with a diagnosis of hypertension whose blood pressure improved during the measurement period.",
     "nationalQualityCode": "ECC",
@@ -5829,7 +5700,6 @@
     "qualityId": "373",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
@@ -5841,7 +5711,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Image Confirmation of Successful Excision of Image-Localized Breast Lesion",
     "description": "Image confirmation of lesion(s) targeted for image guided excisional biopsy or image guided partial mastectomy in patients with nonpalpable, image-detected breast lesion(s). Lesions may include: microcalcifications, mammographic or sonographic mass or architectural distortion, focal suspicious abnormalities on magnetic resonance imaging (MRI) or other breast imaging amenable to localization such as positron emission tomography (PET) mammography, or a biopsy marker demarcating site of confirmed pathology as established by previous core biopsy",
     "nationalQualityCode": "PS",
@@ -5853,7 +5723,6 @@
     "qualityId": "262",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Image confirmation of lesion(s) targeted for image guided excisional biopsy or image guided partial mastectomy in patients with nonpalpable, image-detected breast lesion(s). Lesions may include: microcalcifications, mammographic or sonographic mass or architectural distortion, focal suspicious abnormalities on magnetic resonance imaging (MRI) or other breast imaging amenable to localization such as positron emission tomography (PET) mammography, or a biopsy marker demarcating site of confirmed pathology as established by previous core biopsy",
@@ -5870,7 +5739,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "multiPerformanceRate",
     "title": "Immunizations for Adolescents",
     "description": "The percentage of adolescents 13 years of age who had the recommended immunizations by their 13th birthday",
     "nationalQualityCode": "CPH",
@@ -5882,7 +5751,6 @@
     "qualityId": "394",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "sumNumerators",
     "strata": [
       {
         "description": "Patients who had one dose of meningococcal vaccine on or between the patient’s 11th and 13th birthdays",
@@ -5908,13 +5776,14 @@
     "measureSets": [
       "generalPracticeFamilyMedicine",
       "pediatrics"
-    ]
+    ],
+    "overallAlgorithm": "sumNumerators"
   },
   {
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Inflammatory Bowel Disease (IBD): Assessment of Hepatitis B Virus (HBV) Status Before Initiating Anti-TNF (Tumor Necrosis Factor) Therapy",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of inflammatory bowel disease (IBD) who had Hepatitis B Virus (HBV) status assessed and results interpreted within one year prior to receiving a first course of anti-TNF (tumor necrosis factor) therapy",
     "nationalQualityCode": "ECC",
@@ -5926,7 +5795,6 @@
     "qualityId": "275",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of inflammatory bowel disease (IBD) who had Hepatitis B Virus (HBV) status assessed and results interpreted within one year prior to receiving a first course of anti-TNF (tumor necrosis factor) therapy",
@@ -5945,7 +5813,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Inflammatory Bowel Disease (IBD): Preventive Care: Corticosteroid Related Iatrogenic Injury - Bone Loss Assessment",
     "description": "Percentage of patients aged 18 years and older with an inflammatory bowel disease encounter who were prescribed prednisone equivalents greater than or equal to 10 mg/day for 60 or greater consecutive days or a single prescription equating to 600 mg prednisone or greater for all fills and were documented for risk of bone loss once during the reporting year or the previous calendar year",
     "nationalQualityCode": "ECC",
@@ -5957,7 +5825,6 @@
     "qualityId": "271",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with an inflammatory bowel disease encounter who were prescribed prednisone equivalents greater than or equal to 10 mg/day for 60 or greater consecutive days or a single prescription equating to 600 mg prednisone or greater for all fills and were documented for risk of bone loss once during the reporting year or the previous calendar year",
@@ -5976,7 +5843,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Initiation and Engagement of Alcohol and Other Drug Dependence Treatment",
     "description": "Percentage of patients 13 years of age and older with a new episode of alcohol and other drug (AOD) dependence who received the following. Two rates are reported.\na. Percentage of patients who initiated treatment within 14 days of the diagnosis.\nb. Percentage of patients who initiated treatment and who had two or more additional services with an AOD diagnosis within 30 days of the initiation visit.\n",
     "nationalQualityCode": "ECC",
@@ -5988,7 +5855,6 @@
     "qualityId": "305",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
@@ -6000,7 +5866,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Ischemic Vascular Disease (IVD) All or None Outcome Measure (Optimal Control)",
     "description": "The IVD All-or-None Measure is one outcome measure (optimal control). The measure contains four goals. All four goals within a measure must be reached in order to meet that measure. The numerator for the all-or-none measure should be collected from the organization's total IVD denominator. All-or-None Outcome Measure (Optimal Control) - Using the IVD denominator optimal results include: \n<br/><ul><li> Most recent blood pressure (BP) measurement is less than 140/90 mm Hg -- And \n</li><li> Most recent tobacco status is Tobacco Free -- And \n</li><li> Daily Aspirin or Other Antiplatelet Unless Contraindicated -- And \n</li><li> Statin Use\n</li></ul>",
     "nationalQualityCode": "ECC",
@@ -6012,7 +5878,6 @@
     "qualityId": "441",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "The IVD All-or-None Measure is one outcome measure (optimal control). The measure contains four goals. All four goals within a measure must be reached in order to meet that measure. The numerator for the all-or-none measure should be collected from the organization's total IVD denominator. All-or-None Outcome Measure (Optimal Control) - Using the IVD denominator optimal results include: • Most recent blood pressure (BP) measurement is less than 140/90 mm Hg -- And • Most recent tobacco status is Tobacco Free -- And • Daily Aspirin or Other Antiplatelet Unless Contraindicated -- And • Statin Use",
@@ -6029,7 +5894,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Ischemic Vascular Disease (IVD): Use of Aspirin or Another Antiplatelet",
     "description": "Percentage of patients 18 years of age and older who were diagnosed with acute myocardial infarction (AMI), coronary artery bypass graft (CABG) or percutaneous coronary interventions (PCI) in the 12 months prior to the measurement period, or who had an active diagnosis of ischemic vascular disease (IVD) during the measurement period, and who had documentation of use of aspirin or another antiplatelet during the measurement period.",
     "nationalQualityCode": "ECC",
@@ -6041,7 +5906,6 @@
     "qualityId": "204",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients 18 years of age and older who were diagnosed with acute myocardial infarction (AMI), coronary artery bypass graft (CABG) or percutaneous coronary interventions (PCI) in the 12 months prior to the measurement period, or who had an active diagnosis of ischemic vascular disease (IVD) during the measurement period, and who had documentation of use of aspirin or another antiplatelet during the measurement period",
@@ -6065,7 +5929,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "KRAS Gene Mutation Testing Performed for Patients with Metastatic Colorectal Cancer who receive Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibody Therapy",
     "description": "Percentage of adult patients (aged 18 or over) with metastatic colorectal cancer who receive anti-epidermal growth factor receptor monoclonal antibody therapy for whom KRAS gene mutation testing was performed",
     "nationalQualityCode": "ECC",
@@ -6077,7 +5941,6 @@
     "qualityId": "451",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of adult patients (aged 18 or over) with metastatic colorectal cancer who receive anti-epidermal growth factor receptor monoclonal antibody therapy for whom KRAS gene mutation testing was performed",
@@ -6096,7 +5959,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Lung Cancer Reporting (Biopsy/Cytology Specimens)",
     "description": "Pathology reports based on biopsy and/or cytology specimens with a diagnosis of primary non-small cell lung cancer classified into specific histologic type or classified as NSCLC-NOS with an explanation included in the pathology report",
     "nationalQualityCode": "CCC",
@@ -6108,7 +5971,6 @@
     "qualityId": "395",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Pathology reports based on biopsy and/or cytology specimens with a diagnosis of primary non-small cell lung cancer classified into specific histologic type or classified as NSCLC-NOS with an explanation included in the pathology report",
@@ -6128,7 +5990,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Lung Cancer Reporting (Resection Specimens)",
     "description": "Pathology reports based on resection specimens with a diagnosis of primary lung carcinoma that include the pT category, pN category and for non-small cell lung cancer, histologic type",
     "nationalQualityCode": "CCC",
@@ -6140,7 +6002,6 @@
     "qualityId": "396",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Pathology reports based on resection specimens with a diagnosis of primary lung carcinoma that include the pT category, pN category and for non-small cell lung cancer, histologic type",
@@ -6160,7 +6021,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Maternal Depression Screening",
     "description": "The percentage of children who turned 6 months of age during the measurement year, who had a face-to-face visit between the clinician and the child during child's first 6 months, and who had a maternal depression screening for the mother at least once between 0 and 6 months of life.\n",
     "nationalQualityCode": "CPH",
@@ -6172,7 +6033,6 @@
     "qualityId": "372",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
@@ -6184,7 +6044,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Maternity Care: Elective Delivery or Early Induction Without Medical Indication at >= 37 and < 39 Weeks (Overuse)",
     "description": "Percentage of patients, regardless of age, who gave birth during a 12-month period who delivered a live singleton at\n>= 37 and < 39 weeks of gestation completed who had elective deliveries or early inductions without medical indication\n",
     "nationalQualityCode": "PS",
@@ -6196,7 +6056,6 @@
     "qualityId": "335",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients, regardless of age, who gave birth during a 12-month period who delivered a live singleton at ≥ 37 and < 39 weeks of gestation completed who had elective deliveries or early inductions without medical indication",
@@ -6213,7 +6072,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Maternity Care: Post-Partum Follow-Up and Care Coordination",
     "description": "Percentage of patients, regardless of age, who gave birth during a 12-month period who were seen for post-partum care within 8 weeks of giving birth who received a breast feeding evaluation and education, post-partum depression screening, post-partum glucose screening for gestational diabetes patients, and family and contraceptive planning",
     "nationalQualityCode": "CCC",
@@ -6225,7 +6084,6 @@
     "qualityId": "336",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients, regardless of age, who gave birth during a 12-month period who were seen for post-partum care within 8 weeks of giving birth who received a breast feeding evaluation and education, post-partum depression screening, post-partum glucose screening for gestational diabetes patients, and family and contraceptive planning",
@@ -6242,7 +6100,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Medication Management for People with Asthma",
     "description": "The percentage of patients 5-64 years of age during the measurement year who were identified as having persistent asthma and were dispensed appropriate medications that they remained on for at least 75% of their treatment period",
     "nationalQualityCode": "ECR",
@@ -6254,7 +6112,6 @@
     "qualityId": "444",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "The percentage of patients 5-64 years of age during the measurement year who were identified as having persistent asthma and were dispensed appropriate medications that they remained on for at least 75% of their treatment period",
@@ -6275,7 +6132,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "multiPerformanceRate",
     "title": "Medication Reconciliation Post-Discharge",
     "description": "The percentage of discharges from any inpatient facility (e.g. hospital, skilled nursing facility, or rehabilitation facility) for patients 18 years and older of age seen within 30 days following discharge in the office by the physician, prescribing practitioner, registered nurse, or clinical pharmacist providing on-going care for whom the discharge medication list was reconciled with the current medication list in the outpatient medical record.\nThis measure is reported as three rates stratified by age group:\n<br/><ul><li> Reporting Criteria 1: 18-64 years of age\n</li><li> Reporting Criteria 2: 65 years and older\n</li><li> Total Rate: All patients 18 years of age and older\n</li></ul>",
     "nationalQualityCode": "CCC",
@@ -6287,7 +6144,6 @@
     "qualityId": "046",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Performance Rate 1: Percentage of discharges from any inpatient facility (e.g., hospital, skilled nursing facility, or rehabilitation facility) for patients 18-64 years of age seen within 30 days following discharge in the office by the physician, prescribing practitioner, registered nurse, or clinical pharmacist providing on- going care for whom the discharge medication list was reconciled with the current medication list in the outpatient medical record",
@@ -6308,13 +6164,14 @@
       "cmsWebInterface",
       "registry"
     ],
-    "measureSets": []
+    "measureSets": [],
+    "overallAlgorithm": "simpleAverage"
   },
   {
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Melanoma: Continuity of Care - Recall System",
     "description": "Percentage of patients, regardless of age, with a current diagnosis of melanoma or a history of melanoma whose information was entered, at least once within a 12 month period, into a recall system that includes:\n<br/><ul><li> A target date for the next complete physical skin exam, AND\n</li><li> A process to follow up with patients who either did not make an appointment within the specified timeframe or who missed a scheduled appointment\n</li></ul>",
     "nationalQualityCode": "CCC",
@@ -6326,7 +6183,6 @@
     "qualityId": "137",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients, regardless of age, with a current diagnosis of melanoma or a history of melanoma whose information was entered, at least once within a 12 month period, into a recall system that includes: • A target date for the next complete physical skin exam, • A process to follow up with patients who either did not make an appointment within the specified timeframe or who missed a scheduled appointment",
@@ -6345,7 +6201,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Melanoma: Coordination of Care",
     "description": "Percentage of patient visits, regardless of age, with a new occurrence of melanoma who have a treatment plan documented in the chart that was communicated to the physician(s) providing continuing care within one month of diagnosis",
     "nationalQualityCode": "CCC",
@@ -6357,7 +6213,6 @@
     "qualityId": "138",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patient visits, regardless of age, with a new occurrence of melanoma that have a treatment plan documented in the chart that was communicated to the physician(s) providing continuing care within one month of diagnosis",
@@ -6376,7 +6231,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Melanoma: Overutilization of Imaging Studies in Melanoma",
     "description": "Percentage of patients, regardless of age, with a current diagnosis of Stage 0 through IIC melanoma or a history of melanoma of any stage, without signs or symptoms suggesting systemic spread, seen for an office visit during the one-year measurement period, for whom no diagnostic imaging studies were ordered",
     "nationalQualityCode": "ECR",
@@ -6388,7 +6243,6 @@
     "qualityId": "224",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients, regardless of age, with a current diagnosis of Stage 0 through IIC melanoma or a history of melanoma of any stage, without signs or symptoms suggesting systemic spread, seen for an office visit during the one- year measurement period, for whom no diagnostic imaging studies were ordered",
@@ -6407,7 +6261,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Melanoma Reporting",
     "description": "Pathology reports for primary malignant cutaneous melanoma that include the pT category and a statement on thickness and ulceration and for pT1, mitotic rate",
     "nationalQualityCode": "CCC",
@@ -6419,7 +6273,6 @@
     "qualityId": "397",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Pathology reports for primary malignant cutaneous melanoma that include the pT category and a statement on thickness and ulceration and for pT1, mitotic rate",
@@ -6439,7 +6292,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Non-Recommended Cervical Cancer Screening in Adolescent Females",
     "description": "The percentage of adolescent females 16-20 years of age who were screened unnecessarily for cervical cancer",
     "nationalQualityCode": "PS",
@@ -6451,7 +6304,6 @@
     "qualityId": "443",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "The percentage of adolescent females 16–20 years of age who were screened unnecessarily for cervical cancer",
@@ -6471,7 +6323,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Nuclear Medicine: Correlation with Existing Imaging Studies for All Patients Undergoing Bone Scintigraphy",
     "description": "Percentage of final reports for all patients, regardless of age, undergoing bone scintigraphy that include physician documentation of correlation with existing relevant imaging studies (e.g., x-ray, MRI, CT, etc.) that were performed",
     "nationalQualityCode": "CCC",
@@ -6483,7 +6335,6 @@
     "qualityId": "147",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of final reports for all patients, regardless of age, undergoing bone scintigraphy that include physician documentation of correlation with existing relevant imaging studies (e.g., x-ray, MRI, CT, etc.) that were performed",
@@ -6503,7 +6354,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Oncology: Medical and Radiation - Pain Intensity Quantified",
     "description": "Percentage of patient visits, regardless of patient age, with a diagnosis of cancer currently receiving chemotherapy or radiation therapy in which pain intensity is quantified",
     "nationalQualityCode": "PCCEO",
@@ -6515,7 +6366,6 @@
     "qualityId": "143",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patient visits, regardless of patient age, with a diagnosis of cancer currently receiving chemotherapy or radiation therapy in which pain intensity is quantified",
@@ -6536,7 +6386,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Oncology: Medical and Radiation - Plan of Care for Pain",
     "description": "Percentage of visits for patients, regardless of age, with a diagnosis of cancer currently receiving chemotherapy or radiation therapy who report having pain with a documented plan of care to address pain",
     "nationalQualityCode": "PCCEO",
@@ -6548,7 +6398,6 @@
     "qualityId": "144",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of visits for patients, regardless of age, with a diagnosis of cancer currently receiving chemotherapy or radiation therapy who report having pain with a documented plan of care to address pain",
@@ -6567,7 +6416,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Oncology: Radiation Dose Limits to Normal Tissues",
     "description": "Percentage of patients, regardless of age, with a diagnosis of breast, rectal, pancreatic or lung cancer receiving 3D conformal radiation therapy who had documentation in medical record that radiation dose limits to normal tissues were established prior to the initiation of a course of 3D conformal radiation for a minimum of two tissues",
     "nationalQualityCode": "PS",
@@ -6579,7 +6428,6 @@
     "qualityId": "156",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients, regardless of age, with a diagnosis of breast, rectal, pancreatic or lung cancer receiving 3D conformal radiation therapy who had documentation in medical record that radiation dose limits to normal tissues were established prior to the initiation of a course of 3D conformal radiation for a minimum of two tissues",
@@ -6599,7 +6447,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "One-Time Screening for Hepatitis C Virus (HCV) for Patients at Risk",
     "description": "Percentage of patients aged 18 years and older with one or more of the following: a history of injection drug use, receipt of a blood transfusion prior to 1992, receiving maintenance hemodialysis, OR birthdate in the years 1945-1965 who received one-time screening for hepatitis C virus (HCV) infection",
     "nationalQualityCode": "ECC",
@@ -6611,7 +6459,6 @@
     "qualityId": "400",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with one or more of the following: a history of injection drug use, receipt of a blood transfusion prior to 1992, receiving maintenance hemodialysis, birthdate in the years 1945-1965 who received one-time screening for hepatitis C virus (HCV) infection",
@@ -6631,7 +6478,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Operative Mortality Stratified by the Five STS-EACTS Mortality Categories",
     "description": "Percent of patients undergoing index pediatric and/or congenital heart surgery who die, including both 1) all deaths occurring during the hospitalization in which the procedure was performed, even if after 30 days (including patients transferred to other acute care facilities), and 2) those deaths occurring after discharge from the hospital, but within 30 days of the procedure, stratified by the five STAT Mortality Levels, a multi-institutional validated complexity stratification tool",
     "nationalQualityCode": "PS",
@@ -6643,7 +6490,6 @@
     "qualityId": "446",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percent of patients undergoing index pediatric and/or congenital heart surgery who die, including both 1) all deaths occurring during the hospitalization in which the procedure was performed, even if after 30 days (including patients transferred to other acute care facilities), and 2) those deaths occurring after discharge from the hospital, but within 30 days of the procedure, stratified by the five STAT Mortality Levels, a multi-institutional validated complexity stratification tool",
@@ -6660,7 +6506,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Opioid Therapy Follow-up Evaluation",
     "description": "All patients 18 and older prescribed opiates for longer than six weeks duration who had a follow-up evaluation conducted at least every three months during Opioid Therapy documented in the medical record",
     "nationalQualityCode": "ECC",
@@ -6672,7 +6518,6 @@
     "qualityId": "408",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "All patients 18 and older prescribed opiates for longer than six weeks duration who had a follow-up evaluation conducted at least every three months during Opioid Therapy documented in the medical record",
@@ -6694,7 +6539,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "multiPerformanceRate",
     "title": "Optimal Asthma Control",
     "description": "Composite measure of the percentage of pediatric and adult patients whose asthma is well-controlled as demonstrated by one of three age appropriate patient reported outcome tools and not at risk for exacerbation",
     "nationalQualityCode": "ECC",
@@ -6706,7 +6551,6 @@
     "qualityId": "398",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "weightedAverage",
     "strata": [
       {
         "description": "Overall Percentage for patients (aged 5-50 years) with well-controlled asthma, without elevated risk of exacerbation.",
@@ -6744,13 +6588,14 @@
     "measureSets": [
       "allergyImmunology",
       "generalPracticeFamilyMedicine"
-    ]
+    ],
+    "overallAlgorithm": "weightedAverage"
   },
   {
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Optimizing Patient Exposure to Ionizing Radiation: Appropriateness: Follow-up CT Imaging for Incidentally Detected Pulmonary Nodules According to Recommended Guidelines",
     "description": "Percentage of final reports for computed tomography (CT) imaging studies of the thorax for patients aged 18 years and older with documented follow-up recommendations for incidentally detected pulmonary nodules (e.g., follow-up CT imaging studies needed or that no follow-up is needed) based at a minimum on nodule size AND patient risk factors",
     "nationalQualityCode": "CCC",
@@ -6762,7 +6607,6 @@
     "qualityId": "364",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of final reports for computed tomography (CT) imaging studies of the thorax for patients aged 18 years and older with documented follow-up recommendations for incidentally detected pulmonary nodules (e.g., follow-up CT imaging studies needed or that no follow-up is needed) based at a minimum on nodule size patient risk factors",
@@ -6781,7 +6625,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Optimizing Patient Exposure to Ionizing Radiation: Computed Tomography (CT) Images Available for Patient Follow-up and Comparison Purposes",
     "description": "Percentage of final reports for computed tomography (CT) studies performed for all patients, regardless of age, which document that Digital Imaging and Communications in Medicine (DICOM) format image data are available to non-affiliated external healthcare facilities or entities on a secure, media free, reciprocally searchable basis with patient authorization for at least a 12-month period after the study",
     "nationalQualityCode": "CCC",
@@ -6793,7 +6637,6 @@
     "qualityId": "362",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of final reports for computed tomography (CT) studies performed for all patients, regardless of age, which document that Digital Imaging and Communications in Medicine (DICOM) format image data are available to non- affiliated external healthcare facilities or entities on a secure, media free, reciprocally searchable basis with patient authorization for at least a 12-month period after the study",
@@ -6812,7 +6655,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Optimizing Patient Exposure to Ionizing Radiation: Count of Potential High Dose Radiation Imaging Studies: Computed Tomography (CT) and Cardiac Nuclear Medicine Studies",
     "description": "Percentage of computed tomography (CT) and cardiac nuclear medicine (myocardial perfusion studies) imaging reports for all patients, regardless of age, that document a count of known previous CT (any type of CT) and cardiac nuclear medicine (myocardial perfusion) studies that the patient has received in the 12-month period prior to the current study",
     "nationalQualityCode": "PS",
@@ -6824,7 +6667,6 @@
     "qualityId": "360",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of computed tomography (CT) and cardiac nuclear medicine (myocardial perfusion studies) imaging reports for all patients, regardless of age, that document a count of known previous CT (any type of CT) and cardiac nuclear medicine (myocardial perfusion) studies that the patient has received in the 12-month period prior to the current study",
@@ -6843,7 +6685,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Optimizing Patient Exposure to Ionizing Radiation: Reporting to a Radiation Dose Index Registry",
     "description": "Percentage of total computed tomography (CT) studies performed for all patients, regardless of age, that are reported to a radiation dose index registry that is capable of collecting at a minimum selected data elements",
     "nationalQualityCode": "PS",
@@ -6855,7 +6697,6 @@
     "qualityId": "361",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of total computed tomography (CT) studies performed for all patients, regardless of age, that are reported to a radiation dose index registry that is capable of collecting at a minimum selected data elements",
@@ -6874,7 +6715,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Optimizing Patient Exposure to Ionizing Radiation: Search for Prior Computed Tomography (CT) Studies Through a Secure, Authorized, Media-Free, Shared Archive",
     "description": "Percentage of final reports of computed tomography (CT) studies performed for all patients, regardless of age, which document that a search for Digital Imaging and Communications in Medicine (DICOM) format images was conducted for prior patient CT imaging studies completed at non-affiliated external healthcare facilities or entities within the past 12-months and are available through a secure, authorized, media-free, shared archive prior to an imaging study being performed",
     "nationalQualityCode": "CCC",
@@ -6886,7 +6727,6 @@
     "qualityId": "363",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of final reports of computed tomography (CT) studies performed for all patients, regardless of age, which document that a search for Digital Imaging and Communications in Medicine (DICOM) format images was conducted for prior patient CT imaging studies completed at non-affiliated external healthcare facilities or entities within the past 12-months and are available through a secure, authorized, media-free, shared archive prior to an imaging study being performed",
@@ -6905,7 +6745,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Optimizing Patient Exposure to Ionizing Radiation: Utilization of a Standardized Nomenclature for Computed Tomography (CT) Imaging Description",
     "description": "Percentage of computed tomography (CT) imaging reports for all patients, regardless of age, with the imaging study named according to a standardized nomenclature and the standardized nomenclature is used in institution's computer systems",
     "nationalQualityCode": "CCC",
@@ -6917,7 +6757,6 @@
     "qualityId": "359",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of computed tomography (CT) imaging reports for all patients, regardless of age, with the imaging study named according to a standardized nomenclature and the standardized nomenclature is used in institution’s computer systems",
@@ -6936,7 +6775,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Osteoarthritis (OA): Function and Pain Assessment",
     "description": "Percentage of patient visits for patients aged 21 years and older with a diagnosis of osteoarthritis (OA) with assessment for function and pain",
     "nationalQualityCode": "PCCEO",
@@ -6948,7 +6787,6 @@
     "qualityId": "109",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patient visits for patients aged 21 years and older with a diagnosis of osteoarthritis (OA) with assessment for function and pain",
@@ -6972,7 +6810,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Osteoporosis Management in Women Who Had a Fracture",
     "description": "The percentage of women age 50-85 who suffered a fracture and who either had a bone mineral density test or received a prescription for a drug to treat osteoporosis in the six months after the fracture",
     "nationalQualityCode": "ECC",
@@ -6984,7 +6822,6 @@
     "qualityId": "418",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "The percentage of women age 50-85 who suffered a fracture and who either had a bone mineral density test or received a prescription for a drug to treat osteoporosis in the six months after the fracture",
@@ -7006,7 +6843,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Overuse Of Neuroimaging For Patients With Primary Headache And A Normal Neurological Examination",
     "description": "Percentage of patients with a diagnosis of primary headache disorder whom advanced brain imaging was not ordered",
     "nationalQualityCode": "ECR",
@@ -7018,7 +6855,6 @@
     "qualityId": "419",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients with a diagnosis of primary headache disorder whom advanced brain imaging was not ordered",
@@ -7038,7 +6874,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Pain Assessment and Follow-Up",
     "description": "Percentage of visits for patients aged 18 years and older with documentation of a pain assessment using a standardized tool(s) on each visit AND documentation of a follow-up plan when pain is present",
     "nationalQualityCode": "CCC",
@@ -7050,7 +6886,6 @@
     "qualityId": "131",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of visits for patients aged 18 years and older with documentation of a pain assessment using a standardized tool(s) on each visit documentation of a follow-up plan when pain is present",
@@ -7070,7 +6905,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Pain Brought Under Control Within 48 Hours",
     "description": "Patients aged 18 and older who report being uncomfortable because of pain at the initial assessment (after admission to palliative care services) that report pain was brought to a comfortable level within 48 hours",
     "nationalQualityCode": "PCCEO",
@@ -7082,7 +6917,6 @@
     "qualityId": "342",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Patients aged 18 and older who report being uncomfortable because of pain at the initial assessment (after admission to palliative care services) that report pain was brought to a comfortable level within 48 hours",
@@ -7101,7 +6935,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Parkinson's Disease: Cognitive Impairment or Dysfunction Assessment",
     "description": "All patients with a diagnosis of Parkinson's disease who were assessed for cognitive impairment or dysfunction  in the last 12 months",
     "nationalQualityCode": "ECC",
@@ -7113,7 +6947,6 @@
     "qualityId": "291",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "All patients with a diagnosis of Parkinson’s disease who were assessed for cognitive impairment or dysfunction in the last 12 months",
@@ -7132,7 +6965,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Parkinson's Disease: Parkinson's Disease Medical and Surgical Treatment Options Reviewed",
     "description": "All patients with a diagnosis of Parkinson's disease (or caregiver(s), as appropriate) who had the Parkinson's disease treatment options (e.g., non-pharmacological treatment, pharmacological treatment, or surgical treatment) reviewed at least annually",
     "nationalQualityCode": "CCC",
@@ -7144,7 +6977,6 @@
     "qualityId": "294",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "All patients with a diagnosis of Parkinson’s disease (or caregiver(s), as appropriate) who had the Parkinson’s disease treatment options (e.g., non-pharmacological treatment, pharmacological treatment, or surgical treatment) reviewed at least once annually",
@@ -7163,7 +6995,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Parkinson's Disease: Psychiatric Symptoms Assessment for Patients with Parkinson's Disease",
     "description": "All patients with a diagnosis of Parkinson's disease who were assessed for psychiatric symptoms (e.g., psychosis, depression, anxiety disorder, apathy, or impulse control disorder) in the last 12 months",
     "nationalQualityCode": "ECC",
@@ -7175,7 +7007,6 @@
     "qualityId": "290",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "All patients with a diagnosis of Parkinson’s disease who were assessed for psychiatric symptoms (e.g., psychosis, depression, anxiety disorder, apathy, or impulse control disorder) in the last 12 months",
@@ -7194,7 +7025,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Parkinson's Disease: Rehabilitative Therapy Options",
     "description": "All patients with a diagnosis of Parkinson's Disease (or caregiver(s), as appropriate) who had rehabilitative therapy options (e.g., physical, occupational, or speech therapy) discussed  in the last 12 months",
     "nationalQualityCode": "CCC",
@@ -7206,7 +7037,6 @@
     "qualityId": "293",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "All patients with a diagnosis of Parkinson’s Disease (or caregiver(s), as appropriate) who had rehabilitative therapy options (e.g., physical, occupational, or speech therapy) discussed in the last 12 months",
@@ -7225,7 +7055,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Patient-Centered Surgical Risk Assessment and Communication",
     "description": "Percentage of patients who underwent a non-emergency surgery who had their personalized risks of postoperative complications assessed by their surgical team prior to surgery using a clinical data-based, patient-specific risk calculator and who received personal discussion of those risks with the surgeon",
     "nationalQualityCode": "PCCEO",
@@ -7237,7 +7067,6 @@
     "qualityId": "358",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients who underwent a non-emergency surgery who had their personalized risks of postoperative complications assessed by their surgical team prior to surgery using a clinical data-based, patient-specific risk calculator and who received personal discussion of those risks with the surgeon",
@@ -7261,7 +7090,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Patients with Metastatic Colorectal Cancer and KRAS Gene Mutation Spared Treatment with Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibodies",
     "description": "Percentage of adult patients (aged 18 or over) with metastatic colorectal cancer and KRAS gene mutation spared treatment with anti-EGFR monoclonal antibodies",
     "nationalQualityCode": "PS",
@@ -7273,7 +7102,6 @@
     "qualityId": "452",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of adult patients (aged 18 or over) with metastatic colorectal cancer and KRAS gene mutation spared treatment with anti-EGFR monoclonal antibodies",
@@ -7292,7 +7120,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Pediatric Kidney Disease: Adequacy of Volume Management",
     "description": "Percentage of calendar months within a 12-month period during which patients aged 17 years and younger with a diagnosis of End Stage Renal Disease (ESRD) undergoing maintenance hemodialysis in an outpatient dialysis facility have an assessment of the adequacy of volume management from a nephrologist",
     "nationalQualityCode": "ECC",
@@ -7304,7 +7132,6 @@
     "qualityId": "327",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of calendar months within a 12-month period during which patients aged 17 years and younger with a diagnosis of End Stage Renal Disease (ESRD) undergoing maintenance hemodialysis in an outpatient dialysis facility have an assessment of the adequacy of volume management from a nephrologist",
@@ -7321,7 +7148,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Pediatric Kidney Disease: ESRD Patients Receiving Dialysis: Hemoglobin Level < 10 g/dL",
     "description": "Percentage of calendar months within a 12-month period during which patients aged 17 years and younger with a diagnosis of End Stage Renal Disease (ESRD) receiving hemodialysis or peritoneal dialysis have a hemoglobin level < 10 g/dL",
     "nationalQualityCode": "ECC",
@@ -7333,7 +7160,6 @@
     "qualityId": "328",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of calendar months within a 12-month period during which patients aged 17 years and younger with a diagnosis of End Stage Renal Disease (ESRD) receiving hemodialysis or peritoneal dialysis have a hemoglobin level < 10 g/dL",
@@ -7350,7 +7176,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Pelvic Organ Prolapse: Preoperative Assessment of Occult Stress Urinary Incontinence",
     "description": "Percentage of patients undergoing appropriate preoperative evaluation of stress urinary incontinence prior to pelvic organ prolapse surgery per ACOG/AUGS/AUA guidelines",
     "nationalQualityCode": "ECC",
@@ -7362,7 +7188,6 @@
     "qualityId": "428",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients undergoing appropriate preoperative evaluation of stress urinary incontinence prior to pelvic organ prolapse surgery per ACOG/AUGS/AUA guidelines",
@@ -7379,7 +7204,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Pelvic Organ Prolapse: Preoperative Screening for Uterine Malignancy",
     "description": "Percentage of patients who are screened for uterine malignancy prior to vaginal closure or obliterative surgery for pelvic organ prolapse",
     "nationalQualityCode": "PS",
@@ -7391,7 +7216,6 @@
     "qualityId": "429",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients who are screened for uterine malignancy prior to vaginal closure or obliterative surgery for pelvic organ prolapse",
@@ -7409,7 +7233,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Performing Cystoscopy at the Time of Hysterectomy for Pelvic Organ Prolapse to Detect Lower Urinary Tract Injury",
     "description": "Percentage of patients who undergo cystoscopy to evaluate for lower urinary tract injury at the time of hysterectomy for pelvic organ prolapse",
     "nationalQualityCode": "PS",
@@ -7421,7 +7245,6 @@
     "qualityId": "422",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients who undergo cystoscopy to evaluate for lower urinary tract injury at the time of hysterectomy for pelvic organ prolapse",
@@ -7441,7 +7264,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Perioperative Anti-platelet Therapy for Patients Undergoing Carotid Endarterectomy",
     "description": "Percentage of patients undergoing carotid endarterectomy (CEA) who are taking an anti-platelet agent within 48 hours prior to surgery and are prescribed this medication at hospital discharge following surgery",
     "nationalQualityCode": "ECC",
@@ -7453,7 +7276,6 @@
     "qualityId": "423",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients undergoing carotid endarterectomy (CEA) who are taking an anti-platelet agent within 48 hours prior to surgery and are prescribed this medication at hospital discharge following surgery",
@@ -7471,7 +7293,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Perioperative Care: Selection of Prophylactic Antibiotic - First OR Second Generation Cephalosporin",
     "description": "Percentage of surgical patients aged 18 years and older undergoing procedures with the indications for a first OR second generation cephalosporin prophylactic antibiotic who had an order for a first OR second generation cephalosporin for antimicrobial prophylaxis",
     "nationalQualityCode": "PS",
@@ -7483,7 +7305,6 @@
     "qualityId": "021",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of surgical patients aged 18 years and older undergoing procedures with the indications for a first second generation cephalosporin prophylactic antibiotic who had an order for a first OR second generation cephalosporin for antimicrobial prophylaxis",
@@ -7507,7 +7328,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Perioperative Care: Venous Thromboembolism (VTE) Prophylaxis (When Indicated in ALL Patients)",
     "description": "Percentage of surgical patients aged 18 years and older undergoing procedures for which venous thromboembolism (VTE) prophylaxis is indicated in all patients, who had an order for Low Molecular Weight Heparin (LMWH), Low- Dose Unfractionated Heparin (LDUH), adjusted-dose warfarin, fondaparinux or mechanical prophylaxis to be given within 24 hours prior to incision time or within 24 hours after surgery end time",
     "nationalQualityCode": "PS",
@@ -7519,7 +7340,6 @@
     "qualityId": "023",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of surgical patients aged 18 years and older undergoing procedures for which venous thromboembolism (VTE) prophylaxis is indicated in all patients, who had an order for Low Molecular Weight Heparin (LMWH), Low- Dose Unfractionated Heparin (LDUH), adjusted-dose warfarin, fondaparinux or mechanical prophylaxis to be given within 24 hours prior to incision time or within 24 hours after surgery end time",
@@ -7543,7 +7363,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Perioperative Temperature Management",
     "description": "Percentage of patients, regardless of age, who undergo surgical or therapeutic procedures under general or neuraxial anesthesia of 60 minutes duration or longer for whom at least one body temperature greater than or equal to 35.5 degrees Celsius (or 95.9 degrees Fahrenheit) was recorded within the 30 minutes immediately before or the 15 minutes immediately after anesthesia end time",
     "nationalQualityCode": "PS",
@@ -7555,7 +7375,6 @@
     "qualityId": "424",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients, regardless of age, who undergo surgical or therapeutic procedures under general or neuraxial anesthesia of 60 minutes duration or longer for whom at least one body temperature greater than or equal to 35.5 degrees Celsius (or 95.9 degrees Fahrenheit) was recorded within the 30 minutes immediately before or the 15 minutes immediately after anesthesia end time",
@@ -7574,7 +7393,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Persistence of Beta-Blocker Treatment After a Heart Attack",
     "description": "The percentage of patients 18 years of age and older during the measurement year who were hospitalized and discharged from July 1 of the year prior to the measurement year to June 30 of the measurement year with a diagnosis of acute myocardial infarction (AMI) and who were prescribed persistent beta-blocker treatment for six months after discharge",
     "nationalQualityCode": "ECC",
@@ -7586,7 +7405,6 @@
     "qualityId": "442",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "The percentage of patients 18 years of age and older during the measurement year who were hospitalized and discharged from July 1 of the year prior to the measurement year to June 30 of the measurement year with a diagnosis of acute myocardial infarction (AMI) and who were prescribed persistent beta-blocker treatment for six months after discharge",
@@ -7605,7 +7423,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Photodocumentation of Cecal Intubation",
     "description": "The rate of screening and surveillance colonoscopies for which photodocumentation of landmarks of cecal intubation is performed to establish a complete examination",
     "nationalQualityCode": "ECC",
@@ -7617,7 +7435,6 @@
     "qualityId": "425",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "The rate of screening and surveillance colonoscopies for which photodocumentation of landmarks of cecal intubation is performed to establish a complete examination",
@@ -7635,7 +7452,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Pneumococcal Vaccination Status for Older Adults",
     "description": "Percentage of patients 65 years of age and older who have ever received a pneumococcal vaccine.",
     "nationalQualityCode": "CPH",
@@ -7647,7 +7464,6 @@
     "qualityId": "111",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients 65 years of age and older who have ever received a pneumococcal vaccine",
@@ -7670,7 +7486,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Post-Anesthetic Transfer of Care Measure: Procedure Room to a Post Anesthesia Care Unit (PACU)",
     "description": "Percentage of patients, regardless of age, who are under the care of an anesthesia practitioner and are admitted to a PACU in which a post-anesthetic formal transfer of care protocol or checklist which includes the key transfer of care elements is utilized",
     "nationalQualityCode": "CCC",
@@ -7682,7 +7498,6 @@
     "qualityId": "426",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients, regardless of age, who are under the care of an anesthesia practitioner and are admitted to a PACU in which a post-anesthetic formal transfer of care protocol or checklist which includes the key transfer of care elements is utilized",
@@ -7701,7 +7516,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Post-Anesthetic Transfer of Care: Use of Checklist or Protocol for Direct Transfer of Care from Procedure Room to Intensive Care Unit (ICU)",
     "description": "Percentage of patients, regardless of age, who undergo a procedure under anesthesia and are admitted to an Intensive Care Unit (ICU) directly from the anesthetizing location, who have a documented use of a checklist or protocol for the transfer of care from the responsible anesthesia practitioner to the responsible ICU team or team member",
     "nationalQualityCode": "CCC",
@@ -7713,7 +7528,6 @@
     "qualityId": "427",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients, regardless of age, who undergo a procedure under anesthesia and are admitted to an Intensive Care Unit (ICU) directly from the anesthetizing location, who have a documented use of a checklist or protocol for the transfer of care from the responsible anesthesia practitioner to the responsible ICU team or team member",
@@ -7732,7 +7546,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Pregnant women that had HBsAg testing",
     "description": "This measure identifies pregnant women who had a HBsAg (hepatitis B) test during their pregnancy",
     "nationalQualityCode": "ECC",
@@ -7744,7 +7558,6 @@
     "qualityId": "369",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "OptumInsight",
     "submissionMethods": [
@@ -7756,7 +7569,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Preoperative Diagnosis of Breast Cancer",
     "description": "The percent of patients undergoing breast cancer operations who obtained the diagnosis of breast cancer preoperatively by a minimally invasive biopsy method",
     "nationalQualityCode": "ECC",
@@ -7768,7 +7581,6 @@
     "qualityId": "263",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "The percent of patients undergoing breast cancer operations who obtained the diagnosis of breast cancer preoperatively by a minimally invasive biopsy method",
@@ -7785,7 +7597,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Prevention of Central Venous Catheter (CVC) - Related Bloodstream Infections",
     "description": "Percentage of patients, regardless of age, who undergo central venous catheter (CVC) insertion for whom CVC was inserted with all elements of maximal sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound techniques followed",
     "nationalQualityCode": "PS",
@@ -7797,7 +7609,6 @@
     "qualityId": "076",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients, regardless of age, who undergo central venous catheter (CVC) insertion for whom CVC was inserted with all elements of maximal sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound techniques followed",
@@ -7818,7 +7629,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Prevention of Post-Operative Nausea and Vomiting (PONV) - Combination Therapy",
     "description": "Percentage of patients, aged 18 years and older, who undergo a procedure under an inhalational general anesthetic, AND who have three or more risk factors for post-operative nausea and vomiting (PONV), who receive combination therapy consisting of at least two prophylactic pharmacologic antiemetic agents of different classes preoperatively or intraoperatively",
     "nationalQualityCode": "PS",
@@ -7830,7 +7641,6 @@
     "qualityId": "430",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients, aged 18 years and older, who undergo a procedure under an inhalational general anesthetic, who have three or more risk factors for post-operative nausea and vomiting (PONV), who receive combination therapy consisting of at least two prophylactic pharmacologic antiemetic agents of different classes preoperatively or intraoperatively",
@@ -7849,7 +7659,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan",
     "description": "Percentage of patients aged 18 years and older with a BMI documented during the current encounter or during the previous six months AND with a BMI outside of normal parameters, a follow-up plan is documented during the encounter or during the previous six months of the current encounter  \n\nNormal Parameters:       Age 18 years and older BMI => 18.5 and < 25 kg/m2",
     "nationalQualityCode": "CPH",
@@ -7861,7 +7671,6 @@
     "qualityId": "128",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a BMI documented during the current encounter or during the previous six months with a BMI outside of normal parameters, a follow-up plan is documented during the encounter or during the previous six months of the current encounter Normal Parameters: Age 18 years and older BMI ≥ 18.5 and < 25 kg/m2",
@@ -7898,7 +7707,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Preventive Care and Screening: Influenza Immunization",
     "description": "Percentage of patients aged 6 months and older seen for a visit between October 1 and March 31 who received an influenza immunization OR who reported previous receipt of an influenza immunization",
     "nationalQualityCode": "CPH",
@@ -7910,7 +7719,6 @@
     "qualityId": "110",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 6 months and older seen for a visit between October 1 and March 31 who received an influenza immunization who reported previous receipt of an influenza immunization",
@@ -7937,7 +7745,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Preventive Care and Screening: Screening for Clinical Depression and Follow-Up Plan",
     "description": "Percentage of patients aged 12 years and older screened for depression on the date of the encounter using an age appropriate standardized depression screening tool AND if positive, a follow-up plan is documented on the date of the positive screen",
     "nationalQualityCode": "CPH",
@@ -7949,7 +7757,6 @@
     "qualityId": "134",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 12 years and older screened for depression on the date of the encounter using an age appropriate standardized depression screening tool if positive, a follow-up plan is documented on the date of the positive screen",
@@ -7974,7 +7781,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented",
     "description": "Percentage of patients aged 18 years and older seen during the reporting period who were screened for high blood pressure AND a recommended follow-up plan is documented based on the current blood pressure (BP) reading as indicated",
     "nationalQualityCode": "CPH",
@@ -7986,7 +7793,6 @@
     "qualityId": "317",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older seen during the reporting period who were screened for high blood pressure a recommended follow-up plan is documented based on the current blood pressure (BP) reading as indicated",
@@ -8030,7 +7836,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention",
     "description": "Percentage of patients aged 18 years and older who were screened for tobacco use one or more times within 24 months AND who received cessation counseling intervention if identified as a tobacco user",
     "nationalQualityCode": "CPH",
@@ -8042,7 +7848,6 @@
     "qualityId": "226",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older who were screened for tobacco use one or more times within 24 months who received cessation counseling intervention if identified as a tobacco user",
@@ -8086,7 +7891,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Preventive Care and Screening: Unhealthy Alcohol Use: Screening & Brief Counseling",
     "description": "Percentage of patients aged 18 years and older who were screened for unhealthy alcohol use using a systematic screening method at least once within the last 24 months AND who received brief counseling if identified as an unhealthy alcohol user",
     "nationalQualityCode": "CPH",
@@ -8098,7 +7903,6 @@
     "qualityId": "431",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older who were screened for unhealthy alcohol use using a systematic screening method at least once within the last 24 months who received brief counseling if identified as an unhealthy alcohol user",
@@ -8129,7 +7933,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Primary Caries Prevention Intervention as Offered by Primary Care Providers, including Dentists",
     "description": "Percentage of children, age 0-20 years, who received a fluoride varnish application during the measurement period.",
     "nationalQualityCode": "ECC",
@@ -8141,7 +7945,6 @@
     "qualityId": "379",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
@@ -8155,7 +7958,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of primary open-angle glaucoma (POAG) who have an optic nerve head evaluation during one or more office visits within 12 months",
     "nationalQualityCode": "ECC",
@@ -8167,7 +7970,6 @@
     "qualityId": "012",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of primary open-angle glaucoma (POAG) who have an optic nerve head evaluation during one or more office visits within 12 months",
@@ -8188,7 +7990,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of primary open-angle glaucoma (POAG) whose glaucoma treatment has not failed (the most recent IOP was reduced by at least 15% from the pre-intervention level) OR if the most recent IOP was not reduced by at least 15% from the pre-intervention level, a plan of care was documented within 12 months",
     "nationalQualityCode": "CCC",
@@ -8200,7 +8002,6 @@
     "qualityId": "141",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of primary open-angle glaucoma (POAG) whose glaucoma treatment has not failed (the most recent IOP was reduced by at least 15% from the pre-intervention level) if the most recent IOP was not reduced by at least 15% from the pre-intervention level, a plan of care was documented within 12 months",
@@ -8220,7 +8021,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Proportion Admitted to Hospice for less than 3 days",
     "description": "Proportion of patients who died from cancer, and admitted to hospice and spent less than 3 days there",
     "nationalQualityCode": "ECC",
@@ -8232,7 +8033,6 @@
     "qualityId": "457",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Proportion of patients who died from cancer, and admitted to hospice and spent less than 3 days there",
@@ -8251,7 +8051,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Proportion Admitted to the Intensive Care Unit (ICU) in the Last 30 Days of Life",
     "description": "Proportion of patients who died from cancer admitted to the ICU in the last 30 days of life",
     "nationalQualityCode": "ECC",
@@ -8263,7 +8063,6 @@
     "qualityId": "455",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Proportion of patients who died from cancer admitted to the ICU in the last 30 days of life",
@@ -8282,7 +8081,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Proportion Not Admitted To Hospice",
     "description": "Proportion  of patients who died from cancer not admitted to hospice",
     "nationalQualityCode": "ECC",
@@ -8294,7 +8093,6 @@
     "qualityId": "456",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Proportion of patients who died from cancer not admitted to hospice",
@@ -8313,7 +8111,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Proportion of Patients Sustaining a Bladder Injury at the Time of any Pelvic Organ Prolapse Repair",
     "description": "Percentage of patients undergoing any surgery to repair pelvic organ prolapse who sustains an injury to the bladder recognized either during or within 1 month after surgery",
     "nationalQualityCode": "PS",
@@ -8325,7 +8123,6 @@
     "qualityId": "432",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients undergoing any surgery to repair pelvic organ prolapse who sustains an injury to the bladder recognized either during or within 1 month after surgery",
@@ -8344,7 +8141,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Proportion of Patients Sustaining a Bowel Injury at the time of any Pelvic Organ Prolapse Repair",
     "description": "Percentage of patients undergoing surgical repair of pelvic organ prolapse that is complicated by a bowel injury at the time of index surgery that is recognized intraoperatively or within 1 month after surgery",
     "nationalQualityCode": "PS",
@@ -8356,7 +8153,6 @@
     "qualityId": "433",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients undergoing surgical repair of pelvic organ prolapse that is complicated by a bowel injury at the time of index surgery that is recognized intraoperatively or within 1 month after surgery",
@@ -8375,7 +8171,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Proportion of Patients Sustaining a Ureter Injury at the Time of any Pelvic Organ Prolapse Repair",
     "description": "Percentage of patients undergoing pelvic organ prolapse repairs who sustain an injury to the ureter recognized either during or within 1 month after surgery",
     "nationalQualityCode": "PS",
@@ -8387,7 +8183,6 @@
     "qualityId": "434",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients undergoing pelvic organ prolapse repairs who sustain an injury to the ureter recognized either during or within 1 month after surgery",
@@ -8406,7 +8201,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Proportion of Patients who Died from Cancer with more than One Emergency Department Visit in the Last 30 Days of Life",
     "description": "Proportion of patients who died from cancer with more than one emergency department visit in the last 30 days of life",
     "nationalQualityCode": "ECC",
@@ -8418,7 +8213,6 @@
     "qualityId": "454",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Proportion of patients who died from cancer with more than one emergency department visit in the last 30 days of life",
@@ -8437,7 +8231,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Proportion Receiving Chemotherapy in the Last 14 Days of Life",
     "description": "Proportion of patients who died from cancer receiving chemotherapy in the last 14 days of life",
     "nationalQualityCode": "ECC",
@@ -8449,7 +8243,6 @@
     "qualityId": "453",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Proportion of patients who died from cancer receiving chemotherapy in the last 14 days of life",
@@ -8468,7 +8261,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Prostate Cancer: Adjuvant Hormonal Therapy for High Risk or Very High Risk Prostate Cancer",
     "description": "Percentage of patients, regardless of age, with a diagnosis of prostate cancer at high or very high risk of recurrence receiving external beam radiotherapy to the prostate who were prescribed adjuvant hormonal therapy (GnRH [gonadotropin-releasing hormone] agonist or antagonist)",
     "nationalQualityCode": "ECC",
@@ -8480,7 +8273,6 @@
     "qualityId": "104",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients, regardless of age, with a diagnosis of prostate cancer at high or very high risk of recurrence receiving external beam radiotherapy to the prostate who were prescribed adjuvant hormonal therapy (GnRH [gonadotropin-releasing hormone] agonist or antagonist)",
@@ -8499,7 +8291,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients",
     "description": "Percentage of patients, regardless of age, with a diagnosis of prostate cancer at low (or very low) risk of recurrence receiving interstitial prostate brachytherapy, OR external beam radiotherapy to the prostate, OR radical prostatectomy, OR cryotherapy who did not have a bone scan performed at any time since diagnosis of prostate cancer",
     "nationalQualityCode": "ECR",
@@ -8511,7 +8303,6 @@
     "qualityId": "102",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients, regardless of age, with a diagnosis of prostate cancer at low (or very low) risk of recurrence receiving interstitial prostate brachytherapy, external beam radiotherapy to the prostate, OR radical prostatectomy, OR cryotherapy who did not have a bone scan performed at any time since diagnosis of prostate cancer",
@@ -8533,7 +8324,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Psoriasis: Clinical Response to Oral Systemic or Biologic Medications",
     "description": "Percentage of psoriasis patients receiving oral systemic or biologic therapy who meet minimal physician-or patient- reported disease activity levels. It is implied that establishment and maintenance of an established minimum level of disease control as measured by physician-and/or patient-reported outcomes will increase patient satisfaction with and adherence to treatment",
     "nationalQualityCode": "PCCEO",
@@ -8545,7 +8336,6 @@
     "qualityId": "410",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of psoriasis patients receiving oral systemic or biologic therapy who meet minimal physician-or patient- reported disease activity levels. It is implied that establishment and maintenance of an established minimum level of disease control as measured by physician-and/or patient-reported outcomes will increase patient satisfaction with and adherence to treatment",
@@ -8565,7 +8355,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Quality of Life Assessment For Patients With Primary Headache Disorders",
     "description": "Percentage of patients with a diagnosis of primary headache disorder whose health related quality of life (HRQoL) was assessed with a tool(s) during at least two visits during the 12 month measurement period AND whose health related quality of life score stayed the same or improved",
     "nationalQualityCode": "ECC",
@@ -8577,7 +8367,6 @@
     "qualityId": "435",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients with a diagnosis of primary headache disorder whose health related quality of life (HRQoL) was assessed with a tool(s) during at least two visits during the 12 month measurement period whose health related quality of life score stayed the same or improved",
@@ -8597,7 +8386,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Quantitative Immunohistochemical (IHC) Evaluation of Human Epidermal Growth Factor Receptor 2 Testing (HER2) for Breast Cancer Patients",
     "description": "This is a measure based on whether quantitative evaluation of Human Epidermal Growth Factor Receptor 2 Testing (HER2) by immunohistochemistry (IHC) uses the system recommended in the current ASCO/CAP Guidelines for Human Epidermal Growth Factor Receptor 2 Testing in breast cancer",
     "nationalQualityCode": "ECC",
@@ -8609,7 +8398,6 @@
     "qualityId": "251",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "This is a measure based on whether quantitative evaluation of Human Epidermal Growth Factor Receptor 2 Testing (HER2) by immunohistochemistry (IHC) uses the system recommended in the current ASCO/CAP Guidelines for Human Epidermal Growth Factor Receptor 2 Testing in breast cancer",
@@ -8629,7 +8417,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Radiation Consideration for Adult CT: Utilization of Dose Lowering Techniques",
     "description": "Percentage of final reports for patients aged 18 years and older undergoing CT with documentation that one or more of the following dose reduction techniques were used:\n<br/><ul><li> Automated exposure control\n</li><li> Adjustment of the mA and/or kV according to patient size\n</li><li> Use of iterative reconstruction technique\n\n</li></ul>",
     "nationalQualityCode": "ECC",
@@ -8641,7 +8429,6 @@
     "qualityId": "436",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of final reports for patients aged 18 years and older undergoing CT with documentation that one or more of the following dose reduction techniques were used: • Automated exposure control • Adjustment of the mA and/or kV according to patient size • Use of iterative reconstruction technique",
@@ -8661,7 +8448,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Radical Prostatectomy Pathology Reporting",
     "description": "Percentage of radical prostatectomy pathology reports that include the pT category, the pN category, the Gleason score and a statement about margin status",
     "nationalQualityCode": "ECC",
@@ -8673,7 +8460,6 @@
     "qualityId": "250",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of radical prostatectomy pathology reports that include the pT category, the pN category, the Gleason score and a statement about margin status",
@@ -8694,7 +8480,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Radiology: Exposure Dose or Time Reported for Procedures Using Fluoroscopy",
     "description": "Final reports for procedures using fluoroscopy that document radiation exposure indices, or exposure time and number of fluorographic images (if radiation exposure indices are not available)",
     "nationalQualityCode": "PS",
@@ -8706,7 +8492,6 @@
     "qualityId": "145",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Final reports for procedures using fluoroscopy that document radiation exposure indices, or exposure time and number of fluorographic images (if radiation exposure indices are not available)",
@@ -8726,7 +8511,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Radiology: Inappropriate Use of \"Probably Benign\" Assessment Category in Screening Mammograms",
     "description": "Percentage of final reports for screening mammograms that are classified as \"probably benign\"",
     "nationalQualityCode": "ECR",
@@ -8738,7 +8523,6 @@
     "qualityId": "146",
     "isHighPriority": true,
     "isInverse": true,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of final reports for screening mammograms that are classified as “probably benign”",
@@ -8758,7 +8542,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Radiology: Reminder System for Screening Mammograms",
     "description": "Percentage of patients undergoing a screening mammogram whose information is entered into a reminder system with a target due date for the next mammogram",
     "nationalQualityCode": "CCC",
@@ -8770,7 +8554,6 @@
     "qualityId": "225",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients undergoing a screening mammogram whose information is entered into a reminder system with a target due date for the next mammogram",
@@ -8790,7 +8573,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Radiology: Stenosis Measurement in Carotid Imaging Reports",
     "description": "Percentage of final reports for carotid imaging studies (neck magnetic resonance angiography [MRA], neck computed tomography angiography [CTA], neck duplex ultrasound, carotid angiogram) performed that include direct or indirect reference to measurements of distal internal carotid diameter as the denominator for stenosis measurement",
     "nationalQualityCode": "ECC",
@@ -8802,7 +8585,6 @@
     "qualityId": "195",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of final reports for carotid imaging studies (neck magnetic resonance angiography [MRA], neck computed tomography angiography [CTA], neck duplex ultrasound, carotid angiogram) performed that include direct or indirect reference to measurements of distal internal carotid diameter as the denominator for stenosis measurement",
@@ -8822,7 +8604,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Rate of Carotid Artery Stenting (CAS) for Asymptomatic Patients, Without Major Complications (Discharged to Home by Post-Operative Day #2)",
     "description": "Percent of asymptomatic patients undergoing CAS who are discharged to home no later than post-operative day #2",
     "nationalQualityCode": "ECC",
@@ -8834,7 +8616,6 @@
     "qualityId": "344",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percent of asymptomatic patients undergoing CAS who are discharged to home no later than post-operative day #2",
@@ -8854,7 +8635,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Rate of Carotid Endarterectomy (CEA) for Asymptomatic Patients, without Major Complications (Discharged to Home by Post-Operative Day #2)",
     "description": "Percent of asymptomatic patients undergoing CEA who are discharged to home no later than post-operative day #2",
     "nationalQualityCode": "PS",
@@ -8866,7 +8647,6 @@
     "qualityId": "260",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percent of asymptomatic patients undergoing CEA who are discharged to home no later than post-operative day #2",
@@ -8885,7 +8665,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) Who Die While in Hospital",
     "description": "Percent of patients undergoing endovascular repair of small or moderate infrarenal abdominal aortic aneurysms (AAA) that die while in the hospital",
     "nationalQualityCode": "PS",
@@ -8897,7 +8677,6 @@
     "qualityId": "347",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percent of patients undergoing endovascular repair of small or moderate infrarenal abdominal aortic aneurysms (AAA) that die while in the hospital",
@@ -8916,7 +8695,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post Operative Day #2)",
     "description": "Percent of patients undergoing endovascular repair of small or moderate non-ruptured infrarenal abdominal aortic aneurysms (AAA) that do not experience a major complication (discharged to home no later than post-operative day #2)",
     "nationalQualityCode": "PS",
@@ -8928,7 +8707,6 @@
     "qualityId": "259",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percent of patients undergoing endovascular repair of small or moderate non-ruptured infrarenal abdominal aortic aneurysms (AAA) that do not experience a major complication (discharged to home no later than post-operative day #2)",
@@ -8948,7 +8726,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Rate of Open Repair of Small or Moderate Abdominal Aortic Aneurysms (AAA) Where Patients Are Discharged Alive",
     "description": "Percentage of patients undergoing open repair of small or moderate abdominal aortic aneurysms (AAA) who are discharged alive",
     "nationalQualityCode": "PS",
@@ -8960,7 +8738,6 @@
     "qualityId": "417",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients undergoing open repair of small or moderate abdominal aortic aneurysms (AAA) who are discharged alive",
@@ -8977,7 +8754,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Rate of Open Repair of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post-Operative Day #7)",
     "description": "Percent of patients undergoing open repair of small or moderate sized non-ruptured infrarenal abdominal aortic aneurysms who do not experience a major complication (discharge to home no later than post-operative day #7)",
     "nationalQualityCode": "PS",
@@ -8989,7 +8766,6 @@
     "qualityId": "258",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percent of patients undergoing open repair of small or moderate sized non-ruptured infrarenal abdominal aortic aneurysms who do not experience a major complication (discharge to home no later than post-operative day #7)",
@@ -9008,7 +8784,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Rate of Postoperative Stroke or Death in Asymptomatic Patients Undergoing Carotid Artery Stenting (CAS)",
     "description": "Percent of asymptomatic patients undergoing CAS who experience stroke or death following surgery while in the hospital",
     "nationalQualityCode": "ECC",
@@ -9020,7 +8796,6 @@
     "qualityId": "345",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percent of asymptomatic patients undergoing CAS who experience stroke or death following surgery while in the hospital",
@@ -9040,7 +8815,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Rate of Postoperative Stroke or Death in Asymptomatic Patients Undergoing Carotid Endarterectomy (CEA)",
     "description": "Percent of asymptomatic patients undergoing CEA who experience stroke or death following surgery while in the hospital",
     "nationalQualityCode": "ECC",
@@ -9052,7 +8827,6 @@
     "qualityId": "346",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percent of asymptomatic patients undergoing CEA who experience stroke or death following surgery while in the hospital",
@@ -9069,7 +8843,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Rate of Surgical Conversion from Lower Extremity Endovascular Revascularization Procedure",
     "description": "Inpatients assigned to endovascular treatment for obstructive arterial disease, the percent of patients who undergo unplanned major amputation or surgical bypass within 48 hours of the index procedure",
     "nationalQualityCode": "PS",
@@ -9081,7 +8855,6 @@
     "qualityId": "437",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Inpatients assigned to endovascular treatment for obstructive arterial disease, the percent of patients who undergo unplanned major amputation or surgical bypass within 48 hours of the index procedure",
@@ -9099,7 +8872,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Referral for Otologic Evaluation for Patients with Acute or Chronic Dizziness",
     "description": "Percentage of patients aged birth and older referred to a physician (preferably a physician specially trained in disorders of the ear) for an otologic evaluation subsequent to an audiologic evaluation after presenting with acute or chronic dizziness",
     "nationalQualityCode": "CCC",
@@ -9111,7 +8884,6 @@
     "qualityId": "261",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged birth and older referred to a physician (preferably a physician specially trained in disorders of the ear) for an otologic evaluation subsequent to an audiologic evaluation after presenting with acute or chronic dizziness",
@@ -9129,7 +8901,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Rheumatoid Arthritis (RA): Assessment and Classification of Disease Prognosis",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have an assessment and classification of disease prognosis at least once within 12 months",
     "nationalQualityCode": "ECC",
@@ -9141,7 +8913,6 @@
     "qualityId": "179",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have an assessment and classification of disease prognosis at least once within 12 months",
@@ -9161,7 +8932,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Rheumatoid Arthritis (RA): Functional Status Assessment",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) for whom a functional status assessment was performed at least once within 12 months",
     "nationalQualityCode": "ECC",
@@ -9173,7 +8944,6 @@
     "qualityId": "178",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) for whom a functional status assessment was performed at least once within 12 months",
@@ -9193,7 +8963,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Rheumatoid Arthritis (RA): Glucocorticoid Management",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have been assessed for glucocorticoid use and, for those on prolonged doses of prednisone >= 10 mg daily (or equivalent) with improvement or no change in disease activity, documentation of glucocorticoid management plan within 12 months",
     "nationalQualityCode": "ECC",
@@ -9205,7 +8975,6 @@
     "qualityId": "180",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have been assessed for glucocorticoid use and, for those on prolonged doses of prednisone ≥ 10 mg daily (or equivalent) with improvement or no change in disease activity, documentation of glucocorticoid management plan within 12 months",
@@ -9225,7 +8994,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Rheumatoid Arthritis (RA): Periodic Assessment of Disease Activity",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have an assessment and classification of disease activity within 12 months",
     "nationalQualityCode": "ECC",
@@ -9237,7 +9006,6 @@
     "qualityId": "177",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have an assessment and classification of disease activity within 12 months",
@@ -9256,7 +9024,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Rheumatoid Arthritis (RA): Tuberculosis Screening",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have documentation of a tuberculosis (TB) screening performed and results interpreted within 6 months prior to receiving a first course of therapy using a biologic disease-modifying anti-rheumatic drug (DMARD)",
     "nationalQualityCode": "ECC",
@@ -9268,7 +9036,6 @@
     "qualityId": "176",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have documentation of a tuberculosis (TB) screening performed and results interpreted within 6 months prior to receiving a first course of therapy using a biologic disease-modifying anti-rheumatic drug (DMARD)",
@@ -9287,7 +9054,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Rh Immunoglobulin (Rhogam) for Rh-Negative Pregnant Women at Risk of Fetal Blood Exposure",
     "description": "Percentage of Rh-negative pregnant women aged 14-50 years at risk of fetal blood exposure who receive Rh- Immunoglobulin (Rhogam) in the emergency department (ED)",
     "nationalQualityCode": "ECC",
@@ -9299,7 +9066,6 @@
     "qualityId": "255",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of Rh-negative pregnant women aged 14-50 years at risk of fetal blood exposure who receive Rh- Immunoglobulin (Rhogam) in the emergency department (ED)",
@@ -9319,7 +9085,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Risk-Adjusted Operative Mortality for Coronary Artery Bypass Graft (CABG)",
     "description": "Percent of patients aged 18 years and older undergoing isolated CABG who die, including both all deaths occurring during the hospitalization in which the CABG was performed, even if after 30 days, and those deaths occurring after discharge from the hospital, but within 30 days of the procedure",
     "nationalQualityCode": "ECC",
@@ -9331,7 +9097,6 @@
     "qualityId": "445",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percent of patients aged 18 years and older undergoing isolated CABG who die, including both all deaths occurring during the hospitalization in which the CABG was performed, even if after 30 days, and those deaths occurring after discharge from the hospital, but within 30 days of the procedure",
@@ -9348,7 +9113,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Screening Colonoscopy Adenoma Detection Rate",
     "description": "The percentage of patients age 50 years or older with at least one conventional adenoma or colorectal cancer detected during screening colonoscopy",
     "nationalQualityCode": "ECC",
@@ -9360,7 +9125,6 @@
     "qualityId": "343",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "The percentage of patients age 50 years or older with at least one conventional adenoma or colorectal cancer detected during screening colonoscopy",
@@ -9379,7 +9143,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Screening for Osteoporosis for Women Aged 65-85 Years of Age",
     "description": "Percentage of female patients aged 65-85 years of age who ever had a central dual-energy X-ray absorptiometry (DXA) to check for osteoporosis",
     "nationalQualityCode": "ECC",
@@ -9391,7 +9155,6 @@
     "qualityId": "039",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of female patients aged 65-85 years of age who ever had a central dual-energy X-ray absorptiometry (DXA) to check for osteoporosis",
@@ -9411,7 +9174,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Sentinel Lymph Node Biopsy for Invasive Breast Cancer",
     "description": "The percentage of clinically node negative (clinical stage T1N0M0 or T2N0M0) breast cancer patients who undergo a sentinel lymph node (SLN) procedure",
     "nationalQualityCode": "ECC",
@@ -9423,7 +9186,6 @@
     "qualityId": "264",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "The percentage of clinically node negative (clinical stage T1N0M0 or T2N0M0) breast cancer patients who undergo a sentinel lymph node (SLN) procedure",
@@ -9440,7 +9202,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Sleep Apnea: Assessment of Adherence to Positive Airway Pressure Therapy",
     "description": "Percentage of visits for patients aged 18 years and older with a diagnosis of obstructive sleep apnea who were prescribed positive airway pressure therapy who had documentation that adherence to positive airway pressure therapy was objectively measured",
     "nationalQualityCode": "ECC",
@@ -9452,7 +9214,6 @@
     "qualityId": "279",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of visits for patients aged 18 years and older with a diagnosis of obstructive sleep apnea who were prescribed positive airway pressure therapy who had documentation that adherence to positive airway pressure therapy was objectively measured",
@@ -9469,7 +9230,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Sleep Apnea: Assessment of Sleep Symptoms",
     "description": "Percentage of visits for patients aged 18 years and older with a diagnosis of obstructive sleep apnea that includes documentation of an assessment of sleep symptoms, including presence or absence of snoring and daytime sleepiness",
     "nationalQualityCode": "ECC",
@@ -9481,7 +9242,6 @@
     "qualityId": "276",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of visits for patients aged 18 years and older with a diagnosis of obstructive sleep apnea that includes documentation of an assessment of sleep symptoms, including presence or absence of snoring and daytime sleepiness",
@@ -9498,7 +9258,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Sleep Apnea: Positive Airway Pressure Therapy Prescribed",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of moderate or severe obstructive sleep apnea who were prescribed positive airway pressure therapy",
     "nationalQualityCode": "ECC",
@@ -9510,7 +9270,6 @@
     "qualityId": "278",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of moderate or severe obstructive sleep apnea who were prescribed positive airway pressure therapy",
@@ -9527,7 +9286,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Sleep Apnea: Severity Assessment at Initial Diagnosis",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of obstructive sleep apnea who had an apnea hypopnea index (AHI) or a respiratory disturbance index (RDI) measured at the time of initial diagnosis",
     "nationalQualityCode": "ECC",
@@ -9539,7 +9298,6 @@
     "qualityId": "277",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of obstructive sleep apnea who had an apnea hypopnea index (AHI) or a respiratory disturbance index (RDI) measured at the time of initial diagnosis",
@@ -9556,7 +9314,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Statin Therapy at Discharge after Lower Extremity Bypass (LEB)",
     "description": "Percentage of patients aged 18 years and older undergoing infra-inguinal lower extremity bypass who are prescribed a statin medication at discharge",
     "nationalQualityCode": "ECC",
@@ -9568,7 +9326,6 @@
     "qualityId": "257",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older undergoing infra-inguinal lower extremity bypass who are prescribed a statin medication at discharge",
@@ -9585,7 +9342,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Statin Therapy for the Prevention and Treatment of Cardiovascular Disease",
     "description": "Percentage of the following patients-all considered at high risk of cardiovascular events-who were prescribed or were on statin therapy during the measurement period:\n<br/><ul><li> Adults aged >= 21 years who were previously diagnosed with or currently have an active diagnosis of clinical atherosclerotic cardiovascular disease (ASCVD); OR\n</li><li> Adults aged >=21 years who have ever had  a fasting or direct low-density lipoprotein cholesterol (LDL-C) level >= 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial or pure hypercholesterolemia; OR\n</li><li> Adults aged 40-75 years with a diagnosis of diabetes with a fasting or direct LDL-C level of 70-189 mg/dL\n\n</li></ul>",
     "nationalQualityCode": "ECC",
@@ -9597,7 +9354,6 @@
     "qualityId": "438",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of the following patients—all considered at high risk of cardiovascular events—who were prescribed or were on statin therapy during the measurement period: • Adults aged ≥ 21 years who were previously diagnosed with or currently have an active diagnosis of clinical atherosclerotic cardiovascular disease (ASCVD); • Adults aged ≥21 years who have ever had a fasting or direct low-density lipoprotein cholesterol (LDL-C) level ≥ 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial or pure hypercholesterolemia; OR • Adults aged 40-75 years with a diagnosis of diabetes with a fasting or direct LDL-C level of 70-189 mg/dL",
@@ -9619,7 +9375,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Stroke and Stroke Rehabilitation: Discharged on Antithrombotic Therapy",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of ischemic stroke or transient ischemic attack (TIA) who were prescribed antithrombotic therapy at discharge",
     "nationalQualityCode": "ECC",
@@ -9631,7 +9387,6 @@
     "qualityId": "032",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of ischemic stroke or transient ischemic attack (TIA) who were prescribed antithrombotic therapy at discharge",
@@ -9652,7 +9407,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Stroke and Stroke Rehabilitation: Thrombolytic Therapy",
     "description": "Percentage of patients aged 18 years and older with a diagnosis of acute ischemic stroke who arrive at the hospital within two hours of time last known well and for whom IV t-PA was initiated within three hours of time last known well",
     "nationalQualityCode": "ECC",
@@ -9664,7 +9419,6 @@
     "qualityId": "187",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older with a diagnosis of acute ischemic stroke who arrive at the hospital within two hours of time last known well and for whom IV t-PA was initiated within three hours of time last known well",
@@ -9681,7 +9435,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Surgical Site Infection (SSI)",
     "description": "Percentage of patients aged 18 years and older who had a surgical site infection (SSI)",
     "nationalQualityCode": "ECC",
@@ -9693,7 +9447,6 @@
     "qualityId": "357",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older who had a surgical site infection (SSI)",
@@ -9715,7 +9468,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Tobacco Use and Help with Quitting Among Adolescents",
     "description": "The percentage of adolescents 12 to 20 years of age with a primary care visit during the measurement year for whom tobacco use status was documented and received help with quitting if identified as a tobacco user",
     "nationalQualityCode": "CPH",
@@ -9727,7 +9480,6 @@
     "qualityId": "402",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "The percentage of adolescents 12 to 20 years of age with a primary care visit during the measurement year for whom tobacco use status was documented and received help with quitting if identified as a tobacco user",
@@ -9769,7 +9521,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Total Knee Replacement: Identification of Implanted Prosthesis in Operative Report",
     "description": "Percentage of patients regardless of age  undergoing a total knee replacement whose operative report identifies the prosthetic implant specifications including the prosthetic implant manufacturer, the brand name of the prosthetic implant and the size of each prosthetic implant",
     "nationalQualityCode": "PS",
@@ -9781,7 +9533,6 @@
     "qualityId": "353",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients regardless of age undergoing a total knee replacement whose operative report identifies the prosthetic implant specifications including the prosthetic implant manufacturer, the brand name of the prosthetic implant and the size of each prosthetic implant",
@@ -9800,7 +9551,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Total Knee Replacement: Preoperative Antibiotic Infusion with Proximal Tourniquet",
     "description": "Percentage of patients regardless of age undergoing a total knee replacement who had the prophylactic antibiotic completely infused prior to the inflation of the proximal tourniquet",
     "nationalQualityCode": "PS",
@@ -9812,7 +9563,6 @@
     "qualityId": "352",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients regardless of age undergoing a total knee replacement who had the prophylactic antibiotic completely infused prior to the inflation of the proximal tourniquet",
@@ -9831,7 +9581,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Total Knee Replacement: Shared Decision-Making: Trial of Conservative (Non-surgical) Therapy",
     "description": "Percentage of patients regardless of age undergoing a total knee replacement with documented shared decision-making with discussion of conservative (non-surgical) therapy (e.g., non-steroidal anti-inflammatory drug (NSAIDs), analgesics, weight loss, exercise, injections) prior to the procedure",
     "nationalQualityCode": "CCC",
@@ -9843,7 +9593,6 @@
     "qualityId": "350",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients regardless of age undergoing a total knee replacement with documented shared decision- making with discussion of conservative (non-surgical) therapy (e.g., non-steroidal anti-inflammatory drug (NSAIDs), analgesics, weight loss, exercise, injections) prior to the procedure",
@@ -9862,7 +9611,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Total Knee Replacement: Venous Thromboembolic and Cardiovascular Risk Evaluation",
     "description": "Percentage of patients regardless of age undergoing a total knee replacement who are evaluated for the presence or absence of venous thromboembolic and cardiovascular risk factors within 30 days prior to the procedure (e.g. history of Deep Vein Thrombosis (DVT), Pulmonary Embolism (PE), Myocardial Infarction (MI), Arrhythmia and Stroke)",
     "nationalQualityCode": "PS",
@@ -9874,7 +9623,6 @@
     "qualityId": "351",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients regardless of age undergoing a total knee replacement who are evaluated for the presence or absence of venous thromboembolic and cardiovascular risk factors within 30 days prior to the procedure (e.g. history of Deep Vein Thrombosis (DVT), Pulmonary Embolism (PE), Myocardial Infarction (MI), Arrhythmia and Stroke)",
@@ -9893,7 +9641,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Trastuzumab Received By Patients With AJCC Stage I (T1c) -  III And HER2 Positive Breast Cancer Receiving Adjuvant Chemotherapy",
     "description": "Proportion of female patients (aged 18 years and older) with AJCC stage I (T1c) - III, human epidermal growth factor receptor 2 (HER2) positive breast cancer receiving adjuvant chemotherapy who are also receiving trastuzumab",
     "nationalQualityCode": "ECR",
@@ -9905,7 +9653,6 @@
     "qualityId": "450",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Proportion of female patients (aged 18 years and older) with AJCC stage I (T1c) – III, human epidermal growth factor receptor 2 (HER2) positive breast cancer receiving adjuvant chemotherapy who are also receiving trastuzumab",
@@ -9924,7 +9671,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Tuberculosis (TB) Prevention for Psoriasis, Psoriatic Arthritis and Rheumatoid Arthritis Patients on a Biological Immune Response Modifier",
     "description": "Percentage of patients whose providers are ensuring active tuberculosis prevention either through yearly negative standard tuberculosis screening tests or are reviewing the patient's history to determine if they have had appropriate management for a recent or prior positive test",
     "nationalQualityCode": "ECC",
@@ -9936,7 +9683,6 @@
     "qualityId": "337",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients whose providers are ensuring active tuberculosis prevention either through yearly negative standard tuberculosis screening tests or are reviewing the patient’s history to determine if they have had appropriate management for a recent or prior positive test",
@@ -9957,7 +9703,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Ultrasound Determination of Pregnancy Location for Pregnant Patients with Abdominal Pain",
     "description": "Percentage of pregnant female patients aged 14 to 50 who present to the emergency department (ED) with a chief complaint of abdominal pain or vaginal bleeding who receive a trans-abdominal or trans-vaginal ultrasound to determine pregnancy location",
     "nationalQualityCode": "ECC",
@@ -9969,7 +9715,6 @@
     "qualityId": "254",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of pregnant female patients aged 14 to 50 who present to the emergency department (ED) with a chief complaint of abdominal pain or vaginal bleeding who receive a trans-abdominal or trans-vaginal ultrasound to determine pregnancy location",
@@ -9989,7 +9734,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Unplanned Hospital Readmission within 30 Days of Principal Procedure",
     "description": "Percentage of patients aged 18 years and older who had an unplanned hospital readmission within 30 days of principal procedure",
     "nationalQualityCode": "ECC",
@@ -10001,7 +9746,6 @@
     "qualityId": "356",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older who had an unplanned hospital readmission within 30 days of principal procedure",
@@ -10020,7 +9764,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Unplanned Reoperation within the 30 Day Postoperative Period",
     "description": "Percentage of patients aged 18 years and older who had any unplanned reoperation within the 30 day postoperative period",
     "nationalQualityCode": "PS",
@@ -10032,7 +9776,6 @@
     "qualityId": "355",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients aged 18 years and older who had any unplanned reoperation within the 30 day postoperative period",
@@ -10051,7 +9794,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Urinary Incontinence: Assessment of Presence or Absence of Urinary Incontinence in Women Aged 65 Years and Older",
     "description": "Percentage of female patients aged 65 years and older who were assessed for the presence or absence of urinary incontinence within 12 months",
     "nationalQualityCode": "ECC",
@@ -10063,7 +9806,6 @@
     "qualityId": "048",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of female patients aged 65 years and older who were assessed for the presence or absence of urinary incontinence within 12 months",
@@ -10085,7 +9827,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Years and Older",
     "description": "Percentage of female patients aged 65 years and older with a diagnosis of urinary incontinence with a documented plan of care for urinary incontinence at least once within 12 months",
     "nationalQualityCode": "PCCEO",
@@ -10097,7 +9839,6 @@
     "qualityId": "050",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of female patients aged 65 years and older with a diagnosis of urinary incontinence with a documented plan of care for urinary incontinence at least once within 12 months",
@@ -10120,7 +9861,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "multiPerformanceRate",
     "title": "Use of High-Risk Medications in the Elderly",
     "description": "Percentage of patients 66 years of age and older who were ordered high-risk medications. Two rates are reported.\na. Percentage of patients who were ordered at least one high-risk medication. \nb. Percentage of patients who were ordered at least two different high-risk medications.",
     "nationalQualityCode": "PS",
@@ -10132,7 +9873,6 @@
     "qualityId": "238",
     "isHighPriority": true,
     "isInverse": true,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients who were ordered at least one high-risk medication",
@@ -10148,13 +9888,14 @@
       "ehr",
       "registry"
     ],
-    "measureSets": []
+    "measureSets": [],
+    "overallAlgorithm": "simpleAverage"
   },
   {
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Use of Imaging Studies for Low Back Pain",
     "description": "Percentage of patients 18-50 years of age with a diagnosis of low back pain who did not have an imaging study (plain X-ray, MRI, CT scan) within 28 days of the diagnosis.",
     "nationalQualityCode": "ECR",
@@ -10166,7 +9907,6 @@
     "qualityId": "312",
     "isHighPriority": true,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
@@ -10182,7 +9922,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Varicose Vein Treatment with Saphenous Ablation: Outcome Survey",
     "description": "Percentage of patients treated for varicose veins (CEAP C2-S) who are treated with saphenous ablation (with or without adjunctive tributary treatment) that report an improvement on a disease specific patient reported outcome survey instrument after treatment",
     "nationalQualityCode": "ECC",
@@ -10194,7 +9934,6 @@
     "qualityId": "420",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [
       {
         "description": "Percentage of patients treated for varicose veins (CEAP C2-S) who are treated with saphenous ablation (with or without adjunctive tributary treatment) that report an improvement on a disease specific patient reported outcome survey instrument after treatment",
@@ -10211,7 +9950,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "performanceRate",
+    "metricType": "singlePerformanceRate",
     "title": "Weight Assessment and Counseling for Nutrition and Physical Activity for Children and Adolescents",
     "description": "Percentage of patients 3-17 years of age who had an outpatient visit with a Primary Care Physician (PCP) or Obstetrician/Gynecologist (OB/GYN) and who had evidence of the following during the measurement period. Three rates are reported.\n\n - Percentage of patients with height, weight, and body mass  index (BMI) percentile documentation\n - Percentage of patients with counseling for nutrition\n - Percentage of patients with counseling for physical activity",
     "nationalQualityCode": "CPH",
@@ -10223,7 +9962,6 @@
     "qualityId": "239",
     "isHighPriority": false,
     "isInverse": false,
-    "overallAlgorithm": "simpleAverage",
     "strata": [],
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [

--- a/measures/measures-data.xml
+++ b/measures/measures-data.xml
@@ -1665,7 +1665,7 @@ Provision of same-day or next-day access to a consistent MIPS eligible clinician
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Acute Otitis Externa (AOE): Systemic Antimicrobial Therapy - Avoidance of Inappropriate Use</title>
     <description>Percentage of patients aged 2 years and older with a diagnosis of AOE who were not prescribed systemic antimicrobial therapy</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -1677,7 +1677,6 @@ Provision of same-day or next-day access to a consistent MIPS eligible clinician
     <qualityId>093</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 2 years and older with a diagnosis of AOE who were not prescribed systemic antimicrobial therapy</description>
       <name>AOE</name>
@@ -1694,7 +1693,7 @@ Provision of same-day or next-day access to a consistent MIPS eligible clinician
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Acute Otitis Externa (AOE): Topical Therapy</title>
     <description>Percentage of patients aged 2 years and older with a diagnosis of AOE who were prescribed topical preparations</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -1706,7 +1705,6 @@ Provision of same-day or next-day access to a consistent MIPS eligible clinician
     <qualityId>091</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 2 years and older with a diagnosis of AOE who were prescribed topical preparations</description>
       <name>AOE</name>
@@ -1722,7 +1720,7 @@ Provision of same-day or next-day access to a consistent MIPS eligible clinician
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>ADHD: Follow-Up Care for Children Prescribed Attention-Deficit/Hyperactivity Disorder (ADHD) Medication</title>
     <description>Percentage of children 6-12 years of age and newly dispensed a medication for attention-deficit/hyperactivity disorder (ADHD) who had appropriate follow-up care.  Two rates are reported.  
 a. Percentage of children who had one follow-up visit with a practitioner with prescribing authority during the 30-Day Initiation Phase.
@@ -1737,7 +1735,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>366</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>ehr</submissionMethod>
     <measureSet>mentalBehavioralHealth</measureSet>
@@ -1747,7 +1744,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Adherence to Antipsychotic Medications For Individuals with Schizophrenia</title>
     <description>Percentage of individuals at least 18 years of age as of the beginning of the measurement period with schizophrenia or schizoaffective disorder who had at least two prescriptions filled for any antipsychotic medication and who had a Proportion of Days Covered (PDC) of at least 0.8 for antipsychotic medications during the measurement period (12 consecutive months)</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -1759,7 +1756,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>383</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of individuals at least 18 years of age as of the beginning of the measurement period with schizophrenia or schizoaffective disorder who had at least two prescriptions filled for any antipsychotic medication and who had a Proportion of Days Covered (PDC) of at least 0.8 for antipsychotic medications during the measurement period (12 consecutive months)</description>
       <name>schizophrenia</name>
@@ -1772,7 +1768,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>multiPerformanceRate</metricType>
     <title>Adult Kidney Disease: Blood Pressure Management</title>
     <description>Percentage of patient visits for those patients aged 18 years and older with a diagnosis of chronic kidney disease (CKD) (stage 3, 4, or 5, not receiving Renal Replacement Therapy [RRT]) with a blood pressure &lt; 140/90 mmHg OR &gt;= 140/90 mmHg with a documented plan of care</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -1784,7 +1780,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>122</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>weightedAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patient visits with blood pressure results &lt; 140/90 mmHg</description>
       <name>&lt;140/90mmHg</name>
@@ -1799,12 +1794,13 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     </strata>
     <primarySteward>Renal Physicians Association</primarySteward>
     <submissionMethod>registry</submissionMethod>
+    <overallAlgorithm>weightedAverage</overallAlgorithm>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Adult Kidney Disease: Catheter Use at Initiation of Hemodialysis</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of End Stage Renal Disease (ESRD) who initiate maintenance hemodialysis during the measurement period, whose mode of vascular access is a catheter at the time maintenance hemodialysis is initiated</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -1816,7 +1812,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>329</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of End Stage Renal Disease (ESRD) who initiate maintenance hemodialysis during the measurement period, whose mode of vascular access is a catheter at the time maintenance hemodialysis is initiated</description>
       <name>ESRD</name>
@@ -1828,7 +1823,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Adult Kidney Disease: Catheter Use for Greater Than or Equal to 90 Days</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of End Stage Renal Disease (ESRD) receiving maintenance hemodialysis for greater than or equal to 90 days whose mode of vascular access is a catheter</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -1840,7 +1835,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>330</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of End Stage Renal Disease (ESRD) receiving maintenance hemodialysis for greater than or equal to 90 days whose mode of vascular access is a catheter</description>
       <name>ESRD</name>
@@ -1852,7 +1846,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Adult Kidney Disease: Referral to Hospice</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of ESRD who withdraw from hemodialysis or peritoneal dialysis who are referred to hospice care</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -1864,7 +1858,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>403</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of ESRD who withdraw from hemodialysis or peritoneal dialysis who are referred to hospice care</description>
       <name>ESRD</name>
@@ -1876,7 +1869,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Adult Major Depressive Disorder (MDD): Coordination of Care of Patients with Specific Comorbid Conditions</title>
     <description>Percentage of medical records of patients aged 18 years and older with a diagnosis of major depressive disorder (MDD) and a specific diagnosed comorbid condition (diabetes, coronary artery disease, ischemic stroke, intracranial hemorrhage, chronic kidney disease [stages 4 or 5], End Stage Renal Disease [ESRD] or congestive heart failure) being treated by another clinician with communication to the clinician treating the comorbid condition</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -1888,7 +1881,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>325</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of medical records of patients aged 18 years and older with a diagnosis of major depressive disorder (MDD) and a specific diagnosed comorbid condition (diabetes, coronary artery disease, ischemic stroke, intracranial hemorrhage, chronic kidney disease [stages 4 or 5], End Stage Renal Disease [ESRD] or congestive heart failure) being treated by another clinician with communication to the clinician treating the comorbid condition</description>
       <name>comorbid</name>
@@ -1901,7 +1893,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Adult Major Depressive Disorder (MDD): Suicide Risk Assessment</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of major depressive disorder (MDD) with a suicide risk assessment completed during the visit in which a new diagnosis or recurrent episode was identified</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -1913,7 +1905,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>107</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
     <submissionMethod>ehr</submissionMethod>
   </measure>
@@ -1921,7 +1912,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Adult Primary Rhegmatogenous Retinal Detachment Surgery: No Return to the Operating Room Within 90 Days of Surgery</title>
     <description>Patients aged 18 years and older who had surgery for primary rhegmatogenous retinal detachment who did not require a return to the operating room within 90 days of surgery</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -1933,7 +1924,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>384</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Patients aged 18 years and older who had surgery for primary rhegmatogenous retinal detachment who did not require a return to the operating room within 90 days of surgery</description>
       <name>retinalDetachment</name>
@@ -1946,7 +1936,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Adult Primary Rhegmatogenous Retinal Detachment Surgery: Visual Acuity Improvement Within 90 Days of Surgery</title>
     <description>Patients aged 18 years and older who had surgery for primary rhegmatogenous retinal detachment and achieved an improvement in their visual acuity, from their preoperative level, within 90 days of surgery in the operative eye</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -1958,7 +1948,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>385</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Patients aged 18 years and older who had surgery for primary rhegmatogenous retinal detachment and achieved an improvement in their visual acuity, from their preoperative level, within 90 days of surgery in the operative eye</description>
       <name>retinalDetachment</name>
@@ -1971,7 +1960,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Adult Sinusitis: Antibiotic Prescribed for Acute Sinusitis (Overuse)</title>
     <description>Percentage of patients, aged 18 years and older, with a diagnosis of acute sinusitis who were prescribed an antibiotic within 10 days after onset of symptoms</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -1983,7 +1972,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>331</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>true</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients, aged 18 years and older, with a diagnosis of acute sinusitis who were prescribed an antibiotic within 10 days after onset of symptoms</description>
       <name>sinusitis</name>
@@ -1999,7 +1987,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Adult Sinusitis: Appropriate Choice of Antibiotic: Amoxicillin With or Without Clavulanate Prescribed for Patients with Acute Bacterial Sinusitis (Appropriate Use)</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of acute bacterial sinusitis that were prescribed amoxicillin, with or without clavulanate, as a first line antibiotic at the time of diagnosis</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -2011,7 +1999,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>332</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of acute bacterial sinusitis that were prescribed amoxicillin, with or without clavulanate, as a first line antibiotic at the time of diagnosis</description>
       <name>sinusitis</name>
@@ -2027,7 +2014,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Adult Sinusitis: Computerized Tomography (CT) for Acute Sinusitis (Overuse)</title>
     <description>Percentage of patients aged 18 years and older, with a diagnosis of acute sinusitis who had a computerized tomography (CT) scan of the paranasal sinuses ordered at the time of diagnosis or received within 28 days after date of diagnosis</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -2039,7 +2026,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>333</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>true</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older, with a diagnosis of acute sinusitis who had a computerized tomography (CT) scan of the paranasal sinuses ordered at the time of diagnosis or received within 28 days after date of diagnosis</description>
       <name>sinusitis</name>
@@ -2055,7 +2041,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Adult Sinusitis: More than One Computerized Tomography (CT) Scan Within 90 Days for Chronic Sinusitis (Overuse)</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of chronic sinusitis who had more than one CT scan of the paranasal sinuses ordered or received within 90 days after the date of diagnosis</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -2067,7 +2053,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>334</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>true</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of chronic sinusitis who had more than one CT scan of the paranasal sinuses ordered or received within 90 days after date of diagnosis</description>
       <name>sinusitis</name>
@@ -2083,7 +2068,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Age Appropriate Screening Colonoscopy</title>
     <description>The percentage of patients greater than 85 years of age who received a screening colonoscopy from January 1 to December 31</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -2095,7 +2080,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>439</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>The percentage of patients greater than 85 years of age who received a screening colonoscopy from January 1 to December 31</description>
       <name>colonoscopy</name>
@@ -2108,7 +2092,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Age-Related Macular Degeneration (AMD): Counseling on Antioxidant Supplement</title>
     <description>Percentage of patients aged 50 years and older with a diagnosis of age-related macular degeneration (AMD) or their caregiver(s) who were counseled within 12 months on the benefits and/or risks of the Age-Related Eye Disease Study  (AREDS) formulation for preventing progression of AMD</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2120,7 +2104,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>140</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 50 years and older with a diagnosis of age-related macular degeneration (AMD) or their caregiver(s) who were counseled within 12 months on the benefits and/or risks of the Age-Related Eye Disease Study (AREDS) formulation for preventing progression of AMD</description>
       <name>AMD</name>
@@ -2134,7 +2117,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Age-Related Macular Degeneration (AMD): Dilated Macular Examination</title>
     <description>Percentage of patients aged 50 years and older with a diagnosis of age-related macular degeneration (AMD) who had a dilated macular examination performed which included documentation of the presence or absence of macular thickening or hemorrhage AND the level of macular degeneration severity during one or more office visits within 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2146,7 +2129,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>014</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 50 years and older with a diagnosis of age-related macular degeneration (AMD) who had a dilated macular examination performed which included documentation of the presence or absence of macular thickening or hemorrhage the level of macular degeneration severity during one or more office visits within 12 months</description>
       <name>AMD</name>
@@ -2160,7 +2142,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>All-cause Hospital Readmission</title>
     <description>The 30-day All-Cause Hospital Readmission measure is a risk-standardized readmission rate for beneficiaries age 65 or older who were hospitalized at a short-stay acute care hospital and experienced an unplanned readmission for any cause to an acute care hospital within 30 days of discharge.</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -2172,7 +2154,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>458</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Yale University</primarySteward>
     <submissionMethod>administrativeClaims</submissionMethod>
   </measure>
@@ -2180,7 +2161,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Amyotrophic Lateral Sclerosis (ALS) Patient Care Preferences</title>
     <description>Percentage of patients diagnosed with Amyotrophic Lateral Sclerosis (ALS) who were offered assistance in planning for end of life issues (e.g., advance directives, invasive ventilation, hospice) at least once annually</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -2192,7 +2173,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>386</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients diagnosed with Amyotrophic Lateral Sclerosis (ALS) who were offered assistance in planning for end of life issues (e.g., advance directives, invasive ventilation, hospice) at least once annually</description>
       <name>ALS</name>
@@ -2205,7 +2185,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Anastomotic Leak Intervention</title>
     <description>Percentage of patients aged 18 years and older who required an anastomotic leak intervention following gastric bypass or colectomy surgery</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -2217,7 +2197,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>354</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older who required an anastomotic leak intervention following gastric bypass or colectomy surgery</description>
       <name>colectomy</name>
@@ -2230,7 +2209,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Anesthesiology Smoking Abstinence</title>
     <description>The percentage of current smokers who abstain from cigarettes prior to anesthesia on the day of elective surgery or procedure</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2242,7 +2221,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>404</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>The percentage of current smokers who abstain from cigarettes prior to anesthesia on the day of elective surgery or procedure</description>
       <name>cigarettes</name>
@@ -2255,7 +2233,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Annual Hepatitis C Virus (HCV) Screening for Patients who are Active Injection Drug Users</title>
     <description>Percentage of patients, regardless of age, who are active injection drug users who received screening for HCV infection within the 12 month reporting period</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2267,7 +2245,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <qualityId>387</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients, regardless of age, who are active injection drug users who received screening for HCV infection within the 12 month reporting period</description>
       <name>HCV</name>
@@ -2281,7 +2258,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Anti-Depressant Medication Management</title>
     <description>Percentage of patients 18 years of age and older who were treated with antidepressant medication, had a diagnosis of major depression, and who remained on an antidepressant medication treatment. Two rates are reported. 
 a. Percentage of patients who remained on an antidepressant medication for at least 84 days (12 weeks). 
@@ -2296,7 +2273,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>009</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>ehr</submissionMethod>
     <measureSet>internalMedicine</measureSet>
@@ -2307,7 +2283,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Appropriate Assessment of Retrievable Inferior Vena Cava (IVC) Filters for Removal</title>
     <description>Percentage of patients in whom a retrievable IVC filter is placed who, within 3 months post-placement, have a documented assessment for the appropriateness of continued filtration, device removal or the inability to contact the patient with at least two attempts</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2319,7 +2295,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>421</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients in whom a retrievable IVC filter is placed who, within 3 months post-placement, have a documented assessment for the appropriateness of continued filtration, device removal or the inability to contact the patient with at least two attempts</description>
       <name>IVC</name>
@@ -2331,7 +2306,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Appropriate Follow-up Imaging for Incidental Abdominal Lesions</title>
     <description>Percentage of final reports for abdominal imaging studies for asymptomatic patients aged 18 years and older with one or more of the following noted incidentally with follow-up imaging recommended:
 &lt;br/&gt;&lt;ul&gt;&lt;li&gt; Liver lesion &lt;= 0.5 cm
@@ -2349,7 +2324,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>405</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of final reports for abdominal imaging studies for asymptomatic patients aged 18 years and older with one or more of the following noted incidentally with follow‐up imaging recommended: • Liver lesion ≤ 0.5 cm • Cystic kidney lesion &lt; 1.0 cm • Adrenal lesion ≤ 1.0 cm</description>
       <name>abdominalImaging</name>
@@ -2363,7 +2337,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Appropriate Follow-up Imaging for Incidental Thyroid Nodules in Patients</title>
     <description>Percentage of final reports for computed tomography (CT), CT angiography (CTA) or magnetic resonance imaging (MRI) or magnetic resonance angiogram (MRA) studies of the chest or neck or ultrasound of the neck for patients aged 18 years and older with no known thyroid disease with a thyroid nodule &lt; 1.0 cm noted incidentally with follow-up imaging recommended</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2375,7 +2349,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>406</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of final reports for computed tomography (CT), CT angiography (CTA) or magnetic resonance imaging (MRI) or magnetic resonance angiogram (MRA) studies of the chest or neck or ultrasound of the neck for patients aged 18 years and older with no known thyroid disease with a thyroid nodule &lt; 1.0 cm noted incidentally with follow-up imaging recommended</description>
       <name>CT</name>
@@ -2389,7 +2362,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients</title>
     <description>Percentage of patients aged 50 to 75 years of age receiving a screening colonoscopy without biopsy or polypectomy who had a recommended follow-up interval of at least 10 years for repeat colonoscopy documented in their colonoscopy report</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -2401,7 +2374,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>320</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 50 to 75 years of age receiving a screening colonoscopy without biopsy or polypectomy who had a recommended follow-up interval of at least 10 years for repeat colonoscopy documented in their colonoscopy report</description>
       <name>colonoscopy</name>
@@ -2415,7 +2387,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Appropriate Testing for Children with Pharyngitis</title>
     <description>Percentage of children 3-18 years of age who were diagnosed with pharyngitis, ordered an antibiotic and received a group A streptococcus (strep) test for the episode</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -2427,7 +2399,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>066</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of children 3-18 years of age who were diagnosed with pharyngitis, ordered an antibiotic and received a group A streptococcus (strep) test for the episode</description>
       <name>strep</name>
@@ -2443,7 +2414,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Appropriate Treatment for Children with Upper Respiratory Infection (URI)</title>
     <description>Percentage of children 3 months-18 years of age who were diagnosed with upper respiratory infection (URI) and were not dispensed an antibiotic prescription on or three days after the episode</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -2455,7 +2426,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>065</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of children 3 months - 18 years of age who were diagnosed with upper respiratory infection (URI) and were not dispensed an antibiotic prescription on or three days after the episode</description>
       <name>URI</name>
@@ -2470,7 +2440,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Appropriate Treatment of Methicillin-Sensitive Staphylococcus Aureus (MSSA) Bacteremia</title>
     <description>Percentage of patients with sepsis due to MSSA bacteremia who received beta-lactam antibiotic (e.g. nafcillin, oxacillin or cefazolin) as definitive therapy</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2482,7 +2452,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>407</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients with sepsis due to MSSA bacteremia who received beta-lactam antibiotic (e.g. nafcillin, oxacillin or cefazolin) as definitive therapy</description>
       <name>MSSA</name>
@@ -2496,7 +2465,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Appropriate Workup Prior to Endometrial Ablation</title>
     <description>Percentage of women, aged 18 years and older, who undergo   endometrial sampling or hysteroscopy with biopsy  before undergoing an endometrial ablation</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -2508,7 +2477,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>448</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of women, aged 18 years and older, who undergo endometrial sampling or hysteroscopy with biopsy and results documented before undergoing an endometrial ablation</description>
       <name>endometrialAblation</name>
@@ -2521,7 +2489,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Atrial Fibrillation and Atrial Flutter: Chronic Anticoagulation Therapy</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of nonvalvular atrial fibrillation (AF) or atrial flutter whose assessment of the specified thromboembolic risk factors indicate one or more high-risk factors or more than one moderate risk factor, as determined by CHADS2 risk stratification, who are prescribed warfarin OR another oral anticoagulant drug that is FDA approved for the prevention of thromboembolism</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2533,7 +2501,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>326</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of nonvalvular atrial fibrillation (AF) or atrial flutter whose assessment of the specified thromboembolic risk factors indicate one or more high-risk factors or more than one moderate risk factor, as determined by CHADS2 risk stratification, who are prescribed warfarin another oral anticoagulant drug that is FDA approved for the prevention of thromboembolism</description>
       <name>AF</name>
@@ -2549,7 +2516,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Avoidance of Antibiotic Treatment in Adults With Acute Bronchitis</title>
     <description>The percentage of adults 18-64 years of age with a diagnosis of acute bronchitis who were not dispensed an antibiotic prescription</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -2561,7 +2528,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>116</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>The percentage of adults 18–64 years of age with a diagnosis of acute bronchitis who were not dispensed an antibiotic prescription</description>
       <name>bronchitis</name>
@@ -2576,7 +2542,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Barrett's Esophagus</title>
     <description>Percentage of esophageal biopsy reports that document the presence of Barrett's mucosa that also include a statement about dysplasia</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2588,7 +2554,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>249</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of esophageal biopsy reports that document the presence of Barrett’s mucosa that also include a statement about dysplasia</description>
       <name>barrettsMucosa</name>
@@ -2602,7 +2567,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Basal Cell Carcinoma (BCC)/Squamous Cell Carcinoma: Biopsy Reporting Time - Pathologist to Clinician</title>
     <description>Percentage of biopsies with a diagnosis of cutaneous Basal Cell Carcinoma (BCC) and Squamous Cell Carcinoma (SCC) (including in situ disease) in which the pathologist communicates results to the clinician within 7 days of  biopsy date</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -2614,7 +2579,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>440</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of biopsies with a diagnosis of cutaneous Basal Cell Carcinoma (BCC) and Squamous Cell Carcinoma (SCC) (including in situ disease) in which the pathologist communicates results to the clinician within 7 days of biopsy date</description>
       <name>BCC&amp;SCC</name>
@@ -2626,7 +2590,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Biopsy Follow-Up</title>
     <description>Percentage of new patients whose biopsy results have been reviewed and communicated to the primary care/referring physician and patient by the performing physician</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -2638,7 +2602,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>265</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of new patients whose biopsy results have been reviewed and communicated to the primary care/referring physician and patient by the performing physician</description>
       <name>biopsy</name>
@@ -2654,7 +2617,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Bipolar Disorder and Major Depression: Appraisal for alcohol or chemical substance use</title>
     <description>Percentage of patients with depression or bipolar disorder with evidence of an initial assessment that includes an appraisal for alcohol or chemical substance use</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2666,7 +2629,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>367</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Center for Quality Assessment and Improvement in Mental Health</primarySteward>
     <submissionMethod>ehr</submissionMethod>
   </measure>
@@ -2674,7 +2636,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Breast Cancer Resection Pathology Reporting: pT Category (Primary Tumor) and pN Category (Regional Lymph Nodes) with Histologic Grade</title>
     <description>Percentage of breast cancer resection pathology reports that include the pT category (primary tumor), the pN category (regional lymph nodes), and the histologic grade</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2686,7 +2648,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>099</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of breast cancer resection pathology reports that include the pT category (primary tumor), the pN category (regional lymph nodes), and the histologic grade</description>
       <name>pTpN</name>
@@ -2700,7 +2661,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Breast Cancer Screening</title>
     <description>Percentage of women 50-74 years of age who had a mammogram to screen for breast cancer.</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2712,7 +2673,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>112</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of women 50 - 74 years of age who had a mammogram to screen for breast cancer</description>
       <name>mammogram</name>
@@ -2731,7 +2691,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>CAHPS for MIPS Clinician/Group Survey</title>
     <description>&lt;br/&gt;&lt;ul&gt;&lt;li&gt; Getting timely care, appointments, and information;
 &lt;/li&gt;&lt;li&gt; How well providers Communicate;
@@ -2754,7 +2714,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>321</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Agency for Healthcare Research &amp; Quality</primarySteward>
     <submissionMethod>csv</submissionMethod>
     <measureSet>generalPracticeFamilyMedicine</measureSet>
@@ -2763,7 +2722,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Cardiac Rehabilitation Patient Referral from an Outpatient Setting</title>
     <description>Percentage of patients evaluated in an outpatient setting who within the previous 12 months have experienced an acute myocardial infarction (MI), coronary artery bypass graft (CABG) surgery, a percutaneous coronary intervention (PCI), cardiac valve surgery, or cardiac transplantation, or who have chronic stable angina (CSA) and have not already participated in an early outpatient cardiac rehabilitation/secondary prevention (CR) program for the qualifying event/diagnosis who were referred to a CR program</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -2775,7 +2734,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>243</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients evaluated in an outpatient setting who within the previous 12 months have experienced an acute myocardial infarction (MI), coronary artery bypass graft (CABG) surgery, a percutaneous coronary intervention (PCI), cardiac valve surgery, or cardiac transplantation, or who have chronic stable angina (CSA) and have not already participated in an early outpatient cardiac rehabilitation/secondary prevention (CR) program for the qualifying event/diagnosis who were referred to a CR program Definition: Referral - A referral is defined as an official communication between the health care provider and the patient to recommend and carry out a referral order to an outpatient CR program. This includes the provision of all necessary information to the patient that will allow the patient to enroll in an outpatient CR program. This also includes a written or electronic communication between the healthcare provider or healthcare system and the cardiac rehabilitation program that includes the patient's enrollment information for the program. A hospital discharge summary or office note may potentially be formatted to include the necessary patient information to communicate to the CR program (the patient’s cardiovascular history, testing, and treatments, for instance). According to standards of practice for cardiac rehabilitation programs, care coordination communications are sent to the referring provider, including any issues regarding treatment changes, adverse treatment responses, or new non-emergency condition (new symptoms, patient care questions, etc.) that need attention by the referring provider. These communications also include a progress report once the patient has completed the program. All communications must maintain an appropriate level of confidentiality as outlined by the 1996 Health Insurance Portability and Accountability Act (HIPAA). Note: A patient with a qualifying diagnosis should have a referral to CR within the subsequent 12 months. In the event that the patient has a second (recurrent) qualifying event before the original 12 month “referral” period has ended, a new 12 month “referral” period for CR referral starts at the time of the second qualifying event, since the patient again becomes eligible for CR at that time.</description>
       <name>outpatient</name>
@@ -2787,7 +2745,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low Risk Surgery Patients</title>
     <description>Percentage of stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), or cardiac magnetic resonance (CMR) performed in low risk surgery patients 18 years or older for preoperative evaluation during the 12-month reporting period</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -2799,7 +2757,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>322</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>true</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), or cardiac magnetic resonance (CMR) performed in low risk surgery patients 18 years or older for preoperative evaluation during the 12-month reporting period</description>
       <name>preoperative</name>
@@ -2812,7 +2769,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Routine Testing After Percutaneous Coronary Intervention (PCI)</title>
     <description>Percentage of all stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), and cardiovascular magnetic resonance (CMR) performed in patients aged 18 years and older routinely after percutaneous coronary intervention (PCI), with reference to timing of test after PCI and symptom status</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -2824,7 +2781,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>323</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>true</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of all stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), and cardiovascular magnetic resonance (CMR) performed in patients aged 18 years and older routinely after percutaneous coronary intervention (PCI), with reference to timing of test after PCI and symptom status</description>
       <name>PCI</name>
@@ -2837,7 +2793,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Testing in Asymptomatic, Low-Risk Patients</title>
     <description>Percentage of all stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), and cardiovascular magnetic resonance (CMR) performed in asymptomatic, low coronary heart disease (CHD) risk patients 18 years and older for initial detection and risk assessment</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -2849,7 +2805,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>324</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>true</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of all stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), and cardiovascular magnetic resonance (CMR) performed in asymptomatic, low coronary heart disease (CHD) risk patients 18 years and older for initial detection and risk assessment</description>
       <name>CHD</name>
@@ -2862,7 +2817,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Care Plan</title>
     <description>Percentage of patients aged 65 years and older who have an advance care plan or surrogate decision maker documented in the medical record or documentation in the medical record that an advance care plan was discussed but the patient did not wish or was not able to name a surrogate decision maker or provide an advance care plan</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -2874,7 +2829,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>047</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 65 years and older who have an advance care plan or surrogate decision maker documented in the medical record or documentation in the medical record that an advance care plan was discussed but the patient did not wish or was not able to name a surrogate decision maker or provide an advance care plan</description>
       <name>surrogate</name>
@@ -2908,7 +2862,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Cataracts: 20/40 or Better Visual Acuity within 90 Days Following Cataract Surgery</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of uncomplicated cataract who had cataract surgery and no significant ocular conditions impacting the visual outcome of surgery and had best-corrected visual acuity of 20/40 or better (distance or near) achieved within 90 days following the cataract surgery</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -2920,7 +2874,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>191</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of uncomplicated cataract who had cataract surgery and no significant ocular conditions impacting the visual outcome of surgery and had best-corrected visual acuity of 20/40 or better (distance or near) achieved within 90 days following the cataract surgery</description>
       <name>cataract</name>
@@ -2934,7 +2887,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Cataracts: Complications within 30 Days Following Cataract Surgery Requiring Additional Surgical Procedures</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of uncomplicated cataract who had cataract surgery and had any of a specified list of surgical procedures in the 30 days following cataract surgery which would indicate the occurrence of any of the following major complications: retained nuclear fragments, endophthalmitis, dislocated or wrong power IOL, retinal detachment, or wound dehiscence</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -2946,7 +2899,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>192</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>true</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of uncomplicated cataract who had cataract surgery and had any of a specified list of surgical procedures in the 30 days following cataract surgery which would indicate the occurrence of any of the following major complications: retained nuclear fragments, endophthalmitis, dislocated or wrong power IOL, retinal detachment, or wound dehiscence</description>
       <name>cataract</name>
@@ -2960,7 +2912,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Cataracts: Improvement in Patient's Visual Function within 90 Days Following Cataract Surgery</title>
     <description>Percentage of patients aged 18 years and older who had cataract surgery and had improvement in visual function achieved within 90 days following the cataract surgery, based on completing a pre-operative and post-operative visual function survey</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -2972,7 +2924,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>303</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older who had cataract surgery and had improvement in visual function achieved within 90 days following the cataract surgery, based on completing a pre-operative and post-operative visual function survey</description>
       <name>cataract</name>
@@ -2985,7 +2936,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Cataracts: Patient Satisfaction within 90 Days Following Cataract Surgery</title>
     <description>Percentage of patients aged 18 years and older  who had cataract surgery and were satisfied with their care within 90 days following the cataract surgery, based on completion of the Consumer Assessment of Healthcare Providers and Systems Surgical Care Survey</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -2997,7 +2948,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>304</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older who had cataract surgery and were satisfied with their care within 90 days following the cataract surgery, based on completion of the Consumer Assessment of Healthcare Providers and Systems Surgical Care Survey</description>
       <name>cataract</name>
@@ -3010,7 +2960,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Cataract Surgery: Difference Between Planned and Final Refraction</title>
     <description>Percentage of patients aged 18 years and older who had cataract surgery performed and who achieved a final refraction within +/- 1.0 diopters of their planned (target) refraction</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3022,7 +2972,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>389</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older who had cataract surgery performed and who achieved a final refraction within +/- 1.0 diopters of their planned (target) refraction</description>
       <name>cataract</name>
@@ -3035,7 +2984,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Cataract Surgery with Intra-Operative Complications (Unplanned Rupture of Posterior Capsule Requiring Unplanned Vitrectomy)</title>
     <description>Percentage of patients aged 18 years and older who had cataract surgery performed and had an unplanned rupture of the posterior capsule requiring vitrectomy</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -3047,7 +2996,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>388</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>true</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older who had cataract surgery performed and had an unplanned rupture of the posterior capsule requiring vitrectomy</description>
       <name>cataract</name>
@@ -3060,7 +3008,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Cervical Cancer Screening</title>
     <description>Percentage of women 21-64 years of age who were screened for cervical cancer using either of the following criteria:
 *  Women age 21-64 who had cervical cytology performed every 3 years
@@ -3075,7 +3023,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>309</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>ehr</submissionMethod>
     <measureSet>obstetricsGynecology</measureSet>
@@ -3085,7 +3032,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Child and Adolescent Major Depressive Disorder (MDD): Suicide Risk Assessment</title>
     <description>Percentage of patient visits for those patients aged 6 through 17 years with a diagnosis of major depressive disorder with an assessment for suicide risk
 </description>
@@ -3098,7 +3045,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>382</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
     <submissionMethod>ehr</submissionMethod>
     <measureSet>mentalBehavioralHealth</measureSet>
@@ -3108,7 +3054,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Childhood Immunization Status</title>
     <description>Percentage of children 2 years of age who had four diphtheria, tetanus and acellular pertussis (DTaP); three polio (IPV), one measles, mumps and rubella (MMR); three H influenza type B (HiB); three hepatitis B (Hep B); one chicken pox (VZV); four pneumococcal conjugate (PCV); one hepatitis A (Hep A); two or three rotavirus (RV); and two influenza (flu) vaccines by their second birthday</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -3120,7 +3066,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>240</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>ehr</submissionMethod>
     <measureSet>pediatrics</measureSet>
@@ -3129,7 +3074,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Children Who Have Dental Decay or Cavities</title>
     <description>Percentage of children, age 0-20 years, who have had tooth decay or cavities during the measurement period</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -3141,7 +3086,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>378</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>true</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
     <submissionMethod>ehr</submissionMethod>
   </measure>
@@ -3149,7 +3093,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Chlamydia Screening and Follow Up</title>
     <description>The percentage of female adolescents 16 years of age who had a chlamydia screening test with proper follow-up during the measurement period</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -3161,7 +3105,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>447</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>The percentage of female adolescents 16 years of age who had a chlamydia screening test with proper follow-up during the measurement period</description>
       <name>chlamydia</name>
@@ -3174,7 +3117,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Chlamydia Screening for Women</title>
     <description>Percentage of women 16-24 years of age who were identified as sexually active and who had at least one test for chlamydia during the measurement period</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -3186,7 +3129,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>310</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>ehr</submissionMethod>
     <measureSet>obstetricsGynecology</measureSet>
@@ -3196,7 +3138,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Chronic Obstructive Pulmonary Disease (COPD): Long-Acting Inhaled Bronchodilator Therapy</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of COPD (FEV1/FVC &lt; 70%) and who have an FEV1 less than 60% predicted and have symptoms who were prescribed an long-acting inhaled bronchodilator</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3208,7 +3150,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>052</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of COPD (FEV1/FVC &lt; 70%) and who have an FEV1 less than 60% predicted and have symptoms who were prescribed a long-acting inhaled bronchodilator</description>
       <name>FEV1/FVC&lt;70%</name>
@@ -3221,7 +3162,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Chronic Obstructive Pulmonary Disease (COPD): Spirometry Evaluation</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of COPD who had spirometry results documented</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3233,7 +3174,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>051</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of COPD who had spirometry results documented</description>
       <name>COPD</name>
@@ -3246,7 +3186,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Clinical Outcome Post Endovascular Stroke Treatment</title>
     <description>Percentage of patients with a mRs score of 0 to 2 at 90 days following endovascular stroke intervention</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3258,7 +3198,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>409</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients with a mRs score of 0 to 2 at 90 days following endovascular stroke intervention</description>
       <name>stroke</name>
@@ -3270,7 +3209,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Closing the Referral Loop: Receipt of Specialist Report</title>
     <description>Percentage of patients with referrals, regardless of age, for which the referring provider receives a report from the provider to whom the patient was referred</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -3282,7 +3221,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>374</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
     <submissionMethod>ehr</submissionMethod>
     <measureSet>allergyImmunology</measureSet>
@@ -3311,7 +3249,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Colonoscopy Interval for Patients with a History of Adenomatous Polyps
 - Avoidance of Inappropriate Use</title>
     <description>Percentage of patients aged 18 years and older receiving a surveillance colonoscopy, with a history of a prior adenomatous polyp(s) in previous colonoscopy findings, which had an interval of 3 or more years since their last colonoscopy</description>
@@ -3324,7 +3262,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>185</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older receiving a surveillance colonoscopy, with a history of a prior adenomatous polyp(s) in previous colonoscopy findings, which had an interval of 3 or more years since their last colonoscopy</description>
       <name>colonoscopy</name>
@@ -3338,7 +3275,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Colorectal Cancer Resection Pathology Reporting: pT Category (Primary Tumor) and pN Category (Regional Lymph Nodes) with Histologic Grade</title>
     <description>Percentage of colon and rectum cancer resection pathology reports that include the pT category (primary tumor), the pN category (regional lymph nodes) and the histologic grade</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3350,7 +3287,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>100</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of colon and rectum cancer resection pathology reports that include the pT category (primary tumor), the pN category (regional lymph nodes) and the histologic grade</description>
       <name>pTpN</name>
@@ -3364,7 +3300,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Colorectal Cancer Screening</title>
     <description>Percentage of adults 50-75 years of age who had appropriate screening for colorectal cancer.</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3376,7 +3312,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>113</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients 50-75 years of age who had appropriate screening for colorectal cancer</description>
       <name>colorectalCancer</name>
@@ -3393,7 +3328,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Communication with the Physician or Other Clinician Managing On-going Care Post-Fracture for Men and Women Aged 50 Years and Older</title>
     <description>Percentage of patients aged 50 years and older treated for a fracture with documentation of communication, between the physician treating the fracture and the physician or other clinician managing the patient's on-going care, that a fracture occurred and that the patient was or should be considered for osteoporosis treatment or testing. This measure is reported by the physician who treats the fracture and who therefore is held accountable for the communication</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -3405,7 +3340,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>024</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 50 years and older treated for a fracture with documentation of communication, between the physician treating the fracture and the physician or other clinician managing the patient’s on-going care, that a fracture occurred and that the patient was or should be considered for osteoporosis treatment or testing. This measure is reported by the physician who treats the fracture and who therefore is held accountable for the communication</description>
       <name>fracture</name>
@@ -3419,7 +3353,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Controlling High Blood Pressure</title>
     <description>Percentage of patients 18-85 years of age who had a diagnosis of hypertension and whose blood pressure was adequately controlled (&lt;140/90mmHg) during the measurement period</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3431,7 +3365,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>236</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients 18 - 85 years of age who had a diagnosis of hypertension and whose blood pressure was adequately controlled (&lt; 140/90 mmHg) during the measurement period</description>
       <name>hypertension</name>
@@ -3453,7 +3386,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Coronary Artery Bypass Graft (CABG): Deep Sternal Wound Infection Rate</title>
     <description>Percentage of patients aged 18 years and older undergoing isolated CABG surgery who, within 30 days postoperatively, develop deep sternal wound infection involving muscle, bone, and/or mediastinum requiring operative intervention</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3465,7 +3398,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>165</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>true</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older undergoing isolated CABG surgery who, within 30 days postoperatively, develop deep sternal wound infection involving muscle, bone, and/or mediastinum requiring operative intervention</description>
       <name>CABG</name>
@@ -3478,7 +3410,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Coronary Artery Bypass Graft (CABG): Postoperative Renal Failure</title>
     <description>Percentage of patients aged 18 years and older undergoing isolated CABG surgery (without pre-existing renal failure) who develop postoperative renal failure or require dialysis</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3490,7 +3422,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>167</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>true</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older undergoing isolated CABG surgery (without pre-existing renal failure) who develop postoperative renal failure or require dialysis</description>
       <name>CABG</name>
@@ -3503,7 +3434,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Coronary Artery Bypass Graft (CABG): Preoperative Beta-Blocker in Patients with Isolated CABG Surgery</title>
     <description>Percentage of isolated Coronary Artery Bypass Graft (CABG) surgeries for patients aged 18 years and older who received a beta-blocker within 24 hours prior to surgical incision</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3515,7 +3446,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>044</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of isolated Coronary Artery Bypass Graft (CABG) surgeries for patients aged 18 years and older who received a beta-blocker within 24 hours prior to surgical incision</description>
       <name>CABG</name>
@@ -3528,7 +3458,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Coronary Artery Bypass Graft (CABG): Prolonged Intubation</title>
     <description>Percentage of patients aged 18 years and older undergoing isolated CABG surgery who require postoperative intubation &gt; 24 hours</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3540,7 +3470,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>164</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>true</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older undergoing isolated CABG surgery who require postoperative intubation &gt; 24 hours</description>
       <name>CABG</name>
@@ -3553,7 +3482,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Coronary Artery Bypass Graft (CABG): Stroke</title>
     <description>Percentage of patients aged 18 years and older undergoing isolated CABG surgery who have a postoperative stroke (i.e., any confirmed neurological deficit of abrupt onset caused by a disturbance in blood supply to the brain) that did not resolve within 24 hours</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3565,7 +3494,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>166</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>true</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older undergoing isolated CABG surgery who have a postoperative stroke (i.e., any confirmed neurological deficit of abrupt onset caused by a disturbance in blood supply to the brain) that did not resolve within 24 hours</description>
       <name>CABG</name>
@@ -3578,7 +3506,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Coronary Artery Bypass Graft (CABG): Surgical Re-Exploration</title>
     <description>Percentage of patients aged 18 years and older undergoing isolated CABG surgery who require a return to the operating room (OR) during the current hospitalization for mediastinal bleeding with or without tamponade, graft occlusion, valve dysfunction, or other cardiac reason</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3590,7 +3518,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>168</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>true</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older undergoing isolated CABG surgery who require a return to the operating room () during the current hospitalization for mediastinal bleeding with or without tamponade, graft occlusion, valve dysfunction, or other cardiac reason</description>
       <name>CABG</name>
@@ -3603,7 +3530,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Coronary Artery Bypass Graft (CABG): Use of Internal Mammary Artery (IMA) in Patients with Isolated CABG Surgery</title>
     <description>Percentage of patients aged 18 years and older undergoing isolated CABG surgery who received an IMA graft</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3615,7 +3542,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>043</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older undergoing isolated CABG surgery who received an IMA graft</description>
       <name>IMA</name>
@@ -3627,7 +3553,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Coronary Artery Disease (CAD): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy - Diabetes or Left Ventricular Systolic Dysfunction (LVEF &lt; 40%)</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease seen within a 12 month period who also have diabetes OR a current or prior Left Ventricular Ejection Fraction (LVEF) &lt; 40% who were prescribed ACE inhibitor or ARB therapy</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3639,7 +3565,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>118</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease seen within a 12 month period who also have diabetes a current or prior Left Ventricular Ejection Fraction (LVEF) &lt; 40% who were prescribed ACE inhibitor or ARB therapy</description>
       <name>CAD</name>
@@ -3652,7 +3577,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Coronary Artery Disease (CAD): Antiplatelet Therapy</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease (CAD) seen within a 12 month period who were prescribed aspirin or clopidogrel</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3664,7 +3589,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>006</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease (CAD) seen within a 12 month period who were prescribed aspirin or clopidogrel</description>
       <name>CAD</name>
@@ -3677,7 +3601,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>multiPerformanceRate</metricType>
     <title>Coronary Artery Disease (CAD): Beta-Blocker Therapy-Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF &lt;40%)</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease seen within a 12 month period who also have a prior MI or a current or prior LVEF &lt;40% who were prescribed beta-blocker therapy</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3689,7 +3613,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>007</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>weightedAverage</overallAlgorithm>
     <strata>
       <description>Patients who are 18 years and older with a diagnosis of CAD or history of cardiac surgery who have a current or prior LVEF &lt; 40%</description>
       <name>LVEF&lt;40%</name>
@@ -3703,12 +3626,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <submissionMethod>registry</submissionMethod>
     <measureSet>cardiology</measureSet>
     <measureSet>generalPracticeFamilyMedicine</measureSet>
+    <overallAlgorithm>weightedAverage</overallAlgorithm>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Dementia: Caregiver Education and Support</title>
     <description>Percentage of patients, regardless of age, with a diagnosis of dementia whose caregiver(s) were provided with education on dementia disease management and health behavior changes AND referred to additional resources for support within a 12 month period</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -3720,7 +3644,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>288</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients, regardless of age, with a diagnosis of dementia whose caregiver(s) were provided with education on dementia disease management and health behavior changes referred to additional resources for support within a 12 month period</description>
       <name>dementia</name>
@@ -3734,7 +3657,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Dementia: Cognitive Assessment</title>
     <description>Percentage of patients, regardless of age, with a diagnosis of dementia for whom an assessment of cognition is performed and the results reviewed at least once within a 12 month period</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3746,7 +3669,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>281</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
     <submissionMethod>ehr</submissionMethod>
     <measureSet>neurology</measureSet>
@@ -3756,7 +3678,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Dementia: Counseling Regarding Safety Concerns</title>
     <description>Percentage of patients, regardless of age, with a diagnosis of dementia or their caregiver(s) who were counseled or referred for counseling regarding safety concerns within a 12 month period</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -3768,7 +3690,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>286</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients, regardless of age, with a diagnosis of dementia or their caregiver(s) who were counseled or referred for counseling regarding safety concerns within a 12 month period</description>
       <name>dementia</name>
@@ -3782,7 +3703,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Dementia: Functional Status Assessment</title>
     <description>Percentage of patients, regardless of age, with a diagnosis of dementia for whom an assessment of functional status is performed and the results reviewed at least once within a 12 month period</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3794,7 +3715,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>282</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients, regardless of age, with a diagnosis of dementia for whom an assessment of functional status is performed and the results reviewed at least once within a 12 month period</description>
       <name>dementia</name>
@@ -3808,7 +3728,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Dementia: Management of Neuropsychiatric Symptoms</title>
     <description>Percentage of patients, regardless of age, with a diagnosis of dementia who have one or more neuropsychiatric symptoms who received or were recommended to receive an intervention for neuropsychiatric symptoms within a 12 month period</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3820,7 +3740,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>284</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients, regardless of age, with a diagnosis of dementia who have one or more neuropsychiatric symptoms who received or were recommended to receive an intervention for neuropsychiatric symptoms within a 12 month period</description>
       <name>dementia</name>
@@ -3834,7 +3753,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Dementia: Neuropsychiatric Symptom Assessment</title>
     <description>Percentage of patients, regardless of age, with a diagnosis of dementia and for whom an assessment of neuropsychiatric symptoms is performed and results reviewed at least once in a 12 month period</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3846,7 +3765,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>283</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients, regardless of age, with a diagnosis of dementia and for whom an assessment of neuropsychiatric symptoms is performed and results reviewed at least once in a 12 month period</description>
       <name>dementia</name>
@@ -3860,7 +3778,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Depression Remission at Six Months</title>
     <description>Adult patients age 18 years and older with major depression or dysthymia and an initial PHQ-9 score &gt; 9 who demonstrate remission at six months defined as a PHQ-9 score less than 5. This measure applies to both patients with newly diagnosed and existing depression whose current PHQ-9 score indicates a need for treatment. This measure additionally promotes ongoing contact between the patient and provider as patients who do not have a follow-up PHQ-9 score at six months (+/- 30 days) are also included in the denominator</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3872,7 +3790,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>411</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Adult patients age 18 years and older with major depression or dysthymia and an initial PHQ-9 score &gt; 9 who demonstrate remission at six months defined as a PHQ-9 score less than 5. This measure applies to both patients with newly diagnosed and existing depression whose current PHQ-9 score indicates a need for treatment. This measure additionally promotes ongoing contact between the patient and provider as patients who do not have a follow-up PHQ-9 score at six months (+/- 30 days) are also included in the denominator</description>
       <name>remission</name>
@@ -3885,7 +3802,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Depression Remission at Twelve Months</title>
     <description>Patients age 18 and older with major depression or dysthymia and an initial Patient Health Questionnaire (PHQ-9) score greater than nine who demonstrate remission at twelve months (+/- 30 days after an index visit) defined as a PHQ-9 score less than five. This measure applies to both patients with newly diagnosed and existing depression whose current PHQ-9 score indicates a need for treatment.</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3897,7 +3814,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>370</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Patients age 18 and older with major depression or dysthymia and an initial Patient Health Questionnaire (PHQ-9) score greater than nine who demonstrate remission at twelve months (+/- 30 days after an index visit) defined as a PHQ-9 score less than five. This measure applies to both patients with newly diagnosed and existing depression whose current PHQ-9 score indicates a need for treatment</description>
       <name>depression</name>
@@ -3913,7 +3829,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Depression Utilization of the PHQ-9 Tool</title>
     <description>Patients age 18 and older with the diagnosis of major depression or dysthymia who have a Patient Health Questionnaire (PHQ-9) tool administered at least once during a 4-month period in which there was a qualifying visit</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3925,7 +3841,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>371</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Minnesota Community Measurement</primarySteward>
     <submissionMethod>ehr</submissionMethod>
     <measureSet>mentalBehavioralHealth</measureSet>
@@ -3934,7 +3849,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Diabetes: Eye Exam</title>
     <description>Percentage of patients 18-75 years of age with diabetes who had a retinal or dilated eye exam by an eye care professional during the measurement period or a negative retinal exam (no evidence of retinopathy) in the 12 months prior to the measurement period</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3946,7 +3861,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>117</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients 18 - 75 years of age with diabetes who had a retinal or dilated eye exam by an eye care professional during the measurement period or a negative retinal or dilated eye exam (no evidence of retinopathy) in the 12 months prior to the measurement period</description>
       <name>diabetes</name>
@@ -3964,7 +3878,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Diabetes: Foot Exam</title>
     <description>The percentage of patients 18-75 years of age with diabetes (type 1 and type 2) who received a foot exam (visual inspection and sensory exam with mono filament and a pulse exam) during the measurement year</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3976,7 +3890,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>163</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>ehr</submissionMethod>
     <measureSet>internalMedicine</measureSet>
@@ -3986,7 +3899,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Diabetes: Hemoglobin A1c (HbA1c) Poor Control (&gt;9%)</title>
     <description>Percentage of patients 18-75 years of age with diabetes who had hemoglobin A1c &gt; 9.0% during the measurement period</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -3998,7 +3911,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>001</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>true</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients 18-75 years of age with diabetes who had hemoglobin A1c &gt; 9.0% during the measurement period</description>
       <name>A1c&gt;9.0%</name>
@@ -4016,7 +3928,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Diabetes: Medical Attention for Nephropathy</title>
     <description>The percentage of patients 18-75 years of age with diabetes who had a nephropathy screening test or evidence of nephropathy during the measurement period.</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4028,7 +3940,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>119</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>The percentage of patients 18-75 years of age with diabetes who had a nephropathy screening test or evidence of nephropathy during the measurement period</description>
       <name>diabetes</name>
@@ -4042,7 +3953,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Diabetes Mellitus: Diabetic Foot and Ankle Care, Peripheral Neuropathy - Neurological Evaluation</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of diabetes mellitus who had a neurological examination of their lower extremities within 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4054,7 +3965,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>126</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of diabetes mellitus who had a neurological examination of their lower extremities within 12 months</description>
       <name>DM</name>
@@ -4066,7 +3976,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Diabetes Mellitus: Diabetic Foot and Ankle Care, Ulcer Prevention - Evaluation of Footwear</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of diabetes mellitus who were evaluated for proper footwear and sizing</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4078,7 +3988,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>127</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of diabetes mellitus who were evaluated for proper footwear and sizing</description>
       <name>DM</name>
@@ -4090,7 +3999,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of diabetic retinopathy who had a dilated macular or fundus exam performed with documented communication to the physician who manages the ongoing care of the patient with diabetes mellitus regarding the findings of the macular or fundus exam at least once within 12 months</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4102,7 +4011,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>019</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of diabetic retinopathy who had a dilated macular or fundus exam performed with documented communication to the physician who manages the ongoing care of the patient with diabetes mellitus regarding the findings of the macular or fundus exam at least once within 12 months</description>
       <name>diabeticRetinopathy</name>
@@ -4117,7 +4025,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Diabetic Retinopathy: Documentation of Presence or Absence of Macular Edema and Level of Severity of Retinopathy</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of diabetic retinopathy who had a dilated macular or fundus exam performed which included documentation of the level of severity of retinopathy and the presence or absence of macular edema during one or more office visits within 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4129,7 +4037,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>018</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
     <submissionMethod>ehr</submissionMethod>
     <measureSet>ophthalmology</measureSet>
@@ -4138,7 +4045,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Documentation of Current Medications in the Medical Record</title>
     <description>Percentage of visits for patients aged 18 years and older for which the eligible professional attests to documenting a list of current medications using all immediate resources available on the date of the encounter.  This list must include ALL known prescriptions, over-the-counters, herbals, and vitamin/mineral/dietary (nutritional) supplements AND must contain the medications' name, dosage, frequency and route of administration.</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -4150,7 +4057,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>130</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of visits for patients aged 18 years and older for which the eligible clinician attests to documenting a list of current medications using all immediate resources available on the date of the encounter. This list must include ALL known prescriptions, over-the-counters, herbals, and vitamin/mineral/dietary (nutritional) supplements must contain the medications’ name, dosage, frequency and route of administration</description>
       <name>document</name>
@@ -4188,7 +4094,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Documentation of Signed Opioid Treatment Agreement</title>
     <description>All patients 18 and older prescribed opiates for longer than six weeks duration who signed an opioid treatment agreement at least once during Opioid Therapy documented in the medical record.</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4200,7 +4106,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>412</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>All patients 18 and older prescribed opiates for longer than six weeks duration who signed an opioid treatment agreement at least once during Opioid Therapy documented in the medical record</description>
       <name>opiates</name>
@@ -4216,7 +4121,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Door to Puncture Time for Endovascular Stroke Treatment</title>
     <description>Percentage of patients undergoing endovascular stroke treatment who have a door to puncture time of less than two hours</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4228,7 +4133,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>413</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients undergoing endovascular stroke treatment who have a door to puncture time of less than two hours</description>
       <name>stroke</name>
@@ -4240,7 +4144,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Elder Maltreatment Screen and Follow-Up Plan</title>
     <description>Percentage of patients aged 65 years and older with a documented elder maltreatment screen using an Elder Maltreatment Screening tool on the date of encounter AND a documented follow-up plan on the date of the positive screen</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -4252,7 +4156,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>181</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 65 years and older with a documented elder maltreatment screen using an Elder Maltreatment Screening tool on the date of encounter a documented follow-up plan on the date of the positive screen</description>
       <name>elderMaltreament</name>
@@ -4268,7 +4171,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older</title>
     <description>Percentage of emergency department visits for patients aged 18 years and older who presented within 24 hours of a minor blunt head trauma with a Glasgow Coma Scale (GCS) score of 15 and who had a head CT for trauma ordered by an emergency care provider who have an indication for a head CT</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -4280,7 +4183,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>415</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of emergency department visits for patients aged 18 years and older who presented within 24 hours of a minor blunt head trauma with a Glasgow Coma Scale (GCS) score of 15 and who had a head CT for trauma ordered by an emergency care provider who have an indication for a head CT</description>
       <name>headTrauma</name>
@@ -4294,7 +4196,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years</title>
     <description>Percentage of emergency department visits for patients aged 2 through 17 years who presented within 24 hours of a minor blunt head trauma with a Glasgow Coma Scale (GCS) score of 15 and who had a head CT for trauma ordered by an emergency care provider who are classified as low risk according to the Pediatric Emergency Care Applied Research Network (PECARN) prediction rules for traumatic brain injury</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -4306,7 +4208,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>416</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of emergency department visits for patients aged 2 through 17 years who presented within 24 hours of a minor blunt head trauma with a Glasgow Coma Scale (GCS) score of 15 and who had a head CT for trauma ordered by an emergency care provider who are classified as low risk according to the Pediatric Emergency Care Applied Research Network (PECARN) prediction rules for traumatic brain injury</description>
       <name>headTrauma</name>
@@ -4320,7 +4221,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Epilepsy: Counseling for Women of Childbearing Potential with Epilepsy</title>
     <description>All female patients of childbearing potential (12 - 44 years old) diagnosed with epilepsy who were counseled or referred for counseling for how epilepsy and its treatment may affect contraception OR pregnancy at least once a year</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4332,7 +4233,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>268</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>All female patients of childbearing potential (12 - 44 years old) diagnosed with epilepsy who were counseled or referred for counseling for how epilepsy and its treatment may affect contraception pregnancy at least once a year</description>
       <name>epilepsy</name>
@@ -4346,7 +4246,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Evaluation or Interview for Risk of Opioid Misuse</title>
     <description>All patients 18 and older prescribed opiates for longer than six weeks duration evaluated for risk of opioid misuse using a brief validated instrument (e.g. Opioid Risk Tool, SOAPP-R) or patient interview documented at least once during Opioid Therapy in the medical record</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4358,7 +4258,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>414</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>All patients 18 and older prescribed opiates for longer than six weeks duration evaluated for risk of opioid misuse using a brief validated instrument (e.g. Opioid Risk Tool, SOAPP-R) or patient interview documented at least once during Opioid Therapy in the medical record</description>
       <name>opioidRisk</name>
@@ -4374,7 +4273,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Falls: Plan of Care</title>
     <description>Percentage of patients aged 65 years and older with a history of falls that had a plan of care for falls documented within 12 months</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4386,7 +4285,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>155</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 65 years and older with a history of falls that had a plan of care for falls documented within 12 months</description>
       <name>falls</name>
@@ -4401,7 +4299,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Falls: Risk Assessment</title>
     <description>Percentage of patients aged 65 years and older with a history of falls that had a risk assessment for falls completed within 12 months</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -4413,7 +4311,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>154</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 65 years and older with a history of falls that had a risk assessment for falls completed within 12 months</description>
       <name>falls</name>
@@ -4428,7 +4325,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Falls: Screening for Future Fall Risk</title>
     <description>Percentage of patients 65 years of age and older who were screened for future fall risk during the measurement period.</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -4440,7 +4337,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>318</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>ehr</submissionMethod>
     <submissionMethod>cmsWebInterface</submissionMethod>
@@ -4449,7 +4345,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>multiPerformanceRate</metricType>
     <title>Follow-Up After Hospitalization for Mental Illness (FUH)</title>
     <description>The percentage of discharges for patients 6 years of age and older who were hospitalized for treatment of selected mental illness diagnoses and who had an outpatient visit, an intensive outpatient encounter or partial hospitalization with a mental health practitioner. Two rates are reported:
 &lt;br/&gt;&lt;ul&gt;&lt;li&gt; The percentage of discharges for which the patient received follow-up within 30 days of discharge.
@@ -4465,7 +4361,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>391</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>The percentage of discharges for which the patient received follow-up within 30 days of discharge</description>
       <name>30days</name>
@@ -4478,12 +4373,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <submissionMethod>registry</submissionMethod>
     <measureSet>mentalBehavioralHealth</measureSet>
     <measureSet>pediatrics</measureSet>
+    <overallAlgorithm>simpleAverage</overallAlgorithm>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Functional Outcome Assessment</title>
     <description>Percentage of visits for patients aged 18 years and older with documentation of a current functional outcome assessment using a standardized functional outcome assessment tool on the date of the encounter AND documentation of a care plan based on identified functional outcome deficiencies on the date of the identified deficiencies</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4495,7 +4391,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>182</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of visits for patients aged 18 years and older with documentation of a current functional outcome assessment using a standardized functional outcome assessment tool on the date of the encounter documentation of a care plan based on identified functional outcome deficiencies on the date of the identified deficiencies</description>
       <name>functionalOutcome</name>
@@ -4509,7 +4404,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Functional Status Assessment for Total Hip Replacement</title>
     <description>Percentage of patients 18 years of age and older with primary total hip arthroplasty (THA) who completed baseline and follow-up patient-reported functional status assessments</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -4521,7 +4416,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>376</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
     <submissionMethod>ehr</submissionMethod>
     <measureSet>orthopedicSurgery</measureSet>
@@ -4530,7 +4424,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Functional Status Assessment for Total Knee Replacement</title>
     <description>Percentage of patients 18 years of age and older with primary total knee arthroplasty (TKA) who completed baseline and follow-up patient-reported functional status assessments</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -4542,7 +4436,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>375</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
     <submissionMethod>ehr</submissionMethod>
     <measureSet>orthopedicSurgery</measureSet>
@@ -4551,7 +4444,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Functional Status Assessments for Congestive Heart Failure</title>
     <description>Percentage of patients 65 years of age and older with congestive  heart failure who completed initial and follow-up patient-reported functional status assessments</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -4563,7 +4456,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>377</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
     <submissionMethod>ehr</submissionMethod>
   </measure>
@@ -4571,7 +4463,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Functional Status Change for Patients with Elbow, Wrist or Hand Impairments</title>
     <description>A self-report outcome measure of functional status (FS) for patients 14 years+ with elbow, wrist or hand impairments. The change in FS assessed using FOTO (elbow, wrist and hand) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS  outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4583,7 +4475,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>222</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>A self-report outcome measure of functional status (FS) for patients 14 years+ with elbow, wrist or hand impairments. The change in FS assessed using FOTO (elbow, wrist and hand) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality</description>
       <name>armImpairment</name>
@@ -4595,7 +4486,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Functional Status Change for Patients with Foot or Ankle Impairments</title>
     <description>A self-report measure of change in functional status (FS) for patients 14 years+ with foot and ankle impairments. The change in functional status (FS) assessed using FOTO's (foot and ankle) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4607,7 +4498,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>219</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>A self-report measure of change in functional status (FS) for patients 14 years+ with foot and ankle impairments. The change in functional status (FS) assessed using FOTO’s (foot and ankle) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality</description>
       <name>footImpairment</name>
@@ -4619,7 +4509,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Functional Status Change for Patients with General Orthopaedic Impairments</title>
     <description>A self-report outcome measure of functional status (FS) for patients 14 years+ with general orthopaedic impairments (neck, cranium, mandible, thoracic spine, ribs or other general orthopaedic impairment). The change in FS assessed using FOTO (general orthopaedic) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level by to assess quality</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4631,7 +4521,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>223</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>A self-report outcome measure of functional status (FS) for patients 14 years+ with general orthopaedic impairments (neck, cranium, mandible, thoracic spine, ribs or other general orthopedic impairment). The change in FS assessed using FOTO (general orthopedic) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level by to assess quality</description>
       <name>orthopaedicImpairment</name>
@@ -4643,7 +4532,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Functional Status Change for Patients with Hip Impairments</title>
     <description>A self-report measure of change in functional status (FS) for patients 14 years+ with hip impairments. The change in functional status (FS) assessed using FOTO's (hip) PROM (patient- reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4655,7 +4544,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>218</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>A self-report measure of change in functional status (FS) for patients 14 years+ with hip impairments. The change in functional status (FS) assessed using FOTO’s (hip) PROM (patient- reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality</description>
       <name>hipImpairment</name>
@@ -4667,7 +4555,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Functional Status Change for Patients with Knee Impairments</title>
     <description>A self-report measure of change in functional status for patients 14 year+ with knee impairments. The change in functional status (FS) assessed using FOTO's (knee ) PROM (patient-reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4679,7 +4567,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>217</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>A self-report measure of change in functional status for patients 14 year+ with knee impairments. The change in functional status (FS) assessed using FOTO’s (knee) PROM (patient-reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality</description>
       <name>kneeImpairment</name>
@@ -4691,7 +4578,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Functional Status Change for Patients with Lumbar Impairments</title>
     <description>A self-report outcome measure of change in functional status for patients 14 years+ with lumbar impairments. The change in functional status (FS) assessed using FOTO (lumbar) PROM (patient reported outcome measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level by to assess quality</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4703,7 +4590,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>220</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>A self-report outcome measure of change in functional status for patients 14 years+ with lumbar impairments. The change in functional status (FS) assessed using FOTO (lumbar) PROM (patient reported outcome measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level by to assess quality</description>
       <name>lumbarImpairment</name>
@@ -4715,7 +4601,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Functional Status Change for Patients with Shoulder Impairments</title>
     <description>A self-report outcome measure of change in functional status (FS) for patients 14 years+ with shoulder impairments. The change in functional status (FS) assessed using FOTO's (shoulder) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -4727,7 +4613,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>221</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>A self-report outcome measure of change in functional status (FS) for patients 14 years+ with shoulder impairments. The change in functional status (FS) assessed using FOTO’s (shoulder) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality</description>
       <name>shoulderImpariment</name>
@@ -4739,7 +4624,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy for Left Ventricular Systolic Dysfunction (LVSD)</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of heart failure (HF) with a current or prior left ventricular ejection fraction (LVEF) &lt; 40% who were prescribed ACE inhibitor or ARB therapy either within a 12 month period when seen in the outpatient setting OR at each hospital discharge</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4751,7 +4636,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>005</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of heart failure (HF) with a current or prior left ventricular ejection fraction (LVEF) &lt; 40% who were prescribed ACE inhibitor or ARB therapy either within a 12 month period when seen in the outpatient setting at each hospital discharge</description>
       <name>LVEF&lt;40%</name>
@@ -4768,7 +4652,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Heart Failure (HF): Beta-Blocker Therapy for Left Ventricular Systolic Dysfunction (LVSD)</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of heart failure (HF) with a current or prior left ventricular ejection fraction (LVEF) &lt; 40% who were prescribed beta-blocker therapy either within a 12 month period when seen in the outpatient setting OR at each hospital discharge</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4780,7 +4664,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>008</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of heart failure (HF) with a current or prior left ventricular ejection fraction (LVEF) &lt; 40% who were prescribed beta-blocker therapy either within a 12 month period when seen in the outpatient setting at each hospital discharge</description>
       <name>HF</name>
@@ -4796,7 +4679,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Hematology: Chronic Lymphocytic Leukemia (CLL): Baseline Flow Cytometry</title>
     <description>Percentage of patients aged 18 years and older, seen within a 12 month reporting period, with a diagnosis of chronic lymphocytic leukemia (CLL) made at any time during or prior to the reporting period who had baseline flow cytometry studies performed and documented in the chart</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4808,7 +4691,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>070</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older, seen within a 12 month reporting period, with a diagnosis of chronic lymphocytic leukemia (CLL) made at any time during or prior to the reporting period who had baseline flow cytometry studies performed and documented in the chart</description>
       <name>CLL</name>
@@ -4820,7 +4702,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Hematology: Multiple Myeloma: Treatment with Bisphosphonates</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of multiple myeloma, not in remission, who were prescribed or received intravenous bisphosphonate therapy within the 12 month reporting period</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4832,7 +4714,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>069</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of multiple myeloma, not in remission, who were prescribed or received intravenous bisphosphonate therapy within the 12 month reporting period.</description>
       <name>MM</name>
@@ -4844,7 +4725,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Hematology: Myelodysplastic Syndrome (MDS) and Acute Leukemias: Baseline Cytogenetic Testing Performed on Bone Marrow</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of myelodysplastic syndrome (MDS) or an acute leukemia who had baseline cytogenetic testing performed on bone marrow</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4856,7 +4737,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>067</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of myelodysplastic syndrome (MDS) or an acute leukemia who had baseline cytogenetic testing performed on bone marrow</description>
       <name>MDS</name>
@@ -4868,7 +4748,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Hematology: Myelodysplastic Syndrome (MDS): Documentation of Iron Stores in Patients Receiving Erythropoietin Therapy</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of myelodysplastic syndrome (MDS) who are receiving erythropoietin therapy with documentation of iron stores within 60 days prior to initiating erythropoietin therapy</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4880,7 +4760,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>068</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of myelodysplastic syndrome (MDS) who are receiving erythropoietin therapy with documentation of iron stores within 60 days prior to initiating erythropoietin therapy</description>
       <name>MDS</name>
@@ -4892,7 +4771,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Hepatitis C: Discussion and Shared Decision Making Surrounding Treatment Options</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of hepatitis C with whom a physician or other qualified healthcare professional reviewed the range of treatment options appropriate to their genotype and demonstrated a shared decision making approach with the patient. To meet the measure, there must be documentation in the patient record of a discussion between the physician or other qualified healthcare professional and the patient that includes all of the following: treatment choices appropriate to genotype, risks and benefits, evidence of effectiveness, and patient preferences toward treatment
 </description>
@@ -4905,7 +4784,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>390</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of hepatitis C with whom a physician or other qualified healthcare professional reviewed the range of treatment options appropriate to their genotype and demonstrated a shared decision making approach with the patient. To meet the measure, there must be documentation in the patient record of a discussion between the physician or other qualified healthcare professional and the patient that includes all of the following: treatment choices appropriate to genotype, risks and benefits, evidence of effectiveness, and patient preferences toward treatment</description>
       <name>hepC</name>
@@ -4918,7 +4796,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Hepatitis C: Screening for Hepatocellular Carcinoma (HCC) in Patients with Cirrhosis</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of chronic hepatitis C cirrhosis who underwent imaging with either ultrasound, contrast enhanced CT or MRI for hepatocellular carcinoma (HCC) at least once within the 12 month reporting period</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4930,7 +4808,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>401</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of chronic hepatitis C cirrhosis who underwent imaging with either ultrasound, contrast enhanced CT or MRI for hepatocellular carcinoma (HCC) at least once within the 12 month reporting period</description>
       <name>hepC</name>
@@ -4945,7 +4822,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>HER2 Negative or Undocumented Breast Cancer Patients Spared Treatment with HER2-Targeted Therapies</title>
     <description>Proportion of female patients (aged 18 years and older) with breast cancer who are human epidermal growth factor receptor 2 (HER2)/neu negative who are not administered HER2-targeted therapies</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -4957,7 +4834,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>449</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Proportion of female patients (aged 18 years and older) with breast cancer who are human epidermal growth factor receptor 2 (HER2)/neu negative who are not administered HER2-targeted therapies</description>
       <name>breastCancer</name>
@@ -4970,7 +4846,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>HIV/AIDS: Pneumocystis Jiroveci Pneumonia (PCP) Prophylaxis</title>
     <description>Percentage of patients aged 6 weeks and older with a diagnosis of HIV/AIDS who were prescribed Pneumocystis jiroveci pneumonia (PCP) prophylaxis</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -4982,7 +4858,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>160</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>ehr</submissionMethod>
     <measureSet>allergyImmunology</measureSet>
@@ -4992,7 +4867,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>HIV/AIDS: Sexually Transmitted Disease Screening for Chlamydia, Gonorrhea, and Syphilis</title>
     <description>Percentage of patients aged 13 years and older with a diagnosis of HIV/AIDS for whom chlamydia, gonorrhea, and syphilis screenings were performed at least once since the diagnosis of HIV infection</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5004,7 +4879,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>205</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 13 years and older with a diagnosis of HIV/AIDS for whom chlamydia, gonorrhea, and syphilis screenings were performed at least once since the diagnosis of HIV infection</description>
       <name>HIV/AIDS</name>
@@ -5017,7 +4891,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>HIV Medical Visit Frequency</title>
     <description>Percentage of patients, regardless of age with a diagnosis of HIV who had at least one medical visit in each 6 month period of the 24 month measurement period, with a minimum of 60 days between medical visits</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -5029,7 +4903,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>340</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients, regardless of age with a diagnosis of HIV who had at least one medical visit in each 6 month period of the 24 month measurement period, with a minimum of 60 days between medical visits</description>
       <name>HIV</name>
@@ -5041,7 +4914,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>HIV Viral Load Suppression</title>
     <description>The percentage of patients, regardless of age, with a diagnosis of HIV with a HIV viral load less than 200 copies/mL at last HIV viral load test during the measurement year</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5053,7 +4926,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>338</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>The percentage of patients, regardless of age, with a diagnosis of HIV with a HIV viral load less than 200 copies/mL at last HIV viral load test during the measurement year</description>
       <name>HIV</name>
@@ -5066,7 +4938,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>multiPerformanceRate</metricType>
     <title>HRS-12: Cardiac Tamponade and/or Pericardiocentesis Following Atrial Fibrillation Ablation</title>
     <description>Rate of cardiac tamponade and/or pericardiocentesis following atrial fibrillation ablation This measure is reported as four rates stratified by age and gender:
 &lt;br/&gt;&lt;ul&gt;&lt;li&gt; Reporting Age Criteria 1: Females 18-64years of age
@@ -5083,7 +4955,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>392</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>weightedAverage</overallAlgorithm>
     <strata>
       <description>Females 18-64 years of age</description>
       <name>18-64F</name>
@@ -5107,12 +4978,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <primarySteward>The Heart Rhythm Society</primarySteward>
     <submissionMethod>registry</submissionMethod>
     <measureSet>electrophysiologyCardiacSpecialist</measureSet>
+    <overallAlgorithm>weightedAverage</overallAlgorithm>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>multiPerformanceRate</metricType>
     <title>HRS-3: Implantable Cardioverter-Defibrillator (ICD) Complications Rate</title>
     <description>Patients with physician-specific risk-standardized rates of procedural complications following the first time implantation of an ICD</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -5124,7 +4996,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>348</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>weightedAverage</overallAlgorithm>
     <strata>
       <description>Patients with first time implants with one or more complications or mortality within 30 days</description>
       <name>30</name>
@@ -5136,12 +5007,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <primarySteward>The Heart Rhythm Society</primarySteward>
     <submissionMethod>registry</submissionMethod>
     <measureSet>electrophysiologyCardiacSpecialist</measureSet>
+    <overallAlgorithm>weightedAverage</overallAlgorithm>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>HRS-9: Infection within 180 Days of Cardiac Implantable Electronic Device (CIED) Implantation, Replacement, or Revision</title>
     <description>Infection rate following CIED device implantation, replacement, or revision
 </description>
@@ -5154,7 +5026,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>393</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Infection rate following CIED device implantation, replacement, or revision</description>
       <name>CIED</name>
@@ -5167,7 +5038,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Hypertension: Improvement in Blood Pressure</title>
     <description>Percentage of patients aged 18-85 years of age with a diagnosis of hypertension whose blood pressure improved during the measurement period.</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5179,7 +5050,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>373</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
     <submissionMethod>ehr</submissionMethod>
   </measure>
@@ -5187,7 +5057,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Image Confirmation of Successful Excision of Image-Localized Breast Lesion</title>
     <description>Image confirmation of lesion(s) targeted for image guided excisional biopsy or image guided partial mastectomy in patients with nonpalpable, image-detected breast lesion(s). Lesions may include: microcalcifications, mammographic or sonographic mass or architectural distortion, focal suspicious abnormalities on magnetic resonance imaging (MRI) or other breast imaging amenable to localization such as positron emission tomography (PET) mammography, or a biopsy marker demarcating site of confirmed pathology as established by previous core biopsy</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -5199,7 +5069,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>262</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Image confirmation of lesion(s) targeted for image guided excisional biopsy or image guided partial mastectomy in patients with nonpalpable, image-detected breast lesion(s). Lesions may include: microcalcifications, mammographic or sonographic mass or architectural distortion, focal suspicious abnormalities on magnetic resonance imaging (MRI) or other breast imaging amenable to localization such as positron emission tomography (PET) mammography, or a biopsy marker demarcating site of confirmed pathology as established by previous core biopsy</description>
       <name>imageConfirmation</name>
@@ -5211,7 +5080,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>multiPerformanceRate</metricType>
     <title>Immunizations for Adolescents</title>
     <description>The percentage of adolescents 13 years of age who had the recommended immunizations by their 13th birthday</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -5223,7 +5092,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>394</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>sumNumerators</overallAlgorithm>
     <strata>
       <description>Patients who had one dose of meningococcal vaccine on or between the patient’s 11th and 13th birthdays</description>
       <name>meningococcal</name>
@@ -5244,12 +5112,13 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <submissionMethod>registry</submissionMethod>
     <measureSet>generalPracticeFamilyMedicine</measureSet>
     <measureSet>pediatrics</measureSet>
+    <overallAlgorithm>sumNumerators</overallAlgorithm>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Inflammatory Bowel Disease (IBD): Assessment of Hepatitis B Virus (HBV) Status Before Initiating Anti-TNF (Tumor Necrosis Factor) Therapy</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of inflammatory bowel disease (IBD) who had Hepatitis B Virus (HBV) status assessed and results interpreted within one year prior to receiving a first course of anti-TNF (tumor necrosis factor) therapy</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5261,7 +5130,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>275</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of inflammatory bowel disease (IBD) who had Hepatitis B Virus (HBV) status assessed and results interpreted within one year prior to receiving a first course of anti-TNF (tumor necrosis factor) therapy</description>
       <name>IBD</name>
@@ -5274,7 +5142,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Inflammatory Bowel Disease (IBD): Preventive Care: Corticosteroid Related Iatrogenic Injury - Bone Loss Assessment</title>
     <description>Percentage of patients aged 18 years and older with an inflammatory bowel disease encounter who were prescribed prednisone equivalents greater than or equal to 10 mg/day for 60 or greater consecutive days or a single prescription equating to 600 mg prednisone or greater for all fills and were documented for risk of bone loss once during the reporting year or the previous calendar year</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5286,7 +5154,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <qualityId>271</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with an inflammatory bowel disease encounter who were prescribed prednisone equivalents greater than or equal to 10 mg/day for 60 or greater consecutive days or a single prescription equating to 600 mg prednisone or greater for all fills and were documented for risk of bone loss once during the reporting year or the previous calendar year</description>
       <name>IBD</name>
@@ -5299,7 +5166,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Initiation and Engagement of Alcohol and Other Drug Dependence Treatment</title>
     <description>Percentage of patients 13 years of age and older with a new episode of alcohol and other drug (AOD) dependence who received the following. Two rates are reported.
 a. Percentage of patients who initiated treatment within 14 days of the diagnosis.
@@ -5314,7 +5181,6 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <qualityId>305</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>ehr</submissionMethod>
   </measure>
@@ -5322,7 +5188,7 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Ischemic Vascular Disease (IVD) All or None Outcome Measure (Optimal Control)</title>
     <description>The IVD All-or-None Measure is one outcome measure (optimal control). The measure contains four goals. All four goals within a measure must be reached in order to meet that measure. The numerator for the all-or-none measure should be collected from the organization's total IVD denominator. All-or-None Outcome Measure (Optimal Control) - Using the IVD denominator optimal results include: 
 &lt;br/&gt;&lt;ul&gt;&lt;li&gt; Most recent blood pressure (BP) measurement is less than 140/90 mm Hg -- And 
@@ -5339,7 +5205,6 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <qualityId>441</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>The IVD All-or-None Measure is one outcome measure (optimal control). The measure contains four goals. All four goals within a measure must be reached in order to meet that measure. The numerator for the all-or-none measure should be collected from the organization's total IVD denominator. All-or-None Outcome Measure (Optimal Control) - Using the IVD denominator optimal results include: • Most recent blood pressure (BP) measurement is less than 140/90 mm Hg -- And • Most recent tobacco status is Tobacco Free -- And • Daily Aspirin or Other Antiplatelet Unless Contraindicated -- And • Statin Use</description>
       <name>IVDAllOrNone</name>
@@ -5351,7 +5216,7 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Ischemic Vascular Disease (IVD): Use of Aspirin or Another Antiplatelet</title>
     <description>Percentage of patients 18 years of age and older who were diagnosed with acute myocardial infarction (AMI), coronary artery bypass graft (CABG) or percutaneous coronary interventions (PCI) in the 12 months prior to the measurement period, or who had an active diagnosis of ischemic vascular disease (IVD) during the measurement period, and who had documentation of use of aspirin or another antiplatelet during the measurement period.</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5363,7 +5228,6 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <qualityId>204</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients 18 years of age and older who were diagnosed with acute myocardial infarction (AMI), coronary artery bypass graft (CABG) or percutaneous coronary interventions (PCI) in the 12 months prior to the measurement period, or who had an active diagnosis of ischemic vascular disease (IVD) during the measurement period, and who had documentation of use of aspirin or another antiplatelet during the measurement period</description>
       <name>AMI</name>
@@ -5381,7 +5245,7 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>KRAS Gene Mutation Testing Performed for Patients with Metastatic Colorectal Cancer who receive Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibody Therapy</title>
     <description>Percentage of adult patients (aged 18 or over) with metastatic colorectal cancer who receive anti-epidermal growth factor receptor monoclonal antibody therapy for whom KRAS gene mutation testing was performed</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5393,7 +5257,6 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <qualityId>451</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of adult patients (aged 18 or over) with metastatic colorectal cancer who receive anti-epidermal growth factor receptor monoclonal antibody therapy for whom KRAS gene mutation testing was performed</description>
       <name>KRASGeneMutation</name>
@@ -5406,7 +5269,7 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Lung Cancer Reporting (Biopsy/Cytology Specimens)</title>
     <description>Pathology reports based on biopsy and/or cytology specimens with a diagnosis of primary non-small cell lung cancer classified into specific histologic type or classified as NSCLC-NOS with an explanation included in the pathology report</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -5418,7 +5281,6 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <qualityId>395</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Pathology reports based on biopsy and/or cytology specimens with a diagnosis of primary non-small cell lung cancer classified into specific histologic type or classified as NSCLC-NOS with an explanation included in the pathology report</description>
       <name>lungCancer</name>
@@ -5432,7 +5294,7 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Lung Cancer Reporting (Resection Specimens)</title>
     <description>Pathology reports based on resection specimens with a diagnosis of primary lung carcinoma that include the pT category, pN category and for non-small cell lung cancer, histologic type</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -5444,7 +5306,6 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <qualityId>396</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Pathology reports based on resection specimens with a diagnosis of primary lung carcinoma that include the pT category, pN category and for non-small cell lung cancer, histologic type</description>
       <name>lungCarcinoma</name>
@@ -5458,7 +5319,7 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Maternal Depression Screening</title>
     <description>The percentage of children who turned 6 months of age during the measurement year, who had a face-to-face visit between the clinician and the child during child's first 6 months, and who had a maternal depression screening for the mother at least once between 0 and 6 months of life.
 </description>
@@ -5471,7 +5332,6 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <qualityId>372</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>ehr</submissionMethod>
   </measure>
@@ -5479,7 +5339,7 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Maternity Care: Elective Delivery or Early Induction Without Medical Indication at &gt;= 37 and &lt; 39 Weeks (Overuse)</title>
     <description>Percentage of patients, regardless of age, who gave birth during a 12-month period who delivered a live singleton at
 &gt;= 37 and &lt; 39 weeks of gestation completed who had elective deliveries or early inductions without medical indication
@@ -5493,7 +5353,6 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <qualityId>335</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients, regardless of age, who gave birth during a 12-month period who delivered a live singleton at ≥ 37 and &lt; 39 weeks of gestation completed who had elective deliveries or early inductions without medical indication</description>
       <name>birth</name>
@@ -5505,7 +5364,7 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Maternity Care: Post-Partum Follow-Up and Care Coordination</title>
     <description>Percentage of patients, regardless of age, who gave birth during a 12-month period who were seen for post-partum care within 8 weeks of giving birth who received a breast feeding evaluation and education, post-partum depression screening, post-partum glucose screening for gestational diabetes patients, and family and contraceptive planning</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -5517,7 +5376,6 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <qualityId>336</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients, regardless of age, who gave birth during a 12-month period who were seen for post-partum care within 8 weeks of giving birth who received a breast feeding evaluation and education, post-partum depression screening, post-partum glucose screening for gestational diabetes patients, and family and contraceptive planning</description>
       <name>postPartum</name>
@@ -5529,7 +5387,7 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Medication Management for People with Asthma</title>
     <description>The percentage of patients 5-64 years of age during the measurement year who were identified as having persistent asthma and were dispensed appropriate medications that they remained on for at least 75% of their treatment period</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -5541,7 +5399,6 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <qualityId>444</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>The percentage of patients 5-64 years of age during the measurement year who were identified as having persistent asthma and were dispensed appropriate medications that they remained on for at least 75% of their treatment period</description>
       <name>asthma</name>
@@ -5556,7 +5413,7 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>multiPerformanceRate</metricType>
     <title>Medication Reconciliation Post-Discharge</title>
     <description>The percentage of discharges from any inpatient facility (e.g. hospital, skilled nursing facility, or rehabilitation facility) for patients 18 years and older of age seen within 30 days following discharge in the office by the physician, prescribing practitioner, registered nurse, or clinical pharmacist providing on-going care for whom the discharge medication list was reconciled with the current medication list in the outpatient medical record.
 This measure is reported as three rates stratified by age group:
@@ -5573,7 +5430,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>046</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Performance Rate 1: Percentage of discharges from any inpatient facility (e.g., hospital, skilled nursing facility, or rehabilitation facility) for patients 18-64 years of age seen within 30 days following discharge in the office by the physician, prescribing practitioner, registered nurse, or clinical pharmacist providing on- going care for whom the discharge medication list was reconciled with the current medication list in the outpatient medical record</description>
       <name>18-64</name>
@@ -5590,12 +5446,13 @@ This measure is reported as three rates stratified by age group:
     <submissionMethod>claims</submissionMethod>
     <submissionMethod>cmsWebInterface</submissionMethod>
     <submissionMethod>registry</submissionMethod>
+    <overallAlgorithm>simpleAverage</overallAlgorithm>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Melanoma: Continuity of Care - Recall System</title>
     <description>Percentage of patients, regardless of age, with a current diagnosis of melanoma or a history of melanoma whose information was entered, at least once within a 12 month period, into a recall system that includes:
 &lt;br/&gt;&lt;ul&gt;&lt;li&gt; A target date for the next complete physical skin exam, AND
@@ -5610,7 +5467,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>137</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients, regardless of age, with a current diagnosis of melanoma or a history of melanoma whose information was entered, at least once within a 12 month period, into a recall system that includes: • A target date for the next complete physical skin exam, • A process to follow up with patients who either did not make an appointment within the specified timeframe or who missed a scheduled appointment</description>
       <name>melanoma</name>
@@ -5623,7 +5479,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Melanoma: Coordination of Care</title>
     <description>Percentage of patient visits, regardless of age, with a new occurrence of melanoma who have a treatment plan documented in the chart that was communicated to the physician(s) providing continuing care within one month of diagnosis</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -5635,7 +5491,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>138</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patient visits, regardless of age, with a new occurrence of melanoma that have a treatment plan documented in the chart that was communicated to the physician(s) providing continuing care within one month of diagnosis</description>
       <name>melanoma</name>
@@ -5648,7 +5503,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Melanoma: Overutilization of Imaging Studies in Melanoma</title>
     <description>Percentage of patients, regardless of age, with a current diagnosis of Stage 0 through IIC melanoma or a history of melanoma of any stage, without signs or symptoms suggesting systemic spread, seen for an office visit during the one-year measurement period, for whom no diagnostic imaging studies were ordered</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -5660,7 +5515,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>224</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients, regardless of age, with a current diagnosis of Stage 0 through IIC melanoma or a history of melanoma of any stage, without signs or symptoms suggesting systemic spread, seen for an office visit during the one- year measurement period, for whom no diagnostic imaging studies were ordered</description>
       <name>melanoma</name>
@@ -5673,7 +5527,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Melanoma Reporting</title>
     <description>Pathology reports for primary malignant cutaneous melanoma that include the pT category and a statement on thickness and ulceration and for pT1, mitotic rate</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -5685,7 +5539,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>397</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Pathology reports for primary malignant cutaneous melanoma that include the pT category and a statement on thickness and ulceration and for pT1, mitotic rate</description>
       <name>melanoma</name>
@@ -5699,7 +5552,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Non-Recommended Cervical Cancer Screening in Adolescent Females</title>
     <description>The percentage of adolescent females 16-20 years of age who were screened unnecessarily for cervical cancer</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -5711,7 +5564,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>443</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>The percentage of adolescent females 16–20 years of age who were screened unnecessarily for cervical cancer</description>
       <name>cervicalCancer</name>
@@ -5725,7 +5577,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Nuclear Medicine: Correlation with Existing Imaging Studies for All Patients Undergoing Bone Scintigraphy</title>
     <description>Percentage of final reports for all patients, regardless of age, undergoing bone scintigraphy that include physician documentation of correlation with existing relevant imaging studies (e.g., x-ray, MRI, CT, etc.) that were performed</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -5737,7 +5589,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>147</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of final reports for all patients, regardless of age, undergoing bone scintigraphy that include physician documentation of correlation with existing relevant imaging studies (e.g., x-ray, MRI, CT, etc.) that were performed</description>
       <name>scintigraphy</name>
@@ -5751,7 +5602,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Oncology: Medical and Radiation - Pain Intensity Quantified</title>
     <description>Percentage of patient visits, regardless of patient age, with a diagnosis of cancer currently receiving chemotherapy or radiation therapy in which pain intensity is quantified</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -5763,7 +5614,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>143</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patient visits, regardless of patient age, with a diagnosis of cancer currently receiving chemotherapy or radiation therapy in which pain intensity is quantified</description>
       <name>cancer</name>
@@ -5778,7 +5628,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Oncology: Medical and Radiation - Plan of Care for Pain</title>
     <description>Percentage of visits for patients, regardless of age, with a diagnosis of cancer currently receiving chemotherapy or radiation therapy who report having pain with a documented plan of care to address pain</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -5790,7 +5640,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>144</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of visits for patients, regardless of age, with a diagnosis of cancer currently receiving chemotherapy or radiation therapy who report having pain with a documented plan of care to address pain</description>
       <name>cancer</name>
@@ -5803,7 +5652,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Oncology: Radiation Dose Limits to Normal Tissues</title>
     <description>Percentage of patients, regardless of age, with a diagnosis of breast, rectal, pancreatic or lung cancer receiving 3D conformal radiation therapy who had documentation in medical record that radiation dose limits to normal tissues were established prior to the initiation of a course of 3D conformal radiation for a minimum of two tissues</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -5815,7 +5664,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>156</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients, regardless of age, with a diagnosis of breast, rectal, pancreatic or lung cancer receiving 3D conformal radiation therapy who had documentation in medical record that radiation dose limits to normal tissues were established prior to the initiation of a course of 3D conformal radiation for a minimum of two tissues</description>
       <name>cancer</name>
@@ -5829,7 +5677,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>One-Time Screening for Hepatitis C Virus (HCV) for Patients at Risk</title>
     <description>Percentage of patients aged 18 years and older with one or more of the following: a history of injection drug use, receipt of a blood transfusion prior to 1992, receiving maintenance hemodialysis, OR birthdate in the years 1945-1965 who received one-time screening for hepatitis C virus (HCV) infection</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5841,7 +5689,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>400</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with one or more of the following: a history of injection drug use, receipt of a blood transfusion prior to 1992, receiving maintenance hemodialysis, birthdate in the years 1945-1965 who received one-time screening for hepatitis C virus (HCV) infection</description>
       <name>HCV</name>
@@ -5855,7 +5702,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Operative Mortality Stratified by the Five STS-EACTS Mortality Categories</title>
     <description>Percent of patients undergoing index pediatric and/or congenital heart surgery who die, including both 1) all deaths occurring during the hospitalization in which the procedure was performed, even if after 30 days (including patients transferred to other acute care facilities), and 2) those deaths occurring after discharge from the hospital, but within 30 days of the procedure, stratified by the five STAT Mortality Levels, a multi-institutional validated complexity stratification tool</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -5867,7 +5714,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>446</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percent of patients undergoing index pediatric and/or congenital heart surgery who die, including both 1) all deaths occurring during the hospitalization in which the procedure was performed, even if after 30 days (including patients transferred to other acute care facilities), and 2) those deaths occurring after discharge from the hospital, but within 30 days of the procedure, stratified by the five STAT Mortality Levels, a multi-institutional validated complexity stratification tool</description>
       <name>congenitalHeartSurgery</name>
@@ -5879,7 +5725,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Opioid Therapy Follow-up Evaluation</title>
     <description>All patients 18 and older prescribed opiates for longer than six weeks duration who had a follow-up evaluation conducted at least every three months during Opioid Therapy documented in the medical record</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5891,7 +5737,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>408</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>All patients 18 and older prescribed opiates for longer than six weeks duration who had a follow-up evaluation conducted at least every three months during Opioid Therapy documented in the medical record</description>
       <name>opiates</name>
@@ -5907,7 +5752,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>multiPerformanceRate</metricType>
     <title>Optimal Asthma Control</title>
     <description>Composite measure of the percentage of pediatric and adult patients whose asthma is well-controlled as demonstrated by one of three age appropriate patient reported outcome tools and not at risk for exacerbation</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -5919,7 +5764,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>398</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>weightedAverage</overallAlgorithm>
     <strata>
       <description>Overall Percentage for patients (aged 5-50 years) with well-controlled asthma, without elevated risk of exacerbation.</description>
       <name>overall</name>
@@ -5952,12 +5796,13 @@ This measure is reported as three rates stratified by age group:
     <submissionMethod>registry</submissionMethod>
     <measureSet>allergyImmunology</measureSet>
     <measureSet>generalPracticeFamilyMedicine</measureSet>
+    <overallAlgorithm>weightedAverage</overallAlgorithm>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Optimizing Patient Exposure to Ionizing Radiation: Appropriateness: Follow-up CT Imaging for Incidentally Detected Pulmonary Nodules According to Recommended Guidelines</title>
     <description>Percentage of final reports for computed tomography (CT) imaging studies of the thorax for patients aged 18 years and older with documented follow-up recommendations for incidentally detected pulmonary nodules (e.g., follow-up CT imaging studies needed or that no follow-up is needed) based at a minimum on nodule size AND patient risk factors</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -5969,7 +5814,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>364</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of final reports for computed tomography (CT) imaging studies of the thorax for patients aged 18 years and older with documented follow-up recommendations for incidentally detected pulmonary nodules (e.g., follow-up CT imaging studies needed or that no follow-up is needed) based at a minimum on nodule size patient risk factors</description>
       <name>CT</name>
@@ -5982,7 +5826,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Optimizing Patient Exposure to Ionizing Radiation: Computed Tomography (CT) Images Available for Patient Follow-up and Comparison Purposes</title>
     <description>Percentage of final reports for computed tomography (CT) studies performed for all patients, regardless of age, which document that Digital Imaging and Communications in Medicine (DICOM) format image data are available to non-affiliated external healthcare facilities or entities on a secure, media free, reciprocally searchable basis with patient authorization for at least a 12-month period after the study</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -5994,7 +5838,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>362</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of final reports for computed tomography (CT) studies performed for all patients, regardless of age, which document that Digital Imaging and Communications in Medicine (DICOM) format image data are available to non- affiliated external healthcare facilities or entities on a secure, media free, reciprocally searchable basis with patient authorization for at least a 12-month period after the study</description>
       <name>CT</name>
@@ -6007,7 +5850,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Optimizing Patient Exposure to Ionizing Radiation: Count of Potential High Dose Radiation Imaging Studies: Computed Tomography (CT) and Cardiac Nuclear Medicine Studies</title>
     <description>Percentage of computed tomography (CT) and cardiac nuclear medicine (myocardial perfusion studies) imaging reports for all patients, regardless of age, that document a count of known previous CT (any type of CT) and cardiac nuclear medicine (myocardial perfusion) studies that the patient has received in the 12-month period prior to the current study</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6019,7 +5862,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>360</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of computed tomography (CT) and cardiac nuclear medicine (myocardial perfusion studies) imaging reports for all patients, regardless of age, that document a count of known previous CT (any type of CT) and cardiac nuclear medicine (myocardial perfusion) studies that the patient has received in the 12-month period prior to the current study</description>
       <name>CT</name>
@@ -6032,7 +5874,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Optimizing Patient Exposure to Ionizing Radiation: Reporting to a Radiation Dose Index Registry</title>
     <description>Percentage of total computed tomography (CT) studies performed for all patients, regardless of age, that are reported to a radiation dose index registry that is capable of collecting at a minimum selected data elements</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6044,7 +5886,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>361</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of total computed tomography (CT) studies performed for all patients, regardless of age, that are reported to a radiation dose index registry that is capable of collecting at a minimum selected data elements</description>
       <name>CT</name>
@@ -6057,7 +5898,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Optimizing Patient Exposure to Ionizing Radiation: Search for Prior Computed Tomography (CT) Studies Through a Secure, Authorized, Media-Free, Shared Archive</title>
     <description>Percentage of final reports of computed tomography (CT) studies performed for all patients, regardless of age, which document that a search for Digital Imaging and Communications in Medicine (DICOM) format images was conducted for prior patient CT imaging studies completed at non-affiliated external healthcare facilities or entities within the past 12-months and are available through a secure, authorized, media-free, shared archive prior to an imaging study being performed</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -6069,7 +5910,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>363</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of final reports of computed tomography (CT) studies performed for all patients, regardless of age, which document that a search for Digital Imaging and Communications in Medicine (DICOM) format images was conducted for prior patient CT imaging studies completed at non-affiliated external healthcare facilities or entities within the past 12-months and are available through a secure, authorized, media-free, shared archive prior to an imaging study being performed</description>
       <name>CT</name>
@@ -6082,7 +5922,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Optimizing Patient Exposure to Ionizing Radiation: Utilization of a Standardized Nomenclature for Computed Tomography (CT) Imaging Description</title>
     <description>Percentage of computed tomography (CT) imaging reports for all patients, regardless of age, with the imaging study named according to a standardized nomenclature and the standardized nomenclature is used in institution's computer systems</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -6094,7 +5934,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>359</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of computed tomography (CT) imaging reports for all patients, regardless of age, with the imaging study named according to a standardized nomenclature and the standardized nomenclature is used in institution’s computer systems</description>
       <name>CT</name>
@@ -6107,7 +5946,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Osteoarthritis (OA): Function and Pain Assessment</title>
     <description>Percentage of patient visits for patients aged 21 years and older with a diagnosis of osteoarthritis (OA) with assessment for function and pain</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -6119,7 +5958,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>109</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patient visits for patients aged 21 years and older with a diagnosis of osteoarthritis (OA) with assessment for function and pain</description>
       <name>OA</name>
@@ -6137,7 +5975,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Osteoporosis Management in Women Who Had a Fracture</title>
     <description>The percentage of women age 50-85 who suffered a fracture and who either had a bone mineral density test or received a prescription for a drug to treat osteoporosis in the six months after the fracture</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6149,7 +5987,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>418</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>The percentage of women age 50-85 who suffered a fracture and who either had a bone mineral density test or received a prescription for a drug to treat osteoporosis in the six months after the fracture</description>
       <name>osteoporosis</name>
@@ -6165,7 +6002,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Overuse Of Neuroimaging For Patients With Primary Headache And A Normal Neurological Examination</title>
     <description>Percentage of patients with a diagnosis of primary headache disorder whom advanced brain imaging was not ordered</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -6177,7 +6014,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>419</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients with a diagnosis of primary headache disorder whom advanced brain imaging was not ordered</description>
       <name>headache</name>
@@ -6191,7 +6027,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Pain Assessment and Follow-Up</title>
     <description>Percentage of visits for patients aged 18 years and older with documentation of a pain assessment using a standardized tool(s) on each visit AND documentation of a follow-up plan when pain is present</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -6203,7 +6039,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>131</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of visits for patients aged 18 years and older with documentation of a pain assessment using a standardized tool(s) on each visit documentation of a follow-up plan when pain is present</description>
       <name>painAssessment</name>
@@ -6217,7 +6052,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Pain Brought Under Control Within 48 Hours</title>
     <description>Patients aged 18 and older who report being uncomfortable because of pain at the initial assessment (after admission to palliative care services) that report pain was brought to a comfortable level within 48 hours</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -6229,7 +6064,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>342</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Patients aged 18 and older who report being uncomfortable because of pain at the initial assessment (after admission to palliative care services) that report pain was brought to a comfortable level within 48 hours</description>
       <name>pain</name>
@@ -6242,7 +6076,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Parkinson's Disease: Cognitive Impairment or Dysfunction Assessment</title>
     <description>All patients with a diagnosis of Parkinson's disease who were assessed for cognitive impairment or dysfunction  in the last 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6254,7 +6088,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>291</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>All patients with a diagnosis of Parkinson’s disease who were assessed for cognitive impairment or dysfunction in the last 12 months</description>
       <name>parkinsons</name>
@@ -6267,7 +6100,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Parkinson's Disease: Parkinson's Disease Medical and Surgical Treatment Options Reviewed</title>
     <description>All patients with a diagnosis of Parkinson's disease (or caregiver(s), as appropriate) who had the Parkinson's disease treatment options (e.g., non-pharmacological treatment, pharmacological treatment, or surgical treatment) reviewed at least annually</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -6279,7 +6112,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>294</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>All patients with a diagnosis of Parkinson’s disease (or caregiver(s), as appropriate) who had the Parkinson’s disease treatment options (e.g., non-pharmacological treatment, pharmacological treatment, or surgical treatment) reviewed at least once annually</description>
       <name>parkinsons</name>
@@ -6292,7 +6124,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Parkinson's Disease: Psychiatric Symptoms Assessment for Patients with Parkinson's Disease</title>
     <description>All patients with a diagnosis of Parkinson's disease who were assessed for psychiatric symptoms (e.g., psychosis, depression, anxiety disorder, apathy, or impulse control disorder) in the last 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6304,7 +6136,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>290</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>All patients with a diagnosis of Parkinson’s disease who were assessed for psychiatric symptoms (e.g., psychosis, depression, anxiety disorder, apathy, or impulse control disorder) in the last 12 months</description>
       <name>parkinsons</name>
@@ -6317,7 +6148,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Parkinson's Disease: Rehabilitative Therapy Options</title>
     <description>All patients with a diagnosis of Parkinson's Disease (or caregiver(s), as appropriate) who had rehabilitative therapy options (e.g., physical, occupational, or speech therapy) discussed  in the last 12 months</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -6329,7 +6160,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>293</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>All patients with a diagnosis of Parkinson’s Disease (or caregiver(s), as appropriate) who had rehabilitative therapy options (e.g., physical, occupational, or speech therapy) discussed in the last 12 months</description>
       <name>parkinsons</name>
@@ -6342,7 +6172,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Patient-Centered Surgical Risk Assessment and Communication</title>
     <description>Percentage of patients who underwent a non-emergency surgery who had their personalized risks of postoperative complications assessed by their surgical team prior to surgery using a clinical data-based, patient-specific risk calculator and who received personal discussion of those risks with the surgeon</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -6354,7 +6184,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>358</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients who underwent a non-emergency surgery who had their personalized risks of postoperative complications assessed by their surgical team prior to surgery using a clinical data-based, patient-specific risk calculator and who received personal discussion of those risks with the surgeon</description>
       <name>surgery</name>
@@ -6372,7 +6201,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Patients with Metastatic Colorectal Cancer and KRAS Gene Mutation Spared Treatment with Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibodies</title>
     <description>Percentage of adult patients (aged 18 or over) with metastatic colorectal cancer and KRAS gene mutation spared treatment with anti-EGFR monoclonal antibodies</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6384,7 +6213,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>452</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of adult patients (aged 18 or over) with metastatic colorectal cancer and KRAS gene mutation spared treatment with anti-EGFR monoclonal antibodies</description>
       <name>metastaticColorectalCancer</name>
@@ -6397,7 +6225,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Pediatric Kidney Disease: Adequacy of Volume Management</title>
     <description>Percentage of calendar months within a 12-month period during which patients aged 17 years and younger with a diagnosis of End Stage Renal Disease (ESRD) undergoing maintenance hemodialysis in an outpatient dialysis facility have an assessment of the adequacy of volume management from a nephrologist</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6409,7 +6237,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>327</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of calendar months within a 12-month period during which patients aged 17 years and younger with a diagnosis of End Stage Renal Disease (ESRD) undergoing maintenance hemodialysis in an outpatient dialysis facility have an assessment of the adequacy of volume management from a nephrologist</description>
       <name>ESRD</name>
@@ -6421,7 +6248,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Pediatric Kidney Disease: ESRD Patients Receiving Dialysis: Hemoglobin Level &lt; 10 g/dL</title>
     <description>Percentage of calendar months within a 12-month period during which patients aged 17 years and younger with a diagnosis of End Stage Renal Disease (ESRD) receiving hemodialysis or peritoneal dialysis have a hemoglobin level &lt; 10 g/dL</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6433,7 +6260,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>328</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of calendar months within a 12-month period during which patients aged 17 years and younger with a diagnosis of End Stage Renal Disease (ESRD) receiving hemodialysis or peritoneal dialysis have a hemoglobin level &lt; 10 g/dL</description>
       <name>ESRD</name>
@@ -6445,7 +6271,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Pelvic Organ Prolapse: Preoperative Assessment of Occult Stress Urinary Incontinence</title>
     <description>Percentage of patients undergoing appropriate preoperative evaluation of stress urinary incontinence prior to pelvic organ prolapse surgery per ACOG/AUGS/AUA guidelines</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6457,7 +6283,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>428</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients undergoing appropriate preoperative evaluation of stress urinary incontinence prior to pelvic organ prolapse surgery per ACOG/AUGS/AUA guidelines</description>
       <name>urinaryIncontinence</name>
@@ -6469,7 +6294,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Pelvic Organ Prolapse: Preoperative Screening for Uterine Malignancy</title>
     <description>Percentage of patients who are screened for uterine malignancy prior to vaginal closure or obliterative surgery for pelvic organ prolapse</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6481,7 +6306,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>429</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients who are screened for uterine malignancy prior to vaginal closure or obliterative surgery for pelvic organ prolapse</description>
       <name>uterineMalignancy</name>
@@ -6494,7 +6318,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Performing Cystoscopy at the Time of Hysterectomy for Pelvic Organ Prolapse to Detect Lower Urinary Tract Injury</title>
     <description>Percentage of patients who undergo cystoscopy to evaluate for lower urinary tract injury at the time of hysterectomy for pelvic organ prolapse</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6506,7 +6330,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>422</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients who undergo cystoscopy to evaluate for lower urinary tract injury at the time of hysterectomy for pelvic organ prolapse</description>
       <name>cystoscopy</name>
@@ -6520,7 +6343,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Perioperative Anti-platelet Therapy for Patients Undergoing Carotid Endarterectomy</title>
     <description>Percentage of patients undergoing carotid endarterectomy (CEA) who are taking an anti-platelet agent within 48 hours prior to surgery and are prescribed this medication at hospital discharge following surgery</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6532,7 +6355,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>423</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients undergoing carotid endarterectomy (CEA) who are taking an anti-platelet agent within 48 hours prior to surgery and are prescribed this medication at hospital discharge following surgery</description>
       <name>CEA</name>
@@ -6545,7 +6367,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Perioperative Care: Selection of Prophylactic Antibiotic - First OR Second Generation Cephalosporin</title>
     <description>Percentage of surgical patients aged 18 years and older undergoing procedures with the indications for a first OR second generation cephalosporin prophylactic antibiotic who had an order for a first OR second generation cephalosporin for antimicrobial prophylaxis</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6557,7 +6379,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>021</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of surgical patients aged 18 years and older undergoing procedures with the indications for a first second generation cephalosporin prophylactic antibiotic who had an order for a first OR second generation cephalosporin for antimicrobial prophylaxis</description>
       <name>prophylacticAntibiotic</name>
@@ -6575,7 +6396,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Perioperative Care: Venous Thromboembolism (VTE) Prophylaxis (When Indicated in ALL Patients)</title>
     <description>Percentage of surgical patients aged 18 years and older undergoing procedures for which venous thromboembolism (VTE) prophylaxis is indicated in all patients, who had an order for Low Molecular Weight Heparin (LMWH), Low- Dose Unfractionated Heparin (LDUH), adjusted-dose warfarin, fondaparinux or mechanical prophylaxis to be given within 24 hours prior to incision time or within 24 hours after surgery end time</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6587,7 +6408,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>023</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of surgical patients aged 18 years and older undergoing procedures for which venous thromboembolism (VTE) prophylaxis is indicated in all patients, who had an order for Low Molecular Weight Heparin (LMWH), Low- Dose Unfractionated Heparin (LDUH), adjusted-dose warfarin, fondaparinux or mechanical prophylaxis to be given within 24 hours prior to incision time or within 24 hours after surgery end time</description>
       <name>VTE</name>
@@ -6605,7 +6425,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Perioperative Temperature Management</title>
     <description>Percentage of patients, regardless of age, who undergo surgical or therapeutic procedures under general or neuraxial anesthesia of 60 minutes duration or longer for whom at least one body temperature greater than or equal to 35.5 degrees Celsius (or 95.9 degrees Fahrenheit) was recorded within the 30 minutes immediately before or the 15 minutes immediately after anesthesia end time</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6617,7 +6437,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>424</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients, regardless of age, who undergo surgical or therapeutic procedures under general or neuraxial anesthesia of 60 minutes duration or longer for whom at least one body temperature greater than or equal to 35.5 degrees Celsius (or 95.9 degrees Fahrenheit) was recorded within the 30 minutes immediately before or the 15 minutes immediately after anesthesia end time</description>
       <name>anesthesia</name>
@@ -6630,7 +6449,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Persistence of Beta-Blocker Treatment After a Heart Attack</title>
     <description>The percentage of patients 18 years of age and older during the measurement year who were hospitalized and discharged from July 1 of the year prior to the measurement year to June 30 of the measurement year with a diagnosis of acute myocardial infarction (AMI) and who were prescribed persistent beta-blocker treatment for six months after discharge</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6642,7 +6461,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>442</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>The percentage of patients 18 years of age and older during the measurement year who were hospitalized and discharged from July 1 of the year prior to the measurement year to June 30 of the measurement year with a diagnosis of acute myocardial infarction (AMI) and who were prescribed persistent beta-blocker treatment for six months after discharge</description>
       <name>AMI</name>
@@ -6655,7 +6473,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Photodocumentation of Cecal Intubation</title>
     <description>The rate of screening and surveillance colonoscopies for which photodocumentation of landmarks of cecal intubation is performed to establish a complete examination</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6667,7 +6485,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>425</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>The rate of screening and surveillance colonoscopies for which photodocumentation of landmarks of cecal intubation is performed to establish a complete examination</description>
       <name>colonoscopy</name>
@@ -6680,7 +6497,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Pneumococcal Vaccination Status for Older Adults</title>
     <description>Percentage of patients 65 years of age and older who have ever received a pneumococcal vaccine.</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -6692,7 +6509,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>111</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients 65 years of age and older who have ever received a pneumococcal vaccine</description>
       <name>pneumococcal</name>
@@ -6709,7 +6525,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Post-Anesthetic Transfer of Care Measure: Procedure Room to a Post Anesthesia Care Unit (PACU)</title>
     <description>Percentage of patients, regardless of age, who are under the care of an anesthesia practitioner and are admitted to a PACU in which a post-anesthetic formal transfer of care protocol or checklist which includes the key transfer of care elements is utilized</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -6721,7 +6537,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>426</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients, regardless of age, who are under the care of an anesthesia practitioner and are admitted to a PACU in which a post-anesthetic formal transfer of care protocol or checklist which includes the key transfer of care elements is utilized</description>
       <name>PACU</name>
@@ -6734,7 +6549,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Post-Anesthetic Transfer of Care: Use of Checklist or Protocol for Direct Transfer of Care from Procedure Room to Intensive Care Unit (ICU)</title>
     <description>Percentage of patients, regardless of age, who undergo a procedure under anesthesia and are admitted to an Intensive Care Unit (ICU) directly from the anesthetizing location, who have a documented use of a checklist or protocol for the transfer of care from the responsible anesthesia practitioner to the responsible ICU team or team member</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -6746,7 +6561,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>427</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients, regardless of age, who undergo a procedure under anesthesia and are admitted to an Intensive Care Unit (ICU) directly from the anesthetizing location, who have a documented use of a checklist or protocol for the transfer of care from the responsible anesthesia practitioner to the responsible ICU team or team member</description>
       <name>ICU</name>
@@ -6759,7 +6573,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Pregnant women that had HBsAg testing</title>
     <description>This measure identifies pregnant women who had a HBsAg (hepatitis B) test during their pregnancy</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6771,7 +6585,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>369</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>OptumInsight</primarySteward>
     <submissionMethod>ehr</submissionMethod>
   </measure>
@@ -6779,7 +6592,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Preoperative Diagnosis of Breast Cancer</title>
     <description>The percent of patients undergoing breast cancer operations who obtained the diagnosis of breast cancer preoperatively by a minimally invasive biopsy method</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -6791,7 +6604,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>263</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>The percent of patients undergoing breast cancer operations who obtained the diagnosis of breast cancer preoperatively by a minimally invasive biopsy method</description>
       <name>breastCancer</name>
@@ -6803,7 +6615,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Prevention of Central Venous Catheter (CVC) - Related Bloodstream Infections</title>
     <description>Percentage of patients, regardless of age, who undergo central venous catheter (CVC) insertion for whom CVC was inserted with all elements of maximal sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound techniques followed</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6815,7 +6627,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>076</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients, regardless of age, who undergo central venous catheter (CVC) insertion for whom CVC was inserted with all elements of maximal sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound techniques followed</description>
       <name>CVC</name>
@@ -6830,7 +6641,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Prevention of Post-Operative Nausea and Vomiting (PONV) - Combination Therapy</title>
     <description>Percentage of patients, aged 18 years and older, who undergo a procedure under an inhalational general anesthetic, AND who have three or more risk factors for post-operative nausea and vomiting (PONV), who receive combination therapy consisting of at least two prophylactic pharmacologic antiemetic agents of different classes preoperatively or intraoperatively</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -6842,7 +6653,6 @@ This measure is reported as three rates stratified by age group:
     <qualityId>430</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients, aged 18 years and older, who undergo a procedure under an inhalational general anesthetic, who have three or more risk factors for post-operative nausea and vomiting (PONV), who receive combination therapy consisting of at least two prophylactic pharmacologic antiemetic agents of different classes preoperatively or intraoperatively</description>
       <name>PONV</name>
@@ -6855,7 +6665,7 @@ This measure is reported as three rates stratified by age group:
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan</title>
     <description>Percentage of patients aged 18 years and older with a BMI documented during the current encounter or during the previous six months AND with a BMI outside of normal parameters, a follow-up plan is documented during the encounter or during the previous six months of the current encounter  
 
@@ -6869,7 +6679,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>128</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a BMI documented during the current encounter or during the previous six months with a BMI outside of normal parameters, a follow-up plan is documented during the encounter or during the previous six months of the current encounter Normal Parameters: Age 18 years and older BMI ≥ 18.5 and &lt; 25 kg/m2</description>
       <name>BMI</name>
@@ -6900,7 +6709,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Preventive Care and Screening: Influenza Immunization</title>
     <description>Percentage of patients aged 6 months and older seen for a visit between October 1 and March 31 who received an influenza immunization OR who reported previous receipt of an influenza immunization</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -6912,7 +6721,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>110</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 6 months and older seen for a visit between October 1 and March 31 who received an influenza immunization who reported previous receipt of an influenza immunization</description>
       <name>influenza</name>
@@ -6933,7 +6741,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Preventive Care and Screening: Screening for Clinical Depression and Follow-Up Plan</title>
     <description>Percentage of patients aged 12 years and older screened for depression on the date of the encounter using an age appropriate standardized depression screening tool AND if positive, a follow-up plan is documented on the date of the positive screen</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -6945,7 +6753,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>134</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 12 years and older screened for depression on the date of the encounter using an age appropriate standardized depression screening tool if positive, a follow-up plan is documented on the date of the positive screen</description>
       <name>depression</name>
@@ -6964,7 +6771,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented</title>
     <description>Percentage of patients aged 18 years and older seen during the reporting period who were screened for high blood pressure AND a recommended follow-up plan is documented based on the current blood pressure (BP) reading as indicated</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -6976,7 +6783,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>317</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older seen during the reporting period who were screened for high blood pressure a recommended follow-up plan is documented based on the current blood pressure (BP) reading as indicated</description>
       <name>highBloodPressure</name>
@@ -7014,7 +6820,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention</title>
     <description>Percentage of patients aged 18 years and older who were screened for tobacco use one or more times within 24 months AND who received cessation counseling intervention if identified as a tobacco user</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -7026,7 +6832,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>226</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older who were screened for tobacco use one or more times within 24 months who received cessation counseling intervention if identified as a tobacco user</description>
       <name>tobacco</name>
@@ -7064,7 +6869,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Preventive Care and Screening: Unhealthy Alcohol Use: Screening &amp; Brief Counseling</title>
     <description>Percentage of patients aged 18 years and older who were screened for unhealthy alcohol use using a systematic screening method at least once within the last 24 months AND who received brief counseling if identified as an unhealthy alcohol user</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -7076,7 +6881,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>431</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older who were screened for unhealthy alcohol use using a systematic screening method at least once within the last 24 months who received brief counseling if identified as an unhealthy alcohol user</description>
       <name>alcohol</name>
@@ -7101,7 +6905,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Primary Caries Prevention Intervention as Offered by Primary Care Providers, including Dentists</title>
     <description>Percentage of children, age 0-20 years, who received a fluoride varnish application during the measurement period.</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7113,7 +6917,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>379</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
     <submissionMethod>ehr</submissionMethod>
     <measureSet>pediatrics</measureSet>
@@ -7122,7 +6925,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of primary open-angle glaucoma (POAG) who have an optic nerve head evaluation during one or more office visits within 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7134,7 +6937,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>012</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of primary open-angle glaucoma (POAG) who have an optic nerve head evaluation during one or more office visits within 12 months</description>
       <name>POAG</name>
@@ -7149,7 +6951,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of primary open-angle glaucoma (POAG) whose glaucoma treatment has not failed (the most recent IOP was reduced by at least 15% from the pre-intervention level) OR if the most recent IOP was not reduced by at least 15% from the pre-intervention level, a plan of care was documented within 12 months</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -7161,7 +6963,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>141</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of primary open-angle glaucoma (POAG) whose glaucoma treatment has not failed (the most recent IOP was reduced by at least 15% from the pre-intervention level) if the most recent IOP was not reduced by at least 15% from the pre-intervention level, a plan of care was documented within 12 months</description>
       <name>POAG</name>
@@ -7175,7 +6976,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Proportion Admitted to Hospice for less than 3 days</title>
     <description>Proportion of patients who died from cancer, and admitted to hospice and spent less than 3 days there</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7187,7 +6988,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>457</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Proportion of patients who died from cancer, and admitted to hospice and spent less than 3 days there</description>
       <name>hospice</name>
@@ -7200,7 +7000,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Proportion Admitted to the Intensive Care Unit (ICU) in the Last 30 Days of Life</title>
     <description>Proportion of patients who died from cancer admitted to the ICU in the last 30 days of life</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7212,7 +7012,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>455</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Proportion of patients who died from cancer admitted to the ICU in the last 30 days of life</description>
       <name>ICU</name>
@@ -7225,7 +7024,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Proportion Not Admitted To Hospice</title>
     <description>Proportion  of patients who died from cancer not admitted to hospice</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7237,7 +7036,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>456</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Proportion of patients who died from cancer not admitted to hospice</description>
       <name>noHospice</name>
@@ -7250,7 +7048,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Proportion of Patients Sustaining a Bladder Injury at the Time of any Pelvic Organ Prolapse Repair</title>
     <description>Percentage of patients undergoing any surgery to repair pelvic organ prolapse who sustains an injury to the bladder recognized either during or within 1 month after surgery</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -7262,7 +7060,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>432</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients undergoing any surgery to repair pelvic organ prolapse who sustains an injury to the bladder recognized either during or within 1 month after surgery</description>
       <name>bladder</name>
@@ -7275,7 +7072,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Proportion of Patients Sustaining a Bowel Injury at the time of any Pelvic Organ Prolapse Repair</title>
     <description>Percentage of patients undergoing surgical repair of pelvic organ prolapse that is complicated by a bowel injury at the time of index surgery that is recognized intraoperatively or within 1 month after surgery</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -7287,7 +7084,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>433</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients undergoing surgical repair of pelvic organ prolapse that is complicated by a bowel injury at the time of index surgery that is recognized intraoperatively or within 1 month after surgery</description>
       <name>bowel</name>
@@ -7300,7 +7096,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Proportion of Patients Sustaining a Ureter Injury at the Time of any Pelvic Organ Prolapse Repair</title>
     <description>Percentage of patients undergoing pelvic organ prolapse repairs who sustain an injury to the ureter recognized either during or within 1 month after surgery</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -7312,7 +7108,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>434</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients undergoing pelvic organ prolapse repairs who sustain an injury to the ureter recognized either during or within 1 month after surgery</description>
       <name>ureter</name>
@@ -7325,7 +7120,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Proportion of Patients who Died from Cancer with more than One Emergency Department Visit in the Last 30 Days of Life</title>
     <description>Proportion of patients who died from cancer with more than one emergency department visit in the last 30 days of life</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7337,7 +7132,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>454</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Proportion of patients who died from cancer with more than one emergency department visit in the last 30 days of life</description>
       <name>emergencyDepartment</name>
@@ -7350,7 +7144,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Proportion Receiving Chemotherapy in the Last 14 Days of Life</title>
     <description>Proportion of patients who died from cancer receiving chemotherapy in the last 14 days of life</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7362,7 +7156,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>453</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Proportion of patients who died from cancer receiving chemotherapy in the last 14 days of life</description>
       <name>chemotherapy</name>
@@ -7375,7 +7168,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Prostate Cancer: Adjuvant Hormonal Therapy for High Risk or Very High Risk Prostate Cancer</title>
     <description>Percentage of patients, regardless of age, with a diagnosis of prostate cancer at high or very high risk of recurrence receiving external beam radiotherapy to the prostate who were prescribed adjuvant hormonal therapy (GnRH [gonadotropin-releasing hormone] agonist or antagonist)</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7387,7 +7180,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>104</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients, regardless of age, with a diagnosis of prostate cancer at high or very high risk of recurrence receiving external beam radiotherapy to the prostate who were prescribed adjuvant hormonal therapy (GnRH [gonadotropin-releasing hormone] agonist or antagonist)</description>
       <name>prostateCancer</name>
@@ -7400,7 +7192,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients</title>
     <description>Percentage of patients, regardless of age, with a diagnosis of prostate cancer at low (or very low) risk of recurrence receiving interstitial prostate brachytherapy, OR external beam radiotherapy to the prostate, OR radical prostatectomy, OR cryotherapy who did not have a bone scan performed at any time since diagnosis of prostate cancer</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -7412,7 +7204,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>102</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients, regardless of age, with a diagnosis of prostate cancer at low (or very low) risk of recurrence receiving interstitial prostate brachytherapy, external beam radiotherapy to the prostate, OR radical prostatectomy, OR cryotherapy who did not have a bone scan performed at any time since diagnosis of prostate cancer</description>
       <name>prostateCancer</name>
@@ -7428,7 +7219,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Psoriasis: Clinical Response to Oral Systemic or Biologic Medications</title>
     <description>Percentage of psoriasis patients receiving oral systemic or biologic therapy who meet minimal physician-or patient- reported disease activity levels. It is implied that establishment and maintenance of an established minimum level of disease control as measured by physician-and/or patient-reported outcomes will increase patient satisfaction with and adherence to treatment</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -7440,7 +7231,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>410</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of psoriasis patients receiving oral systemic or biologic therapy who meet minimal physician-or patient- reported disease activity levels. It is implied that establishment and maintenance of an established minimum level of disease control as measured by physician-and/or patient-reported outcomes will increase patient satisfaction with and adherence to treatment</description>
       <name>therapy</name>
@@ -7454,7 +7244,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Quality of Life Assessment For Patients With Primary Headache Disorders</title>
     <description>Percentage of patients with a diagnosis of primary headache disorder whose health related quality of life (HRQoL) was assessed with a tool(s) during at least two visits during the 12 month measurement period AND whose health related quality of life score stayed the same or improved</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7466,7 +7256,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>435</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients with a diagnosis of primary headache disorder whose health related quality of life (HRQoL) was assessed with a tool(s) during at least two visits during the 12 month measurement period whose health related quality of life score stayed the same or improved</description>
       <name>headache</name>
@@ -7480,7 +7269,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Quantitative Immunohistochemical (IHC) Evaluation of Human Epidermal Growth Factor Receptor 2 Testing (HER2) for Breast Cancer Patients</title>
     <description>This is a measure based on whether quantitative evaluation of Human Epidermal Growth Factor Receptor 2 Testing (HER2) by immunohistochemistry (IHC) uses the system recommended in the current ASCO/CAP Guidelines for Human Epidermal Growth Factor Receptor 2 Testing in breast cancer</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7492,7 +7281,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>251</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>This is a measure based on whether quantitative evaluation of Human Epidermal Growth Factor Receptor 2 Testing (HER2) by immunohistochemistry (IHC) uses the system recommended in the current ASCO/CAP Guidelines for Human Epidermal Growth Factor Receptor 2 Testing in breast cancer</description>
       <name>HER2</name>
@@ -7506,7 +7294,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Radiation Consideration for Adult CT: Utilization of Dose Lowering Techniques</title>
     <description>Percentage of final reports for patients aged 18 years and older undergoing CT with documentation that one or more of the following dose reduction techniques were used:
 &lt;br/&gt;&lt;ul&gt;&lt;li&gt; Automated exposure control
@@ -7523,7 +7311,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>436</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of final reports for patients aged 18 years and older undergoing CT with documentation that one or more of the following dose reduction techniques were used: • Automated exposure control • Adjustment of the mA and/or kV according to patient size • Use of iterative reconstruction technique</description>
       <name>CT</name>
@@ -7537,7 +7324,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Radical Prostatectomy Pathology Reporting</title>
     <description>Percentage of radical prostatectomy pathology reports that include the pT category, the pN category, the Gleason score and a statement about margin status</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7549,7 +7336,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>250</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of radical prostatectomy pathology reports that include the pT category, the pN category, the Gleason score and a statement about margin status</description>
       <name>prostatectomy</name>
@@ -7564,7 +7350,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Radiology: Exposure Dose or Time Reported for Procedures Using Fluoroscopy</title>
     <description>Final reports for procedures using fluoroscopy that document radiation exposure indices, or exposure time and number of fluorographic images (if radiation exposure indices are not available)</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -7576,7 +7362,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>145</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Final reports for procedures using fluoroscopy that document radiation exposure indices, or exposure time and number of fluorographic images (if radiation exposure indices are not available)</description>
       <name>radiation</name>
@@ -7590,7 +7375,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Radiology: Inappropriate Use of "Probably Benign" Assessment Category in Screening Mammograms</title>
     <description>Percentage of final reports for screening mammograms that are classified as "probably benign"</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -7602,7 +7387,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>146</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>true</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of final reports for screening mammograms that are classified as “probably benign”</description>
       <name>mammograms</name>
@@ -7616,7 +7400,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Radiology: Reminder System for Screening Mammograms</title>
     <description>Percentage of patients undergoing a screening mammogram whose information is entered into a reminder system with a target due date for the next mammogram</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -7628,7 +7412,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>225</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients undergoing a screening mammogram whose information is entered into a reminder system with a target due date for the next mammogram</description>
       <name>mammogram</name>
@@ -7642,7 +7425,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Radiology: Stenosis Measurement in Carotid Imaging Reports</title>
     <description>Percentage of final reports for carotid imaging studies (neck magnetic resonance angiography [MRA], neck computed tomography angiography [CTA], neck duplex ultrasound, carotid angiogram) performed that include direct or indirect reference to measurements of distal internal carotid diameter as the denominator for stenosis measurement</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7654,7 +7437,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>195</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of final reports for carotid imaging studies (neck magnetic resonance angiography [MRA], neck computed tomography angiography [CTA], neck duplex ultrasound, carotid angiogram) performed that include direct or indirect reference to measurements of distal internal carotid diameter as the denominator for stenosis measurement</description>
       <name>carotidImaging</name>
@@ -7668,7 +7450,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Rate of Carotid Artery Stenting (CAS) for Asymptomatic Patients, Without Major Complications (Discharged to Home by Post-Operative Day #2)</title>
     <description>Percent of asymptomatic patients undergoing CAS who are discharged to home no later than post-operative day #2</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7680,7 +7462,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>344</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percent of asymptomatic patients undergoing CAS who are discharged to home no later than post-operative day #2</description>
       <name>CAS</name>
@@ -7694,7 +7475,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Rate of Carotid Endarterectomy (CEA) for Asymptomatic Patients, without Major Complications (Discharged to Home by Post-Operative Day #2)</title>
     <description>Percent of asymptomatic patients undergoing CEA who are discharged to home no later than post-operative day #2</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -7706,7 +7487,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>260</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percent of asymptomatic patients undergoing CEA who are discharged to home no later than post-operative day #2</description>
       <name>CEA</name>
@@ -7719,7 +7499,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) Who Die While in Hospital</title>
     <description>Percent of patients undergoing endovascular repair of small or moderate infrarenal abdominal aortic aneurysms (AAA) that die while in the hospital</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -7731,7 +7511,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>347</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percent of patients undergoing endovascular repair of small or moderate infrarenal abdominal aortic aneurysms (AAA) that die while in the hospital</description>
       <name>AAA</name>
@@ -7744,7 +7523,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post Operative Day #2)</title>
     <description>Percent of patients undergoing endovascular repair of small or moderate non-ruptured infrarenal abdominal aortic aneurysms (AAA) that do not experience a major complication (discharged to home no later than post-operative day #2)</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -7756,7 +7535,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>259</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percent of patients undergoing endovascular repair of small or moderate non-ruptured infrarenal abdominal aortic aneurysms (AAA) that do not experience a major complication (discharged to home no later than post-operative day #2)</description>
       <name>AAA</name>
@@ -7770,7 +7548,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Rate of Open Repair of Small or Moderate Abdominal Aortic Aneurysms (AAA) Where Patients Are Discharged Alive</title>
     <description>Percentage of patients undergoing open repair of small or moderate abdominal aortic aneurysms (AAA) who are discharged alive</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -7782,7 +7560,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>417</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients undergoing open repair of small or moderate abdominal aortic aneurysms (AAA) who are discharged alive</description>
       <name>AAA</name>
@@ -7794,7 +7571,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Rate of Open Repair of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post-Operative Day #7)</title>
     <description>Percent of patients undergoing open repair of small or moderate sized non-ruptured infrarenal abdominal aortic aneurysms who do not experience a major complication (discharge to home no later than post-operative day #7)</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -7806,7 +7583,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>258</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percent of patients undergoing open repair of small or moderate sized non-ruptured infrarenal abdominal aortic aneurysms who do not experience a major complication (discharge to home no later than post-operative day #7)</description>
       <name>AAA</name>
@@ -7819,7 +7595,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Rate of Postoperative Stroke or Death in Asymptomatic Patients Undergoing Carotid Artery Stenting (CAS)</title>
     <description>Percent of asymptomatic patients undergoing CAS who experience stroke or death following surgery while in the hospital</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7831,7 +7607,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>345</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percent of asymptomatic patients undergoing CAS who experience stroke or death following surgery while in the hospital</description>
       <name>CAS</name>
@@ -7845,7 +7620,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Rate of Postoperative Stroke or Death in Asymptomatic Patients Undergoing Carotid Endarterectomy (CEA)</title>
     <description>Percent of asymptomatic patients undergoing CEA who experience stroke or death following surgery while in the hospital</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7857,7 +7632,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>346</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percent of asymptomatic patients undergoing CEA who experience stroke or death following surgery while in the hospital</description>
       <name>CEA</name>
@@ -7869,7 +7643,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Rate of Surgical Conversion from Lower Extremity Endovascular Revascularization Procedure</title>
     <description>Inpatients assigned to endovascular treatment for obstructive arterial disease, the percent of patients who undergo unplanned major amputation or surgical bypass within 48 hours of the index procedure</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -7881,7 +7655,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>437</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Inpatients assigned to endovascular treatment for obstructive arterial disease, the percent of patients who undergo unplanned major amputation or surgical bypass within 48 hours of the index procedure</description>
       <name>OAD</name>
@@ -7894,7 +7667,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Referral for Otologic Evaluation for Patients with Acute or Chronic Dizziness</title>
     <description>Percentage of patients aged birth and older referred to a physician (preferably a physician specially trained in disorders of the ear) for an otologic evaluation subsequent to an audiologic evaluation after presenting with acute or chronic dizziness</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -7906,7 +7679,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>261</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged birth and older referred to a physician (preferably a physician specially trained in disorders of the ear) for an otologic evaluation subsequent to an audiologic evaluation after presenting with acute or chronic dizziness</description>
       <name>dizziness</name>
@@ -7919,7 +7691,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Rheumatoid Arthritis (RA): Assessment and Classification of Disease Prognosis</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have an assessment and classification of disease prognosis at least once within 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7931,7 +7703,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>179</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have an assessment and classification of disease prognosis at least once within 12 months</description>
       <name>RA</name>
@@ -7945,7 +7716,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Rheumatoid Arthritis (RA): Functional Status Assessment</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) for whom a functional status assessment was performed at least once within 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7957,7 +7728,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>178</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) for whom a functional status assessment was performed at least once within 12 months</description>
       <name>RA</name>
@@ -7971,7 +7741,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Rheumatoid Arthritis (RA): Glucocorticoid Management</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have been assessed for glucocorticoid use and, for those on prolonged doses of prednisone &gt;= 10 mg daily (or equivalent) with improvement or no change in disease activity, documentation of glucocorticoid management plan within 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -7983,7 +7753,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>180</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have been assessed for glucocorticoid use and, for those on prolonged doses of prednisone ≥ 10 mg daily (or equivalent) with improvement or no change in disease activity, documentation of glucocorticoid management plan within 12 months</description>
       <name>RA</name>
@@ -7997,7 +7766,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Rheumatoid Arthritis (RA): Periodic Assessment of Disease Activity</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have an assessment and classification of disease activity within 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -8009,7 +7778,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>177</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have an assessment and classification of disease activity within 12 months</description>
       <name>RA</name>
@@ -8022,7 +7790,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Rheumatoid Arthritis (RA): Tuberculosis Screening</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have documentation of a tuberculosis (TB) screening performed and results interpreted within 6 months prior to receiving a first course of therapy using a biologic disease-modifying anti-rheumatic drug (DMARD)</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -8034,7 +7802,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>176</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have documentation of a tuberculosis (TB) screening performed and results interpreted within 6 months prior to receiving a first course of therapy using a biologic disease-modifying anti-rheumatic drug (DMARD)</description>
       <name>RA</name>
@@ -8047,7 +7814,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Rh Immunoglobulin (Rhogam) for Rh-Negative Pregnant Women at Risk of Fetal Blood Exposure</title>
     <description>Percentage of Rh-negative pregnant women aged 14-50 years at risk of fetal blood exposure who receive Rh- Immunoglobulin (Rhogam) in the emergency department (ED)</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -8059,7 +7826,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>255</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of Rh-negative pregnant women aged 14-50 years at risk of fetal blood exposure who receive Rh- Immunoglobulin (Rhogam) in the emergency department (ED)</description>
       <name>Rhogam</name>
@@ -8073,7 +7839,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Risk-Adjusted Operative Mortality for Coronary Artery Bypass Graft (CABG)</title>
     <description>Percent of patients aged 18 years and older undergoing isolated CABG who die, including both all deaths occurring during the hospitalization in which the CABG was performed, even if after 30 days, and those deaths occurring after discharge from the hospital, but within 30 days of the procedure</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -8085,7 +7851,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>445</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percent of patients aged 18 years and older undergoing isolated CABG who die, including both all deaths occurring during the hospitalization in which the CABG was performed, even if after 30 days, and those deaths occurring after discharge from the hospital, but within 30 days of the procedure</description>
       <name>CABG</name>
@@ -8097,7 +7862,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Screening Colonoscopy Adenoma Detection Rate</title>
     <description>The percentage of patients age 50 years or older with at least one conventional adenoma or colorectal cancer detected during screening colonoscopy</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -8109,7 +7874,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>343</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>The percentage of patients age 50 years or older with at least one conventional adenoma or colorectal cancer detected during screening colonoscopy</description>
       <name>colonoscopy</name>
@@ -8122,7 +7886,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Screening for Osteoporosis for Women Aged 65-85 Years of Age</title>
     <description>Percentage of female patients aged 65-85 years of age who ever had a central dual-energy X-ray absorptiometry (DXA) to check for osteoporosis</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -8134,7 +7898,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>039</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of female patients aged 65-85 years of age who ever had a central dual-energy X-ray absorptiometry (DXA) to check for osteoporosis</description>
       <name>DXA</name>
@@ -8148,7 +7911,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Sentinel Lymph Node Biopsy for Invasive Breast Cancer</title>
     <description>The percentage of clinically node negative (clinical stage T1N0M0 or T2N0M0) breast cancer patients who undergo a sentinel lymph node (SLN) procedure</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -8160,7 +7923,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>264</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>The percentage of clinically node negative (clinical stage T1N0M0 or T2N0M0) breast cancer patients who undergo a sentinel lymph node (SLN) procedure</description>
       <name>SLN</name>
@@ -8172,7 +7934,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Sleep Apnea: Assessment of Adherence to Positive Airway Pressure Therapy</title>
     <description>Percentage of visits for patients aged 18 years and older with a diagnosis of obstructive sleep apnea who were prescribed positive airway pressure therapy who had documentation that adherence to positive airway pressure therapy was objectively measured</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -8184,7 +7946,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>279</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of visits for patients aged 18 years and older with a diagnosis of obstructive sleep apnea who were prescribed positive airway pressure therapy who had documentation that adherence to positive airway pressure therapy was objectively measured</description>
       <name>sleepApnea</name>
@@ -8196,7 +7957,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Sleep Apnea: Assessment of Sleep Symptoms</title>
     <description>Percentage of visits for patients aged 18 years and older with a diagnosis of obstructive sleep apnea that includes documentation of an assessment of sleep symptoms, including presence or absence of snoring and daytime sleepiness</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -8208,7 +7969,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>276</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of visits for patients aged 18 years and older with a diagnosis of obstructive sleep apnea that includes documentation of an assessment of sleep symptoms, including presence or absence of snoring and daytime sleepiness</description>
       <name>sleepApnea</name>
@@ -8220,7 +7980,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Sleep Apnea: Positive Airway Pressure Therapy Prescribed</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of moderate or severe obstructive sleep apnea who were prescribed positive airway pressure therapy</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -8232,7 +7992,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>278</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of moderate or severe obstructive sleep apnea who were prescribed positive airway pressure therapy</description>
       <name>sleepApnea</name>
@@ -8244,7 +8003,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Sleep Apnea: Severity Assessment at Initial Diagnosis</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of obstructive sleep apnea who had an apnea hypopnea index (AHI) or a respiratory disturbance index (RDI) measured at the time of initial diagnosis</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -8256,7 +8015,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>277</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of obstructive sleep apnea who had an apnea hypopnea index (AHI) or a respiratory disturbance index (RDI) measured at the time of initial diagnosis</description>
       <name>sleepApnea</name>
@@ -8268,7 +8026,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Statin Therapy at Discharge after Lower Extremity Bypass (LEB)</title>
     <description>Percentage of patients aged 18 years and older undergoing infra-inguinal lower extremity bypass who are prescribed a statin medication at discharge</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -8280,7 +8038,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>257</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older undergoing infra-inguinal lower extremity bypass who are prescribed a statin medication at discharge</description>
       <name>lowerExtremityBypass</name>
@@ -8292,7 +8049,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Statin Therapy for the Prevention and Treatment of Cardiovascular Disease</title>
     <description>Percentage of the following patients-all considered at high risk of cardiovascular events-who were prescribed or were on statin therapy during the measurement period:
 &lt;br/&gt;&lt;ul&gt;&lt;li&gt; Adults aged &gt;= 21 years who were previously diagnosed with or currently have an active diagnosis of clinical atherosclerotic cardiovascular disease (ASCVD); OR
@@ -8309,7 +8066,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>438</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of the following patients—all considered at high risk of cardiovascular events—who were prescribed or were on statin therapy during the measurement period: • Adults aged ≥ 21 years who were previously diagnosed with or currently have an active diagnosis of clinical atherosclerotic cardiovascular disease (ASCVD); • Adults aged ≥21 years who have ever had a fasting or direct low-density lipoprotein cholesterol (LDL-C) level ≥ 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial or pure hypercholesterolemia; OR • Adults aged 40-75 years with a diagnosis of diabetes with a fasting or direct LDL-C level of 70-189 mg/dL</description>
       <name>highRiskCardiovascular</name>
@@ -8325,7 +8081,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Stroke and Stroke Rehabilitation: Discharged on Antithrombotic Therapy</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of ischemic stroke or transient ischemic attack (TIA) who were prescribed antithrombotic therapy at discharge</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -8337,7 +8093,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>032</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of ischemic stroke or transient ischemic attack (TIA) who were prescribed antithrombotic therapy at discharge</description>
       <name>strokeTIA</name>
@@ -8352,7 +8107,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Stroke and Stroke Rehabilitation: Thrombolytic Therapy</title>
     <description>Percentage of patients aged 18 years and older with a diagnosis of acute ischemic stroke who arrive at the hospital within two hours of time last known well and for whom IV t-PA was initiated within three hours of time last known well</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -8364,7 +8119,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>187</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older with a diagnosis of acute ischemic stroke who arrive at the hospital within two hours of time last known well and for whom IV t-PA was initiated within three hours of time last known well</description>
       <name>stroke</name>
@@ -8376,7 +8130,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Surgical Site Infection (SSI)</title>
     <description>Percentage of patients aged 18 years and older who had a surgical site infection (SSI)</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -8388,7 +8142,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>357</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older who had a surgical site infection (SSI)</description>
       <name>SSI</name>
@@ -8404,7 +8157,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Tobacco Use and Help with Quitting Among Adolescents</title>
     <description>The percentage of adolescents 12 to 20 years of age with a primary care visit during the measurement year for whom tobacco use status was documented and received help with quitting if identified as a tobacco user</description>
     <nationalQualityCode>CPH</nationalQualityCode>
@@ -8416,7 +8169,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>402</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>The percentage of adolescents 12 to 20 years of age with a primary care visit during the measurement year for whom tobacco use status was documented and received help with quitting if identified as a tobacco user</description>
       <name>tobacco</name>
@@ -8452,7 +8204,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Total Knee Replacement: Identification of Implanted Prosthesis in Operative Report</title>
     <description>Percentage of patients regardless of age  undergoing a total knee replacement whose operative report identifies the prosthetic implant specifications including the prosthetic implant manufacturer, the brand name of the prosthetic implant and the size of each prosthetic implant</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -8464,7 +8216,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>353</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients regardless of age undergoing a total knee replacement whose operative report identifies the prosthetic implant specifications including the prosthetic implant manufacturer, the brand name of the prosthetic implant and the size of each prosthetic implant</description>
       <name>kneeReplacement</name>
@@ -8477,7 +8228,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Total Knee Replacement: Preoperative Antibiotic Infusion with Proximal Tourniquet</title>
     <description>Percentage of patients regardless of age undergoing a total knee replacement who had the prophylactic antibiotic completely infused prior to the inflation of the proximal tourniquet</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -8489,7 +8240,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>352</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients regardless of age undergoing a total knee replacement who had the prophylactic antibiotic completely infused prior to the inflation of the proximal tourniquet</description>
       <name>kneeReplacement</name>
@@ -8502,7 +8252,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Total Knee Replacement: Shared Decision-Making: Trial of Conservative (Non-surgical) Therapy</title>
     <description>Percentage of patients regardless of age undergoing a total knee replacement with documented shared decision-making with discussion of conservative (non-surgical) therapy (e.g., non-steroidal anti-inflammatory drug (NSAIDs), analgesics, weight loss, exercise, injections) prior to the procedure</description>
     <nationalQualityCode>CCC</nationalQualityCode>
@@ -8514,7 +8264,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>350</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients regardless of age undergoing a total knee replacement with documented shared decision- making with discussion of conservative (non-surgical) therapy (e.g., non-steroidal anti-inflammatory drug (NSAIDs), analgesics, weight loss, exercise, injections) prior to the procedure</description>
       <name>kneeReplacement</name>
@@ -8527,7 +8276,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Total Knee Replacement: Venous Thromboembolic and Cardiovascular Risk Evaluation</title>
     <description>Percentage of patients regardless of age undergoing a total knee replacement who are evaluated for the presence or absence of venous thromboembolic and cardiovascular risk factors within 30 days prior to the procedure (e.g. history of Deep Vein Thrombosis (DVT), Pulmonary Embolism (PE), Myocardial Infarction (MI), Arrhythmia and Stroke)</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -8539,7 +8288,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>351</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients regardless of age undergoing a total knee replacement who are evaluated for the presence or absence of venous thromboembolic and cardiovascular risk factors within 30 days prior to the procedure (e.g. history of Deep Vein Thrombosis (DVT), Pulmonary Embolism (PE), Myocardial Infarction (MI), Arrhythmia and Stroke)</description>
       <name>kneeReplacement</name>
@@ -8552,7 +8300,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Trastuzumab Received By Patients With AJCC Stage I (T1c) -  III And HER2 Positive Breast Cancer Receiving Adjuvant Chemotherapy</title>
     <description>Proportion of female patients (aged 18 years and older) with AJCC stage I (T1c) - III, human epidermal growth factor receptor 2 (HER2) positive breast cancer receiving adjuvant chemotherapy who are also receiving trastuzumab</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -8564,7 +8312,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>450</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Proportion of female patients (aged 18 years and older) with AJCC stage I (T1c) – III, human epidermal growth factor receptor 2 (HER2) positive breast cancer receiving adjuvant chemotherapy who are also receiving trastuzumab</description>
       <name>AJCC</name>
@@ -8577,7 +8324,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Tuberculosis (TB) Prevention for Psoriasis, Psoriatic Arthritis and Rheumatoid Arthritis Patients on a Biological Immune Response Modifier</title>
     <description>Percentage of patients whose providers are ensuring active tuberculosis prevention either through yearly negative standard tuberculosis screening tests or are reviewing the patient's history to determine if they have had appropriate management for a recent or prior positive test</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -8589,7 +8336,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>337</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients whose providers are ensuring active tuberculosis prevention either through yearly negative standard tuberculosis screening tests or are reviewing the patient’s history to determine if they have had appropriate management for a recent or prior positive test</description>
       <name>tuberculosis</name>
@@ -8604,7 +8350,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Ultrasound Determination of Pregnancy Location for Pregnant Patients with Abdominal Pain</title>
     <description>Percentage of pregnant female patients aged 14 to 50 who present to the emergency department (ED) with a chief complaint of abdominal pain or vaginal bleeding who receive a trans-abdominal or trans-vaginal ultrasound to determine pregnancy location</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -8616,7 +8362,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>254</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of pregnant female patients aged 14 to 50 who present to the emergency department (ED) with a chief complaint of abdominal pain or vaginal bleeding who receive a trans-abdominal or trans-vaginal ultrasound to determine pregnancy location</description>
       <name>ED</name>
@@ -8630,7 +8375,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Unplanned Hospital Readmission within 30 Days of Principal Procedure</title>
     <description>Percentage of patients aged 18 years and older who had an unplanned hospital readmission within 30 days of principal procedure</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -8642,7 +8387,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>356</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older who had an unplanned hospital readmission within 30 days of principal procedure</description>
       <name>readmission</name>
@@ -8655,7 +8399,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Unplanned Reoperation within the 30 Day Postoperative Period</title>
     <description>Percentage of patients aged 18 years and older who had any unplanned reoperation within the 30 day postoperative period</description>
     <nationalQualityCode>PS</nationalQualityCode>
@@ -8667,7 +8411,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>355</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients aged 18 years and older who had any unplanned reoperation within the 30 day postoperative period</description>
       <name>reoperation</name>
@@ -8680,7 +8423,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Urinary Incontinence: Assessment of Presence or Absence of Urinary Incontinence in Women Aged 65 Years and Older</title>
     <description>Percentage of female patients aged 65 years and older who were assessed for the presence or absence of urinary incontinence within 12 months</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -8692,7 +8435,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>048</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of female patients aged 65 years and older who were assessed for the presence or absence of urinary incontinence within 12 months</description>
       <name>UTI</name>
@@ -8708,7 +8450,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Years and Older</title>
     <description>Percentage of female patients aged 65 years and older with a diagnosis of urinary incontinence with a documented plan of care for urinary incontinence at least once within 12 months</description>
     <nationalQualityCode>PCCEO</nationalQualityCode>
@@ -8720,7 +8462,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <qualityId>050</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of female patients aged 65 years and older with a diagnosis of urinary incontinence with a documented plan of care for urinary incontinence at least once within 12 months</description>
       <name>UTI</name>
@@ -8737,7 +8478,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>multiPerformanceRate</metricType>
     <title>Use of High-Risk Medications in the Elderly</title>
     <description>Percentage of patients 66 years of age and older who were ordered high-risk medications. Two rates are reported.
 a. Percentage of patients who were ordered at least one high-risk medication. 
@@ -8751,7 +8492,6 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <qualityId>238</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>true</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients who were ordered at least one high-risk medication</description>
       <name>overall</name>
@@ -8763,12 +8503,13 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>ehr</submissionMethod>
     <submissionMethod>registry</submissionMethod>
+    <overallAlgorithm>simpleAverage</overallAlgorithm>
   </measure>
   <measure>
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Use of Imaging Studies for Low Back Pain</title>
     <description>Percentage of patients 18-50 years of age with a diagnosis of low back pain who did not have an imaging study (plain X-ray, MRI, CT scan) within 28 days of the diagnosis.</description>
     <nationalQualityCode>ECR</nationalQualityCode>
@@ -8780,7 +8521,6 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <qualityId>312</qualityId>
     <isHighPriority>true</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>ehr</submissionMethod>
     <measureSet>orthopedicSurgery</measureSet>
@@ -8791,7 +8531,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Varicose Vein Treatment with Saphenous Ablation: Outcome Survey</title>
     <description>Percentage of patients treated for varicose veins (CEAP C2-S) who are treated with saphenous ablation (with or without adjunctive tributary treatment) that report an improvement on a disease specific patient reported outcome survey instrument after treatment</description>
     <nationalQualityCode>ECC</nationalQualityCode>
@@ -8803,7 +8543,6 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <qualityId>420</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <strata>
       <description>Percentage of patients treated for varicose veins (CEAP C2-S) who are treated with saphenous ablation (with or without adjunctive tributary treatment) that report an improvement on a disease specific patient reported outcome survey instrument after treatment</description>
       <name>CEAP_C2-S</name>
@@ -8815,7 +8554,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>performanceRate</metricType>
+    <metricType>singlePerformanceRate</metricType>
     <title>Weight Assessment and Counseling for Nutrition and Physical Activity for Children and Adolescents</title>
     <description>Percentage of patients 3-17 years of age who had an outpatient visit with a Primary Care Physician (PCP) or Obstetrician/Gynecologist (OB/GYN) and who had evidence of the following during the measurement period. Three rates are reported.
 
@@ -8831,7 +8570,6 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <qualityId>239</qualityId>
     <isHighPriority>false</isHighPriority>
     <isInverse>false</isInverse>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>ehr</submissionMethod>
     <measureSet>pediatrics</measureSet>

--- a/measures/measures-schema.yaml
+++ b/measures/measures-schema.yaml
@@ -15,7 +15,7 @@ definitions:
         enum: [ia, quality, aci, cost]
       metricType:
         description: Type of measurement that the measure requires in order to attest.
-        enum: [boolean, proportion, performanceRate, continuous]
+        enum: [boolean, proportion, singlePerformanceRate, multiPerformanceRate, continuous]
       firstPerformanceYear:
         description: Year in which the measure was introduced.
         type: integer
@@ -101,7 +101,7 @@ definitions:
         description: Formula to determine the overall performance rate, given multiple strata of performance rates.
         enum: [simpleAverage, weightedAverage, sumNumerators]
       strata:
-        description: Population segments for which the measure requires reporting data.
+        description: Population segments for which the measure requires reporting data. Only applicable to multiPerformanceRate measures.
         type: array
         items: { $ref: #/definitions/performanceStrata }
       primarySteward:
@@ -111,7 +111,7 @@ definitions:
         description: Possible methods for submitting performance data for the measure.
         type: array
         items: { $ref: #/definitions/methods }
-    required: [nationalQualityCode, measureType, eMeasureId, nqfEMeasureId, nqfId, qualityId, isHighPriority, isInverse, overallAlgorithm, strata, primarySteward, measureSets]
+    required: [nationalQualityCode, measureType, eMeasureId, nqfEMeasureId, nqfId, qualityId, isHighPriority, isInverse, strata, primarySteward, measureSets]
 
   performanceStrata:
     type: object

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/qpp-measures-data",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/scripts/convert-qpp-to-measures.js
+++ b/scripts/convert-qpp-to-measures.js
@@ -206,8 +206,8 @@ function parseQpp(json) {
       } else if (category === 'quality') {
         // isInverse defaults to false;
         obj.isInverse = qualityIdToIsInverseMap[obj.qualityId.replace(/^0*/, '')] || false;
-        obj.metricType = 'performanceRate';
-        obj.overallAlgorithm = 'simpleAverage';
+        // metricType for quality defaults to singlePerformanceRate
+        obj.metricType = 'singlePerformanceRate';
         obj.strata = [];
       }
     }

--- a/scripts/merge-measures-data.js
+++ b/scripts/merge-measures-data.js
@@ -1,4 +1,4 @@
-// this script merges the tmp/quality-performance-rates.json, 
+// this script merges the tmp/quality-performance-rates.json,
 // measures/quality-measures-additional-info.json, and the measures from stdin
 // into a new file that has more info about each performance strata
 var _     = require('lodash');
@@ -43,6 +43,10 @@ function mergeQpp(qppJson) {
 
       qppJson[index].strata = strataDetails;
       qppJson[index].overallAlgorithm = performanceRateInfo.overallAlgorithm;
+
+      if (performanceRateInfo.metricType) {
+        qppJson[index].metricType = performanceRateInfo.metricType;
+      }
     }
   });
 

--- a/util/quality-measures-strata-details.json
+++ b/util/quality-measures-strata-details.json
@@ -1,1217 +1,992 @@
 [
   {
     "qualityId": "001",
-    "performanceRates": ["A1c>9.0%"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["A1c>9.0%"]
   },
   {
     "qualityId": "005",
-    "performanceRates": ["LVEF<40%"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["LVEF<40%"]
   },
   {
     "qualityId": "006",
-    "performanceRates": ["CAD"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CAD"]
   },
   {
     "qualityId": "007",
     "performanceRates": ["LVEF<40%", "myocardialInfarction"],
-    "overallAlgorithm": "weightedAverage"
+    "overallAlgorithm": "weightedAverage",
+    "metricType": "multiPerformanceRate"
   },
   {
     "qualityId": "008",
-    "performanceRates": ["HF"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["HF"]
   },
   {
     "qualityId": "012",
-    "performanceRates": ["POAG"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["POAG"]
   },
   {
     "qualityId": "014",
-    "performanceRates": ["AMD"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["AMD"]
   },
   {
     "qualityId": "019",
-    "performanceRates": ["diabeticRetinopathy"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["diabeticRetinopathy"]
   },
   {
     "qualityId": "021",
-    "performanceRates": ["prophylacticAntibiotic"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["prophylacticAntibiotic"]
   },
   {
     "qualityId": "023",
-    "performanceRates": ["VTE"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["VTE"]
   },
   {
     "qualityId": "024",
-    "performanceRates": ["fracture"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["fracture"]
   },
   {
     "qualityId": "032",
-    "performanceRates": ["strokeTIA"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["strokeTIA"]
   },
   {
     "qualityId": "039",
-    "performanceRates": ["DXA"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["DXA"]
   },
   {
     "qualityId": "043",
-    "performanceRates": ["IMA"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["IMA"]
   },
   {
     "qualityId": "044",
-    "performanceRates": ["CABG"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CABG"]
   },
   {
     "qualityId": "046",
     "performanceRates": ["18-64", "65+", "overall"],
-    "overallAlgorithm": "simpleAverage"
+    "overallAlgorithm": "simpleAverage",
+    "metricType": "multiPerformanceRate"
   },
   {
     "qualityId": "047",
-    "performanceRates": ["surrogate"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["surrogate"]
   },
   {
     "qualityId": "048",
-    "performanceRates": ["UTI"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["UTI"]
   },
   {
     "qualityId": "050",
-    "performanceRates": ["UTI"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["UTI"]
   },
   {
     "qualityId": "051",
-    "performanceRates": ["COPD"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["COPD"]
   },
   {
     "qualityId": "052",
-    "performanceRates": ["FEV1/FVC<70%"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["FEV1/FVC<70%"]
   },
   {
     "qualityId": "065",
-    "performanceRates": ["URI"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["URI"]
   },
   {
     "qualityId": "066",
-    "performanceRates": ["strep"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["strep"]
   },
   {
     "qualityId": "067",
-    "performanceRates": ["MDS"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["MDS"]
   },
   {
     "qualityId": "068",
-    "performanceRates": ["MDS"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["MDS"]
   },
   {
     "qualityId": "069",
-    "performanceRates": ["MM"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["MM"]
   },
   {
     "qualityId": "070",
-    "performanceRates": ["CLL"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CLL"]
   },
   {
     "qualityId": "076",
-    "performanceRates": ["CVC"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CVC"]
   },
   {
     "qualityId": "091",
-    "performanceRates": ["AOE"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["AOE"]
   },
   {
     "qualityId": "093",
-    "performanceRates": ["AOE"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["AOE"]
   },
   {
     "qualityId": "099",
-    "performanceRates": ["pTpN"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["pTpN"]
   },
   {
     "qualityId": "100",
-    "performanceRates": ["pTpN"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["pTpN"]
   },
   {
     "qualityId": "102",
-    "performanceRates": ["prostateCancer"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["prostateCancer"]
   },
   {
     "qualityId": "104",
-    "performanceRates": ["prostateCancer"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["prostateCancer"]
   },
   {
     "qualityId": "109",
-    "performanceRates": ["OA"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["OA"]
   },
   {
     "qualityId": "110",
-    "performanceRates": ["influenza"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["influenza"]
   },
   {
     "qualityId": "111",
-    "performanceRates": ["pneumococcal"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["pneumococcal"]
   },
   {
     "qualityId": "112",
-    "performanceRates": ["mammogram"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["mammogram"]
   },
   {
     "qualityId": "113",
-    "performanceRates": ["colorectalCancer"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["colorectalCancer"]
   },
   {
     "qualityId": "116",
-    "performanceRates": ["bronchitis"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["bronchitis"]
   },
   {
     "qualityId": "117",
-    "performanceRates": ["diabetes"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["diabetes"]
   },
   {
     "qualityId": "118",
-    "performanceRates": ["CAD"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CAD"]
   },
   {
     "qualityId": "119",
-    "performanceRates": ["diabetes"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["diabetes"]
   },
   {
     "qualityId": "122",
     "performanceRates": ["<140/90mmHg", "planOfCare", "overall"],
-    "overallAlgorithm": "weightedAverage"
+    "overallAlgorithm": "weightedAverage",
+    "metricType": "multiPerformanceRate"
   },
   {
     "qualityId": "126",
-    "performanceRates": ["DM"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["DM"]
   },
   {
     "qualityId": "127",
-    "performanceRates": ["DM"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["DM"]
   },
   {
     "qualityId": "128",
-    "performanceRates": ["BMI"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["BMI"]
   },
   {
     "qualityId": "130",
-    "performanceRates": ["document"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["document"]
   },
   {
     "qualityId": "131",
-    "performanceRates": ["painAssessment"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["painAssessment"]
   },
   {
     "qualityId": "134",
-    "performanceRates": ["depression"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["depression"]
   },
   {
     "qualityId": "137",
-    "performanceRates": ["melanoma"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["melanoma"]
   },
   {
     "qualityId": "138",
-    "performanceRates": ["melanoma"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["melanoma"]
   },
   {
     "qualityId": "140",
-    "performanceRates": ["AMD"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["AMD"]
   },
   {
     "qualityId": "141",
-    "performanceRates": ["POAG"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["POAG"]
   },
   {
     "qualityId": "143",
-    "performanceRates": ["cancer"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["cancer"]
   },
   {
     "qualityId": "144",
-    "performanceRates": ["cancer"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["cancer"]
   },
   {
     "qualityId": "145",
-    "performanceRates": ["radiation"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["radiation"]
   },
   {
     "qualityId": "146",
-    "performanceRates": ["mammograms"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["mammograms"]
   },
   {
     "qualityId": "147",
-    "performanceRates": ["scintigraphy"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["scintigraphy"]
   },
   {
     "qualityId": "154",
-    "performanceRates": ["falls"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["falls"]
   },
   {
     "qualityId": "155",
-    "performanceRates": ["falls"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["falls"]
   },
   {
     "qualityId": "156",
-    "performanceRates": ["cancer"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["cancer"]
   },
   {
     "qualityId": "164",
-    "performanceRates": ["CABG"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CABG"]
   },
   {
     "qualityId": "165",
-    "performanceRates": ["CABG"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CABG"]
   },
   {
     "qualityId": "166",
-    "performanceRates": ["CABG"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CABG"]
   },
   {
     "qualityId": "167",
-    "performanceRates": ["CABG"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CABG"]
   },
   {
     "qualityId": "168",
-    "performanceRates": ["CABG"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CABG"]
   },
   {
     "qualityId": "176",
-    "performanceRates": ["RA"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["RA"]
   },
   {
     "qualityId": "177",
-    "performanceRates": ["RA"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["RA"]
   },
   {
     "qualityId": "178",
-    "performanceRates": ["RA"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["RA"]
   },
   {
     "qualityId": "179",
-    "performanceRates": ["RA"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["RA"]
   },
   {
     "qualityId": "180",
-    "performanceRates": ["RA"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["RA"]
   },
   {
     "qualityId": "181",
-    "performanceRates": ["elderMaltreament"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["elderMaltreament"]
   },
   {
     "qualityId": "182",
-    "performanceRates": ["functionalOutcome"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["functionalOutcome"]
   },
   {
     "qualityId": "185",
-    "performanceRates": ["colonoscopy"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["colonoscopy"]
   },
   {
     "qualityId": "187",
-    "performanceRates": ["stroke"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["stroke"]
   },
   {
     "qualityId": "191",
-    "performanceRates": ["cataract"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["cataract"]
   },
   {
     "qualityId": "192",
-    "performanceRates": ["cataract"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["cataract"]
   },
   {
     "qualityId": "195",
-    "performanceRates": ["carotidImaging"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["carotidImaging"]
   },
   {
     "qualityId": "204",
-    "performanceRates": ["AMI"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["AMI"]
   },
   {
     "qualityId": "205",
-    "performanceRates": ["HIV/AIDS"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["HIV/AIDS"]
   },
   {
     "qualityId": "217",
-    "performanceRates": ["kneeImpairment"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["kneeImpairment"]
   },
   {
     "qualityId": "218",
-    "performanceRates": ["hipImpairment"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["hipImpairment"]
   },
   {
     "qualityId": "219",
-    "performanceRates": ["footImpairment"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["footImpairment"]
   },
   {
     "qualityId": "220",
-    "performanceRates": ["lumbarImpairment"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["lumbarImpairment"]
   },
   {
     "qualityId": "221",
-    "performanceRates": ["shoulderImpariment"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["shoulderImpariment"]
   },
   {
     "qualityId": "222",
-    "performanceRates": ["armImpairment"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["armImpairment"]
   },
   {
     "qualityId": "223",
-    "performanceRates": ["orthopaedicImpairment"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["orthopaedicImpairment"]
   },
   {
     "qualityId": "224",
-    "performanceRates": ["melanoma"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["melanoma"]
   },
   {
     "qualityId": "225",
-    "performanceRates": ["mammogram"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["mammogram"]
   },
   {
     "qualityId": "226",
-    "performanceRates": ["tobacco"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["tobacco"]
   },
   {
     "qualityId": "236",
-    "performanceRates": ["hypertension"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["hypertension"]
   },
   {
     "qualityId": "238",
     "performanceRates": ["overall", "2+"],
-    "overallAlgorithm": "simpleAverage"
+    "overallAlgorithm": "simpleAverage",
+    "metricType": "multiPerformanceRate"
   },
   {
     "qualityId": "243",
-    "performanceRates": ["outpatient"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["outpatient"]
   },
   {
     "qualityId": "249",
-    "performanceRates": ["barrettsMucosa"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["barrettsMucosa"]
   },
   {
     "qualityId": "250",
-    "performanceRates": ["prostatectomy"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["prostatectomy"]
   },
   {
     "qualityId": "251",
-    "performanceRates": ["HER2"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["HER2"]
   },
   {
     "qualityId": "254",
-    "performanceRates": ["ED"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["ED"]
   },
   {
     "qualityId": "255",
-    "performanceRates": ["Rhogam"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["Rhogam"]
   },
   {
     "qualityId": "257",
-    "performanceRates": ["lowerExtremityBypass"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["lowerExtremityBypass"]
   },
   {
     "qualityId": "258",
-    "performanceRates": ["AAA"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["AAA"]
   },
   {
     "qualityId": "259",
-    "performanceRates": ["AAA"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["AAA"]
   },
   {
     "qualityId": "260",
-    "performanceRates": ["CEA"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CEA"]
   },
   {
     "qualityId": "261",
-    "performanceRates": ["dizziness"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["dizziness"]
   },
   {
     "qualityId": "262",
-    "performanceRates": ["imageConfirmation"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["imageConfirmation"]
   },
   {
     "qualityId": "263",
-    "performanceRates": ["breastCancer"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["breastCancer"]
   },
   {
     "qualityId": "264",
-    "performanceRates": ["SLN"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["SLN"]
   },
   {
     "qualityId": "265",
-    "performanceRates": ["biopsy"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["biopsy"]
   },
   {
     "qualityId": "268",
-    "performanceRates": ["epilepsy"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["epilepsy"]
   },
   {
     "qualityId": "271",
-    "performanceRates": ["IBD"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["IBD"]
   },
   {
     "qualityId": "275",
-    "performanceRates": ["IBD"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["IBD"]
   },
   {
     "qualityId": "276",
-    "performanceRates": ["sleepApnea"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["sleepApnea"]
   },
   {
     "qualityId": "277",
-    "performanceRates": ["sleepApnea"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["sleepApnea"]
   },
   {
     "qualityId": "278",
-    "performanceRates": ["sleepApnea"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["sleepApnea"]
   },
   {
     "qualityId": "279",
-    "performanceRates": ["sleepApnea"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["sleepApnea"]
   },
   {
     "qualityId": "282",
-    "performanceRates": ["dementia"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["dementia"]
   },
   {
     "qualityId": "283",
-    "performanceRates": ["dementia"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["dementia"]
   },
   {
     "qualityId": "284",
-    "performanceRates": ["dementia"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["dementia"]
   },
   {
     "qualityId": "286",
-    "performanceRates": ["dementia"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["dementia"]
   },
   {
     "qualityId": "288",
-    "performanceRates": ["dementia"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["dementia"]
   },
   {
     "qualityId": "290",
-    "performanceRates": ["parkinsons"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["parkinsons"]
   },
   {
     "qualityId": "291",
-    "performanceRates": ["parkinsons"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["parkinsons"]
   },
   {
     "qualityId": "293",
-    "performanceRates": ["parkinsons"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["parkinsons"]
   },
   {
     "qualityId": "294",
-    "performanceRates": ["parkinsons"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["parkinsons"]
   },
   {
     "qualityId": "303",
-    "performanceRates": ["cataract"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["cataract"]
   },
   {
     "qualityId": "304",
-    "performanceRates": ["cataract"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["cataract"]
   },
   {
     "qualityId": "317",
-    "performanceRates": ["highBloodPressure"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["highBloodPressure"]
   },
   {
     "qualityId": "320",
-    "performanceRates": ["colonoscopy"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["colonoscopy"]
   },
   {
     "qualityId": "322",
-    "performanceRates": ["preoperative"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["preoperative"]
   },
   {
     "qualityId": "323",
-    "performanceRates": ["PCI"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["PCI"]
   },
   {
     "qualityId": "324",
-    "performanceRates": ["CHD"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CHD"]
   },
   {
     "qualityId": "325",
-    "performanceRates": ["comorbid"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["comorbid"]
   },
   {
     "qualityId": "326",
-    "performanceRates": ["AF"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["AF"]
   },
   {
     "qualityId": "327",
-    "performanceRates": ["ESRD"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["ESRD"]
   },
   {
     "qualityId": "328",
-    "performanceRates": ["ESRD"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["ESRD"]
   },
   {
     "qualityId": "329",
-    "performanceRates": ["ESRD"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["ESRD"]
   },
   {
     "qualityId": "330",
-    "performanceRates": ["ESRD"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["ESRD"]
   },
   {
     "qualityId": "331",
-    "performanceRates": ["sinusitis"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["sinusitis"]
   },
   {
     "qualityId": "332",
-    "performanceRates": ["sinusitis"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["sinusitis"]
   },
   {
     "qualityId": "333",
-    "performanceRates": ["sinusitis"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["sinusitis"]
   },
   {
     "qualityId": "334",
-    "performanceRates": ["sinusitis"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["sinusitis"]
   },
   {
     "qualityId": "335",
-    "performanceRates": ["birth"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["birth"]
   },
   {
     "qualityId": "336",
-    "performanceRates": ["postPartum"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["postPartum"]
   },
   {
     "qualityId": "337",
-    "performanceRates": ["tuberculosis"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["tuberculosis"]
   },
   {
     "qualityId": "338",
-    "performanceRates": ["HIV"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["HIV"]
   },
   {
     "qualityId": "340",
-    "performanceRates": ["HIV"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["HIV"]
   },
   {
     "qualityId": "342",
-    "performanceRates": ["pain"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["pain"]
   },
   {
     "qualityId": "343",
-    "performanceRates": ["colonoscopy"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["colonoscopy"]
   },
   {
     "qualityId": "344",
-    "performanceRates": ["CAS"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CAS"]
   },
   {
     "qualityId": "345",
-    "performanceRates": ["CAS"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CAS"]
   },
   {
     "qualityId": "346",
-    "performanceRates": ["CEA"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CEA"]
   },
   {
     "qualityId": "347",
-    "performanceRates": ["AAA"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["AAA"]
   },
   {
     "qualityId": "348",
     "performanceRates": ["30", "90"],
-    "overallAlgorithm": "weightedAverage"
+    "overallAlgorithm": "weightedAverage",
+    "metricType": "multiPerformanceRate"
   },
   {
     "qualityId": "350",
-    "performanceRates": ["kneeReplacement"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["kneeReplacement"]
   },
   {
     "qualityId": "351",
-    "performanceRates": ["kneeReplacement"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["kneeReplacement"]
   },
   {
     "qualityId": "352",
-    "performanceRates": ["kneeReplacement"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["kneeReplacement"]
   },
   {
     "qualityId": "353",
-    "performanceRates": ["kneeReplacement"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["kneeReplacement"]
   },
   {
     "qualityId": "354",
-    "performanceRates": ["colectomy"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["colectomy"]
   },
   {
     "qualityId": "355",
-    "performanceRates": ["reoperation"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["reoperation"]
   },
   {
     "qualityId": "356",
-    "performanceRates": ["readmission"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["readmission"]
   },
   {
     "qualityId": "357",
-    "performanceRates": ["SSI"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["SSI"]
   },
   {
     "qualityId": "358",
-    "performanceRates": ["surgery"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["surgery"]
   },
   {
     "qualityId": "359",
-    "performanceRates": ["CT"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CT"]
   },
   {
     "qualityId": "360",
-    "performanceRates": ["CT"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CT"]
   },
   {
     "qualityId": "361",
-    "performanceRates": ["CT"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CT"]
   },
   {
     "qualityId": "362",
-    "performanceRates": ["CT"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CT"]
   },
   {
     "qualityId": "363",
-    "performanceRates": ["CT"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CT"]
   },
   {
     "qualityId": "364",
-    "performanceRates": ["CT"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CT"]
   },
   {
     "qualityId": "370",
-    "performanceRates": ["depression"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["depression"]
   },
   {
     "qualityId": "383",
-    "performanceRates": ["schizophrenia"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["schizophrenia"]
   },
   {
     "qualityId": "384",
-    "performanceRates": ["retinalDetachment"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["retinalDetachment"]
   },
   {
     "qualityId": "385",
-    "performanceRates": ["retinalDetachment"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["retinalDetachment"]
   },
   {
     "qualityId": "386",
-    "performanceRates": ["ALS"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["ALS"]
   },
   {
     "qualityId": "387",
-    "performanceRates": ["HCV"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["HCV"]
   },
   {
     "qualityId": "388",
-    "performanceRates": ["cataract"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["cataract"]
   },
   {
     "qualityId": "389",
-    "performanceRates": ["cataract"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["cataract"]
   },
   {
     "qualityId": "390",
-    "performanceRates": ["hepC"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["hepC"]
   },
   {
     "qualityId": "391",
     "performanceRates": ["30days", "overall"],
-    "overallAlgorithm": "simpleAverage"
+    "overallAlgorithm": "simpleAverage",
+    "metricType": "multiPerformanceRate"
   },
   {
     "qualityId": "392",
     "performanceRates": ["18-64F", "18-64M", "65+F", "65+M", "overall"],
-    "overallAlgorithm": "weightedAverage"
+    "overallAlgorithm": "weightedAverage",
+    "metricType": "multiPerformanceRate"
   },
   {
     "qualityId": "393",
-    "performanceRates": ["CIED"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CIED"]
   },
   {
     "qualityId": "394",
     "performanceRates": ["meningococcal", "Tdap", "HPV", "overall"],
-    "overallAlgorithm": "sumNumerators"
+    "overallAlgorithm": "sumNumerators",
+    "metricType": "multiPerformanceRate"
   },
   {
     "qualityId": "395",
-    "performanceRates": ["lungCancer"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["lungCancer"]
   },
   {
     "qualityId": "396",
-    "performanceRates": ["lungCarcinoma"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["lungCarcinoma"]
   },
   {
     "qualityId": "397",
-    "performanceRates": ["melanoma"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["melanoma"]
   },
   {
     "qualityId": "398",
     "performanceRates": ["overall", "5-17", "18-50", "ACT5-17", "ACT18-50", "lowRisk5-17", "lowRisk18-50"],
-    "overallAlgorithm": "weightedAverage"
+    "overallAlgorithm": "weightedAverage",
+    "metricType": "multiPerformanceRate"
   },
   {
     "qualityId": "400",
-    "performanceRates": ["HCV"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["HCV"]
   },
   {
     "qualityId": "401",
-    "performanceRates": ["hepC"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["hepC"]
   },
   {
     "qualityId": "402",
-    "performanceRates": ["tobacco"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["tobacco"]
   },
   {
     "qualityId": "403",
-    "performanceRates": ["ESRD"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["ESRD"]
   },
   {
     "qualityId": "404",
-    "performanceRates": ["cigarettes"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["cigarettes"]
   },
   {
     "qualityId": "405",
-    "performanceRates": ["abdominalImaging"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["abdominalImaging"]
   },
   {
     "qualityId": "406",
-    "performanceRates": ["CT"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CT"]
   },
   {
     "qualityId": "407",
-    "performanceRates": ["MSSA"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["MSSA"]
   },
   {
     "qualityId": "408",
-    "performanceRates": ["opiates"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["opiates"]
   },
   {
     "qualityId": "409",
-    "performanceRates": ["stroke"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["stroke"]
   },
   {
     "qualityId": "410",
-    "performanceRates": ["therapy"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["therapy"]
   },
   {
     "qualityId": "411",
-    "performanceRates": ["remission"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["remission"]
   },
   {
     "qualityId": "412",
-    "performanceRates": ["opiates"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["opiates"]
   },
   {
     "qualityId": "413",
-    "performanceRates": ["stroke"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["stroke"]
   },
   {
     "qualityId": "414",
-    "performanceRates": ["opioidRisk"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["opioidRisk"]
   },
   {
     "qualityId": "415",
-    "performanceRates": ["headTrauma"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["headTrauma"]
   },
   {
     "qualityId": "416",
-    "performanceRates": ["headTrauma"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["headTrauma"]
   },
   {
     "qualityId": "417",
-    "performanceRates": ["AAA"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["AAA"]
   },
   {
     "qualityId": "418",
-    "performanceRates": ["osteoporosis"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["osteoporosis"]
   },
   {
     "qualityId": "419",
-    "performanceRates": ["headache"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["headache"]
   },
   {
     "qualityId": "420",
-    "performanceRates": ["CEAP_C2-S"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CEAP_C2-S"]
   },
   {
     "qualityId": "421",
-    "performanceRates": ["IVC"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["IVC"]
   },
   {
     "qualityId": "422",
-    "performanceRates": ["cystoscopy"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["cystoscopy"]
   },
   {
     "qualityId": "423",
-    "performanceRates": ["CEA"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CEA"]
   },
   {
     "qualityId": "424",
-    "performanceRates": ["anesthesia"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["anesthesia"]
   },
   {
     "qualityId": "425",
-    "performanceRates": ["colonoscopy"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["colonoscopy"]
   },
   {
     "qualityId": "426",
-    "performanceRates": ["PACU"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["PACU"]
   },
   {
     "qualityId": "427",
-    "performanceRates": ["ICU"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["ICU"]
   },
   {
     "qualityId": "428",
-    "performanceRates": ["urinaryIncontinence"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["urinaryIncontinence"]
   },
   {
     "qualityId": "429",
-    "performanceRates": ["uterineMalignancy"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["uterineMalignancy"]
   },
   {
     "qualityId": "430",
-    "performanceRates": ["PONV"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["PONV"]
   },
   {
     "qualityId": "431",
-    "performanceRates": ["alcohol"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["alcohol"]
   },
   {
     "qualityId": "432",
-    "performanceRates": ["bladder"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["bladder"]
   },
   {
     "qualityId": "433",
-    "performanceRates": ["bowel"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["bowel"]
   },
   {
     "qualityId": "434",
-    "performanceRates": ["ureter"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["ureter"]
   },
   {
     "qualityId": "435",
-    "performanceRates": ["headache"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["headache"]
   },
   {
     "qualityId": "436",
-    "performanceRates": ["CT"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CT"]
   },
   {
     "qualityId": "437",
-    "performanceRates": ["OAD"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["OAD"]
   },
   {
     "qualityId": "438",
-    "performanceRates": ["highRiskCardiovascular"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["highRiskCardiovascular"]
   },
   {
     "qualityId": "439",
-    "performanceRates": ["colonoscopy"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["colonoscopy"]
   },
   {
     "qualityId": "440",
-    "performanceRates": ["BCC&SCC"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["BCC&SCC"]
   },
   {
     "qualityId": "441",
-    "performanceRates": ["IVDAllOrNone"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["IVDAllOrNone"]
   },
   {
     "qualityId": "442",
-    "performanceRates": ["AMI"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["AMI"]
   },
   {
     "qualityId": "443",
-    "performanceRates": ["cervicalCancer"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["cervicalCancer"]
   },
   {
     "qualityId": "444",
-    "performanceRates": ["asthma"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["asthma"]
   },
   {
     "qualityId": "445",
-    "performanceRates": ["CABG"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["CABG"]
   },
   {
     "qualityId": "446",
-    "performanceRates": ["congenitalHeartSurgery"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["congenitalHeartSurgery"]
   },
   {
     "qualityId": "447",
-    "performanceRates": ["chlamydia"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["chlamydia"]
   },
   {
     "qualityId": "448",
-    "performanceRates": ["endometrialAblation"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["endometrialAblation"]
   },
   {
     "qualityId": "449",
-    "performanceRates": ["breastCancer"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["breastCancer"]
   },
   {
     "qualityId": "450",
-    "performanceRates": ["AJCC"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["AJCC"]
   },
   {
     "qualityId": "451",
-    "performanceRates": ["KRASGeneMutation"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["KRASGeneMutation"]
   },
   {
     "qualityId": "452",
-    "performanceRates": ["metastaticColorectalCancer"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["metastaticColorectalCancer"]
   },
   {
     "qualityId": "453",
-    "performanceRates": ["chemotherapy"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["chemotherapy"]
   },
   {
     "qualityId": "454",
-    "performanceRates": ["emergencyDepartment"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["emergencyDepartment"]
   },
   {
     "qualityId": "455",
-    "performanceRates": ["ICU"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["ICU"]
   },
   {
     "qualityId": "456",
-    "performanceRates": ["noHospice"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["noHospice"]
   },
   {
     "qualityId": "457",
-    "performanceRates": ["hospice"],
-    "overallAlgorithm": "simpleAverage"
+    "performanceRates": ["hospice"]
   }
 ]


### PR DESCRIPTION
https://jira.cms.gov/browse/QPPA-490

Creates a distinction between single and multi performance rate metric types (useful for work in categorizing different tables, as they will now be represented in the server). Default is now `singlePerformanceRate` and manually generated `quality-measures-strata-details.json` overrides to `multiPerformanceRate` where appropriate. Also updates `overallAlgorithm` to be an optional field, only populated for `multiPerformanceRate` measures.

Testing:
`cat measures/measures-data.json | node scripts/validate-data.js measures` passes