### PR TITLE
fix readme formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 node_modules
 .DS_Store
 yarn.lock
+QPP_quality_measure_specifications.zip
+QPP_quality_measure_specifications
+ecqm_eligibleclinician_jan2017.zip
+ecqm_eligibleclinician_jan2017
+Claims-Registry-Measures.zip
+Claims-Registry-Measures
+Web-Interface-Measures.zip

--- a/README.md
+++ b/README.md
@@ -62,20 +62,20 @@ the measures schema, do the following:
 
 3. Run the script to extract strata descriptions and measure/strata uuids for ecqms from the zip:
 
-    ```
+  ```
     node scripts/get-strata-and-uuids-from-ecqm-zip.js ecqm_eligibleclinician_jan2017.zip
-    ```
+  ```
 
 4. Then run this command to generate a new measures-data.json file:
 
-  ```
-  jq -s add util/additional-measures.json <(curl -s https://qpp.cms.gov/api/v1/aci_measures | node scripts/convert-qpp-to-measures.js aci) <(curl -s https://qpp.cms.gov/api/v1/ia_measures | node scripts/convert-qpp-to-measures.js ia) <(curl -s https://qpp.cms.gov/api/v1/quality_measures | node scripts/convert-qpp-to-measures.js quality) | node scripts/merge-measures-data.js | tee measures/measures-data.json
-  ```
+    ```
+    jq -s add util/additional-measures.json <(curl -s https://qpp.cms.gov/api/v1/aci_measures | node scripts/convert-qpp-to-measures.js aci) <(curl -s https://qpp.cms.gov/api/v1/ia_measures | node scripts/convert-qpp-to-measures.js ia) <(curl -s https://qpp.cms.gov/api/v1/quality_measures | node scripts/convert-qpp-to-measures.js quality) | node scripts/merge-measures-data.js | tee measures/measures-data.json
+    ```
 
   To regenerate the `measures-data.xml` file, run:
-  ```
-  cat measures/measures-data.json | node scripts/convert-json-to-xml.js > measures/measures-data.xml
-  ```
+    ```
+    cat measures/measures-data.json | node scripts/convert-json-to-xml.js > measures/measures-data.xml
+    ```
 
 The measures from `additional-measures.json` must be added, as they are not available via the QPP API.
 

--- a/README.md
+++ b/README.md
@@ -48,17 +48,17 @@ the measures schema, do the following:
 
 1. Download the qpp quality pdfs and ecqm measure specifications
 
-	```
+    ```
     wget https://qpp.cms.gov/docs/QPP_quality_measure_specifications.zip .
     wget https://ecqi.healthit.gov/system/files/ecqm_eligibleclinician_jan2017.zip .
     unzip QPP_quality_measure_specifications.zip
-	```
+    ```
 
 2. Run the convert from pdfs tool to get the quality info from the pdfs. This info needs to be combined with the (manually generated) util/quality-measures-strata-details.json file to get the full quality measures data.
 
-	```
+    ```
     node scripts/get-quality-measures-from-pdfs.js QPP_quality_measure_specifications/Claims-Registry-Measures
-	```
+    ```
 
 3. Run the script to extract strata descriptions and measure/strata uuids for ecqms from the zip:
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ the measures schema, do the following:
     unzip QPP_quality_measure_specifications.zip
     ```
 
-2. Run the convert from pdfs tool to get the quality info from the pdfs. This info needs to be combined with the (manually generated) util/quality-measures-strata-details.json file to get the full quality measures data.
+2. Run the convert from pdfs tool to get the quality info from the pdfs. This info needs to be combined with the (manually generated) `util/quality-measures-strata-details.json` file to get the full quality measures data.
 
     ```
     node scripts/get-quality-measures-from-pdfs.js QPP_quality_measure_specifications/Claims-Registry-Measures
