### PR TITLE
[QPPA-743] Ignore empty denom exceptions/exclusions from eCQM zip

### DIFF
--- a/measures/measures-data.json
+++ b/measures/measures-data.json
@@ -3781,7 +3781,8 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "A417988B-395B-4108-9988-1AE443A1E254",
           "denominatorUuid": "F25492A9-8164-4833-9A91-EA160ECC9190",
-          "numeratorUuid": "D387E1DC-F06A-4054-87B1-40B863FCF8EC"
+          "numeratorUuid": "D387E1DC-F06A-4054-87B1-40B863FCF8EC",
+          "denominatorExclusionUuid": "341797C7-3664-41E2-9771-6D85B2085BFA"
         },
         "name": "chlamydia"
       }
@@ -8374,6 +8375,7 @@
           "initialPopulationUuid": "55D921A2-0700-43F0-8C6F-1DB4ADDD7FAB",
           "denominatorUuid": "CB0D06D7-9C40-45B0-AEC2-60C39262ABA0",
           "numeratorUuid": "D94BAE8B-1EAC-4832-B040-884B4BBC5BD0",
+          "denominatorExceptionUuid": "E98E90BE-F3BD-42CD-A194-D6BEFA1BB714",
           "denominatorExclusionUuid": "8C56B86F-EFE9-404D-B97C-F8FC4691D50D"
         }
       }

--- a/measures/measures-data.json
+++ b/measures/measures-data.json
@@ -2005,8 +2005,7 @@
           "initialPopulationUuid": "4DF80BC3-980B-465E-8591-616C7DB74FBD",
           "denominatorUuid": "815F709E-9703-4A6E-860F-CB0096A98B71",
           "numeratorUuid": "341DBA96-D1CC-409F-99D9-8AB80D03B4A8",
-          "denominatorExclusionUuid": "FE028D3B-7AB5-418B-A90C-CCFE76F25078",
-          "denominatorExceptionUuid": "abe7771d-6723-4a05-a56a-17a04f981c59"
+          "denominatorExclusionUuid": "FE028D3B-7AB5-418B-A90C-CCFE76F25078"
         },
         "name": "visitWithin30Days"
       },
@@ -2016,8 +2015,7 @@
           "initialPopulationUuid": "9FC61BF5-1EBD-44DE-ADCB-64E70FD3C0A5",
           "denominatorUuid": "62FDAE01-000B-40A0-9C74-4A803BA37A96",
           "numeratorUuid": "5097B983-9C47-4F28-9194-C795F42053AF",
-          "denominatorExclusionUuid": "425772D2-6437-4F33-9B1E-349E1C6587D9",
-          "denominatorExceptionUuid": "57124f7c-9f15-4b23-9b29-722aeb6d43ee"
+          "denominatorExclusionUuid": "425772D2-6437-4F33-9B1E-349E1C6587D9"
         },
         "name": "visitAndFollowups"
       }
@@ -2229,9 +2227,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "9CDC88D7-31DA-44F1-9348-CFDD29F4B20B",
           "denominatorUuid": "1EC810C4-E6D2-4ED6-AE02-A0BF4D675F05",
-          "numeratorUuid": "693493EC-2E8E-447C-88A3-FC93AD771AB9",
-          "denominatorExclusionUuid": "f1f029d5-89a7-4c0b-acec-4ddc4fefc799",
-          "denominatorExceptionUuid": "94a41537-ee3d-4e8b-bd88-08c70e8dde3d"
+          "numeratorUuid": "693493EC-2E8E-447C-88A3-FC93AD771AB9"
         },
         "name": "assessedSuicideRisk"
       }
@@ -2679,8 +2675,7 @@
           "initialPopulationUuid": "220EBFDC-C2DF-431B-B14A-8982026B10F1",
           "denominatorUuid": "50E80E87-0A09-4914-8632-BD0797460B34",
           "numeratorUuid": "02A8409A-7B63-4FE9-B865-87C650DD7459",
-          "denominatorExclusionUuid": "BA926F92-CA87-43B3-A5C4-FD9FF8B59BB5",
-          "denominatorExceptionUuid": "a4a6db02-ab9a-489d-845a-06eccd0b957d"
+          "denominatorExclusionUuid": "BA926F92-CA87-43B3-A5C4-FD9FF8B59BB5"
         },
         "name": ">=84Days"
       },
@@ -2690,8 +2685,7 @@
           "initialPopulationUuid": "1E041190-8EE7-46B0-A735-B416C5FA76FC",
           "denominatorUuid": "B1C6949E-6854-4182-8BC9-C0EE75B705A2",
           "numeratorUuid": "3A4FA8BB-D8BC-4F66-9367-A71DF03A868D",
-          "denominatorExclusionUuid": "8C51C326-AE19-462B-9745-6C8ABE92AE27",
-          "denominatorExceptionUuid": "fdcf818a-10f3-43d8-8568-8d2545106a07"
+          "denominatorExclusionUuid": "8C51C326-AE19-462B-9745-6C8ABE92AE27"
         },
         "name": ">=180Days"
       }
@@ -2848,8 +2842,7 @@
           "initialPopulationUuid": "6BE37D85-960E-4C32-AD2D-FE036A058EB4",
           "denominatorUuid": "AE00EE88-B26B-449D-94DE-EA3887BB66E0",
           "numeratorUuid": "86A8B7E8-EEA2-4C19-8A1B-74B905939505",
-          "denominatorExclusionUuid": "A0B43F8B-E6EE-4229-A05D-ECF1B601CEAF",
-          "denominatorExceptionUuid": "7f8af6e7-489b-4f64-a627-6c9b50400d9e"
+          "denominatorExclusionUuid": "A0B43F8B-E6EE-4229-A05D-ECF1B601CEAF"
         }
       }
     ],
@@ -2888,8 +2881,7 @@
           "initialPopulationUuid": "A5BF87B0-15CF-4012-9E29-DC85010676BC",
           "denominatorUuid": "FDE4FCC5-826B-42C6-82BE-1694DD18A48D",
           "numeratorUuid": "27037F9E-5C8E-41FE-A973-E2E020C97DA7",
-          "denominatorExclusionUuid": "8E32E552-A70A-4BBC-A92A-F8D3D48113CF",
-          "denominatorExceptionUuid": "cc580a24-5718-4c00-a7f3-fff702791e15"
+          "denominatorExclusionUuid": "8E32E552-A70A-4BBC-A92A-F8D3D48113CF"
         }
       }
     ],
@@ -3136,9 +3128,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "AB5E9E84-65FB-4566-8254-D3488CA9A169",
           "denominatorUuid": "9656501E-1FAB-4B81-AB59-6646F1114394",
-          "numeratorUuid": "3C942ABF-C287-4FBB-AFEE-67BC5FC93BD0",
-          "denominatorExclusionUuid": "672f9875-55d9-4fb3-b56f-85205699103f",
-          "denominatorExceptionUuid": "3a57a106-7404-476e-b026-23282a95d75f"
+          "numeratorUuid": "3C942ABF-C287-4FBB-AFEE-67BC5FC93BD0"
         },
         "name": "substanceUse"
       }
@@ -3203,8 +3193,7 @@
           "initialPopulationUuid": "66FD640C-70BB-400F-9926-98EA1ACEBEBA",
           "denominatorUuid": "40FB2D5F-7DEF-4D41-80C4-F3FBA0ED5851",
           "numeratorUuid": "0AB40D2B-08CE-4185-8A54-336C3140644D",
-          "denominatorExclusionUuid": "EC5CC49E-42A7-4DD8-BD40-A6258E71DCB9",
-          "denominatorExceptionUuid": "f8f1841f-42d9-4f20-bc7f-960ce90c17ae"
+          "denominatorExclusionUuid": "EC5CC49E-42A7-4DD8-BD40-A6258E71DCB9"
         }
       }
     ],
@@ -3434,8 +3423,7 @@
           "initialPopulationUuid": "D790598C-DC4A-4DF8-8E50-9878AF4E886F",
           "denominatorUuid": "16000621-529F-4F4E-A0A8-ACA703D3B40A",
           "numeratorUuid": "2F166EEC-4528-474A-966F-D9C8AD49C7AD",
-          "denominatorExclusionUuid": "9D7B933B-8A97-4BA3-A546-220E1BF789CC",
-          "denominatorExceptionUuid": "d164dbe6-d3d5-4bc4-8df1-d54b1d07ef10"
+          "denominatorExclusionUuid": "9D7B933B-8A97-4BA3-A546-220E1BF789CC"
         }
       }
     ],
@@ -3472,8 +3460,7 @@
           "initialPopulationUuid": "1B6E9DCF-15DC-4D57-97DB-F8A8619DDB1B",
           "denominatorUuid": "44BB8D98-F611-48FD-BD3F-05BB998F3754",
           "numeratorUuid": "A4AE5A30-F400-4849-B054-FB19138AC580",
-          "denominatorExclusionUuid": "AE555E04-C8C0-4ABE-AE9B-C5FC2B46F263",
-          "denominatorExceptionUuid": "4af92697-0940-49aa-b67e-dca6646aed47"
+          "denominatorExclusionUuid": "AE555E04-C8C0-4ABE-AE9B-C5FC2B46F263"
         }
       }
     ],
@@ -3625,8 +3612,7 @@
           "initialPopulationUuid": "3A29C38D-E468-47CC-995B-B281B1B066CF",
           "denominatorUuid": "7CDA5C1B-CD31-4D16-80C4-22AE2F549D88",
           "numeratorUuid": "3854BDE6-9614-475D-8E3B-5A041C04C291",
-          "denominatorExclusionUuid": "45A2163C-25C2-4245-A3C6-0BEE64E18B64",
-          "denominatorExceptionUuid": "bc43554a-5399-4d55-9c48-7dc2c1cbbb65"
+          "denominatorExclusionUuid": "45A2163C-25C2-4245-A3C6-0BEE64E18B64"
         },
         "name": "screenedForCancer"
       }
@@ -3662,9 +3648,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "008509CF-85E8-40C0-9434-65FE19EFC090",
           "denominatorUuid": "92E101F9-795A-46DD-BEDE-EA94743AC232",
-          "numeratorUuid": "78D2FEEA-45D3-4D08-9227-773E70E3AAD5",
-          "denominatorExclusionUuid": "e21f777c-f8c6-4250-9428-2535d91b4a96",
-          "denominatorExceptionUuid": "6267da42-6e04-4614-bbe6-bb17021cc4b1"
+          "numeratorUuid": "78D2FEEA-45D3-4D08-9227-773E70E3AAD5"
         },
         "name": "assessedSuicideRisk"
       }
@@ -3700,9 +3684,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "DA379EC2-EE2E-4548-AEF0-DD4F14F80279",
           "denominatorUuid": "CC8AFFF0-A436-42CD-8322-5EBCEF9CBF06",
-          "numeratorUuid": "AE7A33AF-0DA7-4772-A23C-2D2CA732D53A",
-          "denominatorExclusionUuid": "19d26b5e-9be2-4313-80f4-67be1e0dde37",
-          "denominatorExceptionUuid": "01a1c883-e2e6-4aec-81de-17f3cd9b63b3"
+          "numeratorUuid": "AE7A33AF-0DA7-4772-A23C-2D2CA732D53A"
         },
         "name": "vaccinesOrExposure"
       }
@@ -3737,9 +3719,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "72D79C93-6D03-4BA2-B250-5316E370B766",
           "denominatorUuid": "E87F18F1-F70C-4BB3-A95C-7C1D4561E73D",
-          "numeratorUuid": "3D9AD35A-7456-4AA2-8FDB-D4B06DF72CC9",
-          "denominatorExclusionUuid": "c7cc2c7e-892e-4b35-b1ed-b25a094f25d5",
-          "denominatorExceptionUuid": "7637d114-553a-4bc4-b084-d05b3a125bb8"
+          "numeratorUuid": "3D9AD35A-7456-4AA2-8FDB-D4B06DF72CC9"
         },
         "name": "cavitiesOrDecayed"
       }
@@ -3801,9 +3781,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "A417988B-395B-4108-9988-1AE443A1E254",
           "denominatorUuid": "F25492A9-8164-4833-9A91-EA160ECC9190",
-          "numeratorUuid": "D387E1DC-F06A-4054-87B1-40B863FCF8EC",
-          "denominatorExclusionUuid": "341797C7-3664-41E2-9771-6D85B2085BFA",
-          "denominatorExceptionUuid": "2e71982a-b165-480e-afc8-4d1eaee6073b"
+          "numeratorUuid": "D387E1DC-F06A-4054-87B1-40B863FCF8EC"
         },
         "name": "chlamydia"
       }
@@ -3922,9 +3900,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "E7A4AE77-FC46-44F1-BF25-9E99A89CED9B",
           "denominatorUuid": "B710DA92-D4B9-4217-8D1E-94B35163BECE",
-          "numeratorUuid": "9824B759-A263-44DE-9F5E-93DA4E8F4627",
-          "denominatorExclusionUuid": "38db92d1-881b-452b-930e-79bff2e4e490",
-          "denominatorExceptionUuid": "c8dcc3f8-38e7-4004-956e-ab8abe965231"
+          "numeratorUuid": "9824B759-A263-44DE-9F5E-93DA4E8F4627"
         },
         "name": "patientsWithReferral"
       }
@@ -4041,8 +4017,7 @@
           "initialPopulationUuid": "4D1C7452-B908-4616-B9E9-36C9AA71005B",
           "denominatorUuid": "589C2FD6-6AA9-4AF8-9E1C-973170361917",
           "numeratorUuid": "52ADE511-39D4-4CBC-84B6-A82059741359",
-          "denominatorExclusionUuid": "93AA9C96-E1FE-435B-BA0B-FAF0C5592275",
-          "denominatorExceptionUuid": "385e49f7-501d-498f-b99d-681c67c6a22d"
+          "denominatorExclusionUuid": "93AA9C96-E1FE-435B-BA0B-FAF0C5592275"
         }
       }
     ],
@@ -4112,8 +4087,7 @@
           "initialPopulationUuid": "3AD33404-E734-4F67-9144-E4B63CB3F4BE",
           "denominatorUuid": "E62FEBA3-0F98-460D-93CD-44314D7203A8",
           "numeratorUuid": "F9FEBF42-4B21-47A9-B03E-D2DA5CF8492B",
-          "denominatorExclusionUuid": "55A6D5F3-2029-4896-B850-4C7894161D7D",
-          "denominatorExceptionUuid": "fafa1d59-6f64-487c-9f95-ed81c139d2c0"
+          "denominatorExclusionUuid": "55A6D5F3-2029-4896-B850-4C7894161D7D"
         }
       }
     ],
@@ -4497,7 +4471,6 @@
           "initialPopulationUuid": "1D86EE69-7DA7-4A73-8611-2E71176568B6",
           "denominatorUuid": "2DA1439F-7941-411C-8885-91306F0CD9DD",
           "numeratorUuid": "2C2431A3-7DE3-4C97-80C0-4BF96D4880F0",
-          "denominatorExclusionUuid": "7b3728ef-a1b8-489a-8a7c-f682c26e0d7f",
           "denominatorExceptionUuid": "2EE99933-7653-4C53-8506-2A76D0657064"
         },
         "name": "assessed12Months"
@@ -4685,8 +4658,7 @@
           "initialPopulationUuid": "8AAC0F5B-DC7F-4FA3-8DE9-439C663E6B41",
           "denominatorUuid": "1C6771A4-4C26-4E2C-9E10-FF6F1A5D0907",
           "numeratorUuid": "52837728-F488-4BA5-9921-FFDEEC0F0803",
-          "denominatorExclusionUuid": "72259A21-874C-4E51-9465-9989019193D0",
-          "denominatorExceptionUuid": "1de2c677-5e1b-48fb-b554-24996d0fc30c"
+          "denominatorExclusionUuid": "72259A21-874C-4E51-9465-9989019193D0"
         }
       }
     ],
@@ -4784,9 +4756,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "321FB2D3-477E-41B7-8BB1-02EE94D08417",
           "denominatorUuid": "98CE7ECC-1F09-4F52-906C-E53EAB545F00",
-          "numeratorUuid": "3F48A9B6-7B99-4BF4-AB1E-50DC1FFB9D1A",
-          "denominatorExclusionUuid": "7f24aecc-ef66-4bfc-b86b-15c973bca8c3",
-          "denominatorExceptionUuid": "5421c143-d990-478f-bbef-1f152fee4d22"
+          "numeratorUuid": "3F48A9B6-7B99-4BF4-AB1E-50DC1FFB9D1A"
         }
       }
     ],
@@ -4826,8 +4796,7 @@
           "initialPopulationUuid": "9AB84D25-5883-4D85-A868-0D702403F250",
           "denominatorUuid": "61B09878-32B3-4ECB-8E78-D1093E1FDDF9",
           "numeratorUuid": "60EC6098-950A-40E5-994F-E9A62CFF6FC2",
-          "denominatorExclusionUuid": "02D13BF4-EF77-4DF4-A436-834AEDBE043C",
-          "denominatorExceptionUuid": "b508d087-5c33-4d49-b042-6da769499b06"
+          "denominatorExclusionUuid": "02D13BF4-EF77-4DF4-A436-834AEDBE043C"
         },
         "name": "receivedFootExams"
       }
@@ -4864,9 +4833,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "0739FE2E-B8DE-4A56-B064-877CC8E0977D",
           "denominatorUuid": "D346DA74-F16E-4159-BEDF-331BA28837FB",
