### PR TITLE
Updates README.md to use correct library calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The module can be used with the following pattern:
 var qppMeasuresData = require('qpp-measures-data');
 var measuresData = qppMeasuresData.getMeasuresData();
 var measuresSchema = qppMeasuresData.getMeasuresSchema();
-var benchmarksData = qppMeasuresData.getBenchmarksData(2017);
+var benchmarksData = qppMeasuresData.getBenchmarksData();
+var benchmark2017Data = benchmarksData[2017];
 var benchmarksSchema = qppMeasuresData.getBenchmarksSchema();
 ```
 


### PR DESCRIPTION
Very (VERY) simple update to the README to fix the usage of `qppMeasuresData.getBenchmarksData` to no longer take the performance year as a parameter (removed in commit 67dca947f6bc5f1736d07441a6895e8f6b66c802).