### PR TITLE
Adding the pre-commit npm package so we can ensure tests pass before commits to master

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "test": "node_modules/.bin/_mocha --colors",
     "build:measures": "scripts/build-measures",
-    "build:benchmarks": "scripts/build-benchmarks"
+    "build:benchmarks": "scripts/build-benchmarks",
+    "pre-commit": "tools/pre-commit.sh"
   },
   "license": "MIT",
   "devDependencies": {
@@ -27,6 +28,10 @@
     "xml2js": "~0.4.17"
   },
   "dependencies": {
+    "pre-commit": "^1.2.2",
     "yamljs": "^0.2.8"
-  }
+  },
+  "pre-commit": [
+    "pre-commit"
+  ]
 }

--- a/tools/pre-commit.sh
+++ b/tools/pre-commit.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+if [[ `git symbolic-ref --short HEAD` == 'master' ]]; then
+    npm test
+fi


### PR DESCRIPTION
We need a way of ensuring that the automated tests pass in this
repository before new code is committed to master -- to do this, there
is now a script in tools/ that will run the automated tests if something
is committed to master and this is triggered with the pre-commit npm
package which is now apart of this repo