-          "numeratorUuid": "6D01A564-58CC-4CF5-929F-B83583701BFE",
-          "denominatorExclusionUuid": "25d4b54e-697c-4afe-a2e2-636ce9fe7bf2",
-          "denominatorExceptionUuid": "7c4dda50-c802-4a70-b58f-c50780cf5edd"
+          "numeratorUuid": "6D01A564-58CC-4CF5-929F-B83583701BFE"
         }
       }
     ],
@@ -4906,9 +4873,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "A27FD818-3C97-4516-A796-319B89E306AC",
           "denominatorUuid": "0CC16DE4-474A-4F6E-BFB8-0104709B1E05",
-          "numeratorUuid": "5647E3D0-6550-4B0B-AE76-53CD9E99D20B",
-          "denominatorExclusionUuid": "9887c765-7188-4af0-8c30-cba92f11ea1c",
-          "denominatorExceptionUuid": "68ac0f19-3c01-42cf-9056-154ea55e4789"
+          "numeratorUuid": "5647E3D0-6550-4B0B-AE76-53CD9E99D20B"
         }
       }
     ],
@@ -4999,7 +4964,6 @@
           "initialPopulationUuid": "2072A4E8-4486-4A10-AF97-F84ADE0EB62E",
           "denominatorUuid": "2BB9F18C-8E26-44D6-904E-849495A6AF90",
           "numeratorUuid": "BCB8AEEC-EABC-477E-AA6D-6DB34220CD85",
-          "denominatorExclusionUuid": "9e1763e9-74f8-4f09-b57f-0f74a9adb3c7",
           "denominatorExceptionUuid": "608279BD-7620-4FC4-8752-08E3040BA160"
         }
       }
@@ -5037,7 +5001,6 @@
           "initialPopulationUuid": "3EB89216-BC0B-4DF7-8B8D-06B9AB68DB49",
           "denominatorUuid": "04507C05-46D4-4D96-9D9D-853CA557F4B2",
           "numeratorUuid": "3186154C-6A01-4FAF-A77F-B5233A3F078C",
-          "denominatorExclusionUuid": "305ce4ad-9e91-4236-af6d-1c5c65db586c",
           "denominatorExceptionUuid": "170B3877-D83D-424C-BD7E-29F644B0A6DC"
         },
         "name": "dilatedExam12Months"
@@ -5075,7 +5038,6 @@
           "initialPopulationUuid": "D412322D-11F1-4573-893E-E6A05855DE10",
           "denominatorUuid": "375D0559-C749-4BB9-9267-81EDF447650B",
           "numeratorUuid": "EFFE261C-0D57-423E-992C-7141B132768C",
-          "denominatorExclusionUuid": "a5dd46b0-f412-4d7d-a3b4-16c8ad4a4f43",
           "denominatorExceptionUuid": "3C100EC4-2990-4D79-AE14-E816F5E78AC8"
         }
       }
@@ -5411,7 +5373,6 @@
           "initialPopulationUuid": "0175F89E-9CD7-4CD8-8D7F-38CB825D2BDD",
           "denominatorUuid": "A3F77B7C-2398-470D-A359-E2A31539DF91",
           "numeratorUuid": "F0F4094E-CE53-44EE-8CEF-0555479E37B2",
-          "denominatorExclusionUuid": "c4aa6477-f361-4990-ac25-0549bd86e1c7",
           "denominatorExceptionUuid": "CF7E1913-CB4E-42F7-BAEC-0EFFF01ECB17"
         },
         "name": "screenedForFallRisk"
@@ -5512,8 +5473,7 @@
           "initialPopulationUuid": "642D0090-BEAB-410B-B3B3-8D1A5EC5B919",
           "denominatorUuid": "FFA80359-2E09-48C8-8862-DD6E1F5F5428",
           "numeratorUuid": "7D021618-E1EE-4C2F-AD6A-F74E03D69E43",
-          "denominatorExclusionUuid": "65458ECD-6573-4203-8C56-515063BAFE19",
-          "denominatorExceptionUuid": "029ee8ff-899f-434b-9e83-cb5503bdfebb"
+          "denominatorExclusionUuid": "65458ECD-6573-4203-8C56-515063BAFE19"
         },
         "name": "functionalStatus"
       }
@@ -5549,8 +5509,7 @@
           "initialPopulationUuid": "F0D80FC4-5E5E-46F3-A519-1B99013E2761",
           "denominatorUuid": "D795B824-0575-47B3-93DB-D48CD5643677",
           "numeratorUuid": "0DD7EF36-2B1D-4447-8E52-BF9C4A3E7ED3",
-          "denominatorExclusionUuid": "0E8BFC37-A4BA-4DE6-A6F3-DF4C188AB129",
-          "denominatorExceptionUuid": "a059c9d5-0445-40a5-8b55-db98a69891f4"
+          "denominatorExclusionUuid": "0E8BFC37-A4BA-4DE6-A6F3-DF4C188AB129"
         },
         "name": "functionalStatus"
       }
@@ -5586,8 +5545,7 @@
           "initialPopulationUuid": "AD37C6FE-2537-4A9B-8AD9-A372E3215F76",
           "denominatorUuid": "19ECF222-71EF-4D75-9CC2-19ED201107EA",
           "numeratorUuid": "F9B4C929-8F37-48D1-953C-489C028AE725",
-          "denominatorExclusionUuid": "32DBECF3-11EC-40FB-B35D-FA1BF7366492",
-          "denominatorExceptionUuid": "b156a02c-e64c-4b93-97d3-48b6af51fbf5"
+          "denominatorExclusionUuid": "32DBECF3-11EC-40FB-B35D-FA1BF7366492"
         },
         "name": "functionalStatus"
       }
@@ -5811,7 +5769,6 @@
           "initialPopulationUuid": "F3000871-B8FD-4F74-8892-281C250C11EA",
           "denominatorUuid": "C1E20830-ADFE-4D88-B979-166FA0820D5C",
           "numeratorUuid": "49E476F4-E8A1-48A6-B800-A8172073DBFB",
-          "denominatorExclusionUuid": "a2cd75d1-24b1-4216-a241-b0b07fecde1f",
           "denominatorExceptionUuid": "41E08783-4358-4E0D-81BE-9616A8F58319"
         }
       }
@@ -5852,7 +5809,6 @@
           "initialPopulationUuid": "5ED1A428-A266-47E5-AE4F-DB97A65BB1D4",
           "denominatorUuid": "1E6C181E-91F6-4A61-82E0-7360C81CE3B0",
           "numeratorUuid": "ABBFFB54-E629-4520-875E-F6D18BC651B1",
-          "denominatorExclusionUuid": "8d38d97e-589e-4a22-881e-fa41649b54f1",
           "denominatorExceptionUuid": "E9280685-6046-438D-AE45-0F7EDBA29C33"
         }
       }
@@ -6088,7 +6044,6 @@
           "initialPopulationUuid": "E681DBF8-F827-4586-B3E0-178FF19EC3A2",
           "denominatorUuid": "04BF53CE-6993-4EA2-BFE5-66E36172B388",
           "numeratorUuid": "631C0B49-83F4-4A54-96C4-7E0766B2407C",
-          "denominatorExclusionUuid": "4c42d3ad-5ad4-4e97-ac7d-81c9758fbead",
           "denominatorExceptionUuid": "58347456-D1F3-4BBB-9B35-5D42825A0AB3"
         },
         "name": "CD4<200/mm3"
@@ -6099,7 +6054,6 @@
           "initialPopulationUuid": "AAC578DB-1900-43BD-BBBF-50014A5457E5",
           "denominatorUuid": "1574973E-EB52-40C7-9709-25ABEDBA99A3",
           "numeratorUuid": "5B7AC4EC-547A-47E5-AC5E-618401175511",
-          "denominatorExclusionUuid": "659d5fba-93ed-4b1f-bd17-233362e37e58",
           "denominatorExceptionUuid": "B7CCA1A6-F352-4A23-BC89-6FE9B60DC0C6"
         },
         "name": "CD4<500/mm3OrCD4<15%"
@@ -6109,9 +6063,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "AF36C4A9-8BD9-4E21-838D-A47A1845EB90",
           "denominatorUuid": "B95BC0D3-572E-462B-BAA2-46CD33A865CD",
-          "numeratorUuid": "86F74F07-D593-44F6-AA12-405966400963",
-          "denominatorExclusionUuid": "8d54df2e-8a7e-49e3-a99a-0132f5139b7c",
-          "denominatorExceptionUuid": "28ee691d-8155-41fe-8c20-12a5d2e1fb75"
+          "numeratorUuid": "86F74F07-D593-44F6-AA12-405966400963"
         },
         "name": "atDiagnosis"
       }
@@ -6343,8 +6295,7 @@
           "initialPopulationUuid": "78CD5ACE-054C-43DF-A743-5F1E5BA4C099",
           "denominatorUuid": "CE973C7A-B867-422B-8408-83538E236039",
           "numeratorUuid": "F67DCC8F-4F0F-491B-957F-B21E721B040B",
-          "denominatorExclusionUuid": "74F900B9-65DA-4E6C-BB2D-592189ABDDE5",
-          "denominatorExceptionUuid": "6add5684-4b28-4d80-bf3d-dd0ea530a529"
+          "denominatorExclusionUuid": "74F900B9-65DA-4E6C-BB2D-592189ABDDE5"
         },
         "name": "lowerFollowupBP"
       }
@@ -6506,8 +6457,7 @@
           "initialPopulationUuid": "EC2C5F63-AF76-4D3C-85F0-5423F8C28541",
           "denominatorUuid": "BC948E65-B908-493B-B48B-04AC342D3E6C",
           "numeratorUuid": "0BBF8596-4CFE-47F4-A0D7-9BEAB94BA4CD",
-          "denominatorExclusionUuid": "56BC7FA2-C22A-4440-8652-2D3568852C60",
-          "denominatorExceptionUuid": "506b11e2-8e60-4254-8277-5a3670bb6287"
+          "denominatorExclusionUuid": "56BC7FA2-C22A-4440-8652-2D3568852C60"
         },
         "name": "14DaysOfDiagnosis"
       },
@@ -6517,8 +6467,7 @@
           "initialPopulationUuid": "1511AD34-240C-4F3E-A87B-73511AABFC5C",
           "denominatorUuid": "4A09AB89-D9B8-4DD1-BC4E-78BCFD1C5873",
           "numeratorUuid": "7FFA49C4-D708-491E-85FE-6855F0A725DF",
-          "denominatorExclusionUuid": "206A891D-C3E1-4660-BF2C-6CDBDF9282FB",
-          "denominatorExceptionUuid": "3870dc26-e32d-4ba5-9025-6b00d8259f16"
+          "denominatorExclusionUuid": "206A891D-C3E1-4660-BF2C-6CDBDF9282FB"
         },
         "name": "30DaysOfVisit"
       }
@@ -6581,8 +6530,7 @@
           "initialPopulationUuid": "C3E458D8-8ED4-4F09-A661-6221A2B9355D",
           "denominatorUuid": "FE6E1AA0-EE26-4F9E-A2FD-8E36058DCB47",
           "numeratorUuid": "0A3C80F4-A9FF-4BDF-B018-D647E7D777EB",
-          "denominatorExclusionUuid": "D564DEEE-17E7-4442-921D-436E5113788A",
-          "denominatorExceptionUuid": "4b5358ad-05f3-484a-a66b-c652b4e825d1"
+          "denominatorExclusionUuid": "D564DEEE-17E7-4442-921D-436E5113788A"
         }
       }
     ],
@@ -6710,9 +6658,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "D3ADB281-2F53-4BE6-89A9-124480DE787D",
           "denominatorUuid": "6B845134-C1B7-4383-AFB3-1FFB7EAD359B",
-          "numeratorUuid": "D2A5FF72-DE5E-413A-829E-C763FC07DF4A",
-          "denominatorExclusionUuid": "3a0f2630-297f-481e-980c-252371b90b4b",
-          "denominatorExceptionUuid": "4e37becd-1435-4aa7-b64f-e3b853b005e7"
+          "numeratorUuid": "D2A5FF72-DE5E-413A-829E-C763FC07DF4A"
         },
         "name": "screeningOrTreatment"
       }
@@ -7046,9 +6992,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "8494E3CD-7119-4471-9F2F-42540A797498",
           "denominatorUuid": "D1358E7F-9C53-414C-9D4D-DEF7AE9B6E68",
-          "numeratorUuid": "95484C04-C98A-4A77-B2A7-9FE583060582",
-          "denominatorExclusionUuid": "8357720f-e333-419c-b274-d0d8a7c0c52c",
-          "denominatorExceptionUuid": "3ccb17ee-f833-4839-ad7e-e32315697409"
+          "numeratorUuid": "95484C04-C98A-4A77-B2A7-9FE583060582"
         }
       }
     ],
@@ -8117,9 +8061,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "E1A2F7D4-0B24-47FC-9369-0700771B2D40",
           "denominatorUuid": "B57EA797-15A1-4C60-B34C-BAE292FE3B76",
-          "numeratorUuid": "CBD0926D-6088-44EE-883C-0A0F9E77E2A1",
-          "denominatorExclusionUuid": "43958624-b741-4a41-9407-cda6e8d75029",
-          "denominatorExceptionUuid": "704fc6d6-ecc6-47a7-a411-829c6d327993"
+          "numeratorUuid": "CBD0926D-6088-44EE-883C-0A0F9E77E2A1"
         }
       }
     ],
@@ -8216,7 +8158,6 @@
           "initialPopulationUuid": "328FF8FF-8A53-42CF-A33E-789BC7E0D8ED",
           "denominatorUuid": "9826C75F-8106-44DE-AFB5-47669443C153",
           "numeratorUuid": "4ADA7675-6263-4018-997E-D27CE43A11D6",
-          "denominatorExclusionUuid": "72135b92-8866-4315-992d-38ca6490da49",
           "denominatorExceptionUuid": "F77E40ED-F649-4250-B99A-3C35414D88B0"
         },
         "name": "hepB"
@@ -8339,8 +8280,8 @@
           "initialPopulationUuid": "4D10500F-6738-4541-BF24-4C95C74B45AB",
           "denominatorUuid": "36CCB819-C150-466D-A55A-0A175B19E751",
           "numeratorUuid": "51D06394-AF97-41DD-BF41-68D58786A9D2",
-          "denominatorExclusionUuid": "EE5FFA67-A42D-4472-8159-ED4B87BE6CDA",
-          "denominatorExceptionUuid": "0E162220-C93B-48B0-AAB1-E2F8E7FE7EA1"
+          "denominatorExceptionUuid": "0E162220-C93B-48B0-AAB1-E2F8E7FE7EA1",
+          "denominatorExclusionUuid": "EE5FFA67-A42D-4472-8159-ED4B87BE6CDA"
         }
       }
     ],
@@ -8394,7 +8335,6 @@
           "initialPopulationUuid": "FF48C33E-49B3-45D1-AB44-D283F39AE73D",
           "denominatorUuid": "56E05D20-4529-4EB7-8E30-17C95BBC5223",
           "numeratorUuid": "A6516D8B-0A7D-426D-A0EC-F3F4999A2588",
-          "denominatorExclusionUuid": "98a4272d-cff5-477d-a728-23d4303c2fba",
           "denominatorExceptionUuid": "9411528A-67EF-439B-9C00-37372B2096E3"
         }
       }
@@ -8439,8 +8379,7 @@
           "initialPopulationUuid": "55D921A2-0700-43F0-8C6F-1DB4ADDD7FAB",
           "denominatorUuid": "CB0D06D7-9C40-45B0-AEC2-60C39262ABA0",
           "numeratorUuid": "D94BAE8B-1EAC-4832-B040-884B4BBC5BD0",
-          "denominatorExclusionUuid": "8C56B86F-EFE9-404D-B97C-F8FC4691D50D",
-          "denominatorExceptionUuid": "E98E90BE-F3BD-42CD-A194-D6BEFA1BB714"
+          "denominatorExclusionUuid": "8C56B86F-EFE9-404D-B97C-F8FC4691D50D"
         }
       }
     ],
@@ -8482,8 +8421,8 @@
           "initialPopulationUuid": "C7E7C7AF-464F-43A0-8C84-CDFF99953C97",
           "denominatorUuid": "65AFB8BA-F5CC-4ABA-A3FB-2F95FEE2B6FA",
           "numeratorUuid": "8964CE5A-64A4-4259-9359-39A1CDC07B8D",
-          "denominatorExclusionUuid": "8867C7A7-F8F1-4B61-A6C7-9390C5B5B4EF",
-          "denominatorExceptionUuid": "2338C9B7-B2C5-4348-BF2B-C9E636FD7A45"
+          "denominatorExceptionUuid": "2338C9B7-B2C5-4348-BF2B-C9E636FD7A45",
+          "denominatorExclusionUuid": "8867C7A7-F8F1-4B61-A6C7-9390C5B5B4EF"
         }
       }
     ],
@@ -8544,7 +8483,6 @@
           "initialPopulationUuid": "CA679308-8AF3-4374-91DC-907951440D72",
           "denominatorUuid": "FFC4DDE0-C91C-4235-BF69-E3EF79457FBB",
           "numeratorUuid": "44BEAC3C-8402-46F0-9494-81B33C502F0A",
-          "denominatorExclusionUuid": "a5a204a2-1a11-4ea7-8153-48c2f6b1dbce",
           "denominatorExceptionUuid": "655C9F36-02F7-498B-AE18-D322EA2B3726"
         }
       }
@@ -8645,9 +8583,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "BCE39253-0C5F-4DFA-A5BD-0828A8B2BB22",
           "denominatorUuid": "B41B2DF9-B4BF-4B89-A483-5B0C1A9D9804",
