### PR TITLE
QPPA-783: Shortening strata names as they need to be less than 20 characters

### DIFF
--- a/measures/measures-data.json
+++ b/measures/measures-data.json
@@ -3140,7 +3140,7 @@
           "denominatorExclusionUuid": "672f9875-55d9-4fb3-b56f-85205699103f",
           "denominatorExceptionUuid": "3a57a106-7404-476e-b026-23282a95d75f"
         },
-        "name": "evidenceOfSubstanceUseBetweenDiagnosisAndTreatment"
+        "name": "substanceUse"
       }
     ],
     "isHighPriority": false,
@@ -3628,7 +3628,7 @@
           "denominatorExclusionUuid": "45A2163C-25C2-4245-A3C6-0BEE64E18B64",
           "denominatorExceptionUuid": "bc43554a-5399-4d55-9c48-7dc2c1cbbb65"
         },
-        "name": "screenedForCervicalCancer"
+        "name": "screenedForCancer"
       }
     ],
     "isHighPriority": false,
@@ -3704,7 +3704,7 @@
           "denominatorExclusionUuid": "19d26b5e-9be2-4313-80f4-67be1e0dde37",
           "denominatorExceptionUuid": "01a1c883-e2e6-4aec-81de-17f3cd9b63b3"
         },
-        "name": "receivedVaccinesOrExposure"
+        "name": "vaccinesOrExposure"
       }
     ],
     "isHighPriority": false,
@@ -3741,7 +3741,7 @@
           "denominatorExclusionUuid": "c7cc2c7e-892e-4b35-b1ed-b25a094f25d5",
           "denominatorExceptionUuid": "7637d114-553a-4bc4-b084-d05b3a125bb8"
         },
-        "name": "hadCavitiesOrDecayedTeeth"
+        "name": "cavitiesOrDecayed"
       }
     ],
     "isHighPriority": true,
@@ -4499,7 +4499,7 @@
           "denominatorExclusionUuid": "7b3728ef-a1b8-489a-8a7c-f682c26e0d7f",
           "denominatorExceptionUuid": "2EE99933-7653-4C53-8506-2A76D0657064"
         },
-        "name": "assessedCognitionWithin12Months"
+        "name": "assessed12Months"
       }
     ],
     "isHighPriority": false,
@@ -4719,7 +4719,7 @@
     "strata": [
       {
         "description": "Office visit, Psych visit, or Face to Face Interaction (No ED) within 4 months of the end of the measurement period that leads to a diagnosis of major depression including remission or dysthymia",
-        "name": "within4MonthsOfEnd",
+        "name": "4MonthsOfEnd",
         "eMeasureUuids": {
           "initialPopulationUuid": "92656CE7-C9B1-44A8-8778-A8EF1ED90A18",
           "denominatorUuid": "C7DFE664-71AE-4EAD-AB65-CDFCF825A44E",
@@ -4730,7 +4730,7 @@
       },
       {
         "description": "Office visit, Psych visit, or Face to Face Interaction (No ED) between 4 and 8 months after the start of the measurement period that leads to a diagnosis of major depression including remission or dysthymia",
-        "name": "between4And8MonthsAfterStart",
+        "name": "4&8MonthsAfterStart",
         "eMeasureUuids": {
           "initialPopulationUuid": "757F3066-31E7-45D1-BA50-3EFB27ABB8E5",
           "denominatorUuid": "32635FEA-918B-438F-8421-8A6A14E238E8",
@@ -4741,7 +4741,7 @@
       },
       {
         "description": "Office visit, Psych visit, or Face to Face Interaction (No ED) within 4 months of the start of the measurement period that leads to a diagnosis of major depression including remission or dysthymia",
-        "name": "within4MonthsOfStart",
+        "name": "4MonthsOfStart",
         "eMeasureUuids": {
           "initialPopulationUuid": "5631A7DF-CA44-4AD4-A691-DC0CED303F6A",
           "denominatorUuid": "9665A8D2-F896-47A9-AA7E-271E9815D3CE",
@@ -5038,7 +5038,7 @@
           "denominatorExclusionUuid": "305ce4ad-9e91-4236-af6d-1c5c65db586c",
           "denominatorExceptionUuid": "170B3877-D83D-424C-BD7E-29F644B0A6DC"
         },
-        "name": "dilatedMacularOrFundusExamWithin12Months"
+        "name": "dilatedExam12Months"
       }
     ],
     "isHighPriority": false,
@@ -5513,7 +5513,7 @@
           "denominatorExclusionUuid": "65458ECD-6573-4203-8C56-515063BAFE19",
           "denominatorExceptionUuid": "029ee8ff-899f-434b-9e83-cb5503bdfebb"
         },
-        "name": "reportedFunctionalStatus"
+        "name": "functionalStatus"
       }
     ],
     "isHighPriority": true,
