### PR TITLE
move yamljs to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
     "lodash": "^4.16.4",
     "mocha": "^3.2.0",
     "pdf-to-text": "0.0.6",
-    "xml2js": "~0.4.17",
-    "yamljs": "~0.2.8",
-    "rimraf": "^2.6.1"
+    "rimraf": "^2.6.1",
+    "xml2js": "~0.4.17"
+  },
+  "dependencies": {
+    "yamljs": "^0.2.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I mistakenly moved yamljs to `devDependencies` in https://github.com/CMSgov/qpp-measures-data/pull/32/commits/5cabba29e25e1d87758e750b5b9dee63e5938a55 - this needs to be a `dependency`.

cc @sietekk @bijujoseph 