-          "numeratorUuid": "BEF89159-5D5C-47C6-953D-63FCAEA41548",
-          "denominatorExclusionUuid": "a73c666b-2ccf-462a-860b-985b8c9b4454",
-          "denominatorExceptionUuid": "45089ed9-59a2-49b5-9162-a49b72f3da9a"
+          "numeratorUuid": "BEF89159-5D5C-47C6-953D-63FCAEA41548"
         },
         "name": "fluorideVarnish"
       }
@@ -8684,7 +8620,6 @@
           "initialPopulationUuid": "56091E02-5F5C-4073-9602-D0B5BB93A26E",
           "denominatorUuid": "262ADC93-EE8C-4B95-9EFF-A6223C66ECA8",
           "numeratorUuid": "2902F791-D7AB-49B2-B024-45B1077E0374",
-          "denominatorExclusionUuid": "57c33ac4-db05-42ce-b750-ddc6d49caa62",
           "denominatorExceptionUuid": "1FA6B8AF-0583-418D-852B-9B1D9708DDFF"
         }
       }
@@ -9014,7 +8949,6 @@
           "initialPopulationUuid": "73B68FA6-B437-4166-8555-F54EDD2BD797",
           "denominatorUuid": "F457BF14-DBBF-4F25-9C27-3F1A77E6341A",
           "numeratorUuid": "ECBF5473-BA0F-4662-90A9-BCCF981F92CD",
-          "denominatorExclusionUuid": "b975ce93-b67c-4cf8-9794-6d00b8ead043",
           "denominatorExceptionUuid": "01197FE4-C21E-482E-8A98-05506308A206"
         }
       }
@@ -10540,9 +10474,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "C7BCE5A3-AC0D-440E-AA29-C98239F37A8B",
           "denominatorUuid": "07F04D61-0383-487E-942C-690BBBC6437D",
-          "numeratorUuid": "7A0001AC-4BE0-4FAA-94AE-4843C9FFFCA8",
-          "denominatorExclusionUuid": "718a29a0-49b3-4483-ab9d-dc37074f39f5",
-          "denominatorExceptionUuid": "bba507df-e957-4649-98b9-ff70c1dd7971"
+          "numeratorUuid": "7A0001AC-4BE0-4FAA-94AE-4843C9FFFCA8"
         }
       },
       {
@@ -10551,9 +10483,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "BC02D7CE-7133-46C6-8592-658668B09948",
           "denominatorUuid": "00401314-1B01-4896-A9FC-E991CDF29B6B",
-          "numeratorUuid": "FA7BF805-C21E-4077-B43E-C63F8D17B5CF",
-          "denominatorExclusionUuid": "41d84550-23c6-46a7-bb50-85708fa8607b",
-          "denominatorExceptionUuid": "0e953aff-ae2e-4a74-b774-ca3d9cd40e00"
+          "numeratorUuid": "FA7BF805-C21E-4077-B43E-C63F8D17B5CF"
         }
       }
     ],
@@ -10588,8 +10518,7 @@
           "initialPopulationUuid": "45D3A3ED-A7D6-45B9-AC95-647BFFE7018E",
           "denominatorUuid": "0E27156C-B8EB-48E7-A588-4AB97A0914E1",
           "numeratorUuid": "13C60632-9CF4-491B-82E9-A06118111C44",
-          "denominatorExclusionUuid": "0E9E3C94-6AA0-4C3C-A311-72CB0F2698B6",
-          "denominatorExceptionUuid": "ff61928c-0cb1-4a7f-a617-9b18bcfce0e4"
+          "denominatorExclusionUuid": "0E9E3C94-6AA0-4C3C-A311-72CB0F2698B6"
         },
         "name": "noStudy28Days"
       }
@@ -10654,8 +10583,7 @@
           "initialPopulationUuid": "0ADE9325-3FB7-402F-AD89-34C9F2753D03",
           "denominatorUuid": "933D86C8-2C2B-4AFF-AE81-DF2F9882A3A4",
           "numeratorUuid": "61887626-5457-484C-A02D-75EF8547F559",
-          "denominatorExclusionUuid": "6938F4DD-D5AB-4C40-BA03-EB0F0959615C",
-          "denominatorExceptionUuid": "3cac2acd-a3ed-4629-967a-83464c25fee4"
+          "denominatorExclusionUuid": "6938F4DD-D5AB-4C40-BA03-EB0F0959615C"
         },
         "name": "BMI"
       },
@@ -10665,8 +10593,7 @@
           "initialPopulationUuid": "25286925-4221-4396-9DE0-60EA606924DF",
           "denominatorUuid": "CFB8E3E2-FF4F-4D25-B613-7EC142BAE8A9",
           "numeratorUuid": "EEAD441F-B3B2-4DC9-A890-B35E14B38EA7",
-          "denominatorExclusionUuid": "A399FA9C-48CF-41E5-812A-3445188B8301",
-          "denominatorExceptionUuid": "9fc3a9e2-6e5f-4310-9d12-5546add1a4d2"
+          "denominatorExclusionUuid": "A399FA9C-48CF-41E5-812A-3445188B8301"
         },
         "name": "nutrition"
       },
@@ -10676,8 +10603,7 @@
           "initialPopulationUuid": "48747E9D-674C-4013-9585-268114190119",
           "denominatorUuid": "208B74F2-6592-4381-BEC1-EB136004C3B2",
           "numeratorUuid": "21409D88-B5E3-4745-8DE2-D99DBB9F4DF0",
-          "denominatorExclusionUuid": "507F7EC3-D380-48BE-B920-ABB1EB258256",
-          "denominatorExceptionUuid": "15a2ed8f-4300-4ad9-b2ec-63d6f389feba"
+          "denominatorExclusionUuid": "507F7EC3-D380-48BE-B920-ABB1EB258256"
         },
         "name": "physicalActivity"
       }

--- a/measures/measures-data.json
+++ b/measures/measures-data.json
@@ -4391,7 +4391,6 @@
           "initialPopulationUuid": "27982FD6-7C42-44E7-A871-0BB7F858A6D5",
           "denominatorUuid": "2294F966-EECD-4C61-8D94-D5E4B09BD9BB",
           "numeratorUuid": "02A4DDAC-D615-457A-9304-F1E382D3811C",
-          "denominatorExclusionUuid": "e497e337-9671-4805-94e9-1c7113bf187b",
           "denominatorExceptionUuid": "487E15AB-CDE2-4955-9B93-1A2CDAE6B1F2"
         }
       },
@@ -4402,7 +4401,6 @@
           "initialPopulationUuid": "2EE8137A-4627-471C-8837-85BDBF665017",
           "denominatorUuid": "CC31BC83-F06C-4381-8A4F-1EEBE9ECF7BC",
           "numeratorUuid": "5C03C433-8F8A-4204-B536-D7381835CE8C",
-          "denominatorExclusionUuid": "1804358a-4620-44e2-8fb9-526eecdc2fd1",
           "denominatorExceptionUuid": "F79E2A13-6F9E-4B84-99E0-4603E99C83C3"
         }
       }
@@ -4697,8 +4695,7 @@
           "initialPopulationUuid": "92656CE7-C9B1-44A8-8778-A8EF1ED90A18",
           "denominatorUuid": "C7DFE664-71AE-4EAD-AB65-CDFCF825A44E",
           "numeratorUuid": "B5FA6E85-0F2E-4674-A3F8-E14D834E73AB",
-          "denominatorExclusionUuid": "76B54A59-41A9-4664-B85C-F61238AE1DC4",
-          "denominatorExceptionUuid": "1c1e013a-b202-4f9e-9ee5-02be9507b7c4"
+          "denominatorExclusionUuid": "76B54A59-41A9-4664-B85C-F61238AE1DC4"
         }
       },
       {
@@ -4708,8 +4705,7 @@
           "initialPopulationUuid": "757F3066-31E7-45D1-BA50-3EFB27ABB8E5",
           "denominatorUuid": "32635FEA-918B-438F-8421-8A6A14E238E8",
           "numeratorUuid": "33538979-8425-45A4-B724-D74CC0A84EF3",
-          "denominatorExclusionUuid": "29931862-020D-401E-B9E9-953791263D87",
-          "denominatorExceptionUuid": "a9770f07-3989-4c20-8a7a-605e4a77cbe2"
+          "denominatorExclusionUuid": "29931862-020D-401E-B9E9-953791263D87"
         }
       },
       {
@@ -4719,8 +4715,7 @@
           "initialPopulationUuid": "5631A7DF-CA44-4AD4-A691-DC0CED303F6A",
           "denominatorUuid": "9665A8D2-F896-47A9-AA7E-271E9815D3CE",
           "numeratorUuid": "2D4D6446-C9CD-4661-868B-C8B9B13A8E08",
-          "denominatorExclusionUuid": "910A0EE9-ECDA-494C-83E9-30DD9E224FFB",
-          "denominatorExceptionUuid": "2cc2a6f9-d57f-48f0-ac88-7b8670cf4f4c"
+          "denominatorExclusionUuid": "910A0EE9-ECDA-494C-83E9-30DD9E224FFB"
         }
       }
     ],

--- a/measures/measures-data.xml
+++ b/measures/measures-data.xml
@@ -1994,7 +1994,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
         <denominatorUuid>815F709E-9703-4A6E-860F-CB0096A98B71</denominatorUuid>
         <numeratorUuid>341DBA96-D1CC-409F-99D9-8AB80D03B4A8</numeratorUuid>
         <denominatorExclusionUuid>FE028D3B-7AB5-418B-A90C-CCFE76F25078</denominatorExclusionUuid>
-        <denominatorExceptionUuid>abe7771d-6723-4a05-a56a-17a04f981c59</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>visitWithin30Days</name>
     </strata>
@@ -2005,7 +2004,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
         <denominatorUuid>62FDAE01-000B-40A0-9C74-4A803BA37A96</denominatorUuid>
         <numeratorUuid>5097B983-9C47-4F28-9194-C795F42053AF</numeratorUuid>
         <denominatorExclusionUuid>425772D2-6437-4F33-9B1E-349E1C6587D9</denominatorExclusionUuid>
-        <denominatorExceptionUuid>57124f7c-9f15-4b23-9b29-722aeb6d43ee</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>visitAndFollowups</name>
     </strata>
@@ -2180,8 +2178,6 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
         <initialPopulationUuid>9CDC88D7-31DA-44F1-9348-CFDD29F4B20B</initialPopulationUuid>
         <denominatorUuid>1EC810C4-E6D2-4ED6-AE02-A0BF4D675F05</denominatorUuid>
         <numeratorUuid>693493EC-2E8E-447C-88A3-FC93AD771AB9</numeratorUuid>
-        <denominatorExclusionUuid>f1f029d5-89a7-4c0b-acec-4ddc4fefc799</denominatorExclusionUuid>
-        <denominatorExceptionUuid>94a41537-ee3d-4e8b-bd88-08c70e8dde3d</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>assessedSuicideRisk</name>
     </strata>
@@ -2546,7 +2542,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <denominatorUuid>50E80E87-0A09-4914-8632-BD0797460B34</denominatorUuid>
         <numeratorUuid>02A8409A-7B63-4FE9-B865-87C650DD7459</numeratorUuid>
         <denominatorExclusionUuid>BA926F92-CA87-43B3-A5C4-FD9FF8B59BB5</denominatorExclusionUuid>
-        <denominatorExceptionUuid>a4a6db02-ab9a-489d-845a-06eccd0b957d</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>&gt;=84Days</name>
     </strata>
@@ -2557,7 +2552,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <denominatorUuid>B1C6949E-6854-4182-8BC9-C0EE75B705A2</denominatorUuid>
         <numeratorUuid>3A4FA8BB-D8BC-4F66-9367-A71DF03A868D</numeratorUuid>
         <denominatorExclusionUuid>8C51C326-AE19-462B-9745-6C8ABE92AE27</denominatorExclusionUuid>
-        <denominatorExceptionUuid>fdcf818a-10f3-43d8-8568-8d2545106a07</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>&gt;=180Days</name>
     </strata>
@@ -2692,7 +2686,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <denominatorUuid>AE00EE88-B26B-449D-94DE-EA3887BB66E0</denominatorUuid>
         <numeratorUuid>86A8B7E8-EEA2-4C19-8A1B-74B905939505</numeratorUuid>
         <denominatorExclusionUuid>A0B43F8B-E6EE-4229-A05D-ECF1B601CEAF</denominatorExclusionUuid>
-        <denominatorExceptionUuid>7f8af6e7-489b-4f64-a627-6c9b50400d9e</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
     <isHighPriority>true</isHighPriority>
@@ -2726,7 +2719,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <denominatorUuid>FDE4FCC5-826B-42C6-82BE-1694DD18A48D</denominatorUuid>
         <numeratorUuid>27037F9E-5C8E-41FE-A973-E2E020C97DA7</numeratorUuid>
         <denominatorExclusionUuid>8E32E552-A70A-4BBC-A92A-F8D3D48113CF</denominatorExclusionUuid>
-        <denominatorExceptionUuid>cc580a24-5718-4c00-a7f3-fff702791e15</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
     <isHighPriority>true</isHighPriority>
@@ -2927,8 +2919,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <initialPopulationUuid>AB5E9E84-65FB-4566-8254-D3488CA9A169</initialPopulationUuid>
         <denominatorUuid>9656501E-1FAB-4B81-AB59-6646F1114394</denominatorUuid>
         <numeratorUuid>3C942ABF-C287-4FBB-AFEE-67BC5FC93BD0</numeratorUuid>
-        <denominatorExclusionUuid>672f9875-55d9-4fb3-b56f-85205699103f</denominatorExclusionUuid>
-        <denominatorExceptionUuid>3a57a106-7404-476e-b026-23282a95d75f</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>substanceUse</name>
     </strata>
@@ -2983,7 +2973,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <denominatorUuid>40FB2D5F-7DEF-4D41-80C4-F3FBA0ED5851</denominatorUuid>
         <numeratorUuid>0AB40D2B-08CE-4185-8A54-336C3140644D</numeratorUuid>
         <denominatorExclusionUuid>EC5CC49E-42A7-4DD8-BD40-A6258E71DCB9</denominatorExclusionUuid>
-        <denominatorExceptionUuid>f8f1841f-42d9-4f20-bc7f-960ce90c17ae</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
     <isHighPriority>false</isHighPriority>
@@ -3185,7 +3174,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <denominatorUuid>16000621-529F-4F4E-A0A8-ACA703D3B40A</denominatorUuid>
         <numeratorUuid>2F166EEC-4528-474A-966F-D9C8AD49C7AD</numeratorUuid>
         <denominatorExclusionUuid>9D7B933B-8A97-4BA3-A546-220E1BF789CC</denominatorExclusionUuid>
-        <denominatorExceptionUuid>d164dbe6-d3d5-4bc4-8df1-d54b1d07ef10</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
     <isHighPriority>true</isHighPriority>
@@ -3217,7 +3205,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <denominatorUuid>44BB8D98-F611-48FD-BD3F-05BB998F3754</denominatorUuid>
         <numeratorUuid>A4AE5A30-F400-4849-B054-FB19138AC580</numeratorUuid>
         <denominatorExclusionUuid>AE555E04-C8C0-4ABE-AE9B-C5FC2B46F263</denominatorExclusionUuid>
-        <denominatorExceptionUuid>4af92697-0940-49aa-b67e-dca6646aed47</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
     <isHighPriority>true</isHighPriority>
@@ -3347,7 +3334,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <denominatorUuid>7CDA5C1B-CD31-4D16-80C4-22AE2F549D88</denominatorUuid>
         <numeratorUuid>3854BDE6-9614-475D-8E3B-5A041C04C291</numeratorUuid>
         <denominatorExclusionUuid>45A2163C-25C2-4245-A3C6-0BEE64E18B64</denominatorExclusionUuid>
-        <denominatorExceptionUuid>bc43554a-5399-4d55-9c48-7dc2c1cbbb65</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>screenedForCancer</name>
     </strata>
@@ -3379,8 +3365,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <initialPopulationUuid>008509CF-85E8-40C0-9434-65FE19EFC090</initialPopulationUuid>
         <denominatorUuid>92E101F9-795A-46DD-BEDE-EA94743AC232</denominatorUuid>
         <numeratorUuid>78D2FEEA-45D3-4D08-9227-773E70E3AAD5</numeratorUuid>
-        <denominatorExclusionUuid>e21f777c-f8c6-4250-9428-2535d91b4a96</denominatorExclusionUuid>
-        <denominatorExceptionUuid>6267da42-6e04-4614-bbe6-bb17021cc4b1</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>assessedSuicideRisk</name>
     </strata>
@@ -3411,8 +3395,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <initialPopulationUuid>DA379EC2-EE2E-4548-AEF0-DD4F14F80279</initialPopulationUuid>
         <denominatorUuid>CC8AFFF0-A436-42CD-8322-5EBCEF9CBF06</denominatorUuid>
         <numeratorUuid>AE7A33AF-0DA7-4772-A23C-2D2CA732D53A</numeratorUuid>
-        <denominatorExclusionUuid>19d26b5e-9be2-4313-80f4-67be1e0dde37</denominatorExclusionUuid>
-        <denominatorExceptionUuid>01a1c883-e2e6-4aec-81de-17f3cd9b63b3</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>vaccinesOrExposure</name>
     </strata>
@@ -3442,8 +3424,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <initialPopulationUuid>72D79C93-6D03-4BA2-B250-5316E370B766</initialPopulationUuid>
         <denominatorUuid>E87F18F1-F70C-4BB3-A95C-7C1D4561E73D</denominatorUuid>
         <numeratorUuid>3D9AD35A-7456-4AA2-8FDB-D4B06DF72CC9</numeratorUuid>
