### PR TITLE
Fix duplicate version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.0.0-alpha.15",
   "version": "1.0.0-alpha.16",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {


### PR DESCRIPTION
Accidentally duplicated the version property during a merge conflict on #85 yesterday and didn't notice. Fixing now.

- [ ] After merging this PR to master, re-publish and update the Github release to point at this commit instead

Reviewers: anyone