### PR TITLE
QPPQS 442 additional correction to topped out measures

### DIFF
--- a/benchmarks/2017.json
+++ b/benchmarks/2017.json
@@ -57,7 +57,7 @@
     "submissionMethod": "claims",
     "deciles": [
       0,
-      100,
+      0,
       100,
       100,
       100,
@@ -839,7 +839,7 @@
     "submissionMethod": "claims",
     "deciles": [
       0,
-      100,
+      0,
       100,
       100,
       100,
@@ -907,7 +907,7 @@
     "submissionMethod": "claims",
     "deciles": [
       0,
-      100,
+      0,
       100,
       100,
       100,
@@ -941,7 +941,7 @@
     "submissionMethod": "electronicHealthRecord",
     "deciles": [
       0,
-      100,
+      0,
       100,
       100,
       100,
@@ -1247,7 +1247,7 @@
     "submissionMethod": "registry",
     "deciles": [
       100,
-      0,
+      100,
       0,
       0,
       0,
@@ -1468,7 +1468,7 @@
     "submissionMethod": "claims",
     "deciles": [
       0,
-      100,
+      0,
       100,
       100,
       100,
@@ -1672,7 +1672,7 @@
     "submissionMethod": "claims",
     "deciles": [
       0,
-      100,
+      0,
       100,
       100,
       100,
@@ -1706,7 +1706,7 @@
     "submissionMethod": "registry",
     "deciles": [
       0,
-      100,
+      0,
       100,
       100,
       100,
@@ -1808,7 +1808,7 @@
     "submissionMethod": "claims",
     "deciles": [
       0,
-      100,
+      0,
       100,
       100,
       100,
@@ -1995,7 +1995,7 @@
     "submissionMethod": "claims",
     "deciles": [
       0,
-      100,
+      0,
       100,
       100,
       100,
@@ -2012,7 +2012,7 @@
     "submissionMethod": "registry",
     "deciles": [
       0,
-      100,
+      0,
       100,
       100,
       100,
@@ -2029,7 +2029,7 @@
     "submissionMethod": "claims",
     "deciles": [
       0,
-      100,
+      0,
       100,
       100,
       100,
@@ -2046,7 +2046,7 @@
     "submissionMethod": "claims",
     "deciles": [
       0,
-      100,
+      0,
       100,
       100,
       100,
@@ -2063,7 +2063,7 @@
     "submissionMethod": "registry",
     "deciles": [
       0,
-      100,
+      0,
       100,
       100,
       100,
@@ -2080,7 +2080,7 @@
     "submissionMethod": "registry",
     "deciles": [
       0,
-      100,
+      0,
       100,
       100,
       100,
@@ -2692,7 +2692,7 @@
     "submissionMethod": "registry",
     "deciles": [
       0,
-      100,
+      0,
       100,
       100,
       100,
@@ -2709,7 +2709,7 @@
     "submissionMethod": "registry",
     "deciles": [
       0,
-      100,
+      0,
       100,
       100,
       100,
@@ -2726,7 +2726,7 @@
     "submissionMethod": "registry",
     "deciles": [
       0,
-      100,
+      0,
       100,
       100,
       100,
@@ -3355,7 +3355,7 @@
     "submissionMethod": "claims",
     "deciles": [
       0,
-      100,
+      0,
       100,
       100,
       100,
@@ -3678,7 +3678,7 @@
     "submissionMethod": "claims",
     "deciles": [
       0,
-      100,
+      0,
       100,
       100,
       100,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/scripts/benchmarks/format-benchmark-record.js
+++ b/scripts/benchmarks/format-benchmark-record.js
@@ -106,11 +106,11 @@ var formatDecileGenerator = function(record) {
     if (!definedPredecessor &&
       definedSuccessor &&
       nextIndex === array.length) {
-      if (isInverseMeasure && index === 1) {
+      if (isInverseMeasure && (index === 1 || index === 2)) {
         return 100;
       } else if (isInverseMeasure) {
         return 0;
-      } else if (index === 1) {
+      } else if (index === 1 || index === 2) {
         return 0;
       } else {
         return 100;

--- a/test/scripts/benchmarks/format-benchmark-record-spec.js
+++ b/test/scripts/benchmarks/format-benchmark-record-spec.js
@@ -161,7 +161,7 @@ describe('formatBenchmarkRecord', function() {
           assert.equal(benchmark.submissionMethod, 'claims', 'submissionMethod');
           assert.equal(benchmark.benchmarkYear, 2016, 'benchmarkYear');
           assert.equal(benchmark.performanceYear, 2018, 'performanceYear');
-          assert.deepEqual(benchmark.deciles, [0, 100, 100, 100, 100, 100, 100, 100, 100], 'deciles');
+          assert.deepEqual(benchmark.deciles, [0, 0, 100, 100, 100, 100, 100, 100, 100], 'deciles');
         });
       });
     });
@@ -251,7 +251,7 @@ describe('formatBenchmarkRecord', function() {
           assert.equal(benchmark.submissionMethod, 'registry', 'submissionMethod');
           assert.equal(benchmark.benchmarkYear, 2016, 'benchmarkYear');
           assert.equal(benchmark.performanceYear, 2018, 'performanceYear');
-          assert.deepEqual(benchmark.deciles, [100, 0, 0, 0, 0, 0, 0, 0, 0], 'deciles');
+          assert.deepEqual(benchmark.deciles, [100, 100, 0, 0, 0, 0, 0, 0, 0], 'deciles');
         });
       });
 


### PR DESCRIPTION
For topped out measures with only 0-100 or 100-0 (inverse), deciles should either be:
[0, 0, 100, 100, 100, 100, 100, 100, 100]
or 
[100, 100, 0, 0, 0, 0, 0, 0, 0]

The decile array starts at decile 2 and ends at decile 10.  In the regular (non-inverse) case, a performance rate of zero places the measurement below decile 3, a performance rate above zero (but not 100) places the measurement in decile 3, and a performance rate of 100 places the measurement in decile 10.

This is now consistent with other variations of topped out measures.