-        <denominatorExclusionUuid>c7cc2c7e-892e-4b35-b1ed-b25a094f25d5</denominatorExclusionUuid>
-        <denominatorExceptionUuid>7637d114-553a-4bc4-b084-d05b3a125bb8</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>cavitiesOrDecayed</name>
     </strata>
@@ -3495,8 +3475,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <initialPopulationUuid>A417988B-395B-4108-9988-1AE443A1E254</initialPopulationUuid>
         <denominatorUuid>F25492A9-8164-4833-9A91-EA160ECC9190</denominatorUuid>
         <numeratorUuid>D387E1DC-F06A-4054-87B1-40B863FCF8EC</numeratorUuid>
-        <denominatorExclusionUuid>341797C7-3664-41E2-9771-6D85B2085BFA</denominatorExclusionUuid>
-        <denominatorExceptionUuid>2e71982a-b165-480e-afc8-4d1eaee6073b</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>chlamydia</name>
     </strata>
@@ -3595,8 +3573,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <initialPopulationUuid>E7A4AE77-FC46-44F1-BF25-9E99A89CED9B</initialPopulationUuid>
         <denominatorUuid>B710DA92-D4B9-4217-8D1E-94B35163BECE</denominatorUuid>
         <numeratorUuid>9824B759-A263-44DE-9F5E-93DA4E8F4627</numeratorUuid>
-        <denominatorExclusionUuid>38db92d1-881b-452b-930e-79bff2e4e490</denominatorExclusionUuid>
-        <denominatorExceptionUuid>c8dcc3f8-38e7-4004-956e-ab8abe965231</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>patientsWithReferral</name>
     </strata>
@@ -3700,7 +3676,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <denominatorUuid>589C2FD6-6AA9-4AF8-9E1C-973170361917</denominatorUuid>
         <numeratorUuid>52ADE511-39D4-4CBC-84B6-A82059741359</numeratorUuid>
         <denominatorExclusionUuid>93AA9C96-E1FE-435B-BA0B-FAF0C5592275</denominatorExclusionUuid>
-        <denominatorExceptionUuid>385e49f7-501d-498f-b99d-681c67c6a22d</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
     <isHighPriority>false</isHighPriority>
@@ -3759,7 +3734,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <denominatorUuid>E62FEBA3-0F98-460D-93CD-44314D7203A8</denominatorUuid>
         <numeratorUuid>F9FEBF42-4B21-47A9-B03E-D2DA5CF8492B</numeratorUuid>
         <denominatorExclusionUuid>55A6D5F3-2029-4896-B850-4C7894161D7D</denominatorExclusionUuid>
-        <denominatorExceptionUuid>fafa1d59-6f64-487c-9f95-ed81c139d2c0</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
     <isHighPriority>true</isHighPriority>
@@ -4072,7 +4046,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <initialPopulationUuid>1D86EE69-7DA7-4A73-8611-2E71176568B6</initialPopulationUuid>
         <denominatorUuid>2DA1439F-7941-411C-8885-91306F0CD9DD</denominatorUuid>
         <numeratorUuid>2C2431A3-7DE3-4C97-80C0-4BF96D4880F0</numeratorUuid>
-        <denominatorExclusionUuid>7b3728ef-a1b8-489a-8a7c-f682c26e0d7f</denominatorExclusionUuid>
         <denominatorExceptionUuid>2EE99933-7653-4C53-8506-2A76D0657064</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>assessed12Months</name>
@@ -4225,7 +4198,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <denominatorUuid>1C6771A4-4C26-4E2C-9E10-FF6F1A5D0907</denominatorUuid>
         <numeratorUuid>52837728-F488-4BA5-9921-FFDEEC0F0803</numeratorUuid>
         <denominatorExclusionUuid>72259A21-874C-4E51-9465-9989019193D0</denominatorExclusionUuid>
-        <denominatorExceptionUuid>1de2c677-5e1b-48fb-b554-24996d0fc30c</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
     <isHighPriority>true</isHighPriority>
@@ -4313,8 +4285,6 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <initialPopulationUuid>321FB2D3-477E-41B7-8BB1-02EE94D08417</initialPopulationUuid>
         <denominatorUuid>98CE7ECC-1F09-4F52-906C-E53EAB545F00</denominatorUuid>
         <numeratorUuid>3F48A9B6-7B99-4BF4-AB1E-50DC1FFB9D1A</numeratorUuid>
-        <denominatorExclusionUuid>7f24aecc-ef66-4bfc-b86b-15c973bca8c3</denominatorExclusionUuid>
-        <denominatorExceptionUuid>5421c143-d990-478f-bbef-1f152fee4d22</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
     <isHighPriority>false</isHighPriority>
@@ -4349,7 +4319,6 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <denominatorUuid>61B09878-32B3-4ECB-8E78-D1093E1FDDF9</denominatorUuid>
         <numeratorUuid>60EC6098-950A-40E5-994F-E9A62CFF6FC2</numeratorUuid>
         <denominatorExclusionUuid>02D13BF4-EF77-4DF4-A436-834AEDBE043C</denominatorExclusionUuid>
-        <denominatorExceptionUuid>b508d087-5c33-4d49-b042-6da769499b06</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>receivedFootExams</name>
     </strata>
@@ -4381,8 +4350,6 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <initialPopulationUuid>0739FE2E-B8DE-4A56-B064-877CC8E0977D</initialPopulationUuid>
         <denominatorUuid>D346DA74-F16E-4159-BEDF-331BA28837FB</denominatorUuid>
         <numeratorUuid>6D01A564-58CC-4CF5-929F-B83583701BFE</numeratorUuid>
-        <denominatorExclusionUuid>25d4b54e-697c-4afe-a2e2-636ce9fe7bf2</denominatorExclusionUuid>
-        <denominatorExceptionUuid>7c4dda50-c802-4a70-b58f-c50780cf5edd</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
     <isHighPriority>true</isHighPriority>
@@ -4417,8 +4384,6 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <initialPopulationUuid>A27FD818-3C97-4516-A796-319B89E306AC</initialPopulationUuid>
         <denominatorUuid>0CC16DE4-474A-4F6E-BFB8-0104709B1E05</denominatorUuid>
         <numeratorUuid>5647E3D0-6550-4B0B-AE76-53CD9E99D20B</numeratorUuid>
-        <denominatorExclusionUuid>9887c765-7188-4af0-8c30-cba92f11ea1c</denominatorExclusionUuid>
-        <denominatorExceptionUuid>68ac0f19-3c01-42cf-9056-154ea55e4789</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
     <isHighPriority>false</isHighPriority>
@@ -4493,7 +4458,6 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <initialPopulationUuid>2072A4E8-4486-4A10-AF97-F84ADE0EB62E</initialPopulationUuid>
         <denominatorUuid>2BB9F18C-8E26-44D6-904E-849495A6AF90</denominatorUuid>
         <numeratorUuid>BCB8AEEC-EABC-477E-AA6D-6DB34220CD85</numeratorUuid>
-        <denominatorExclusionUuid>9e1763e9-74f8-4f09-b57f-0f74a9adb3c7</denominatorExclusionUuid>
         <denominatorExceptionUuid>608279BD-7620-4FC4-8752-08E3040BA160</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
@@ -4525,7 +4489,6 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <initialPopulationUuid>3EB89216-BC0B-4DF7-8B8D-06B9AB68DB49</initialPopulationUuid>
         <denominatorUuid>04507C05-46D4-4D96-9D9D-853CA557F4B2</denominatorUuid>
         <numeratorUuid>3186154C-6A01-4FAF-A77F-B5233A3F078C</numeratorUuid>
-        <denominatorExclusionUuid>305ce4ad-9e91-4236-af6d-1c5c65db586c</denominatorExclusionUuid>
         <denominatorExceptionUuid>170B3877-D83D-424C-BD7E-29F644B0A6DC</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>dilatedExam12Months</name>
@@ -4557,7 +4520,6 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <initialPopulationUuid>D412322D-11F1-4573-893E-E6A05855DE10</initialPopulationUuid>
         <denominatorUuid>375D0559-C749-4BB9-9267-81EDF447650B</denominatorUuid>
         <numeratorUuid>EFFE261C-0D57-423E-992C-7141B132768C</numeratorUuid>
-        <denominatorExclusionUuid>a5dd46b0-f412-4d7d-a3b4-16c8ad4a4f43</denominatorExclusionUuid>
         <denominatorExceptionUuid>3C100EC4-2990-4D79-AE14-E816F5E78AC8</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
@@ -4834,7 +4796,6 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <initialPopulationUuid>0175F89E-9CD7-4CD8-8D7F-38CB825D2BDD</initialPopulationUuid>
         <denominatorUuid>A3F77B7C-2398-470D-A359-E2A31539DF91</denominatorUuid>
         <numeratorUuid>F0F4094E-CE53-44EE-8CEF-0555479E37B2</numeratorUuid>
-        <denominatorExclusionUuid>c4aa6477-f361-4990-ac25-0549bd86e1c7</denominatorExclusionUuid>
         <denominatorExceptionUuid>CF7E1913-CB4E-42F7-BAEC-0EFFF01ECB17</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>screenedForFallRisk</name>
@@ -4923,7 +4884,6 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <denominatorUuid>FFA80359-2E09-48C8-8862-DD6E1F5F5428</denominatorUuid>
         <numeratorUuid>7D021618-E1EE-4C2F-AD6A-F74E03D69E43</numeratorUuid>
         <denominatorExclusionUuid>65458ECD-6573-4203-8C56-515063BAFE19</denominatorExclusionUuid>
-        <denominatorExceptionUuid>029ee8ff-899f-434b-9e83-cb5503bdfebb</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>functionalStatus</name>
     </strata>
@@ -4954,7 +4914,6 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <denominatorUuid>D795B824-0575-47B3-93DB-D48CD5643677</denominatorUuid>
         <numeratorUuid>0DD7EF36-2B1D-4447-8E52-BF9C4A3E7ED3</numeratorUuid>
         <denominatorExclusionUuid>0E8BFC37-A4BA-4DE6-A6F3-DF4C188AB129</denominatorExclusionUuid>
-        <denominatorExceptionUuid>a059c9d5-0445-40a5-8b55-db98a69891f4</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>functionalStatus</name>
     </strata>
@@ -4985,7 +4944,6 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <denominatorUuid>19ECF222-71EF-4D75-9CC2-19ED201107EA</denominatorUuid>
         <numeratorUuid>F9B4C929-8F37-48D1-953C-489C028AE725</numeratorUuid>
         <denominatorExclusionUuid>32DBECF3-11EC-40FB-B35D-FA1BF7366492</denominatorExclusionUuid>
-        <denominatorExceptionUuid>b156a02c-e64c-4b93-97d3-48b6af51fbf5</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>functionalStatus</name>
     </strata>
@@ -5169,7 +5127,6 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <initialPopulationUuid>F3000871-B8FD-4F74-8892-281C250C11EA</initialPopulationUuid>
         <denominatorUuid>C1E20830-ADFE-4D88-B979-166FA0820D5C</denominatorUuid>
         <numeratorUuid>49E476F4-E8A1-48A6-B800-A8172073DBFB</numeratorUuid>
-        <denominatorExclusionUuid>a2cd75d1-24b1-4216-a241-b0b07fecde1f</denominatorExclusionUuid>
         <denominatorExceptionUuid>41E08783-4358-4E0D-81BE-9616A8F58319</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
@@ -5204,7 +5161,6 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <initialPopulationUuid>5ED1A428-A266-47E5-AE4F-DB97A65BB1D4</initialPopulationUuid>
         <denominatorUuid>1E6C181E-91F6-4A61-82E0-7360C81CE3B0</denominatorUuid>
         <numeratorUuid>ABBFFB54-E629-4520-875E-F6D18BC651B1</numeratorUuid>
-        <denominatorExclusionUuid>8d38d97e-589e-4a22-881e-fa41649b54f1</denominatorExclusionUuid>
         <denominatorExceptionUuid>E9280685-6046-438D-AE45-0F7EDBA29C33</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
@@ -5397,7 +5353,6 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <initialPopulationUuid>E681DBF8-F827-4586-B3E0-178FF19EC3A2</initialPopulationUuid>
         <denominatorUuid>04BF53CE-6993-4EA2-BFE5-66E36172B388</denominatorUuid>
         <numeratorUuid>631C0B49-83F4-4A54-96C4-7E0766B2407C</numeratorUuid>
-        <denominatorExclusionUuid>4c42d3ad-5ad4-4e97-ac7d-81c9758fbead</denominatorExclusionUuid>
         <denominatorExceptionUuid>58347456-D1F3-4BBB-9B35-5D42825A0AB3</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>CD4&lt;200/mm3</name>
@@ -5408,7 +5363,6 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <initialPopulationUuid>AAC578DB-1900-43BD-BBBF-50014A5457E5</initialPopulationUuid>
         <denominatorUuid>1574973E-EB52-40C7-9709-25ABEDBA99A3</denominatorUuid>
         <numeratorUuid>5B7AC4EC-547A-47E5-AC5E-618401175511</numeratorUuid>
-        <denominatorExclusionUuid>659d5fba-93ed-4b1f-bd17-233362e37e58</denominatorExclusionUuid>
         <denominatorExceptionUuid>B7CCA1A6-F352-4A23-BC89-6FE9B60DC0C6</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>CD4&lt;500/mm3OrCD4&lt;15%</name>
@@ -5419,8 +5373,6 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
         <initialPopulationUuid>AF36C4A9-8BD9-4E21-838D-A47A1845EB90</initialPopulationUuid>
         <denominatorUuid>B95BC0D3-572E-462B-BAA2-46CD33A865CD</denominatorUuid>
         <numeratorUuid>86F74F07-D593-44F6-AA12-405966400963</numeratorUuid>
-        <denominatorExclusionUuid>8d54df2e-8a7e-49e3-a99a-0132f5139b7c</denominatorExclusionUuid>
-        <denominatorExceptionUuid>28ee691d-8155-41fe-8c20-12a5d2e1fb75</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>atDiagnosis</name>
     </strata>
@@ -5620,7 +5572,6 @@ If a follow-up blood pressure reading is not recorded during the measurement yea
         <denominatorUuid>CE973C7A-B867-422B-8408-83538E236039</denominatorUuid>
         <numeratorUuid>F67DCC8F-4F0F-491B-957F-B21E721B040B</numeratorUuid>
         <denominatorExclusionUuid>74F900B9-65DA-4E6C-BB2D-592189ABDDE5</denominatorExclusionUuid>
-        <denominatorExceptionUuid>6add5684-4b28-4d80-bf3d-dd0ea530a529</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>lowerFollowupBP</name>
     </strata>
@@ -5758,7 +5709,6 @@ b. Percentage of patients who initiated treatment and who had two or more additi
         <denominatorUuid>BC948E65-B908-493B-B48B-04AC342D3E6C</denominatorUuid>
         <numeratorUuid>0BBF8596-4CFE-47F4-A0D7-9BEAB94BA4CD</numeratorUuid>
         <denominatorExclusionUuid>56BC7FA2-C22A-4440-8652-2D3568852C60</denominatorExclusionUuid>
-        <denominatorExceptionUuid>506b11e2-8e60-4254-8277-5a3670bb6287</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>14DaysOfDiagnosis</name>
     </strata>
@@ -5769,7 +5719,6 @@ b. Percentage of patients who initiated treatment and who had two or more additi
         <denominatorUuid>4A09AB89-D9B8-4DD1-BC4E-78BCFD1C5873</denominatorUuid>
         <numeratorUuid>7FFA49C4-D708-491E-85FE-6855F0A725DF</numeratorUuid>
         <denominatorExclusionUuid>206A891D-C3E1-4660-BF2C-6CDBDF9282FB</denominatorExclusionUuid>
-        <denominatorExceptionUuid>3870dc26-e32d-4ba5-9025-6b00d8259f16</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>30DaysOfVisit</name>
     </strata>
@@ -5828,7 +5777,6 @@ b. Percentage of patients who initiated treatment and who had two or more additi
         <denominatorUuid>FE6E1AA0-EE26-4F9E-A2FD-8E36058DCB47</denominatorUuid>
         <numeratorUuid>0A3C80F4-A9FF-4BDF-B018-D647E7D777EB</numeratorUuid>
         <denominatorExclusionUuid>D564DEEE-17E7-4442-921D-436E5113788A</denominatorExclusionUuid>
-        <denominatorExceptionUuid>4b5358ad-05f3-484a-a66b-c652b4e825d1</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
     <isHighPriority>false</isHighPriority>
@@ -5934,8 +5882,6 @@ b. Percentage of patients who initiated treatment and who had two or more additi
         <initialPopulationUuid>D3ADB281-2F53-4BE6-89A9-124480DE787D</initialPopulationUuid>
         <denominatorUuid>6B845134-C1B7-4383-AFB3-1FFB7EAD359B</denominatorUuid>
         <numeratorUuid>D2A5FF72-DE5E-413A-829E-C763FC07DF4A</numeratorUuid>
-        <denominatorExclusionUuid>3a0f2630-297f-481e-980c-252371b90b4b</denominatorExclusionUuid>
-        <denominatorExceptionUuid>4e37becd-1435-4aa7-b64f-e3b853b005e7</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>screeningOrTreatment</name>
     </strata>
@@ -6218,8 +6164,6 @@ This measure is reported as three rates stratified by age group:
         <initialPopulationUuid>8494E3CD-7119-4471-9F2F-42540A797498</initialPopulationUuid>
         <denominatorUuid>D1358E7F-9C53-414C-9D4D-DEF7AE9B6E68</denominatorUuid>
         <numeratorUuid>95484C04-C98A-4A77-B2A7-9FE583060582</numeratorUuid>
