### PR TITLE
Add transition exclusion measures

### DIFF
--- a/measures/measures-data.json
+++ b/measures/measures-data.json
@@ -86,12 +86,44 @@
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
     "metricType": "boolean",
+    "measureId": "ACI_TRANS_LVPP_1",
+    "title": "Low-Volume Permissible Prescriptions",
+    "description": "A MIPS eligible clinician (EC) who writes fewer than 100 permissible prescriptions during the performance period is eligible for exclusion from the required e-prescribing measure.",
+    "isRequired": false,
+    "weight": 0,
+    "measureSets": [
+      "transition"
+    ],
+    "isBonus": false,
+    "objective": "electronicPrescribing"
+  },
+  {
+    "category": "aci",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "boolean",
     "measureId": "ACI_LVOTC_1",
     "title": "Low-Volume Outgoing Transfer of Care",
     "description": "Any MIPS eligible clinician who transfers a patient to another setting or refers a patient less than 100 times during the performance period.",
     "isRequired": false,
     "weight": 0,
     "measureSets": [],
+    "isBonus": false,
+    "objective": "healthInformationExchange"
+  },
+  {
+    "category": "aci",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "boolean",
+    "measureId": "ACI_TRANS_LVOTC_1",
+    "title": "Low-Volume Outgoing Transfer of Care",
+    "description": "Any MIPS eligible clinician who transfers a patient to another setting or refers a patient less than 100 times during the performance period.",
+    "isRequired": false,
+    "weight": 0,
+    "measureSets": [
+      "transition"
+    ],
     "isBonus": false,
     "objective": "healthInformationExchange"
   },

--- a/measures/measures-data.xml
+++ b/measures/measures-data.xml
@@ -85,11 +85,39 @@ AND (2) If requested, cooperated in good faith with ONC direct review of his or 
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
     <metricType>boolean</metricType>
+    <measureId>ACI_TRANS_LVPP_1</measureId>
+    <title>Low-Volume Permissible Prescriptions</title>
+    <description>A MIPS eligible clinician (EC) who writes fewer than 100 permissible prescriptions during the performance period is eligible for exclusion from the required e-prescribing measure.</description>
+    <isRequired>false</isRequired>
+    <weight>0</weight>
+    <measureSet>transition</measureSet>
+    <isBonus>false</isBonus>
+    <objective>electronicPrescribing</objective>
+  </measure>
+  <measure>
+    <category>aci</category>
+    <firstPerformanceYear>2017</firstPerformanceYear>
+    <lastPerformanceYear/>
+    <metricType>boolean</metricType>
     <measureId>ACI_LVOTC_1</measureId>
     <title>Low-Volume Outgoing Transfer of Care</title>
     <description>Any MIPS eligible clinician who transfers a patient to another setting or refers a patient less than 100 times during the performance period.</description>
     <isRequired>false</isRequired>
     <weight>0</weight>
+    <isBonus>false</isBonus>
+    <objective>healthInformationExchange</objective>
+  </measure>
+  <measure>
+    <category>aci</category>
+    <firstPerformanceYear>2017</firstPerformanceYear>
+    <lastPerformanceYear/>
+    <metricType>boolean</metricType>
+    <measureId>ACI_TRANS_LVOTC_1</measureId>
+    <title>Low-Volume Outgoing Transfer of Care</title>
+    <description>Any MIPS eligible clinician who transfers a patient to another setting or refers a patient less than 100 times during the performance period.</description>
+    <isRequired>false</isRequired>
+    <weight>0</weight>
+    <measureSet>transition</measureSet>
     <isBonus>false</isBonus>
     <objective>healthInformationExchange</objective>
   </measure>

--- a/util/additional-measures.json
+++ b/util/additional-measures.json
@@ -86,12 +86,44 @@
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
     "metricType": "boolean",
+    "measureId": "ACI_TRANS_LVPP_1",
+    "title": "Low-Volume Permissible Prescriptions",
+    "description": "A MIPS eligible clinician (EC) who writes fewer than 100 permissible prescriptions during the performance period is eligible for exclusion from the required e-prescribing measure.",
+    "isRequired": false,
+    "weight": 0,
+    "measureSets": [
+      "transition"
+    ],
+    "isBonus": false,
+    "objective": "electronicPrescribing"
+  },
+  {
+    "category": "aci",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "boolean",
     "measureId": "ACI_LVOTC_1",
     "title": "Low-Volume Outgoing Transfer of Care",
     "description": "Any MIPS eligible clinician who transfers a patient to another setting or refers a patient less than 100 times during the performance period.",
     "isRequired": false,
     "weight": 0,
     "measureSets": [],
+    "isBonus": false,
+    "objective": "healthInformationExchange"
+  },
+  {
+    "category": "aci",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "boolean",
+    "measureId": "ACI_TRANS_LVOTC_1",
+    "title": "Low-Volume Outgoing Transfer of Care",
+    "description": "Any MIPS eligible clinician who transfers a patient to another setting or refers a patient less than 100 times during the performance period.",
+    "isRequired": false,
+    "weight": 0,
+    "measureSets": [
+      "transition"
+    ],
     "isBonus": false,
     "objective": "healthInformationExchange"
   },
@@ -108,5 +140,5 @@
     "measureSets": [],
     "isBonus": false,
     "objective": "healthInformationExchange"
-  }  
+  }
 ]


### PR DESCRIPTION
https://jira.cms.gov/browse/QPPA-603

Policy has requested that we add explicit exclusion measures, ACI_TRANS_LVOTC_1 to apply to ACI_TRANS_HIE_1 and ACI_TRANS_LVPP_1 to apply to ACI_TRANS_EP_1. 

Confirmed that schema is still valid.

Will release in Sprint 3.4