### PR TITLE
QPPA-925: Manually setting "overallAlgorithm" for measures 238, 391, and 398 to new value "overallStratumOnly"

### DIFF
--- a/measures/measures-data.json
+++ b/measures/measures-data.json
@@ -5591,7 +5591,7 @@
       "mentalBehavioralHealth",
       "pediatrics"
     ],
-    "overallAlgorithm": "simpleAverage"
+    "overallAlgorithm": "overallStratumOnly"
   },
   {
     "category": "quality",
@@ -7380,7 +7380,7 @@
       "allergyImmunology",
       "generalPracticeFamilyMedicine"
     ],
-    "overallAlgorithm": "weightedAverage"
+    "overallAlgorithm": "overallStratumOnly"
   },
   {
     "category": "quality",
@@ -10666,7 +10666,7 @@
       "registry"
     ],
     "measureSets": [],
-    "overallAlgorithm": "simpleAverage",
+    "overallAlgorithm": "overallStratumOnly",
     "eMeasureUuid": "40280381-52fc-3a32-0153-56d2b4f01ae5"
   },
   {

--- a/measures/measures-data.xml
+++ b/measures/measures-data.xml
@@ -4940,7 +4940,7 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
     <submissionMethod>registry</submissionMethod>
     <measureSet>mentalBehavioralHealth</measureSet>
     <measureSet>pediatrics</measureSet>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
+    <overallAlgorithm>overallStratumOnly</overallAlgorithm>
   </measure>
   <measure>
     <category>quality</category>
@@ -6443,7 +6443,7 @@ This measure is reported as three rates stratified by age group:
     <submissionMethod>registry</submissionMethod>
     <measureSet>allergyImmunology</measureSet>
     <measureSet>generalPracticeFamilyMedicine</measureSet>
-    <overallAlgorithm>weightedAverage</overallAlgorithm>
+    <overallAlgorithm>overallStratumOnly</overallAlgorithm>
   </measure>
   <measure>
     <category>quality</category>
@@ -9134,7 +9134,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
     <submissionMethod>registry</submissionMethod>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
+    <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <eMeasureUuid>40280381-52fc-3a32-0153-56d2b4f01ae5</eMeasureUuid>
   </measure>
   <measure>

--- a/measures/measures-schema.yaml
+++ b/measures/measures-schema.yaml
@@ -109,7 +109,7 @@ definitions:
         default: false
       overallAlgorithm:
         description: Formula to determine the overall performance rate, given multiple strata of performance rates.
-        enum: [simpleAverage, weightedAverage, sumNumerators]
+        enum: [simpleAverage, weightedAverage, sumNumerators, overallStratumOnly]
       strata:
         description: Population segments for which the measure requires reporting data. Only applicable to multiPerformanceRate measures.
         type: array

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.5",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",


### PR DESCRIPTION
As far as I can tell, at this point in the qpp-measures-data repository, we're about to make the existing `measures-data.json` into a `base-measures-data.json` file, which will be the gold standard base set of measures that other staging data will change -- which means changing the `overallAlgorithm` of three measures (238, 391, 398), which this PR is all about, means changing those values _manually_ in the `measures-data.json` file directly (and then generating the `measures-data.xml` file) -- which is what I've done here.

I've also changed the `measures-schema.yaml` to include this new `overallAlgorithm` option so the file is valid. 

(the associated change in the Submissions API to support this new `overallAlgorithm` is here: https://github.com/CMSgov/qpp-submissions-api/pull/576)

Associated Jira issues:
* https://jira.cms.gov/browse/QPPA-925

Reviewers: @kencheeto @abarciauskas-bgse 