-        <denominatorExclusionUuid>8357720f-e333-419c-b274-d0d8a7c0c52c</denominatorExclusionUuid>
-        <denominatorExceptionUuid>3ccb17ee-f833-4839-ad7e-e32315697409</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
     <isHighPriority>true</isHighPriority>
@@ -7086,8 +7030,6 @@ This measure is reported as three rates stratified by age group:
         <initialPopulationUuid>E1A2F7D4-0B24-47FC-9369-0700771B2D40</initialPopulationUuid>
         <denominatorUuid>B57EA797-15A1-4C60-B34C-BAE292FE3B76</denominatorUuid>
         <numeratorUuid>CBD0926D-6088-44EE-883C-0A0F9E77E2A1</numeratorUuid>
-        <denominatorExclusionUuid>43958624-b741-4a41-9407-cda6e8d75029</denominatorExclusionUuid>
-        <denominatorExceptionUuid>704fc6d6-ecc6-47a7-a411-829c6d327993</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
     <isHighPriority>false</isHighPriority>
@@ -7166,7 +7108,6 @@ This measure is reported as three rates stratified by age group:
         <initialPopulationUuid>328FF8FF-8A53-42CF-A33E-789BC7E0D8ED</initialPopulationUuid>
         <denominatorUuid>9826C75F-8106-44DE-AFB5-47669443C153</denominatorUuid>
         <numeratorUuid>4ADA7675-6263-4018-997E-D27CE43A11D6</numeratorUuid>
-        <denominatorExclusionUuid>72135b92-8866-4315-992d-38ca6490da49</denominatorExclusionUuid>
         <denominatorExceptionUuid>F77E40ED-F649-4250-B99A-3C35414D88B0</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>hepB</name>
@@ -7269,8 +7210,8 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
         <initialPopulationUuid>4D10500F-6738-4541-BF24-4C95C74B45AB</initialPopulationUuid>
         <denominatorUuid>36CCB819-C150-466D-A55A-0A175B19E751</denominatorUuid>
         <numeratorUuid>51D06394-AF97-41DD-BF41-68D58786A9D2</numeratorUuid>
-        <denominatorExclusionUuid>EE5FFA67-A42D-4472-8159-ED4B87BE6CDA</denominatorExclusionUuid>
         <denominatorExceptionUuid>0E162220-C93B-48B0-AAB1-E2F8E7FE7EA1</denominatorExceptionUuid>
+        <denominatorExclusionUuid>EE5FFA67-A42D-4472-8159-ED4B87BE6CDA</denominatorExclusionUuid>
       </eMeasureUuids>
     </strata>
     <isHighPriority>false</isHighPriority>
@@ -7318,7 +7259,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
         <initialPopulationUuid>FF48C33E-49B3-45D1-AB44-D283F39AE73D</initialPopulationUuid>
         <denominatorUuid>56E05D20-4529-4EB7-8E30-17C95BBC5223</denominatorUuid>
         <numeratorUuid>A6516D8B-0A7D-426D-A0EC-F3F4999A2588</numeratorUuid>
-        <denominatorExclusionUuid>98a4272d-cff5-477d-a728-23d4303c2fba</denominatorExclusionUuid>
         <denominatorExceptionUuid>9411528A-67EF-439B-9C00-37372B2096E3</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
@@ -7358,7 +7298,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
         <denominatorUuid>CB0D06D7-9C40-45B0-AEC2-60C39262ABA0</denominatorUuid>
         <numeratorUuid>D94BAE8B-1EAC-4832-B040-884B4BBC5BD0</numeratorUuid>
         <denominatorExclusionUuid>8C56B86F-EFE9-404D-B97C-F8FC4691D50D</denominatorExclusionUuid>
-        <denominatorExceptionUuid>E98E90BE-F3BD-42CD-A194-D6BEFA1BB714</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
     <isHighPriority>false</isHighPriority>
@@ -7394,8 +7333,8 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
         <initialPopulationUuid>C7E7C7AF-464F-43A0-8C84-CDFF99953C97</initialPopulationUuid>
         <denominatorUuid>65AFB8BA-F5CC-4ABA-A3FB-2F95FEE2B6FA</denominatorUuid>
         <numeratorUuid>8964CE5A-64A4-4259-9359-39A1CDC07B8D</numeratorUuid>
-        <denominatorExclusionUuid>8867C7A7-F8F1-4B61-A6C7-9390C5B5B4EF</denominatorExclusionUuid>
         <denominatorExceptionUuid>2338C9B7-B2C5-4348-BF2B-C9E636FD7A45</denominatorExceptionUuid>
+        <denominatorExclusionUuid>8867C7A7-F8F1-4B61-A6C7-9390C5B5B4EF</denominatorExclusionUuid>
       </eMeasureUuids>
     </strata>
     <isHighPriority>false</isHighPriority>
@@ -7450,7 +7389,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
         <initialPopulationUuid>CA679308-8AF3-4374-91DC-907951440D72</initialPopulationUuid>
         <denominatorUuid>FFC4DDE0-C91C-4235-BF69-E3EF79457FBB</denominatorUuid>
         <numeratorUuid>44BEAC3C-8402-46F0-9494-81B33C502F0A</numeratorUuid>
-        <denominatorExclusionUuid>a5a204a2-1a11-4ea7-8153-48c2f6b1dbce</denominatorExclusionUuid>
         <denominatorExceptionUuid>655C9F36-02F7-498B-AE18-D322EA2B3726</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
@@ -7540,8 +7478,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
         <initialPopulationUuid>BCE39253-0C5F-4DFA-A5BD-0828A8B2BB22</initialPopulationUuid>
         <denominatorUuid>B41B2DF9-B4BF-4B89-A483-5B0C1A9D9804</denominatorUuid>
         <numeratorUuid>BEF89159-5D5C-47C6-953D-63FCAEA41548</numeratorUuid>
-        <denominatorExclusionUuid>a73c666b-2ccf-462a-860b-985b8c9b4454</denominatorExclusionUuid>
-        <denominatorExceptionUuid>45089ed9-59a2-49b5-9162-a49b72f3da9a</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>fluorideVarnish</name>
     </strata>
@@ -7572,7 +7508,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
         <initialPopulationUuid>56091E02-5F5C-4073-9602-D0B5BB93A26E</initialPopulationUuid>
         <denominatorUuid>262ADC93-EE8C-4B95-9EFF-A6223C66ECA8</denominatorUuid>
         <numeratorUuid>2902F791-D7AB-49B2-B024-45B1077E0374</numeratorUuid>
-        <denominatorExclusionUuid>57c33ac4-db05-42ce-b750-ddc6d49caa62</denominatorExclusionUuid>
         <denominatorExceptionUuid>1FA6B8AF-0583-418D-852B-9B1D9708DDFF</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
@@ -7836,7 +7771,6 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
         <initialPopulationUuid>73B68FA6-B437-4166-8555-F54EDD2BD797</initialPopulationUuid>
         <denominatorUuid>F457BF14-DBBF-4F25-9C27-3F1A77E6341A</denominatorUuid>
         <numeratorUuid>ECBF5473-BA0F-4662-90A9-BCCF981F92CD</numeratorUuid>
-        <denominatorExclusionUuid>b975ce93-b67c-4cf8-9794-6d00b8ead043</denominatorExclusionUuid>
         <denominatorExceptionUuid>01197FE4-C21E-482E-8A98-05506308A206</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
@@ -9081,8 +9015,6 @@ b. Percentage of patients who were ordered at least two different high-risk medi
         <initialPopulationUuid>C7BCE5A3-AC0D-440E-AA29-C98239F37A8B</initialPopulationUuid>
         <denominatorUuid>07F04D61-0383-487E-942C-690BBBC6437D</denominatorUuid>
         <numeratorUuid>7A0001AC-4BE0-4FAA-94AE-4843C9FFFCA8</numeratorUuid>
-        <denominatorExclusionUuid>718a29a0-49b3-4483-ab9d-dc37074f39f5</denominatorExclusionUuid>
-        <denominatorExceptionUuid>bba507df-e957-4649-98b9-ff70c1dd7971</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
     <strata>
@@ -9092,8 +9024,6 @@ b. Percentage of patients who were ordered at least two different high-risk medi
         <initialPopulationUuid>BC02D7CE-7133-46C6-8592-658668B09948</initialPopulationUuid>
         <denominatorUuid>00401314-1B01-4896-A9FC-E991CDF29B6B</denominatorUuid>
         <numeratorUuid>FA7BF805-C21E-4077-B43E-C63F8D17B5CF</numeratorUuid>
-        <denominatorExclusionUuid>41d84550-23c6-46a7-bb50-85708fa8607b</denominatorExclusionUuid>
-        <denominatorExceptionUuid>0e953aff-ae2e-4a74-b774-ca3d9cd40e00</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
     <isHighPriority>true</isHighPriority>
@@ -9124,7 +9054,6 @@ b. Percentage of patients who were ordered at least two different high-risk medi
         <denominatorUuid>0E27156C-B8EB-48E7-A588-4AB97A0914E1</denominatorUuid>
         <numeratorUuid>13C60632-9CF4-491B-82E9-A06118111C44</numeratorUuid>
         <denominatorExclusionUuid>0E9E3C94-6AA0-4C3C-A311-72CB0F2698B6</denominatorExclusionUuid>
-        <denominatorExceptionUuid>ff61928c-0cb1-4a7f-a617-9b18bcfce0e4</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>noStudy28Days</name>
     </strata>
@@ -9183,7 +9112,6 @@ b. Percentage of patients who were ordered at least two different high-risk medi
         <denominatorUuid>933D86C8-2C2B-4AFF-AE81-DF2F9882A3A4</denominatorUuid>
         <numeratorUuid>61887626-5457-484C-A02D-75EF8547F559</numeratorUuid>
         <denominatorExclusionUuid>6938F4DD-D5AB-4C40-BA03-EB0F0959615C</denominatorExclusionUuid>
-        <denominatorExceptionUuid>3cac2acd-a3ed-4629-967a-83464c25fee4</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>BMI</name>
     </strata>
@@ -9194,7 +9122,6 @@ b. Percentage of patients who were ordered at least two different high-risk medi
         <denominatorUuid>CFB8E3E2-FF4F-4D25-B613-7EC142BAE8A9</denominatorUuid>
         <numeratorUuid>EEAD441F-B3B2-4DC9-A890-B35E14B38EA7</numeratorUuid>
         <denominatorExclusionUuid>A399FA9C-48CF-41E5-812A-3445188B8301</denominatorExclusionUuid>
-        <denominatorExceptionUuid>9fc3a9e2-6e5f-4310-9d12-5546add1a4d2</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>nutrition</name>
     </strata>
@@ -9205,7 +9132,6 @@ b. Percentage of patients who were ordered at least two different high-risk medi
         <denominatorUuid>208B74F2-6592-4381-BEC1-EB136004C3B2</denominatorUuid>
         <numeratorUuid>21409D88-B5E3-4745-8DE2-D99DBB9F4DF0</numeratorUuid>
         <denominatorExclusionUuid>507F7EC3-D380-48BE-B920-ABB1EB258256</denominatorExclusionUuid>
-        <denominatorExceptionUuid>15a2ed8f-4300-4ad9-b2ec-63d6f389feba</denominatorExceptionUuid>
       </eMeasureUuids>
       <name>physicalActivity</name>
     </strata>

--- a/measures/measures-data.xml
+++ b/measures/measures-data.xml
@@ -3475,6 +3475,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <initialPopulationUuid>A417988B-395B-4108-9988-1AE443A1E254</initialPopulationUuid>
         <denominatorUuid>F25492A9-8164-4833-9A91-EA160ECC9190</denominatorUuid>
         <numeratorUuid>D387E1DC-F06A-4054-87B1-40B863FCF8EC</numeratorUuid>
+        <denominatorExclusionUuid>341797C7-3664-41E2-9771-6D85B2085BFA</denominatorExclusionUuid>
       </eMeasureUuids>
       <name>chlamydia</name>
     </strata>
@@ -7292,6 +7293,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
         <initialPopulationUuid>55D921A2-0700-43F0-8C6F-1DB4ADDD7FAB</initialPopulationUuid>
         <denominatorUuid>CB0D06D7-9C40-45B0-AEC2-60C39262ABA0</denominatorUuid>
         <numeratorUuid>D94BAE8B-1EAC-4832-B040-884B4BBC5BD0</numeratorUuid>
+        <denominatorExceptionUuid>E98E90BE-F3BD-42CD-A194-D6BEFA1BB714</denominatorExceptionUuid>
         <denominatorExclusionUuid>8C56B86F-EFE9-404D-B97C-F8FC4691D50D</denominatorExclusionUuid>
       </eMeasureUuids>
     </strata>

--- a/measures/measures-data.xml
+++ b/measures/measures-data.xml
@@ -3978,7 +3978,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <initialPopulationUuid>27982FD6-7C42-44E7-A871-0BB7F858A6D5</initialPopulationUuid>
         <denominatorUuid>2294F966-EECD-4C61-8D94-D5E4B09BD9BB</denominatorUuid>
         <numeratorUuid>02A4DDAC-D615-457A-9304-F1E382D3811C</numeratorUuid>
-        <denominatorExclusionUuid>e497e337-9671-4805-94e9-1c7113bf187b</denominatorExclusionUuid>
         <denominatorExceptionUuid>487E15AB-CDE2-4955-9B93-1A2CDAE6B1F2</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
@@ -3989,7 +3988,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <initialPopulationUuid>2EE8137A-4627-471C-8837-85BDBF665017</initialPopulationUuid>
         <denominatorUuid>CC31BC83-F06C-4381-8A4F-1EEBE9ECF7BC</denominatorUuid>
         <numeratorUuid>5C03C433-8F8A-4204-B536-D7381835CE8C</numeratorUuid>
-        <denominatorExclusionUuid>1804358a-4620-44e2-8fb9-526eecdc2fd1</denominatorExclusionUuid>
         <denominatorExceptionUuid>F79E2A13-6F9E-4B84-99E0-4603E99C83C3</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
@@ -4231,7 +4229,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <denominatorUuid>C7DFE664-71AE-4EAD-AB65-CDFCF825A44E</denominatorUuid>
         <numeratorUuid>B5FA6E85-0F2E-4674-A3F8-E14D834E73AB</numeratorUuid>
         <denominatorExclusionUuid>76B54A59-41A9-4664-B85C-F61238AE1DC4</denominatorExclusionUuid>
-        <denominatorExceptionUuid>1c1e013a-b202-4f9e-9ee5-02be9507b7c4</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
     <strata>
@@ -4242,7 +4239,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <denominatorUuid>32635FEA-918B-438F-8421-8A6A14E238E8</denominatorUuid>
         <numeratorUuid>33538979-8425-45A4-B724-D74CC0A84EF3</numeratorUuid>
         <denominatorExclusionUuid>29931862-020D-401E-B9E9-953791263D87</denominatorExclusionUuid>
-        <denominatorExceptionUuid>a9770f07-3989-4c20-8a7a-605e4a77cbe2</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
     <strata>
@@ -4253,7 +4249,6 @@ b. Percentage of patients who remained on an antidepressant medication for at le
         <denominatorUuid>9665A8D2-F896-47A9-AA7E-271E9815D3CE</denominatorUuid>
         <numeratorUuid>2D4D6446-C9CD-4661-868B-C8B9B13A8E08</numeratorUuid>
         <denominatorExclusionUuid>910A0EE9-ECDA-494C-83E9-30DD9E224FFB</denominatorExclusionUuid>
-        <denominatorExceptionUuid>2cc2a6f9-d57f-48f0-ac88-7b8670cf4f4c</denominatorExceptionUuid>
       </eMeasureUuids>
     </strata>
     <isHighPriority>false</isHighPriority>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/scripts/find-ecqms-with-missing-data.js
+++ b/scripts/find-ecqms-with-missing-data.js
@@ -49,7 +49,6 @@ const outlierEcqms = [
           "initialPopulationUuid": "27982FD6-7C42-44E7-A871-0BB7F858A6D5",
           "denominatorUuid": "2294F966-EECD-4C61-8D94-D5E4B09BD9BB",
           "numeratorUuid": "02A4DDAC-D615-457A-9304-F1E382D3811C",
-          "denominatorExclusionUuid": "e497e337-9671-4805-94e9-1c7113bf187b",
           "denominatorExceptionUuid": "487E15AB-CDE2-4955-9B93-1A2CDAE6B1F2"
         }
       },
@@ -60,7 +59,6 @@ const outlierEcqms = [
           "initialPopulationUuid": "2EE8137A-4627-471C-8837-85BDBF665017",
           "denominatorUuid": "CC31BC83-F06C-4381-8A4F-1EEBE9ECF7BC",
           "numeratorUuid": "5C03C433-8F8A-4204-B536-D7381835CE8C",
-          "denominatorExclusionUuid": "1804358a-4620-44e2-8fb9-526eecdc2fd1",
           "denominatorExceptionUuid": "F79E2A13-6F9E-4B84-99E0-4603E99C83C3"
         }
       }
