### PR TITLE
QPPA-1299 WIP adds webAttestation as submission method

### DIFF
--- a/measures/measures-data.json
+++ b/measures/measures-data.json
@@ -504,7 +504,8 @@
     "isHighPriority": true,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "cmsWebInterface"
+      "cmsWebInterface",
+      "webAttestation"
     ],
     "measureSets": [],
     "isRegistryMeasure": false,
@@ -3642,7 +3643,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -4573,7 +4575,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -4655,7 +4658,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -5299,7 +5303,8 @@
     "submissionMethods": [
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "mentalBehavioralHealth",
@@ -5405,7 +5410,8 @@
       "claims",
       "cmsWebInterface",
       "electronicHealthRecord",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -5492,7 +5498,8 @@
       "claims",
       "cmsWebInterface",
       "electronicHealthRecord",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -6105,7 +6112,8 @@
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
       "electronicHealthRecord",
-      "cmsWebInterface"
+      "cmsWebInterface",
+      "webAttestation"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-51f0-825b-0152-22aae8a21778",
@@ -7411,7 +7419,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -7696,7 +7705,8 @@
     "submissionMethods": [
       "claims",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [],
     "overallAlgorithm": "overallStratumOnly",
@@ -9160,7 +9170,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "allergyImmunology",
@@ -9411,7 +9422,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -9471,7 +9483,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "allergyImmunology",
@@ -9522,7 +9535,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -9637,7 +9651,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "allergyImmunology",
@@ -11332,7 +11347,8 @@
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",

--- a/measures/measures-data.xml
+++ b/measures/measures-data.xml
@@ -421,6 +421,7 @@ AND (2) If requested, cooperated in good faith with ONC direct review of his or 
     <isHighPriority>true</isHighPriority>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>cmsWebInterface</submissionMethod>
+    <submissionMethod>webAttestation</submissionMethod>
     <isRegistryMeasure>false</isRegistryMeasure>
     <measureSpecification>
       <cmsWebInterface>https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Web-Interface-Measures/2017 WI_DM.pdf</cmsWebInterface>
@@ -3352,6 +3353,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <submissionMethod>electronicHealthRecord</submissionMethod>
     <submissionMethod>cmsWebInterface</submissionMethod>
     <submissionMethod>registry</submissionMethod>
+    <submissionMethod>webAttestation</submissionMethod>
     <measureSet>internalMedicine</measureSet>
     <measureSet>obstetricsGynecology</measureSet>
     <measureSet>preventiveMedicine</measureSet>
@@ -4162,6 +4164,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <submissionMethod>electronicHealthRecord</submissionMethod>
     <submissionMethod>cmsWebInterface</submissionMethod>
     <submissionMethod>registry</submissionMethod>
+    <submissionMethod>webAttestation</submissionMethod>
     <measureSet>internalMedicine</measureSet>
     <measureSet>generalPracticeFamilyMedicine</measureSet>
     <eMeasureUuid>40280381-51f0-825b-0152-22a1e7e81737</eMeasureUuid>
@@ -4232,6 +4235,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <submissionMethod>electronicHealthRecord</submissionMethod>
     <submissionMethod>cmsWebInterface</submissionMethod>
     <submissionMethod>registry</submissionMethod>
+    <submissionMethod>webAttestation</submissionMethod>
     <measureSet>internalMedicine</measureSet>
     <measureSet>cardiology</measureSet>
     <measureSet>obstetricsGynecology</measureSet>
@@ -4769,6 +4773,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <submissionMethod>electronicHealthRecord</submissionMethod>
     <submissionMethod>cmsWebInterface</submissionMethod>
     <submissionMethod>registry</submissionMethod>
+    <submissionMethod>webAttestation</submissionMethod>
     <measureSet>mentalBehavioralHealth</measureSet>
     <measureSet>generalPracticeFamilyMedicine</measureSet>
     <eMeasureUuid>40280381-5118-2f4e-0151-3a9382cd09ba</eMeasureUuid>
@@ -4864,6 +4869,7 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
     <submissionMethod>cmsWebInterface</submissionMethod>
     <submissionMethod>electronicHealthRecord</submissionMethod>
     <submissionMethod>registry</submissionMethod>
+    <submissionMethod>webAttestation</submissionMethod>
     <measureSet>internalMedicine</measureSet>
     <measureSet>ophthalmology</measureSet>
     <measureSet>generalPracticeFamilyMedicine</measureSet>
@@ -4939,6 +4945,7 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
     <submissionMethod>cmsWebInterface</submissionMethod>
     <submissionMethod>electronicHealthRecord</submissionMethod>
     <submissionMethod>registry</submissionMethod>
+    <submissionMethod>webAttestation</submissionMethod>
     <measureSet>internalMedicine</measureSet>
     <measureSet>preventiveMedicine</measureSet>
     <measureSet>generalPracticeFamilyMedicine</measureSet>
@@ -5459,6 +5466,7 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
     <submissionMethod>cmsWebInterface</submissionMethod>
+    <submissionMethod>webAttestation</submissionMethod>
     <eMeasureUuid>40280381-51f0-825b-0152-22aae8a21778</eMeasureUuid>
     <isRegistryMeasure>false</isRegistryMeasure>
     <cpcPlusGroup>B</cpcPlusGroup>
@@ -6588,6 +6596,7 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <submissionMethod>electronicHealthRecord</submissionMethod>
     <submissionMethod>cmsWebInterface</submissionMethod>
     <submissionMethod>registry</submissionMethod>
+    <submissionMethod>webAttestation</submissionMethod>
     <measureSet>internalMedicine</measureSet>
     <measureSet>cardiology</measureSet>
     <measureSet>generalPracticeFamilyMedicine</measureSet>
@@ -6836,6 +6845,7 @@ This measure is reported as three rates stratified by age group:
     <submissionMethod>claims</submissionMethod>
     <submissionMethod>cmsWebInterface</submissionMethod>
     <submissionMethod>registry</submissionMethod>
+    <submissionMethod>webAttestation</submissionMethod>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <isRegistryMeasure>false</isRegistryMeasure>
     <measureSpecification>
@@ -8059,6 +8069,7 @@ This measure is reported as three rates stratified by age group:
     <submissionMethod>electronicHealthRecord</submissionMethod>
     <submissionMethod>cmsWebInterface</submissionMethod>
     <submissionMethod>registry</submissionMethod>
+    <submissionMethod>webAttestation</submissionMethod>
     <measureSet>allergyImmunology</measureSet>
     <measureSet>preventiveMedicine</measureSet>
     <eMeasureUuid>40280381-52fc-3a32-0153-1a646a2a0bfa</eMeasureUuid>
@@ -8272,6 +8283,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <submissionMethod>electronicHealthRecord</submissionMethod>
     <submissionMethod>cmsWebInterface</submissionMethod>
     <submissionMethod>registry</submissionMethod>
+    <submissionMethod>webAttestation</submissionMethod>
     <measureSet>internalMedicine</measureSet>
     <measureSet>cardiology</measureSet>
     <measureSet>gastroenterology</measureSet>
@@ -8326,6 +8338,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <submissionMethod>electronicHealthRecord</submissionMethod>
     <submissionMethod>cmsWebInterface</submissionMethod>
     <submissionMethod>registry</submissionMethod>
+    <submissionMethod>webAttestation</submissionMethod>
     <measureSet>allergyImmunology</measureSet>
     <measureSet>internalMedicine</measureSet>
     <measureSet>obstetricsGynecology</measureSet>
@@ -8371,6 +8384,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <submissionMethod>electronicHealthRecord</submissionMethod>
     <submissionMethod>cmsWebInterface</submissionMethod>
     <submissionMethod>registry</submissionMethod>
+    <submissionMethod>webAttestation</submissionMethod>
     <measureSet>internalMedicine</measureSet>
     <measureSet>mentalBehavioralHealth</measureSet>
     <measureSet>generalPracticeFamilyMedicine</measureSet>
@@ -8474,6 +8488,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <submissionMethod>electronicHealthRecord</submissionMethod>
     <submissionMethod>cmsWebInterface</submissionMethod>
     <submissionMethod>registry</submissionMethod>
+    <submissionMethod>webAttestation</submissionMethod>
     <measureSet>allergyImmunology</measureSet>
     <measureSet>internalMedicine</measureSet>
     <measureSet>cardiology</measureSet>
@@ -9896,6 +9911,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
     <submissionMethod>cmsWebInterface</submissionMethod>
     <submissionMethod>registry</submissionMethod>
+    <submissionMethod>webAttestation</submissionMethod>
     <measureSet>internalMedicine</measureSet>
     <measureSet>cardiology</measureSet>
     <measureSet>generalPracticeFamilyMedicine</measureSet>

--- a/measures/measures-schema.yaml
+++ b/measures/measures-schema.yaml
@@ -221,6 +221,7 @@ definitions:
       - cmsWebInterface
       - electronicHealthRecord
       - registry
+      - webAttestation
 
   measureSpecification:
     type: object

--- a/staging/measures-data-with-qcdrs.json
+++ b/staging/measures-data-with-qcdrs.json
@@ -504,7 +504,8 @@
     "isHighPriority": true,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "cmsWebInterface"
+      "cmsWebInterface",
+      "webAttestation"
     ],
     "measureSets": [],
     "isRegistryMeasure": false
@@ -3433,7 +3434,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -4283,7 +4285,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -4355,7 +4358,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -4941,7 +4945,8 @@
     "submissionMethods": [
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "mentalBehavioralHealth",
@@ -5039,7 +5044,8 @@
       "claims",
       "cmsWebInterface",
       "electronicHealthRecord",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -5118,7 +5124,8 @@
       "claims",
       "cmsWebInterface",
       "electronicHealthRecord",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -5673,7 +5680,8 @@
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
       "electronicHealthRecord",
-      "cmsWebInterface"
+      "cmsWebInterface",
+      "webAttestation"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-51f0-825b-0152-22aae8a21778",
@@ -6867,7 +6875,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -7124,7 +7133,8 @@
     "submissionMethods": [
       "claims",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [],
     "overallAlgorithm": "overallStratumOnly",
@@ -8448,7 +8458,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "allergyImmunology",
@@ -8675,7 +8686,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -8730,7 +8742,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "allergyImmunology",
@@ -8776,7 +8789,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -8882,7 +8896,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "allergyImmunology",
@@ -10412,7 +10427,8 @@
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",

--- a/staging/measures-data.json
+++ b/staging/measures-data.json
@@ -492,7 +492,8 @@
     "isHighPriority": true,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "cmsWebInterface"
+      "cmsWebInterface",
+      "webAttestation"
     ],
     "measureSets": []
   },
@@ -3380,7 +3381,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -4205,7 +4207,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -4275,7 +4278,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -4843,7 +4847,8 @@
     "submissionMethods": [
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "mentalBehavioralHealth",
@@ -4939,7 +4944,8 @@
       "claims",
       "cmsWebInterface",
       "electronicHealthRecord",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -5016,7 +5022,8 @@
       "claims",
       "cmsWebInterface",
       "electronicHealthRecord",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -5555,7 +5562,8 @@
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
       "electronicHealthRecord",
-      "cmsWebInterface"
+      "cmsWebInterface",
+      "webAttestation"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-51f0-825b-0152-22aae8a21778"
@@ -6713,7 +6721,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -6962,7 +6971,8 @@
     "submissionMethods": [
       "claims",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [],
     "overallAlgorithm": "overallStratumOnly"
@@ -8244,7 +8254,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "allergyImmunology",
@@ -8464,7 +8475,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -8518,7 +8530,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "allergyImmunology",
@@ -8563,7 +8576,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",
@@ -8667,7 +8681,8 @@
       "claims",
       "electronicHealthRecord",
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "allergyImmunology",
@@ -10148,7 +10163,8 @@
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
       "cmsWebInterface",
-      "registry"
+      "registry",
+      "webAttestation"
     ],
     "measureSets": [
       "internalMedicine",


### PR DESCRIPTION
Added `webAttestation` to all measures that had `cmsWebInterface` as a valid submission method.

this code snippet did the trick:
```js
const fs = require('fs');
const measures = require('./staging/measures-data');

measures.forEach(measure => {
  if (!measure.submissionMethods) return;
  if (measure.submissionMethods.includes('cmsWebInterface')) {
    measure.submissionMethods.push('webAttestation');
  }
});

fs.writeFileSync('./output.json', JSON.stringify(measures, null, 2));
```

This PR is marked as WIP because we need to add benchmarks for these measures, but it's not finalized yet what the benchmarks should be (copies of cmsWebInterface?)