### PR TITLE
Bump version to 1.0.0-alpha.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.0.0-alpha.16",
+  "version": "1.0.0-alpha.17",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",


### PR DESCRIPTION
In #88, I should have bumped the version to 1.0.0-alpha.17 since I'd already published 1.0.0-alpha.16 in #85, and npm doesn't allow re-publishing with the same version number. This fixes it.

Reviewers: anyone