@@ -79,8 +77,7 @@ const outlierEcqms = [
           "initialPopulationUuid": "92656CE7-C9B1-44A8-8778-A8EF1ED90A18",
           "denominatorUuid": "C7DFE664-71AE-4EAD-AB65-CDFCF825A44E",
           "numeratorUuid": "B5FA6E85-0F2E-4674-A3F8-E14D834E73AB",
-          "denominatorExclusionUuid": "76B54A59-41A9-4664-B85C-F61238AE1DC4",
-          "denominatorExceptionUuid": "1c1e013a-b202-4f9e-9ee5-02be9507b7c4"
+          "denominatorExclusionUuid": "76B54A59-41A9-4664-B85C-F61238AE1DC4"
         }
       },
       {
@@ -90,8 +87,7 @@ const outlierEcqms = [
           "initialPopulationUuid": "757F3066-31E7-45D1-BA50-3EFB27ABB8E5",
           "denominatorUuid": "32635FEA-918B-438F-8421-8A6A14E238E8",
           "numeratorUuid": "33538979-8425-45A4-B724-D74CC0A84EF3",
-          "denominatorExclusionUuid": "29931862-020D-401E-B9E9-953791263D87",
-          "denominatorExceptionUuid": "a9770f07-3989-4c20-8a7a-605e4a77cbe2"
+          "denominatorExclusionUuid": "29931862-020D-401E-B9E9-953791263D87"
         }
       },
       {
@@ -101,8 +97,7 @@ const outlierEcqms = [
           "initialPopulationUuid": "5631A7DF-CA44-4AD4-A691-DC0CED303F6A",
           "denominatorUuid": "9665A8D2-F896-47A9-AA7E-271E9815D3CE",
           "numeratorUuid": "2D4D6446-C9CD-4661-868B-C8B9B13A8E08",
-          "denominatorExclusionUuid": "910A0EE9-ECDA-494C-83E9-30DD9E224FFB",
-          "denominatorExceptionUuid": "2cc2a6f9-d57f-48f0-ac88-7b8670cf4f4c"
+          "denominatorExclusionUuid": "910A0EE9-ECDA-494C-83E9-30DD9E224FFB"
         }
       }
     ]

--- a/scripts/get-strata-and-uuids-from-ecqm-zip.js
+++ b/scripts/get-strata-and-uuids-from-ecqm-zip.js
@@ -87,9 +87,25 @@ function extractStrata(measure) {
     strata[index].eMeasureUuids = {
       initialPopulationUuid: ids.find(item => item.$.type === 'initialPopulation').$.uuid,
       denominatorUuid: ids.find(item => item.$.type === 'denominator').$.uuid,
-      numeratorUuid: ids.find(item => item.$.type === 'numerator').$.uuid,
-      denominatorExclusionUuid: ids.find(item => item.$.type === 'denominatorExclusions').$.uuid,
-      denominatorExceptionUuid: ids.find(item => item.$.type === 'denominatorExceptions').$.uuid,
+      numeratorUuid: ids.find(item => item.$.type === 'numerator').$.uuid
+    };
+
+    const denominatorException = ids
+      .find(item => (
+        (item.$.type === 'denominatorExceptions') && // is denominatorExceptions
+        (_.get(item, 'logicalOp[0].subTreeRef[0].$.displayName')) // and non-empty, as 'None' denominatorExceptions still get UUIDs :(
+      ));
+    if (denominatorException) {
+      strata[index].eMeasureUuids.denominatorExceptionUuid = denominatorException.$.uuid;
+    }
+
+    const denominatorExclusion = ids
+      .find(item => (
+        (item.$.type === 'denominatorExclusions') &&
+        (_.get(item, 'logicalOp[0].subTreeRef[0].$.displayName'))
+      ));
+    if (denominatorExclusion) {
+      strata[index].eMeasureUuids.denominatorExclusionUuid = denominatorExclusion.$.uuid;
     }
   });
 

--- a/scripts/get-strata-and-uuids-from-ecqm-zip.js
+++ b/scripts/get-strata-and-uuids-from-ecqm-zip.js
@@ -62,12 +62,14 @@ return strata name, description, and uuids like so
   ...
 */
 function extractStrata(measure) {
-  const details = measure.measure.measureDetails[0];
   // our version of 'strata' are described as 'numerators'
   // parse out strata descriptions from numerator text
-  const description = details.numeratorDescription[0];
   // descriptions are like "Numerator 1: Patients who initiated treatment within 14 days of the diagnosis\nNumerator 2: Patients who initiated treatment and who had two or more additional services with an AOD diagnosis within 30 days of the initiation visit"
-  let strataDescriptions = _.compact(description.split('\n'))
+  const description = measure.subjectOf
+    .find(item => item.measureAttribute[0].code[0].$.code === 'NUMER')
+    .measureAttribute[0].value[0].$.value;
+
+  let strataDescriptions = _.compact(description.split(/\n|\r|&#xA;/))
     // if multiple strata, they're enumerated as 'Numerator x: '
     .filter(string => string.match(/^(Numerator \d: )/))
     // all the text after 'Numerator 1:'
@@ -80,33 +82,26 @@ function extractStrata(measure) {
   const strata = strataDescriptions.map(description => ({ description }));
 
   // pull out uuids for each stratum
-  // ASSUMPTION: numerators are ordered the same as measure groupings
-  // if not we need to key on something
-  measure.measure.measureGrouping[0].group.forEach((group, index) => {
-    const ids = group.clause;
-    strata[index].eMeasureUuids = {
-      initialPopulationUuid: ids.find(item => item.$.type === 'initialPopulation').$.uuid,
-      denominatorUuid: ids.find(item => item.$.type === 'denominator').$.uuid,
-      numeratorUuid: ids.find(item => item.$.type === 'numerator').$.uuid
+  const components = measure.component.slice(1);
+  components.forEach((component, index) => {
+    const ids = component.populationCriteriaSection[0].component;
+    const eMeasureUuids = {
+      initialPopulationUuid: ids.find(item => item.initialPopulationCriteria).initialPopulationCriteria[0].id[0].$.root,
+      denominatorUuid: ids.find(item => item.denominatorCriteria).denominatorCriteria[0].id[0].$.root,
+      numeratorUuid: ids.find(item => item.numeratorCriteria).numeratorCriteria[0].id[0].$.root
     };
 
-    const denominatorException = ids
-      .find(item => (
-        (item.$.type === 'denominatorExceptions') && // is denominatorExceptions
-        (_.get(item, 'logicalOp[0].subTreeRef[0].$.displayName')) // and non-empty, as 'None' denominatorExceptions still get UUIDs :(
-      ));
+    const denominatorException = ids.find(item => item.denominatorExceptionCriteria);
     if (denominatorException) {
-      strata[index].eMeasureUuids.denominatorExceptionUuid = denominatorException.$.uuid;
+      eMeasureUuids.denominatorExceptionUuid = denominatorException.denominatorExceptionCriteria[0].id[0].$.root;
     }
 
-    const denominatorExclusion = ids
-      .find(item => (
-        (item.$.type === 'denominatorExclusions') &&
-        (_.get(item, 'logicalOp[0].subTreeRef[0].$.displayName'))
-      ));
+    const denominatorExclusion = ids.find(item => item.denominatorExclusionCriteria);
     if (denominatorExclusion) {
-      strata[index].eMeasureUuids.denominatorExclusionUuid = denominatorExclusion.$.uuid;
+      eMeasureUuids.denominatorExclusionUuid = denominatorExclusion.denominatorExclusionCriteria[0].id[0].$.root;
     }
+
+    strata[index].eMeasureUuids = eMeasureUuids;
   });
 
   return strata;
@@ -120,10 +115,10 @@ const xmlFiles = fs.readdirSync(tmpDir).map(measureZip => {
   const zip = new AdmZip(path.join(tmpDir, measureZip));
 
   const filename = zip.getEntries()
-    .find(entry => entry.entryName.match(/[^0-9]\.xml$/))
+    .find(entry => entry.entryName.match(/[0-9]\.xml$/))
     .entryName;
 
-  // extract 'CMS75v5_SimpleXML.xml' to /xmls
+  // extract 'CMS75v5.xml' to /xmls
   zip.extractEntryTo(filename, tmpDir + '/xmls', false, true);
 
   return filename.split('/')[1];
@@ -137,10 +132,10 @@ Promise.all(
   })
 )
 // extract data from converted JavaScript objects
-.then(measures => {
-  return _.compact(measures.map(measure => {
-    const details = measure.measure.measureDetails[0];
-    const emeasureid = details.emeasureid[0];
+.then(docs => {
+  return _.compact(docs.map(doc => {
+    const measure = doc.QualityMeasureDocument;
+    const emeasureid = measure.subjectOf[0].measureAttribute[0].value[0].$.value;
     if (emeasureid === '145') {
       console.warn('WARNING: CMS145v5 has one numerator but two initial populations and needs to be added manually - see /tmp/ecqm/EC_CMS145v5_NQFXXXX_CAD_BB.zip');
       return;
@@ -150,12 +145,11 @@ Promise.all(
       return;
     }
     const strata = extractStrata(measure);
-    const version = details.version[0].split('.')[0];
+    const version = measure.versionNumber[0].$.value.split('.')[0];
     const eMeasureId = `CMS${emeasureid}v${version}`;
     return  {
       eMeasureId,
-      eMeasureUuid: details.uuid[0],
-      // overallAlgorithm: '', // these need to be added manually
+      eMeasureUuid: measure.id[0].$.root,
       strata: strata,
       metricType: strata.length > 1 ? 'multiPerformanceRate' : 'singlePerformanceRate'
     };
@@ -167,4 +161,3 @@ Promise.all(
   fs.writeFileSync(path.join(__dirname, '../util/generated-ecqm-data.json'), JSON.stringify(sortedEcqms, null, 2));
   console.warn('remember to add the strata names manually!')
 });
-

--- a/util/generated-ecqm-data.json
+++ b/util/generated-ecqm-data.json
@@ -414,7 +414,8 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "A417988B-395B-4108-9988-1AE443A1E254",
           "denominatorUuid": "F25492A9-8164-4833-9A91-EA160ECC9190",
-          "numeratorUuid": "D387E1DC-F06A-4054-87B1-40B863FCF8EC"
+          "numeratorUuid": "D387E1DC-F06A-4054-87B1-40B863FCF8EC",
+          "denominatorExclusionUuid": "341797C7-3664-41E2-9771-6D85B2085BFA"
         }
       }
     ],
@@ -676,6 +677,7 @@
           "initialPopulationUuid": "55D921A2-0700-43F0-8C6F-1DB4ADDD7FAB",
           "denominatorUuid": "CB0D06D7-9C40-45B0-AEC2-60C39262ABA0",
           "numeratorUuid": "D94BAE8B-1EAC-4832-B040-884B4BBC5BD0",
+          "denominatorExceptionUuid": "E98E90BE-F3BD-42CD-A194-D6BEFA1BB714",
           "denominatorExclusionUuid": "8C56B86F-EFE9-404D-B97C-F8FC4691D50D"
         }
       }

--- a/util/generated-ecqm-data.json
+++ b/util/generated-ecqm-data.json
@@ -8,9 +8,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "DA379EC2-EE2E-4548-AEF0-DD4F14F80279",
           "denominatorUuid": "CC8AFFF0-A436-42CD-8322-5EBCEF9CBF06",
-          "numeratorUuid": "AE7A33AF-0DA7-4772-A23C-2D2CA732D53A",
-          "denominatorExclusionUuid": "19d26b5e-9be2-4313-80f4-67be1e0dde37",
-          "denominatorExceptionUuid": "01a1c883-e2e6-4aec-81de-17f3cd9b63b3"
+          "numeratorUuid": "AE7A33AF-0DA7-4772-A23C-2D2CA732D53A"
         }
       }
     ],
@@ -25,9 +23,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "0739FE2E-B8DE-4A56-B064-877CC8E0977D",
           "denominatorUuid": "D346DA74-F16E-4159-BEDF-331BA28837FB",
-          "numeratorUuid": "6D01A564-58CC-4CF5-929F-B83583701BFE",
-          "denominatorExclusionUuid": "25d4b54e-697c-4afe-a2e2-636ce9fe7bf2",
-          "denominatorExceptionUuid": "7c4dda50-c802-4a70-b58f-c50780cf5edd"
+          "numeratorUuid": "6D01A564-58CC-4CF5-929F-B83583701BFE"
         }
       }
     ],
@@ -43,8 +39,7 @@
           "initialPopulationUuid": "9AB84D25-5883-4D85-A868-0D702403F250",
           "denominatorUuid": "61B09878-32B3-4ECB-8E78-D1093E1FDDF9",
           "numeratorUuid": "60EC6098-950A-40E5-994F-E9A62CFF6FC2",
-          "denominatorExclusionUuid": "02D13BF4-EF77-4DF4-A436-834AEDBE043C",
-          "denominatorExceptionUuid": "b508d087-5c33-4d49-b042-6da769499b06"
+          "denominatorExclusionUuid": "02D13BF4-EF77-4DF4-A436-834AEDBE043C"
         }
       }
     ],
@@ -60,8 +55,7 @@
           "initialPopulationUuid": "3A29C38D-E468-47CC-995B-B281B1B066CF",
           "denominatorUuid": "7CDA5C1B-CD31-4D16-80C4-22AE2F549D88",
           "numeratorUuid": "3854BDE6-9614-475D-8E3B-5A041C04C291",
-          "denominatorExclusionUuid": "45A2163C-25C2-4245-A3C6-0BEE64E18B64",
-          "denominatorExceptionUuid": "bc43554a-5399-4d55-9c48-7dc2c1cbbb65"
+          "denominatorExclusionUuid": "45A2163C-25C2-4245-A3C6-0BEE64E18B64"
         }
       }
     ],
@@ -77,8 +71,7 @@
           "initialPopulationUuid": "66FD640C-70BB-400F-9926-98EA1ACEBEBA",
           "denominatorUuid": "40FB2D5F-7DEF-4D41-80C4-F3FBA0ED5851",
           "numeratorUuid": "0AB40D2B-08CE-4185-8A54-336C3140644D",
-          "denominatorExclusionUuid": "EC5CC49E-42A7-4DD8-BD40-A6258E71DCB9",
-          "denominatorExceptionUuid": "f8f1841f-42d9-4f20-bc7f-960ce90c17ae"
+          "denominatorExclusionUuid": "EC5CC49E-42A7-4DD8-BD40-A6258E71DCB9"
         }
       }
     ],
@@ -93,9 +86,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "E1A2F7D4-0B24-47FC-9369-0700771B2D40",
           "denominatorUuid": "B57EA797-15A1-4C60-B34C-BAE292FE3B76",
-          "numeratorUuid": "CBD0926D-6088-44EE-883C-0A0F9E77E2A1",
-          "denominatorExclusionUuid": "43958624-b741-4a41-9407-cda6e8d75029",
-          "denominatorExceptionUuid": "704fc6d6-ecc6-47a7-a411-829c6d327993"
+          "numeratorUuid": "CBD0926D-6088-44EE-883C-0A0F9E77E2A1"
         }
       }
     ],
@@ -111,8 +102,7 @@
           "initialPopulationUuid": "220EBFDC-C2DF-431B-B14A-8982026B10F1",
           "denominatorUuid": "50E80E87-0A09-4914-8632-BD0797460B34",
           "numeratorUuid": "02A8409A-7B63-4FE9-B865-87C650DD7459",
-          "denominatorExclusionUuid": "BA926F92-CA87-43B3-A5C4-FD9FF8B59BB5",
-          "denominatorExceptionUuid": "a4a6db02-ab9a-489d-845a-06eccd0b957d"
+          "denominatorExclusionUuid": "BA926F92-CA87-43B3-A5C4-FD9FF8B59BB5"
         }
       },
       {
@@ -121,8 +111,7 @@
           "initialPopulationUuid": "1E041190-8EE7-46B0-A735-B416C5FA76FC",
           "denominatorUuid": "B1C6949E-6854-4182-8BC9-C0EE75B705A2",
           "numeratorUuid": "3A4FA8BB-D8BC-4F66-9367-A71DF03A868D",
-          "denominatorExclusionUuid": "8C51C326-AE19-462B-9745-6C8ABE92AE27",
-          "denominatorExceptionUuid": "fdcf818a-10f3-43d8-8568-8d2545106a07"
+          "denominatorExclusionUuid": "8C51C326-AE19-462B-9745-6C8ABE92AE27"
         }
       }
     ],
@@ -138,7 +127,6 @@
           "initialPopulationUuid": "73B68FA6-B437-4166-8555-F54EDD2BD797",
           "denominatorUuid": "F457BF14-DBBF-4F25-9C27-3F1A77E6341A",
           "numeratorUuid": "ECBF5473-BA0F-4662-90A9-BCCF981F92CD",
-          "denominatorExclusionUuid": "b975ce93-b67c-4cf8-9794-6d00b8ead043",
           "denominatorExceptionUuid": "01197FE4-C21E-482E-8A98-05506308A206"
         }
       }
@@ -155,8 +143,7 @@
           "initialPopulationUuid": "4D1C7452-B908-4616-B9E9-36C9AA71005B",
           "denominatorUuid": "589C2FD6-6AA9-4AF8-9E1C-973170361917",
           "numeratorUuid": "52ADE511-39D4-4CBC-84B6-A82059741359",
-          "denominatorExclusionUuid": "93AA9C96-E1FE-435B-BA0B-FAF0C5592275",
-          "denominatorExceptionUuid": "385e49f7-501d-498f-b99d-681c67c6a22d"
+          "denominatorExclusionUuid": "93AA9C96-E1FE-435B-BA0B-FAF0C5592275"
         }
       }
     ],
@@ -171,9 +158,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "321FB2D3-477E-41B7-8BB1-02EE94D08417",
           "denominatorUuid": "98CE7ECC-1F09-4F52-906C-E53EAB545F00",
-          "numeratorUuid": "3F48A9B6-7B99-4BF4-AB1E-50DC1FFB9D1A",
-          "denominatorExclusionUuid": "7f24aecc-ef66-4bfc-b86b-15c973bca8c3",
-          "denominatorExceptionUuid": "5421c143-d990-478f-bbef-1f152fee4d22"
+          "numeratorUuid": "3F48A9B6-7B99-4BF4-AB1E-50DC1FFB9D1A"
         }
       }
     ],
