### PR TITLE
Feature/qppqs 510 multi performance measures

### DIFF
--- a/measures/measures-data.json
+++ b/measures/measures-data.json
@@ -2367,7 +2367,7 @@
       "registry"
     ],
     "measureSets": [],
-    "overallAlgorithm": "weightedAverage",
+    "overallAlgorithm": "overallStratumOnly",
     "measureSpecification": {
       "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2017_Measure_122_Registry.pdf"
     }
@@ -6893,7 +6893,7 @@
     "measureSets": [
       "electrophysiologyCardiacSpecialist"
     ],
-    "overallAlgorithm": "weightedAverage",
+    "overallAlgorithm": "overallStratumOnly",
     "measureSpecification": {
       "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2017_Measure_392_Registry.pdf"
     }
@@ -7075,7 +7075,7 @@
       "generalPracticeFamilyMedicine",
       "pediatrics"
     ],
-    "overallAlgorithm": "sumNumerators",
+    "overallAlgorithm": "overallStratumOnly",
     "measureSpecification": {
       "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2017_Measure_394_Registry.pdf"
     }
@@ -7535,7 +7535,7 @@
       "registry"
     ],
     "measureSets": [],
-    "overallAlgorithm": "simpleAverage",
+    "overallAlgorithm": "overallStratumOnly",
     "measureSpecification": {
       "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2017_Measure_046_Claims.pdf",
       "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2017_Measure_046_Registry.pdf"

--- a/measures/measures-data.xml
+++ b/measures/measures-data.xml
@@ -2271,7 +2271,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isHighPriority>true</isHighPriority>
     <primarySteward>Renal Physicians Association</primarySteward>
     <submissionMethod>registry</submissionMethod>
-    <overallAlgorithm>weightedAverage</overallAlgorithm>
+    <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <measureSpecification>
       <registry>https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2017_Measure_122_Registry.pdf</registry>
     </measureSpecification>
@@ -6111,7 +6111,7 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
     <primarySteward>The Heart Rhythm Society</primarySteward>
     <submissionMethod>registry</submissionMethod>
     <measureSet>electrophysiologyCardiacSpecialist</measureSet>
-    <overallAlgorithm>weightedAverage</overallAlgorithm>
+    <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <measureSpecification>
       <registry>https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2017_Measure_392_Registry.pdf</registry>
     </measureSpecification>
@@ -6268,7 +6268,7 @@ If a follow-up blood pressure reading is not recorded during the measurement yea
     <submissionMethod>registry</submissionMethod>
     <measureSet>generalPracticeFamilyMedicine</measureSet>
     <measureSet>pediatrics</measureSet>
-    <overallAlgorithm>sumNumerators</overallAlgorithm>
+    <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <measureSpecification>
       <registry>https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2017_Measure_394_Registry.pdf</registry>
     </measureSpecification>
@@ -6672,7 +6672,7 @@ This measure is reported as three rates stratified by age group:
     <submissionMethod>claims</submissionMethod>
     <submissionMethod>cmsWebInterface</submissionMethod>
     <submissionMethod>registry</submissionMethod>
-    <overallAlgorithm>simpleAverage</overallAlgorithm>
+    <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <measureSpecification>
       <claims>https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2017_Measure_046_Claims.pdf</claims>
       <registry>https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2017_Measure_046_Registry.pdf</registry>

--- a/staging/measures-data.json
+++ b/staging/measures-data.json
@@ -2272,7 +2272,7 @@
       "registry"
     ],
     "measureSets": [],
-    "overallAlgorithm": "weightedAverage"
+    "overallAlgorithm": "overallStratumOnly"
   },
   {
     "category": "quality",
@@ -6380,7 +6380,7 @@
     "measureSets": [
       "electrophysiologyCardiacSpecialist"
     ],
-    "overallAlgorithm": "weightedAverage"
+    "overallAlgorithm": "overallStratumOnly"
   },
   {
     "category": "quality",
@@ -6547,7 +6547,7 @@
       "generalPracticeFamilyMedicine",
       "pediatrics"
     ],
-    "overallAlgorithm": "sumNumerators"
+    "overallAlgorithm": "overallStratumOnly"
   },
   {
     "category": "quality",
@@ -6963,7 +6963,7 @@
       "registry"
     ],
     "measureSets": [],
-    "overallAlgorithm": "simpleAverage"
+    "overallAlgorithm": "overallStratumOnly"
   },
   {
     "category": "quality",


### PR DESCRIPTION
Updated measures 046, 122, 238, 391, 392, 394 and 398 to `overallAlgorithm` = `overallStratumOnly`  When calculating the performance rate for these measures, the API should only use the "overall" stratum.

https://jira.cms.gov/browse/QPPQS-510