@@ -5550,7 +5550,7 @@
           "denominatorExclusionUuid": "0E8BFC37-A4BA-4DE6-A6F3-DF4C188AB129",
           "denominatorExceptionUuid": "a059c9d5-0445-40a5-8b55-db98a69891f4"
         },
-        "name": "reportedFunctionalStatus"
+        "name": "functionalStatus"
       }
     ],
     "isHighPriority": true,
@@ -5587,7 +5587,7 @@
           "denominatorExclusionUuid": "32DBECF3-11EC-40FB-B35D-FA1BF7366492",
           "denominatorExceptionUuid": "b156a02c-e64c-4b93-97d3-48b6af51fbf5"
         },
-        "name": "reportedFunctionalStatus"
+        "name": "functionalStatus"
       }
     ],
     "isHighPriority": true,
@@ -5669,7 +5669,7 @@
     "strata": [
       {
         "description": "A self-report outcome measure of functional status (FS) for patients 14 years+ with general orthopaedic impairments (neck, cranium, mandible, thoracic spine, ribs or other general orthopedic impairment). The change in FS assessed using FOTO (general orthopedic) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level by to assess quality",
-        "name": "orthopaedicImpairment"
+        "name": "orthoImpairment"
       }
     ],
     "isHighPriority": true,
@@ -6089,7 +6089,7 @@
           "denominatorExclusionUuid": "4c42d3ad-5ad4-4e97-ac7d-81c9758fbead",
           "denominatorExceptionUuid": "58347456-D1F3-4BBB-9B35-5D42825A0AB3"
         },
-        "name": "within3MonthsCD4<200/mm3"
+        "name": "CD4<200/mm3"
       },
       {
         "description": "Patients who were prescribed Pneumocystis jiroveci pneumonia (PCP) prophylaxis within 3 months of CD4 count below 500 cells/mm3 or a CD4 percentage below 15%",
@@ -6100,7 +6100,7 @@
           "denominatorExclusionUuid": "659d5fba-93ed-4b1f-bd17-233362e37e58",
           "denominatorExceptionUuid": "B7CCA1A6-F352-4A23-BC89-6FE9B60DC0C6"
         },
-        "name": "within3MonthsCD4<500/mm3OrCD4<15%"
+        "name": "CD4<500/mm3OrCD4<15%"
       },
       {
         "description": "Patients who were prescribed Pneumocystis jiroveci pneumonia (PCP) prophylaxis at the time of diagnosis of HIV",
@@ -6344,7 +6344,7 @@
           "denominatorExclusionUuid": "74F900B9-65DA-4E6C-BB2D-592189ABDDE5",
           "denominatorExceptionUuid": "6add5684-4b28-4d80-bf3d-dd0ea530a529"
         },
-        "name": "lowerFollowupBloodPressure"
+        "name": "lowerFollowupBP"
       }
     ],
     "isHighPriority": true,
@@ -6507,7 +6507,7 @@
           "denominatorExclusionUuid": "56BC7FA2-C22A-4440-8652-2D3568852C60",
           "denominatorExceptionUuid": "506b11e2-8e60-4254-8277-5a3670bb6287"
         },
-        "name": "treatmentWithin14DaysOfDiagnosis"
+        "name": "14DaysOfDiagnosis"
       },
       {
         "description": "Patients who initiated treatment and who had two or more additional services with an AOD diagnosis within 30 days of the initiation visit",
@@ -6518,7 +6518,7 @@
           "denominatorExclusionUuid": "206A891D-C3E1-4660-BF2C-6CDBDF9282FB",
           "denominatorExceptionUuid": "3870dc26-e32d-4ba5-9025-6b00d8259f16"
         },
-        "name": "treatmentPlusServicesWithin30DaysOfVisit"
+        "name": "30DaysOfVisit"
       }
     ],
     "isHighPriority": false,
@@ -6712,7 +6712,7 @@
           "denominatorExclusionUuid": "3a0f2630-297f-481e-980c-252371b90b4b",
           "denominatorExceptionUuid": "4e37becd-1435-4aa7-b64f-e3b853b005e7"
         },
-        "name": "documentedScreeningOrTreatment"
+        "name": "screeningOrTreatment"
       }
     ],
     "isHighPriority": false,