@@ -189,8 +174,7 @@
           "initialPopulationUuid": "1B6E9DCF-15DC-4D57-97DB-F8A8619DDB1B",
           "denominatorUuid": "44BB8D98-F611-48FD-BD3F-05BB998F3754",
           "numeratorUuid": "A4AE5A30-F400-4849-B054-FB19138AC580",
-          "denominatorExclusionUuid": "AE555E04-C8C0-4ABE-AE9B-C5FC2B46F263",
-          "denominatorExceptionUuid": "4af92697-0940-49aa-b67e-dca6646aed47"
+          "denominatorExclusionUuid": "AE555E04-C8C0-4ABE-AE9B-C5FC2B46F263"
         }
       }
     ],
@@ -206,8 +190,7 @@
           "initialPopulationUuid": "D790598C-DC4A-4DF8-8E50-9878AF4E886F",
           "denominatorUuid": "16000621-529F-4F4E-A0A8-ACA703D3B40A",
           "numeratorUuid": "2F166EEC-4528-474A-966F-D9C8AD49C7AD",
-          "denominatorExclusionUuid": "9D7B933B-8A97-4BA3-A546-220E1BF789CC",
-          "denominatorExceptionUuid": "d164dbe6-d3d5-4bc4-8df1-d54b1d07ef10"
+          "denominatorExclusionUuid": "9D7B933B-8A97-4BA3-A546-220E1BF789CC"
         }
       }
     ],
@@ -222,9 +205,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "A27FD818-3C97-4516-A796-319B89E306AC",
           "denominatorUuid": "0CC16DE4-474A-4F6E-BFB8-0104709B1E05",
-          "numeratorUuid": "5647E3D0-6550-4B0B-AE76-53CD9E99D20B",
-          "denominatorExclusionUuid": "9887c765-7188-4af0-8c30-cba92f11ea1c",
-          "denominatorExceptionUuid": "68ac0f19-3c01-42cf-9056-154ea55e4789"
+          "numeratorUuid": "5647E3D0-6550-4B0B-AE76-53CD9E99D20B"
         }
       }
     ],
@@ -240,7 +221,6 @@
           "initialPopulationUuid": "F3000871-B8FD-4F74-8892-281C250C11EA",
           "denominatorUuid": "C1E20830-ADFE-4D88-B979-166FA0820D5C",
           "numeratorUuid": "49E476F4-E8A1-48A6-B800-A8172073DBFB",
-          "denominatorExclusionUuid": "a2cd75d1-24b1-4216-a241-b0b07fecde1f",
           "denominatorExceptionUuid": "41E08783-4358-4E0D-81BE-9616A8F58319"
         }
       }
@@ -257,8 +237,7 @@
           "initialPopulationUuid": "4DF80BC3-980B-465E-8591-616C7DB74FBD",
           "denominatorUuid": "815F709E-9703-4A6E-860F-CB0096A98B71",
           "numeratorUuid": "341DBA96-D1CC-409F-99D9-8AB80D03B4A8",
-          "denominatorExclusionUuid": "FE028D3B-7AB5-418B-A90C-CCFE76F25078",
-          "denominatorExceptionUuid": "abe7771d-6723-4a05-a56a-17a04f981c59"
+          "denominatorExclusionUuid": "FE028D3B-7AB5-418B-A90C-CCFE76F25078"
         }
       },
       {
@@ -267,8 +246,7 @@
           "initialPopulationUuid": "9FC61BF5-1EBD-44DE-ADCB-64E70FD3C0A5",
           "denominatorUuid": "62FDAE01-000B-40A0-9C74-4A803BA37A96",
           "numeratorUuid": "5097B983-9C47-4F28-9194-C795F42053AF",
-          "denominatorExclusionUuid": "425772D2-6437-4F33-9B1E-349E1C6587D9",
-          "denominatorExceptionUuid": "57124f7c-9f15-4b23-9b29-722aeb6d43ee"
+          "denominatorExclusionUuid": "425772D2-6437-4F33-9B1E-349E1C6587D9"
         }
       }
     ],
@@ -284,8 +262,7 @@
           "initialPopulationUuid": "EC2C5F63-AF76-4D3C-85F0-5423F8C28541",
           "denominatorUuid": "BC948E65-B908-493B-B48B-04AC342D3E6C",
           "numeratorUuid": "0BBF8596-4CFE-47F4-A0D7-9BEAB94BA4CD",
-          "denominatorExclusionUuid": "56BC7FA2-C22A-4440-8652-2D3568852C60",
-          "denominatorExceptionUuid": "506b11e2-8e60-4254-8277-5a3670bb6287"
+          "denominatorExclusionUuid": "56BC7FA2-C22A-4440-8652-2D3568852C60"
         }
       },
       {
@@ -294,8 +271,7 @@
           "initialPopulationUuid": "1511AD34-240C-4F3E-A87B-73511AABFC5C",
           "denominatorUuid": "4A09AB89-D9B8-4DD1-BC4E-78BCFD1C5873",
           "numeratorUuid": "7FFA49C4-D708-491E-85FE-6855F0A725DF",
-          "denominatorExclusionUuid": "206A891D-C3E1-4660-BF2C-6CDBDF9282FB",
-          "denominatorExceptionUuid": "3870dc26-e32d-4ba5-9025-6b00d8259f16"
+          "denominatorExclusionUuid": "206A891D-C3E1-4660-BF2C-6CDBDF9282FB"
         }
       }
     ],
@@ -311,7 +287,6 @@
           "initialPopulationUuid": "CA679308-8AF3-4374-91DC-907951440D72",
           "denominatorUuid": "FFC4DDE0-C91C-4235-BF69-E3EF79457FBB",
           "numeratorUuid": "44BEAC3C-8402-46F0-9494-81B33C502F0A",
-          "denominatorExclusionUuid": "a5a204a2-1a11-4ea7-8153-48c2f6b1dbce",
           "denominatorExceptionUuid": "655C9F36-02F7-498B-AE18-D322EA2B3726"
         }
       }
@@ -328,7 +303,6 @@
           "initialPopulationUuid": "0175F89E-9CD7-4CD8-8D7F-38CB825D2BDD",
           "denominatorUuid": "A3F77B7C-2398-470D-A359-E2A31539DF91",
           "numeratorUuid": "F0F4094E-CE53-44EE-8CEF-0555479E37B2",
-          "denominatorExclusionUuid": "c4aa6477-f361-4990-ac25-0549bd86e1c7",
           "denominatorExceptionUuid": "CF7E1913-CB4E-42F7-BAEC-0EFFF01ECB17"
         }
       }
@@ -345,7 +319,6 @@
           "initialPopulationUuid": "2072A4E8-4486-4A10-AF97-F84ADE0EB62E",
           "denominatorUuid": "2BB9F18C-8E26-44D6-904E-849495A6AF90",
           "numeratorUuid": "BCB8AEEC-EABC-477E-AA6D-6DB34220CD85",
-          "denominatorExclusionUuid": "9e1763e9-74f8-4f09-b57f-0f74a9adb3c7",
           "denominatorExceptionUuid": "608279BD-7620-4FC4-8752-08E3040BA160"
         }
       }
@@ -362,7 +335,6 @@
           "initialPopulationUuid": "56091E02-5F5C-4073-9602-D0B5BB93A26E",
           "denominatorUuid": "262ADC93-EE8C-4B95-9EFF-A6223C66ECA8",
           "numeratorUuid": "2902F791-D7AB-49B2-B024-45B1077E0374",
-          "denominatorExclusionUuid": "57c33ac4-db05-42ce-b750-ddc6d49caa62",
           "denominatorExceptionUuid": "1FA6B8AF-0583-418D-852B-9B1D9708DDFF"
         }
       }
@@ -379,7 +351,6 @@
           "initialPopulationUuid": "5ED1A428-A266-47E5-AE4F-DB97A65BB1D4",
           "denominatorUuid": "1E6C181E-91F6-4A61-82E0-7360C81CE3B0",
           "numeratorUuid": "ABBFFB54-E629-4520-875E-F6D18BC651B1",
-          "denominatorExclusionUuid": "8d38d97e-589e-4a22-881e-fa41649b54f1",
           "denominatorExceptionUuid": "E9280685-6046-438D-AE45-0F7EDBA29C33"
         }
       }
@@ -396,8 +367,7 @@
           "initialPopulationUuid": "6BE37D85-960E-4C32-AD2D-FE036A058EB4",
           "denominatorUuid": "AE00EE88-B26B-449D-94DE-EA3887BB66E0",
           "numeratorUuid": "86A8B7E8-EEA2-4C19-8A1B-74B905939505",
-          "denominatorExclusionUuid": "A0B43F8B-E6EE-4229-A05D-ECF1B601CEAF",
-          "denominatorExceptionUuid": "7f8af6e7-489b-4f64-a627-6c9b50400d9e"
+          "denominatorExclusionUuid": "A0B43F8B-E6EE-4229-A05D-ECF1B601CEAF"
         }
       }
     ],
@@ -413,7 +383,6 @@
           "initialPopulationUuid": "FF48C33E-49B3-45D1-AB44-D283F39AE73D",
           "denominatorUuid": "56E05D20-4529-4EB7-8E30-17C95BBC5223",
           "numeratorUuid": "A6516D8B-0A7D-426D-A0EC-F3F4999A2588",
-          "denominatorExclusionUuid": "98a4272d-cff5-477d-a728-23d4303c2fba",
           "denominatorExceptionUuid": "9411528A-67EF-439B-9C00-37372B2096E3"
         }
       }
@@ -430,7 +399,6 @@
           "initialPopulationUuid": "1D86EE69-7DA7-4A73-8611-2E71176568B6",
           "denominatorUuid": "2DA1439F-7941-411C-8885-91306F0CD9DD",
           "numeratorUuid": "2C2431A3-7DE3-4C97-80C0-4BF96D4880F0",
-          "denominatorExclusionUuid": "7b3728ef-a1b8-489a-8a7c-f682c26e0d7f",
           "denominatorExceptionUuid": "2EE99933-7653-4C53-8506-2A76D0657064"
         }
       }
@@ -446,9 +414,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "A417988B-395B-4108-9988-1AE443A1E254",
           "denominatorUuid": "F25492A9-8164-4833-9A91-EA160ECC9190",
-          "numeratorUuid": "D387E1DC-F06A-4054-87B1-40B863FCF8EC",
-          "denominatorExclusionUuid": "341797C7-3664-41E2-9771-6D85B2085BFA",
-          "denominatorExceptionUuid": "2e71982a-b165-480e-afc8-4d1eaee6073b"
+          "numeratorUuid": "D387E1DC-F06A-4054-87B1-40B863FCF8EC"
         }
       }
     ],
@@ -464,8 +430,7 @@
           "initialPopulationUuid": "A5BF87B0-15CF-4012-9E29-DC85010676BC",
           "denominatorUuid": "FDE4FCC5-826B-42C6-82BE-1694DD18A48D",
           "numeratorUuid": "27037F9E-5C8E-41FE-A973-E2E020C97DA7",
-          "denominatorExclusionUuid": "8E32E552-A70A-4BBC-A92A-F8D3D48113CF",
-          "denominatorExceptionUuid": "cc580a24-5718-4c00-a7f3-fff702791e15"
+          "denominatorExclusionUuid": "8E32E552-A70A-4BBC-A92A-F8D3D48113CF"
         }
       }
     ],
@@ -481,8 +446,7 @@
           "initialPopulationUuid": "0ADE9325-3FB7-402F-AD89-34C9F2753D03",
           "denominatorUuid": "933D86C8-2C2B-4AFF-AE81-DF2F9882A3A4",
           "numeratorUuid": "61887626-5457-484C-A02D-75EF8547F559",
-          "denominatorExclusionUuid": "6938F4DD-D5AB-4C40-BA03-EB0F0959615C",
-          "denominatorExceptionUuid": "3cac2acd-a3ed-4629-967a-83464c25fee4"
+          "denominatorExclusionUuid": "6938F4DD-D5AB-4C40-BA03-EB0F0959615C"
         }
       },
       {
@@ -491,8 +455,7 @@
           "initialPopulationUuid": "25286925-4221-4396-9DE0-60EA606924DF",
           "denominatorUuid": "CFB8E3E2-FF4F-4D25-B613-7EC142BAE8A9",
           "numeratorUuid": "EEAD441F-B3B2-4DC9-A890-B35E14B38EA7",
-          "denominatorExclusionUuid": "A399FA9C-48CF-41E5-812A-3445188B8301",
-          "denominatorExceptionUuid": "9fc3a9e2-6e5f-4310-9d12-5546add1a4d2"
+          "denominatorExclusionUuid": "A399FA9C-48CF-41E5-812A-3445188B8301"
         }
       },
       {
@@ -501,8 +464,7 @@
           "initialPopulationUuid": "48747E9D-674C-4013-9585-268114190119",
           "denominatorUuid": "208B74F2-6592-4381-BEC1-EB136004C3B2",
           "numeratorUuid": "21409D88-B5E3-4745-8DE2-D99DBB9F4DF0",
-          "denominatorExclusionUuid": "507F7EC3-D380-48BE-B920-ABB1EB258256",
-          "denominatorExceptionUuid": "15a2ed8f-4300-4ad9-b2ec-63d6f389feba"
+          "denominatorExclusionUuid": "507F7EC3-D380-48BE-B920-ABB1EB258256"
         }
       }
     ],
@@ -517,9 +479,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "C7BCE5A3-AC0D-440E-AA29-C98239F37A8B",
           "denominatorUuid": "07F04D61-0383-487E-942C-690BBBC6437D",
-          "numeratorUuid": "7A0001AC-4BE0-4FAA-94AE-4843C9FFFCA8",
-          "denominatorExclusionUuid": "718a29a0-49b3-4483-ab9d-dc37074f39f5",
-          "denominatorExceptionUuid": "bba507df-e957-4649-98b9-ff70c1dd7971"
+          "numeratorUuid": "7A0001AC-4BE0-4FAA-94AE-4843C9FFFCA8"
         }
       },
       {
@@ -527,9 +487,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "BC02D7CE-7133-46C6-8592-658668B09948",
           "denominatorUuid": "00401314-1B01-4896-A9FC-E991CDF29B6B",
-          "numeratorUuid": "FA7BF805-C21E-4077-B43E-C63F8D17B5CF",
-          "denominatorExclusionUuid": "41d84550-23c6-46a7-bb50-85708fa8607b",
-          "denominatorExceptionUuid": "0e953aff-ae2e-4a74-b774-ca3d9cd40e00"
+          "numeratorUuid": "FA7BF805-C21E-4077-B43E-C63F8D17B5CF"
         }
       }
     ],
@@ -544,9 +502,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "8494E3CD-7119-4471-9F2F-42540A797498",
           "denominatorUuid": "D1358E7F-9C53-414C-9D4D-DEF7AE9B6E68",
-          "numeratorUuid": "95484C04-C98A-4A77-B2A7-9FE583060582",
-          "denominatorExclusionUuid": "8357720f-e333-419c-b274-d0d8a7c0c52c",
-          "denominatorExceptionUuid": "3ccb17ee-f833-4839-ad7e-e32315697409"
+          "numeratorUuid": "95484C04-C98A-4A77-B2A7-9FE583060582"
         }
       }
     ],
@@ -562,7 +518,6 @@
           "initialPopulationUuid": "328FF8FF-8A53-42CF-A33E-789BC7E0D8ED",
           "denominatorUuid": "9826C75F-8106-44DE-AFB5-47669443C153",
           "numeratorUuid": "4ADA7675-6263-4018-997E-D27CE43A11D6",
-          "denominatorExclusionUuid": "72135b92-8866-4315-992d-38ca6490da49",
           "denominatorExceptionUuid": "F77E40ED-F649-4250-B99A-3C35414D88B0"
         }
       }
@@ -579,8 +534,7 @@
           "initialPopulationUuid": "8AAC0F5B-DC7F-4FA3-8DE9-439C663E6B41",
           "denominatorUuid": "1C6771A4-4C26-4E2C-9E10-FF6F1A5D0907",
           "numeratorUuid": "52837728-F488-4BA5-9921-FFDEEC0F0803",
-          "denominatorExclusionUuid": "72259A21-874C-4E51-9465-9989019193D0",
-          "denominatorExceptionUuid": "1de2c677-5e1b-48fb-b554-24996d0fc30c"
+          "denominatorExclusionUuid": "72259A21-874C-4E51-9465-9989019193D0"
         }
       }
     ],
@@ -595,9 +549,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "9CDC88D7-31DA-44F1-9348-CFDD29F4B20B",
           "denominatorUuid": "1EC810C4-E6D2-4ED6-AE02-A0BF4D675F05",
-          "numeratorUuid": "693493EC-2E8E-447C-88A3-FC93AD771AB9",
-          "denominatorExclusionUuid": "f1f029d5-89a7-4c0b-acec-4ddc4fefc799",
-          "denominatorExceptionUuid": "94a41537-ee3d-4e8b-bd88-08c70e8dde3d"
+          "numeratorUuid": "693493EC-2E8E-447C-88A3-FC93AD771AB9"
         }
       }
     ],
@@ -613,8 +565,7 @@
           "initialPopulationUuid": "C3E458D8-8ED4-4F09-A661-6221A2B9355D",
           "denominatorUuid": "FE6E1AA0-EE26-4F9E-A2FD-8E36058DCB47",
           "numeratorUuid": "0A3C80F4-A9FF-4BDF-B018-D647E7D777EB",