@@ -66,7 +66,7 @@ the measures schema, do the following:
     node scripts/get-strata-and-uuids-from-ecqm-zip.js ecqm_eligibleclinician_jan2017.zip
     ```
 
-4. Then run this command to generate a new measures-data.json file:
+4. Then run this command to generate a new `measures-data.json` file:
 
     ```
     jq -s add util/additional-measures.json <(curl -s https://qpp.cms.gov/api/v1/aci_measures | node scripts/convert-qpp-to-measures.js aci) <(curl -s https://qpp.cms.gov/api/v1/ia_measures | node scripts/convert-qpp-to-measures.js ia) <(curl -s https://qpp.cms.gov/api/v1/quality_measures | node scripts/convert-qpp-to-measures.js quality) | node scripts/merge-measures-data.js | tee measures/measures-data.json

--- a/README.md
+++ b/README.md
@@ -66,17 +66,16 @@ the measures schema, do the following:
     node scripts/get-strata-and-uuids-from-ecqm-zip.js ecqm_eligibleclinician_jan2017.zip
     ```
 
+4. Then run this command to generate a new measures-data.json file:
 
-Then run this command to generate a new measures-data.json file:
+  ```
+  jq -s add util/additional-measures.json <(curl -s https://qpp.cms.gov/api/v1/aci_measures | node scripts/convert-qpp-to-measures.js aci) <(curl -s https://qpp.cms.gov/api/v1/ia_measures | node scripts/convert-qpp-to-measures.js ia) <(curl -s https://qpp.cms.gov/api/v1/quality_measures | node scripts/convert-qpp-to-measures.js quality) | node scripts/merge-measures-data.js | tee measures/measures-data.json
+  ```
 
-```
-jq -s add util/additional-measures.json <(curl -s https://qpp.cms.gov/api/v1/aci_measures | node scripts/convert-qpp-to-measures.js aci) <(curl -s https://qpp.cms.gov/api/v1/ia_measures | node scripts/convert-qpp-to-measures.js ia) <(curl -s https://qpp.cms.gov/api/v1/quality_measures | node scripts/convert-qpp-to-measures.js quality) | node scripts/merge-measures-data.js | tee measures/measures-data.json
-```
-
-To regenerate the `measures-data.xml` file, run:
-```
-cat measures/measures-data.json | node scripts/convert-json-to-xml.js > measures/measures-data.xml
-```
+  To regenerate the `measures-data.xml` file, run:
+  ```
+  cat measures/measures-data.json | node scripts/convert-json-to-xml.js > measures/measures-data.xml
+  ```
 
 The measures from `additional-measures.json` must be added, as they are not available via the QPP API.
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,6 @@ the measures schema, do the following:
     cat measures/measures-data.json | node scripts/convert-json-to-xml.js > measures/measures-data.xml
     ```
 
-The measures from `additional-measures.json` must be added, as they are not available via the QPP API.
-
 ### Generating benchmarks data
 To regenerate benchmarks data from historical data use the `scripts/parse-benchmarks-data.js` script
 like so:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ To regenerate the `measures-data.json` file, which contains additional metadata 
 the measures schema, do the following:
 
 1. Download the qpp quality pdfs and ecqm measure specifications
+
 	```
     wget https://qpp.cms.gov/docs/QPP_quality_measure_specifications.zip .
     wget https://ecqi.healthit.gov/system/files/ecqm_eligibleclinician_jan2017.zip .
@@ -54,11 +55,13 @@ the measures schema, do the following:
 	```
 
 2. Run the convert from pdfs tool to get the quality info from the pdfs. This info needs to be combined with the (manually generated) util/quality-measures-strata-details.json file to get the full quality measures data.
+
 	```
     node scripts/get-quality-measures-from-pdfs.js QPP_quality_measure_specifications/Claims-Registry-Measures
 	```
 
 3. Run the script to extract strata descriptions and measure/strata uuids for ecqms from the zip:
+
   ```
     node scripts/get-strata-and-uuids-from-ecqm-zip.js ecqm_eligibleclinician_jan2017.zip
   ```

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ the measures schema, do the following:
     node scripts/get-strata-and-uuids-from-ecqm-zip.js ecqm_eligibleclinician_jan2017.zip
   ```
 
+
 Then run this command to generate a new measures-data.json file:
 
 ```

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ the measures schema, do the following:
 3. Run the script to extract strata descriptions and measure/strata uuids for ecqms from the zip:
 
     ```
-      node scripts/get-strata-and-uuids-from-ecqm-zip.js ecqm_eligibleclinician_jan2017.zip
+    node scripts/get-strata-and-uuids-from-ecqm-zip.js ecqm_eligibleclinician_jan2017.zip
     ```
 
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ the measures schema, do the following:
 
 3. Run the script to extract strata descriptions and measure/strata uuids for ecqms from the zip:
 
-  ```
+    ```
     node scripts/get-strata-and-uuids-from-ecqm-zip.js ecqm_eligibleclinician_jan2017.zip
-  ```
+    ```
 
 4. Then run this command to generate a new measures-data.json file:
 
@@ -72,7 +72,8 @@ the measures schema, do the following:
     jq -s add util/additional-measures.json <(curl -s https://qpp.cms.gov/api/v1/aci_measures | node scripts/convert-qpp-to-measures.js aci) <(curl -s https://qpp.cms.gov/api/v1/ia_measures | node scripts/convert-qpp-to-measures.js ia) <(curl -s https://qpp.cms.gov/api/v1/quality_measures | node scripts/convert-qpp-to-measures.js quality) | node scripts/merge-measures-data.js | tee measures/measures-data.json
     ```
 
-  To regenerate the `measures-data.xml` file, run:
+5. To regenerate the `measures-data.xml` file, run:
+
     ```
     cat measures/measures-data.json | node scripts/convert-json-to-xml.js > measures/measures-data.xml
     ```

--- a/README.md
+++ b/README.md
@@ -48,19 +48,19 @@ the measures schema, do the following:
 
 1. Download the qpp quality pdfs and ecqm measure specifications
 	```
-	wget https://qpp.cms.gov/docs/QPP_quality_measure_specifications.zip .
-  wget https://ecqi.healthit.gov/system/files/ecqm_eligibleclinician_jan2017.zip .
-	unzip QPP_quality_measure_specifications.zip
+    wget https://qpp.cms.gov/docs/QPP_quality_measure_specifications.zip .
+    wget https://ecqi.healthit.gov/system/files/ecqm_eligibleclinician_jan2017.zip .
+    unzip QPP_quality_measure_specifications.zip
 	```
 
 2. Run the convert from pdfs tool to get the quality info from the pdfs. This info needs to be combined with the (manually generated) util/quality-measures-strata-details.json file to get the full quality measures data.
 	```
-	node scripts/get-quality-measures-from-pdfs.js QPP_quality_measure_specifications/Claims-Registry-Measures
+    node scripts/get-quality-measures-from-pdfs.js QPP_quality_measure_specifications/Claims-Registry-Measures
 	```
 
 3. Run the script to extract strata descriptions and measure/strata uuids for ecqms from the zip:
   ```
-  node scripts/get-strata-and-uuids-from-ecqm-zip.js ecqm_eligibleclinician_jan2017.zip
+    node scripts/get-strata-and-uuids-from-ecqm-zip.js ecqm_eligibleclinician_jan2017.zip
   ```
 
 Then run this command to generate a new measures-data.json file:

--- a/README.md
+++ b/README.md
@@ -52,10 +52,12 @@ the measures schema, do the following:
   wget https://ecqi.healthit.gov/system/files/ecqm_eligibleclinician_jan2017.zip .
 	unzip QPP_quality_measure_specifications.zip
 	```
+
 2. Run the convert from pdfs tool to get the quality info from the pdfs. This info needs to be combined with the (manually generated) util/quality-measures-strata-details.json file to get the full quality measures data.
 	```
 	node scripts/get-quality-measures-from-pdfs.js QPP_quality_measure_specifications/Claims-Registry-Measures
 	```
+
 3. Run the script to extract strata descriptions and measure/strata uuids for ecqms from the zip:
   ```
   node scripts/get-strata-and-uuids-from-ecqm-zip.js ecqm_eligibleclinician_jan2017.zip

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ the measures schema, do the following:
 
 3. Run the script to extract strata descriptions and measure/strata uuids for ecqms from the zip:
 
-  ```
-    node scripts/get-strata-and-uuids-from-ecqm-zip.js ecqm_eligibleclinician_jan2017.zip
-  ```
+    ```
+      node scripts/get-strata-and-uuids-from-ecqm-zip.js ecqm_eligibleclinician_jan2017.zip
+    ```
 
 
 Then run this command to generate a new measures-data.json file:


### PR DESCRIPTION
The rich diff illustrates the fix here; I botched something with github markdown in https://github.com/CMSgov/qpp-measures-data/pull/32. Not really sure why the extra nesting on just the code fences for step 3 are necessary 🤷‍♂️ 