@@ -7168,7 +7168,7 @@
     "strata": [
       {
         "description": "Percent of patients undergoing index pediatric and/or congenital heart surgery who die, including both 1) all deaths occurring during the hospitalization in which the procedure was performed, even if after 30 days (including patients transferred to other acute care facilities), and 2) those deaths occurring after discharge from the hospital, but within 30 days of the procedure, stratified by the five STAT Mortality Levels, a multi-institutional validated complexity stratification tool",
-        "name": "congenitalHeartSurgery"
+        "name": "heartSurgery"
       }
     ],
     "isHighPriority": true,
@@ -7761,7 +7761,7 @@
     "strata": [
       {
         "description": "Percentage of adult patients (aged 18 or over) with metastatic colorectal cancer and KRAS gene mutation spared treatment with anti-EGFR monoclonal antibodies",
-        "name": "metastaticColorectalCancer"
+        "name": "colorectalCancer"
       }
     ],
     "isHighPriority": true,
@@ -7957,7 +7957,7 @@
     "strata": [
       {
         "description": "Percentage of surgical patients aged 18 years and older undergoing procedures with the indications for a first second generation cephalosporin prophylactic antibiotic who had an order for a first OR second generation cephalosporin for antimicrobial prophylaxis",
-        "name": "prophylacticAntibiotic"
+        "name": "antibiotic"
       }
     ],
     "isHighPriority": true,
@@ -8647,7 +8647,7 @@
           "denominatorExclusionUuid": "a73c666b-2ccf-462a-860b-985b8c9b4454",
           "denominatorExceptionUuid": "45089ed9-59a2-49b5-9162-a49b72f3da9a"
         },
-        "name": "receivedFluorideVarnish"
+        "name": "fluorideVarnish"
       }
     ],
     "isHighPriority": false,
@@ -10031,7 +10031,7 @@
     "strata": [
       {
         "description": "Percentage of the following patients—all considered at high risk of cardiovascular events—who were prescribed or were on statin therapy during the measurement period: • Adults aged ≥ 21 years who were previously diagnosed with or currently have an active diagnosis of clinical atherosclerotic cardiovascular disease (ASCVD); • Adults aged ≥21 years who have ever had a fasting or direct low-density lipoprotein cholesterol (LDL-C) level ≥ 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial or pure hypercholesterolemia; OR • Adults aged 40-75 years with a diagnosis of diabetes with a fasting or direct LDL-C level of 70-189 mg/dL",
-        "name": "highRiskCardiovascular"
+        "name": "highRiskCardio"
       }
     ],
     "isHighPriority": false,
@@ -10589,7 +10589,7 @@
           "denominatorExclusionUuid": "0E9E3C94-6AA0-4C3C-A311-72CB0F2698B6",
           "denominatorExceptionUuid": "ff61928c-0cb1-4a7f-a617-9b18bcfce0e4"
         },
-        "name": "noImagingStudyWithin28Days"
+        "name": "noStudy28Days"
       }
     ],
     "isHighPriority": true,

--- a/measures/measures-data.xml
+++ b/measures/measures-data.xml
@@ -2930,7 +2930,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <denominatorExclusionUuid>672f9875-55d9-4fb3-b56f-85205699103f</denominatorExclusionUuid>
         <denominatorExceptionUuid>3a57a106-7404-476e-b026-23282a95d75f</denominatorExceptionUuid>
       </eMeasureUuids>
-      <name>evidenceOfSubstanceUseBetweenDiagnosisAndTreatment</name>
+      <name>substanceUse</name>
     </strata>
     <isHighPriority>false</isHighPriority>
     <primarySteward>Center for Quality Assessment and Improvement in Mental Health</primarySteward>
@@ -3349,7 +3349,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <denominatorExclusionUuid>45A2163C-25C2-4245-A3C6-0BEE64E18B64</denominatorExclusionUuid>
         <denominatorExceptionUuid>bc43554a-5399-4d55-9c48-7dc2c1cbbb65</denominatorExceptionUuid>
       </eMeasureUuids>
-      <name>screenedForCervicalCancer</name>
+      <name>screenedForCancer</name>
     </strata>
     <isHighPriority>false</isHighPriority>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
@@ -3414,7 +3414,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <denominatorExclusionUuid>19d26b5e-9be2-4313-80f4-67be1e0dde37</denominatorExclusionUuid>
         <denominatorExceptionUuid>01a1c883-e2e6-4aec-81de-17f3cd9b63b3</denominatorExceptionUuid>
       </eMeasureUuids>
-      <name>receivedVaccinesOrExposure</name>
+      <name>vaccinesOrExposure</name>
     </strata>
     <isHighPriority>false</isHighPriority>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
@@ -3445,7 +3445,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <denominatorExclusionUuid>c7cc2c7e-892e-4b35-b1ed-b25a094f25d5</denominatorExclusionUuid>
         <denominatorExceptionUuid>7637d114-553a-4bc4-b084-d05b3a125bb8</denominatorExceptionUuid>
       </eMeasureUuids>