-          "denominatorExclusionUuid": "D564DEEE-17E7-4442-921D-436E5113788A",
-          "denominatorExceptionUuid": "4b5358ad-05f3-484a-a66b-c652b4e825d1"
+          "denominatorExclusionUuid": "D564DEEE-17E7-4442-921D-436E5113788A"
         }
       }
     ],
@@ -630,8 +581,7 @@
           "initialPopulationUuid": "3AD33404-E734-4F67-9144-E4B63CB3F4BE",
           "denominatorUuid": "E62FEBA3-0F98-460D-93CD-44314D7203A8",
           "numeratorUuid": "F9FEBF42-4B21-47A9-B03E-D2DA5CF8492B",
-          "denominatorExclusionUuid": "55A6D5F3-2029-4896-B850-4C7894161D7D",
-          "denominatorExceptionUuid": "fafa1d59-6f64-487c-9f95-ed81c139d2c0"
+          "denominatorExclusionUuid": "55A6D5F3-2029-4896-B850-4C7894161D7D"
         }
       }
     ],
@@ -647,8 +597,7 @@
           "initialPopulationUuid": "45D3A3ED-A7D6-45B9-AC95-647BFFE7018E",
           "denominatorUuid": "0E27156C-B8EB-48E7-A588-4AB97A0914E1",
           "numeratorUuid": "13C60632-9CF4-491B-82E9-A06118111C44",
-          "denominatorExclusionUuid": "0E9E3C94-6AA0-4C3C-A311-72CB0F2698B6",
-          "denominatorExceptionUuid": "ff61928c-0cb1-4a7f-a617-9b18bcfce0e4"
+          "denominatorExclusionUuid": "0E9E3C94-6AA0-4C3C-A311-72CB0F2698B6"
         }
       }
     ],
@@ -664,7 +613,6 @@
           "initialPopulationUuid": "3EB89216-BC0B-4DF7-8B8D-06B9AB68DB49",
           "denominatorUuid": "04507C05-46D4-4D96-9D9D-853CA557F4B2",
           "numeratorUuid": "3186154C-6A01-4FAF-A77F-B5233A3F078C",
-          "denominatorExclusionUuid": "305ce4ad-9e91-4236-af6d-1c5c65db586c",
           "denominatorExceptionUuid": "170B3877-D83D-424C-BD7E-29F644B0A6DC"
         }
       }
@@ -680,9 +628,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "AB5E9E84-65FB-4566-8254-D3488CA9A169",
           "denominatorUuid": "9656501E-1FAB-4B81-AB59-6646F1114394",
-          "numeratorUuid": "3C942ABF-C287-4FBB-AFEE-67BC5FC93BD0",
-          "denominatorExclusionUuid": "672f9875-55d9-4fb3-b56f-85205699103f",
-          "denominatorExceptionUuid": "3a57a106-7404-476e-b026-23282a95d75f"
+          "numeratorUuid": "3C942ABF-C287-4FBB-AFEE-67BC5FC93BD0"
         }
       }
     ],
@@ -697,9 +643,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "008509CF-85E8-40C0-9434-65FE19EFC090",
           "denominatorUuid": "92E101F9-795A-46DD-BEDE-EA94743AC232",
-          "numeratorUuid": "78D2FEEA-45D3-4D08-9227-773E70E3AAD5",
-          "denominatorExclusionUuid": "e21f777c-f8c6-4250-9428-2535d91b4a96",
-          "denominatorExceptionUuid": "6267da42-6e04-4614-bbe6-bb17021cc4b1"
+          "numeratorUuid": "78D2FEEA-45D3-4D08-9227-773E70E3AAD5"
         }
       }
     ],
@@ -715,8 +659,8 @@
           "initialPopulationUuid": "C7E7C7AF-464F-43A0-8C84-CDFF99953C97",
           "denominatorUuid": "65AFB8BA-F5CC-4ABA-A3FB-2F95FEE2B6FA",
           "numeratorUuid": "8964CE5A-64A4-4259-9359-39A1CDC07B8D",
-          "denominatorExclusionUuid": "8867C7A7-F8F1-4B61-A6C7-9390C5B5B4EF",
-          "denominatorExceptionUuid": "2338C9B7-B2C5-4348-BF2B-C9E636FD7A45"
+          "denominatorExceptionUuid": "2338C9B7-B2C5-4348-BF2B-C9E636FD7A45",
+          "denominatorExclusionUuid": "8867C7A7-F8F1-4B61-A6C7-9390C5B5B4EF"
         }
       }
     ],
@@ -732,8 +676,7 @@
           "initialPopulationUuid": "55D921A2-0700-43F0-8C6F-1DB4ADDD7FAB",
           "denominatorUuid": "CB0D06D7-9C40-45B0-AEC2-60C39262ABA0",
           "numeratorUuid": "D94BAE8B-1EAC-4832-B040-884B4BBC5BD0",
-          "denominatorExclusionUuid": "8C56B86F-EFE9-404D-B97C-F8FC4691D50D",
-          "denominatorExceptionUuid": "E98E90BE-F3BD-42CD-A194-D6BEFA1BB714"
+          "denominatorExclusionUuid": "8C56B86F-EFE9-404D-B97C-F8FC4691D50D"
         }
       }
     ],
@@ -748,9 +691,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "E7A4AE77-FC46-44F1-BF25-9E99A89CED9B",
           "denominatorUuid": "B710DA92-D4B9-4217-8D1E-94B35163BECE",
-          "numeratorUuid": "9824B759-A263-44DE-9F5E-93DA4E8F4627",
-          "denominatorExclusionUuid": "38db92d1-881b-452b-930e-79bff2e4e490",
-          "denominatorExceptionUuid": "c8dcc3f8-38e7-4004-956e-ab8abe965231"
+          "numeratorUuid": "9824B759-A263-44DE-9F5E-93DA4E8F4627"
         }
       }
     ],
@@ -766,7 +707,6 @@
           "initialPopulationUuid": "E681DBF8-F827-4586-B3E0-178FF19EC3A2",
           "denominatorUuid": "04BF53CE-6993-4EA2-BFE5-66E36172B388",
           "numeratorUuid": "631C0B49-83F4-4A54-96C4-7E0766B2407C",
-          "denominatorExclusionUuid": "4c42d3ad-5ad4-4e97-ac7d-81c9758fbead",
           "denominatorExceptionUuid": "58347456-D1F3-4BBB-9B35-5D42825A0AB3"
         }
       },
@@ -776,7 +716,6 @@
           "initialPopulationUuid": "AAC578DB-1900-43BD-BBBF-50014A5457E5",
           "denominatorUuid": "1574973E-EB52-40C7-9709-25ABEDBA99A3",
           "numeratorUuid": "5B7AC4EC-547A-47E5-AC5E-618401175511",
-          "denominatorExclusionUuid": "659d5fba-93ed-4b1f-bd17-233362e37e58",
           "denominatorExceptionUuid": "B7CCA1A6-F352-4A23-BC89-6FE9B60DC0C6"
         }
       },
@@ -785,9 +724,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "AF36C4A9-8BD9-4E21-838D-A47A1845EB90",
           "denominatorUuid": "B95BC0D3-572E-462B-BAA2-46CD33A865CD",
-          "numeratorUuid": "86F74F07-D593-44F6-AA12-405966400963",
-          "denominatorExclusionUuid": "8d54df2e-8a7e-49e3-a99a-0132f5139b7c",
-          "denominatorExceptionUuid": "28ee691d-8155-41fe-8c20-12a5d2e1fb75"
+          "numeratorUuid": "86F74F07-D593-44F6-AA12-405966400963"
         }
       }
     ],
@@ -803,8 +740,7 @@
           "initialPopulationUuid": "642D0090-BEAB-410B-B3B3-8D1A5EC5B919",
           "denominatorUuid": "FFA80359-2E09-48C8-8862-DD6E1F5F5428",
           "numeratorUuid": "7D021618-E1EE-4C2F-AD6A-F74E03D69E43",
-          "denominatorExclusionUuid": "65458ECD-6573-4203-8C56-515063BAFE19",
-          "denominatorExceptionUuid": "029ee8ff-899f-434b-9e83-cb5503bdfebb"
+          "denominatorExclusionUuid": "65458ECD-6573-4203-8C56-515063BAFE19"
         }
       }
     ],
@@ -820,8 +756,7 @@
           "initialPopulationUuid": "78CD5ACE-054C-43DF-A743-5F1E5BA4C099",
           "denominatorUuid": "CE973C7A-B867-422B-8408-83538E236039",
           "numeratorUuid": "F67DCC8F-4F0F-491B-957F-B21E721B040B",
-          "denominatorExclusionUuid": "74F900B9-65DA-4E6C-BB2D-592189ABDDE5",
-          "denominatorExceptionUuid": "6add5684-4b28-4d80-bf3d-dd0ea530a529"
+          "denominatorExclusionUuid": "74F900B9-65DA-4E6C-BB2D-592189ABDDE5"
         }
       }
     ],
@@ -837,8 +772,7 @@
           "initialPopulationUuid": "F0D80FC4-5E5E-46F3-A519-1B99013E2761",
           "denominatorUuid": "D795B824-0575-47B3-93DB-D48CD5643677",
           "numeratorUuid": "0DD7EF36-2B1D-4447-8E52-BF9C4A3E7ED3",
-          "denominatorExclusionUuid": "0E8BFC37-A4BA-4DE6-A6F3-DF4C188AB129",
-          "denominatorExceptionUuid": "a059c9d5-0445-40a5-8b55-db98a69891f4"
+          "denominatorExclusionUuid": "0E8BFC37-A4BA-4DE6-A6F3-DF4C188AB129"
         }
       }
     ],
@@ -854,7 +788,6 @@
           "initialPopulationUuid": "D412322D-11F1-4573-893E-E6A05855DE10",
           "denominatorUuid": "375D0559-C749-4BB9-9267-81EDF447650B",
           "numeratorUuid": "EFFE261C-0D57-423E-992C-7141B132768C",
-          "denominatorExclusionUuid": "a5dd46b0-f412-4d7d-a3b4-16c8ad4a4f43",
           "denominatorExceptionUuid": "3C100EC4-2990-4D79-AE14-E816F5E78AC8"
         }
       }
@@ -871,8 +804,8 @@
           "initialPopulationUuid": "4D10500F-6738-4541-BF24-4C95C74B45AB",
           "denominatorUuid": "36CCB819-C150-466D-A55A-0A175B19E751",
           "numeratorUuid": "51D06394-AF97-41DD-BF41-68D58786A9D2",
-          "denominatorExclusionUuid": "EE5FFA67-A42D-4472-8159-ED4B87BE6CDA",
-          "denominatorExceptionUuid": "0E162220-C93B-48B0-AAB1-E2F8E7FE7EA1"
+          "denominatorExceptionUuid": "0E162220-C93B-48B0-AAB1-E2F8E7FE7EA1",
+          "denominatorExclusionUuid": "EE5FFA67-A42D-4472-8159-ED4B87BE6CDA"
         }
       }
     ],
@@ -887,9 +820,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "BCE39253-0C5F-4DFA-A5BD-0828A8B2BB22",
           "denominatorUuid": "B41B2DF9-B4BF-4B89-A483-5B0C1A9D9804",
-          "numeratorUuid": "BEF89159-5D5C-47C6-953D-63FCAEA41548",
-          "denominatorExclusionUuid": "a73c666b-2ccf-462a-860b-985b8c9b4454",
-          "denominatorExceptionUuid": "45089ed9-59a2-49b5-9162-a49b72f3da9a"
+          "numeratorUuid": "BEF89159-5D5C-47C6-953D-63FCAEA41548"
         }
       }
     ],
@@ -904,9 +835,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "72D79C93-6D03-4BA2-B250-5316E370B766",
           "denominatorUuid": "E87F18F1-F70C-4BB3-A95C-7C1D4561E73D",
-          "numeratorUuid": "3D9AD35A-7456-4AA2-8FDB-D4B06DF72CC9",
-          "denominatorExclusionUuid": "c7cc2c7e-892e-4b35-b1ed-b25a094f25d5",
-          "denominatorExceptionUuid": "7637d114-553a-4bc4-b084-d05b3a125bb8"
+          "numeratorUuid": "3D9AD35A-7456-4AA2-8FDB-D4B06DF72CC9"
         }
       }
     ],
@@ -921,9 +850,7 @@
         "eMeasureUuids": {
           "initialPopulationUuid": "D3ADB281-2F53-4BE6-89A9-124480DE787D",
           "denominatorUuid": "6B845134-C1B7-4383-AFB3-1FFB7EAD359B",
-          "numeratorUuid": "D2A5FF72-DE5E-413A-829E-C763FC07DF4A",
-          "denominatorExclusionUuid": "3a0f2630-297f-481e-980c-252371b90b4b",
-          "denominatorExceptionUuid": "4e37becd-1435-4aa7-b64f-e3b853b005e7"
+          "numeratorUuid": "D2A5FF72-DE5E-413A-829E-C763FC07DF4A"
         }
       }
     ],
@@ -939,8 +866,7 @@
           "initialPopulationUuid": "AD37C6FE-2537-4A9B-8AD9-A372E3215F76",
           "denominatorUuid": "19ECF222-71EF-4D75-9CC2-19ED201107EA",
           "numeratorUuid": "F9B4C929-8F37-48D1-953C-489C028AE725",
-          "denominatorExclusionUuid": "32DBECF3-11EC-40FB-B35D-FA1BF7366492",
-          "denominatorExceptionUuid": "b156a02c-e64c-4b93-97d3-48b6af51fbf5"
+          "denominatorExclusionUuid": "32DBECF3-11EC-40FB-B35D-FA1BF7366492"
         }
       }
     ],

--- a/util/manually-added-ecqm-data.json
+++ b/util/manually-added-ecqm-data.json
@@ -90,7 +90,6 @@
           "initialPopulationUuid": "27982FD6-7C42-44E7-A871-0BB7F858A6D5",
           "denominatorUuid": "2294F966-EECD-4C61-8D94-D5E4B09BD9BB",
           "numeratorUuid": "02A4DDAC-D615-457A-9304-F1E382D3811C",
-          "denominatorExclusionUuid": "e497e337-9671-4805-94e9-1c7113bf187b",
           "denominatorExceptionUuid": "487E15AB-CDE2-4955-9B93-1A2CDAE6B1F2"
         }
       },
@@ -101,7 +100,6 @@
           "initialPopulationUuid": "2EE8137A-4627-471C-8837-85BDBF665017",
           "denominatorUuid": "CC31BC83-F06C-4381-8A4F-1EEBE9ECF7BC",
           "numeratorUuid": "5C03C433-8F8A-4204-B536-D7381835CE8C",
-          "denominatorExclusionUuid": "1804358a-4620-44e2-8fb9-526eecdc2fd1",
           "denominatorExceptionUuid": "F79E2A13-6F9E-4B84-99E0-4603E99C83C3"
         }
       }
@@ -165,8 +163,7 @@
           "initialPopulationUuid": "92656CE7-C9B1-44A8-8778-A8EF1ED90A18",
           "denominatorUuid": "C7DFE664-71AE-4EAD-AB65-CDFCF825A44E",
           "numeratorUuid": "B5FA6E85-0F2E-4674-A3F8-E14D834E73AB",
-          "denominatorExclusionUuid": "76B54A59-41A9-4664-B85C-F61238AE1DC4",
-          "denominatorExceptionUuid": "1c1e013a-b202-4f9e-9ee5-02be9507b7c4"
+          "denominatorExclusionUuid": "76B54A59-41A9-4664-B85C-F61238AE1DC4"
         }
       },
       {
@@ -176,8 +173,7 @@
           "initialPopulationUuid": "757F3066-31E7-45D1-BA50-3EFB27ABB8E5",
           "denominatorUuid": "32635FEA-918B-438F-8421-8A6A14E238E8",
           "numeratorUuid": "33538979-8425-45A4-B724-D74CC0A84EF3",
-          "denominatorExclusionUuid": "29931862-020D-401E-B9E9-953791263D87",
-          "denominatorExceptionUuid": "a9770f07-3989-4c20-8a7a-605e4a77cbe2"
+          "denominatorExclusionUuid": "29931862-020D-401E-B9E9-953791263D87"
         }
       },
       {
@@ -187,8 +183,7 @@
           "initialPopulationUuid": "5631A7DF-CA44-4AD4-A691-DC0CED303F6A",
           "denominatorUuid": "9665A8D2-F896-47A9-AA7E-271E9815D3CE",
           "numeratorUuid": "2D4D6446-C9CD-4661-868B-C8B9B13A8E08",
-          "denominatorExclusionUuid": "910A0EE9-ECDA-494C-83E9-30DD9E224FFB",
-          "denominatorExceptionUuid": "2cc2a6f9-d57f-48f0-ac88-7b8670cf4f4c"
+          "denominatorExclusionUuid": "910A0EE9-ECDA-494C-83E9-30DD9E224FFB"
         }
       }
     ]


### PR DESCRIPTION
https://jira.cms.gov/browse/QPPA-743

The `CMSXvY_Simple.xml` files included UUIDs for denominator exception and exclusion fields that were marked as 'None'. I've refactored `get-strata-and-uuids-from-ecqm-zip.js` to parse the `CMSXvY.xml` files instead, which only provide the UUIDs in the [reference PDF](https://www.cms.gov/Regulations-and-Guidance/Legislation/EHRIncentivePrograms/Downloads/eCQM_QRDA_EC.pdf
). I've also updated 145v5 and 160v5 since those were manually pulled, removing the UUIDs for denominator fields that are blank.

I have verified that all of the changes to measures-data in this pr are correct when comparing to the reference PDF, so I only need review for the script changes 🙏 