-      <name>hadCavitiesOrDecayedTeeth</name>
+      <name>cavitiesOrDecayed</name>
     </strata>
     <isHighPriority>true</isHighPriority>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
@@ -4074,7 +4074,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <denominatorExclusionUuid>7b3728ef-a1b8-489a-8a7c-f682c26e0d7f</denominatorExclusionUuid>
         <denominatorExceptionUuid>2EE99933-7653-4C53-8506-2A76D0657064</denominatorExceptionUuid>
       </eMeasureUuids>
-      <name>assessedCognitionWithin12Months</name>
+      <name>assessed12Months</name>
     </strata>
     <isHighPriority>false</isHighPriority>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
@@ -4252,7 +4252,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isInverse>false</isInverse>
     <strata>
       <description>Office visit, Psych visit, or Face to Face Interaction (No ED) within 4 months of the end of the measurement period that leads to a diagnosis of major depression including remission or dysthymia</description>
-      <name>within4MonthsOfEnd</name>
+      <name>4MonthsOfEnd</name>
       <eMeasureUuids>
         <initialPopulationUuid>92656CE7-C9B1-44A8-8778-A8EF1ED90A18</initialPopulationUuid>
         <denominatorUuid>C7DFE664-71AE-4EAD-AB65-CDFCF825A44E</denominatorUuid>
@@ -4263,7 +4263,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     </strata>
     <strata>
       <description>Office visit, Psych visit, or Face to Face Interaction (No ED) between 4 and 8 months after the start of the measurement period that leads to a diagnosis of major depression including remission or dysthymia</description>
-      <name>between4And8MonthsAfterStart</name>
+      <name>4&amp;8MonthsAfterStart</name>
       <eMeasureUuids>
         <initialPopulationUuid>757F3066-31E7-45D1-BA50-3EFB27ABB8E5</initialPopulationUuid>
         <denominatorUuid>32635FEA-918B-438F-8421-8A6A14E238E8</denominatorUuid>
@@ -4274,7 +4274,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     </strata>
     <strata>
       <description>Office visit, Psych visit, or Face to Face Interaction (No ED) within 4 months of the start of the measurement period that leads to a diagnosis of major depression including remission or dysthymia</description>
-      <name>within4MonthsOfStart</name>
+      <name>4MonthsOfStart</name>
       <eMeasureUuids>
         <initialPopulationUuid>5631A7DF-CA44-4AD4-A691-DC0CED303F6A</initialPopulationUuid>
         <denominatorUuid>9665A8D2-F896-47A9-AA7E-271E9815D3CE</denominatorUuid>
@@ -4526,7 +4526,7 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <denominatorExclusionUuid>305ce4ad-9e91-4236-af6d-1c5c65db586c</denominatorExclusionUuid>
         <denominatorExceptionUuid>170B3877-D83D-424C-BD7E-29F644B0A6DC</denominatorExceptionUuid>
       </eMeasureUuids>
-      <name>dilatedMacularOrFundusExamWithin12Months</name>
+      <name>dilatedExam12Months</name>
     </strata>
     <isHighPriority>false</isHighPriority>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
@@ -4923,7 +4923,7 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <denominatorExclusionUuid>65458ECD-6573-4203-8C56-515063BAFE19</denominatorExclusionUuid>
         <denominatorExceptionUuid>029ee8ff-899f-434b-9e83-cb5503bdfebb</denominatorExceptionUuid>
       </eMeasureUuids>
-      <name>reportedFunctionalStatus</name>
+      <name>functionalStatus</name>
     </strata>
     <isHighPriority>true</isHighPriority>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
@@ -4954,7 +4954,7 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <denominatorExclusionUuid>0E8BFC37-A4BA-4DE6-A6F3-DF4C188AB129</denominatorExclusionUuid>
         <denominatorExceptionUuid>a059c9d5-0445-40a5-8b55-db98a69891f4</denominatorExceptionUuid>
       </eMeasureUuids>
-      <name>reportedFunctionalStatus</name>
+      <name>functionalStatus</name>
     </strata>
     <isHighPriority>true</isHighPriority>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
@@ -4985,7 +4985,7 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <denominatorExclusionUuid>32DBECF3-11EC-40FB-B35D-FA1BF7366492</denominatorExclusionUuid>
         <denominatorExceptionUuid>b156a02c-e64c-4b93-97d3-48b6af51fbf5</denominatorExceptionUuid>
       </eMeasureUuids>
-      <name>reportedFunctionalStatus</name>
+      <name>functionalStatus</name>
     </strata>
     <isHighPriority>true</isHighPriority>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
@@ -5052,7 +5052,7 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
     <isInverse>false</isInverse>
     <strata>
       <description>A self-report outcome measure of functional status (FS) for patients 14 years+ with general orthopaedic impairments (neck, cranium, mandible, thoracic spine, ribs or other general orthopedic impairment). The change in FS assessed using FOTO (general orthopedic) PROM (patient reported outcomes measure) is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level by to assess quality</description>
-      <name>orthopaedicImpairment</name>
+      <name>orthoImpairment</name>
     </strata>
     <isHighPriority>true</isHighPriority>
     <primarySteward>Focus on Therapeutic Outcomes, Inc.</primarySteward>
@@ -5398,7 +5398,7 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <denominatorExclusionUuid>4c42d3ad-5ad4-4e97-ac7d-81c9758fbead</denominatorExclusionUuid>
         <denominatorExceptionUuid>58347456-D1F3-4BBB-9B35-5D42825A0AB3</denominatorExceptionUuid>
       </eMeasureUuids>
-      <name>within3MonthsCD4&lt;200/mm3</name>
+      <name>CD4&lt;200/mm3</name>
     </strata>
     <strata>
       <description>Patients who were prescribed Pneumocystis jiroveci pneumonia (PCP) prophylaxis within 3 months of CD4 count below 500 cells/mm3 or a CD4 percentage below 15%</description>
@@ -5409,7 +5409,7 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <denominatorExclusionUuid>659d5fba-93ed-4b1f-bd17-233362e37e58</denominatorExclusionUuid>
         <denominatorExceptionUuid>B7CCA1A6-F352-4A23-BC89-6FE9B60DC0C6</denominatorExceptionUuid>
       </eMeasureUuids>
-      <name>within3MonthsCD4&lt;500/mm3OrCD4&lt;15%</name>
+      <name>CD4&lt;500/mm3OrCD4&lt;15%</name>
     </strata>
     <strata>
       <description>Patients who were prescribed Pneumocystis jiroveci pneumonia (PCP) prophylaxis at the time of diagnosis of HIV</description>
@@ -5620,7 +5620,7 @@ If a follow-up blood pressure reading is not recorded during the measurement yea
         <denominatorExclusionUuid>74F900B9-65DA-4E6C-BB2D-592189ABDDE5</denominatorExclusionUuid>
         <denominatorExceptionUuid>6add5684-4b28-4d80-bf3d-dd0ea530a529</denominatorExceptionUuid>
       </eMeasureUuids>
-      <name>lowerFollowupBloodPressure</name>
+      <name>lowerFollowupBP</name>
     </strata>
     <isHighPriority>true</isHighPriority>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
@@ -5758,7 +5758,7 @@ b. Percentage of patients who initiated treatment and who had two or more additi
         <denominatorExclusionUuid>56BC7FA2-C22A-4440-8652-2D3568852C60</denominatorExclusionUuid>
         <denominatorExceptionUuid>506b11e2-8e60-4254-8277-5a3670bb6287</denominatorExceptionUuid>
       </eMeasureUuids>
-      <name>treatmentWithin14DaysOfDiagnosis</name>
+      <name>14DaysOfDiagnosis</name>
     </strata>
     <strata>
       <description>Patients who initiated treatment and who had two or more additional services with an AOD diagnosis within 30 days of the initiation visit</description>
@@ -5769,7 +5769,7 @@ b. Percentage of patients who initiated treatment and who had two or more additi
         <denominatorExclusionUuid>206A891D-C3E1-4660-BF2C-6CDBDF9282FB</denominatorExclusionUuid>
         <denominatorExceptionUuid>3870dc26-e32d-4ba5-9025-6b00d8259f16</denominatorExceptionUuid>
       </eMeasureUuids>
-      <name>treatmentPlusServicesWithin30DaysOfVisit</name>
+      <name>30DaysOfVisit</name>
     </strata>
     <isHighPriority>false</isHighPriority>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
@@ -5935,7 +5935,7 @@ b. Percentage of patients who initiated treatment and who had two or more additi
         <denominatorExclusionUuid>3a0f2630-297f-481e-980c-252371b90b4b</denominatorExclusionUuid>
         <denominatorExceptionUuid>4e37becd-1435-4aa7-b64f-e3b853b005e7</denominatorExceptionUuid>
       </eMeasureUuids>
-      <name>documentedScreeningOrTreatment</name>
+      <name>screeningOrTreatment</name>
     </strata>
     <isHighPriority>false</isHighPriority>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
@@ -6315,7 +6315,7 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <strata>
       <description>Percent of patients undergoing index pediatric and/or congenital heart surgery who die, including both 1) all deaths occurring during the hospitalization in which the procedure was performed, even if after 30 days (including patients transferred to other acute care facilities), and 2) those deaths occurring after discharge from the hospital, but within 30 days of the procedure, stratified by the five STAT Mortality Levels, a multi-institutional validated complexity stratification tool</description>
-      <name>congenitalHeartSurgery</name>
+      <name>heartSurgery</name>
     </strata>
     <isHighPriority>true</isHighPriority>
     <primarySteward>Society of Thoracic Surgeons</primarySteward>
@@ -6795,7 +6795,7 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <strata>
       <description>Percentage of adult patients (aged 18 or over) with metastatic colorectal cancer and KRAS gene mutation spared treatment with anti-EGFR monoclonal antibodies</description>
-      <name>metastaticColorectalCancer</name>
+      <name>colorectalCancer</name>
     </strata>
     <isHighPriority>true</isHighPriority>
     <primarySteward>American Society of Clinical Oncology</primarySteward>
@@ -6954,7 +6954,7 @@ This measure is reported as three rates stratified by age group:
     <isInverse>false</isInverse>
     <strata>
       <description>Percentage of surgical patients aged 18 years and older undergoing procedures with the indications for a first second generation cephalosporin prophylactic antibiotic who had an order for a first OR second generation cephalosporin for antimicrobial prophylaxis</description>
-      <name>prophylacticAntibiotic</name>
+      <name>antibiotic</name>
     </strata>
     <isHighPriority>true</isHighPriority>
     <primarySteward>American Society of Plastic Surgeons</primarySteward>
@@ -7541,7 +7541,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
         <denominatorExclusionUuid>a73c666b-2ccf-462a-860b-985b8c9b4454</denominatorExclusionUuid>
         <denominatorExceptionUuid>45089ed9-59a2-49b5-9162-a49b72f3da9a</denominatorExceptionUuid>
       </eMeasureUuids>
-      <name>receivedFluorideVarnish</name>
+      <name>fluorideVarnish</name>
     </strata>
     <isHighPriority>false</isHighPriority>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
@@ -8664,7 +8664,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isInverse>false</isInverse>
     <strata>
       <description>Percentage of the following patients—all considered at high risk of cardiovascular events—who were prescribed or were on statin therapy during the measurement period: • Adults aged ≥ 21 years who were previously diagnosed with or currently have an active diagnosis of clinical atherosclerotic cardiovascular disease (ASCVD); • Adults aged ≥21 years who have ever had a fasting or direct low-density lipoprotein cholesterol (LDL-C) level ≥ 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial or pure hypercholesterolemia; OR • Adults aged 40-75 years with a diagnosis of diabetes with a fasting or direct LDL-C level of 70-189 mg/dL</description>
-      <name>highRiskCardiovascular</name>
+      <name>highRiskCardio</name>
     </strata>
     <isHighPriority>false</isHighPriority>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
@@ -9124,7 +9124,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
         <denominatorExclusionUuid>0E9E3C94-6AA0-4C3C-A311-72CB0F2698B6</denominatorExclusionUuid>
         <denominatorExceptionUuid>ff61928c-0cb1-4a7f-a617-9b18bcfce0e4</denominatorExceptionUuid>
       </eMeasureUuids>
-      <name>noImagingStudyWithin28Days</name>
+      <name>noStudy28Days</name>
     </strata>
     <isHighPriority>true</isHighPriority>
     <primarySteward>National Committee for Quality Assurance</primarySteward>

--- a/measures/measures-schema.yaml
+++ b/measures/measures-schema.yaml
@@ -130,6 +130,7 @@ definitions:
         type: string
       name:
         type: string
+        maxLength: 20
       eMeasureUuids:
         type: object
         properties:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/util/manually-added-ecqm-data.json
+++ b/util/manually-added-ecqm-data.json
@@ -3,7 +3,7 @@
     "eMeasureId": "CMS117v5",
     "strata": [
       {
-        "name": "receivedVaccinesOrExposure",
+        "name": "vaccinesOrExposure",
         "description": "Children who have evidence showing they received recommended vaccines, had documented history of the illness, had a seropositive test result, or had an allergic reaction to the vaccine by their second birthday"
       }
     ]
@@ -21,7 +21,7 @@
     "eMeasureId": "CMS124v5",
     "strata": [
       {
-        "name": "screenedForCervicalCancer",
+        "name": "screenedForCancer",
         "description": "Women with one or more screenings for cervical cancer. Appropriate screenings are defined by any one of the following criteria:\r\n\r\n- Cervical cytology performed during the measurement period or the two years prior to the measurement period for women who are at least 21 years old at the time of the test\r\n \r\n- Cervical cytology/human papillomavirus (HPV) co-testing performed during the measurement period or the four years prior to the measurement period for women who are at least 30 years old at the time of the test"
       }
     ]
@@ -58,11 +58,11 @@
     "eMeasureId": "CMS137v5",
     "strata": [
       {
-        "name": "treatmentWithin14DaysOfDiagnosis",
+        "name": "14DaysOfDiagnosis",
         "description": "Patients who initiated treatment within 14 days of the diagnosis"
       },
       {
-        "name": "treatmentPlusServicesWithin30DaysOfVisit",
+        "name": "30DaysOfVisit",
         "description": "Patients who initiated treatment and who had two or more additional services with an AOD diagnosis within 30 days of the initiation visit"
       }
     ],
@@ -110,7 +110,7 @@
     "eMeasureId": "CMS149v5",
     "strata": [
       {
-        "name": "assessedCognitionWithin12Months",
+        "name": "assessed12Months",
         "description": "Patients for whom an assessment of cognition is performed and the results reviewed at least once within a 12 month period"
       }
     ]
@@ -158,7 +158,7 @@
     "strata": [
       {
         "description": "Office visit, Psych visit, or Face to Face Interaction (No ED) within 4 months of the end of the measurement period that leads to a diagnosis of major depression including remission or dysthymia",
-        "name": "within4MonthsOfEnd",
+        "name": "4MonthsOfEnd",
         "eMeasureUuids": {
           "initialPopulationUuid": "92656CE7-C9B1-44A8-8778-A8EF1ED90A18",
           "denominatorUuid": "C7DFE664-71AE-4EAD-AB65-CDFCF825A44E",
@@ -169,7 +169,7 @@
       },
       {
         "description": "Office visit, Psych visit, or Face to Face Interaction (No ED) between 4 and 8 months after the start of the measurement period that leads to a diagnosis of major depression including remission or dysthymia",
-        "name": "between4And8MonthsAfterStart",
+        "name": "4&8MonthsAfterStart",
         "eMeasureUuids": {
           "initialPopulationUuid": "757F3066-31E7-45D1-BA50-3EFB27ABB8E5",
           "denominatorUuid": "32635FEA-918B-438F-8421-8A6A14E238E8",
@@ -180,7 +180,7 @@
       },
       {
         "description": "Office visit, Psych visit, or Face to Face Interaction (No ED) within 4 months of the start of the measurement period that leads to a diagnosis of major depression including remission or dysthymia",
-        "name": "within4MonthsOfStart",
+        "name": "4MonthsOfStart",
         "eMeasureUuids": {
           "initialPopulationUuid": "5631A7DF-CA44-4AD4-A691-DC0CED303F6A",
           "denominatorUuid": "9665A8D2-F896-47A9-AA7E-271E9815D3CE",
@@ -204,7 +204,7 @@
     "eMeasureId": "CMS166v6",
     "strata": [
       {
-        "name": "noImagingStudyWithin28Days",
+        "name": "noStudy28Days",
         "description": "Patients without an imaging study conducted on the date of the outpatient or emergency department visit or in the 28 days following the outpatient or emergency department visit"
       }
     ]
@@ -213,7 +213,7 @@
     "eMeasureId": "CMS167v5",
     "strata": [
       {
-        "name": "dilatedMacularOrFundusExamWithin12Months",
+        "name": "dilatedExam12Months",
         "description": "Patients who had a dilated macular or fundus exam performed which included documentation of the level of severity of retinopathy AND the presence or absence of macular edema during one or more office visits within 12 months"
       }
     ]
@@ -222,7 +222,7 @@
     "eMeasureId": "CMS169v5",
     "strata": [
       {
-        "name": "evidenceOfSubstanceUseBetweenDiagnosisAndTreatment",
+        "name": "substanceUse",
         "description": "Patients in the denominator with evidence of an assessment for alcohol or other substance use following or concurrent with the new diagnosis, and prior to or concurrent with the initiation of treatment for that diagnosis"
       }
     ]
@@ -249,11 +249,11 @@
     "eMeasureId": "CMS52v5",
     "strata": [
       {
-        "name": "within3MonthsCD4<200/mm3",
+        "name": "CD4<200/mm3",
         "description": "Patients who were prescribed Pneumocystis jiroveci pneumonia (PCP) prophylaxis within 3 months of CD4 count below 200 cells/mm3"
       },
       {
-        "name": "within3MonthsCD4<500/mm3OrCD4<15%",
+        "name": "CD4<500/mm3OrCD4<15%",
         "description": "Patients who were prescribed Pneumocystis jiroveci pneumonia (PCP) prophylaxis within 3 months of CD4 count below 500 cells/mm3 or a CD4 percentage below 15%"
       },
       {
@@ -267,7 +267,7 @@
     "eMeasureId": "CMS56v5",
     "strata": [
       {
-        "name": "reportedFunctionalStatus",
+        "name": "functionalStatus",
         "description": "Patients with patient-reported functional status assessment results (eg, VR-12, VR-36,PROMIS-10-Global Health, PROMIS-29, HOOS) not more than 180 days prior to the primary THA procedure, and at least 60 days and not more than 180 days after THA procedure"
       }
     ]
@@ -276,7 +276,7 @@
     "eMeasureId": "CMS65v6",
     "strata": [
       {
-        "name": "lowerFollowupBloodPressure",
+        "name": "lowerFollowupBP",
         "description": "Patients whose follow-up blood pressure is at least 10 mmHg less than their baseline blood pressure or is adequately controlled.\r\n\r\nIf a follow-up blood pressure reading is not recorded during the measurement year, the patient's blood pressure is assumed \"not improved.\""
       }
     ]
@@ -285,7 +285,7 @@
     "eMeasureId": "CMS66v5",
     "strata": [
       {
-        "name": "reportedFunctionalStatus",
+        "name": "functionalStatus",
         "description": "Patients with patient-reported functional status assessment results (eg, VR-12, VR-36, PROMIS-10 Global Health, PROMIS-29, KOOS) not more than 180 days prior to the primary TKA procedure, and at least 60 days and not more than 180 days after TKA procedure"
       }
     ]
@@ -294,7 +294,7 @@
     "eMeasureId": "CMS74v6",
     "strata": [
       {
-        "name": "receivedFluorideVarnish",
+        "name": "fluorideVarnish",
         "description": "Children who receive a fluoride varnish application"
       }
     ]
@@ -303,7 +303,7 @@
     "eMeasureId": "CMS75v5",
     "strata": [
       {
-        "name": "hadCavitiesOrDecayedTeeth",
+        "name": "cavitiesOrDecayed",
         "description": "Children who had cavities or decayed teeth"
       }
     ]
@@ -312,7 +312,7 @@
     "eMeasureId": "CMS82v4",
     "strata": [
       {
-        "name": "documentedScreeningOrTreatment",
+        "name": "screeningOrTreatment",
         "description": "Children with documentation of maternal screening or treatment for postpartum depression for the mother."
       }
     ]
@@ -321,7 +321,7 @@
     "eMeasureId": "CMS90v6",
     "strata": [
       {
-        "name": "reportedFunctionalStatus",
+        "name": "functionalStatus",
         "description": "Patients with patient reported functional status assessment results (eg, VR-12; VR-36; MLHF-Q; KCCQ; PROMIS-10 Global Health, PROMIS-29) present in the EHR within two weeks before or during the initial encounter and the follow-up encounter during the measurement year"
       }
     ]

--- a/util/quality-measures-strata-details.json
+++ b/util/quality-measures-strata-details.json
@@ -35,7 +35,7 @@
   },
   {
     "qualityId": "021",
-    "performanceRates": ["prophylacticAntibiotic"]
+    "performanceRates": ["antibiotic"]
   },
   {
     "qualityId": "023",
@@ -355,7 +355,7 @@
   },
   {
     "qualityId": "223",
-    "performanceRates": ["orthopaedicImpairment"]
+    "performanceRates": ["orthoImpairment"]
   },
   {
     "qualityId": "224",
@@ -911,7 +911,7 @@
   },
   {
     "qualityId": "438",
-    "performanceRates": ["highRiskCardiovascular"]
+    "performanceRates": ["highRiskCardio"]
   },
   {
     "qualityId": "439",
@@ -943,7 +943,7 @@
   },
   {
     "qualityId": "446",
-    "performanceRates": ["congenitalHeartSurgery"]
+    "performanceRates": ["heartSurgery"]
   },
   {
     "qualityId": "447",
@@ -967,7 +967,7 @@
   },
   {
     "qualityId": "452",
-    "performanceRates": ["metastaticColorectalCancer"]
+    "performanceRates": ["colorectalCancer"]
   },
   {
     "qualityId": "453",


### PR DESCRIPTION
Strata names need to be 20 characters or shorter to fit in the column in the database, so we need to shorten the names of strata that are too long. Also I've changed the schema file to enforce the 20-character limit on the name field so that a JSON file will be invalid if the names are too long. Lastly, bumping version of package up to 0.0.34

https://jira.cms.gov/browse/QPPA-783

As a separate thought, should we put in a pre-commit hook that checks the JSON file against the schema to make sure it's valid?