### PR TITLE
[QPPA-1350] Add submissionmethods = registry to QCDR measures

### DIFF
--- a/measures/measures-data.json
+++ b/measures/measures-data.json
@@ -12082,7 +12082,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAAAI5",
@@ -12102,7 +12105,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAAAI6",
@@ -12122,7 +12128,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAAAI8",
@@ -12142,7 +12151,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAAAI9",
@@ -12162,7 +12174,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAAAI11",
@@ -12182,7 +12197,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAAAI12",
@@ -12202,7 +12220,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAAAI17",
@@ -12222,7 +12243,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAAAI18",
@@ -12242,7 +12266,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAAAI19",
@@ -12277,6 +12304,9 @@
         "name": "overall",
         "description": "Total patients prescribed long-term control medication"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -12297,7 +12327,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAD2",
@@ -12317,7 +12350,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAD3",
@@ -12337,7 +12373,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAD4",
@@ -12357,7 +12396,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAD5",
@@ -12377,7 +12419,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ARCO11",
@@ -12397,7 +12442,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ARCO12",
@@ -12417,7 +12465,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ARCO13",
@@ -12456,6 +12507,9 @@
         "name": "LDL",
         "description": "The percent of ischemic stroke patients with an LDL greater than or equal to 100 mg/dL, OR LDL not measured, OR who were on a lipid-lowering medication prior to hospital arrival who were prescribed statin medication at hospital discharge"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -12476,7 +12530,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NOF12",
@@ -12496,7 +12553,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ARCO7",
@@ -12516,7 +12576,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACR7",
@@ -12536,7 +12599,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ARCO14",
@@ -12556,7 +12622,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ARCO10",
@@ -12576,7 +12645,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCCath1",
@@ -12596,7 +12668,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCCath2",
@@ -12616,7 +12691,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCCath3",
@@ -12636,7 +12714,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCCath4",
@@ -12656,7 +12737,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCCath5",
@@ -12676,7 +12760,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCCath6",
@@ -12696,7 +12783,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCCath8",
@@ -12716,7 +12806,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCCath9",
@@ -12736,7 +12829,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCCath13",
@@ -12756,7 +12852,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAN4",
@@ -12776,7 +12875,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAN9",
@@ -12796,7 +12898,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAN10",
@@ -12816,7 +12921,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAN1",
@@ -12836,7 +12944,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAN2",
@@ -12856,7 +12967,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAN5",
@@ -12876,7 +12990,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAN11",
@@ -12896,7 +13013,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAN8",
@@ -12916,7 +13036,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS1",
@@ -12936,7 +13059,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS2",
@@ -12956,7 +13082,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS3",
@@ -12976,7 +13105,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS4",
@@ -12996,7 +13128,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS5",
@@ -13016,7 +13151,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS6",
@@ -13036,7 +13174,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS7",
@@ -13056,7 +13197,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS8",
@@ -13076,7 +13220,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS9",
@@ -13096,7 +13243,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS10",
@@ -13116,7 +13266,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS11",
@@ -13136,7 +13289,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS13",
@@ -13156,7 +13312,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS16",
@@ -13176,7 +13335,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS17",
@@ -13196,7 +13358,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS18",
@@ -13216,7 +13381,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS19",
@@ -13236,7 +13404,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS20",
@@ -13256,7 +13427,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS21",
@@ -13276,7 +13450,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS22",
@@ -13296,7 +13473,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS23",
@@ -13316,7 +13496,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS24",
@@ -13336,7 +13519,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS25",
@@ -13356,7 +13542,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS26",
@@ -13376,7 +13565,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Q415",
@@ -13396,7 +13588,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Q416",
@@ -13416,7 +13611,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP21",
@@ -13436,7 +13634,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP22",
@@ -13456,7 +13657,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP24",
@@ -13476,7 +13680,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP25",
@@ -13496,7 +13703,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP26",
@@ -13516,7 +13726,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP27",
@@ -13536,7 +13749,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP28",
@@ -13556,7 +13772,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP29",
@@ -13576,7 +13795,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP30",
@@ -13596,7 +13818,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP31",
@@ -13616,7 +13841,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP32",
@@ -13636,7 +13864,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP33",
@@ -13656,7 +13887,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP35",
@@ -13676,7 +13910,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP36",
@@ -13696,7 +13933,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP37",
@@ -13716,7 +13956,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP38",
@@ -13736,7 +13979,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP39",
@@ -13756,7 +14002,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP40",
@@ -13776,7 +14025,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP41",
@@ -13796,7 +14048,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP43",
@@ -13816,7 +14071,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP44",
@@ -13836,7 +14094,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP45",
@@ -13856,7 +14117,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP46",
@@ -13876,7 +14140,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP47",
@@ -13896,7 +14163,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP48",
@@ -13916,7 +14186,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP49",
@@ -13936,7 +14209,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACPGR1",
@@ -13956,7 +14232,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET20",
@@ -13976,7 +14255,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACPGR2",
@@ -13996,7 +14278,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACPGR3",
@@ -14016,7 +14301,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Q408",
@@ -14036,7 +14324,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Q414",
@@ -14056,7 +14347,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad26",
@@ -14076,7 +14370,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad2",
@@ -14096,7 +14393,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad1",
@@ -14116,7 +14416,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad23",
@@ -14136,7 +14439,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad21",
@@ -14156,7 +14462,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad22",
@@ -14176,7 +14485,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad31",
@@ -14196,7 +14508,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad32",
@@ -14216,7 +14531,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad33",
@@ -14236,7 +14554,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad30",
@@ -14256,7 +14577,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad28",
@@ -14276,7 +14600,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad29",
@@ -14296,7 +14623,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad18",
@@ -14316,7 +14646,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad25",
@@ -14336,7 +14669,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad17",
@@ -14356,7 +14692,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad19",
@@ -14376,7 +14715,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad15",
@@ -14396,7 +14738,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad16",
@@ -14416,7 +14761,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad5",
@@ -14436,7 +14784,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad3",
@@ -14456,7 +14807,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad8",
@@ -14476,7 +14830,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad7",
@@ -14496,7 +14853,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad6",
@@ -14516,7 +14876,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad27",
@@ -14536,7 +14899,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACS15",
@@ -14556,7 +14922,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACS16",
@@ -14576,7 +14945,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACS17",
@@ -14596,7 +14968,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACS18",
@@ -14616,7 +14991,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACS19",
@@ -14636,7 +15014,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACS20",
@@ -14656,7 +15037,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACS21",
@@ -14676,7 +15060,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACS22",
@@ -14696,7 +15083,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACS23",
@@ -14716,7 +15106,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc51",
@@ -14736,7 +15129,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "APMA1",
@@ -14756,7 +15152,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CDR2",
@@ -14776,7 +15175,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC1",
@@ -14796,7 +15198,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC2",
@@ -14816,7 +15221,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC3",
@@ -14836,7 +15244,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC4",
@@ -14856,7 +15267,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC13",
@@ -14876,7 +15290,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC14",
@@ -14896,7 +15313,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC17",
@@ -14916,7 +15336,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC18",
@@ -14936,7 +15359,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC19",
@@ -14956,7 +15382,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC20",
@@ -14976,7 +15405,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC21",
@@ -14996,7 +15428,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC22",
@@ -15016,7 +15451,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC23",
@@ -15036,7 +15474,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC24",
@@ -15056,7 +15497,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC25",
@@ -15076,7 +15520,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CDR1",
@@ -15096,7 +15543,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPS5",
@@ -15116,7 +15566,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPS6",
@@ -15136,7 +15589,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AUGS1",
@@ -15156,7 +15612,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AUGS2",
@@ -15176,7 +15635,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AUGS3",
@@ -15196,7 +15658,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AUGS4",
@@ -15216,7 +15681,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AUGS5",
@@ -15236,7 +15704,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AUGS6",
@@ -15256,7 +15727,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AUGS7",
@@ -15276,7 +15750,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AUGS8",
@@ -15296,7 +15773,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AUGS9",
@@ -15316,7 +15796,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA5",
@@ -15336,7 +15819,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA6",
@@ -15356,7 +15842,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA12",
@@ -15376,7 +15865,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA3",
@@ -15396,7 +15888,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA8",
@@ -15416,7 +15911,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA4",
@@ -15436,7 +15934,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA11",
@@ -15456,7 +15957,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA10",
@@ -15476,7 +15980,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MUSIC4",
@@ -15496,7 +16003,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA14",
@@ -15516,7 +16026,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA13",
@@ -15536,7 +16049,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA15",
@@ -15556,7 +16072,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA16",
@@ -15576,7 +16095,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA17",
@@ -15596,7 +16118,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA18",
@@ -15616,7 +16141,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AHSQC1",
@@ -15636,7 +16164,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AHSQC2",
@@ -15656,7 +16187,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AHSQC6",
@@ -15691,6 +16225,9 @@
         "name": "hernia>10cm",
         "description": "Abdominal Wall Reconstruction Surgical Site Occurrence Requiring Procedural Intervention within the 30 Day Postoperative Period-Hernia width of >10cm"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -15711,7 +16248,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AHSQC8",
@@ -15731,7 +16271,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AHSQC9",
@@ -15762,6 +16305,9 @@
         "name": "email",
         "description": "Ventral Hernia Repair: Pain and Functional Status Assessment-Email engagement completion rate"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -15782,7 +16328,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG29",
@@ -15802,7 +16351,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG30",
@@ -15822,7 +16374,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG31",
@@ -15842,7 +16397,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG32",
@@ -15862,7 +16420,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG33",
@@ -15882,7 +16443,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG34",
@@ -15902,7 +16466,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG1",
@@ -15922,7 +16489,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI35",
@@ -15942,7 +16512,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG4",
@@ -15962,7 +16535,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG5",
@@ -15982,7 +16558,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG7",
@@ -16002,7 +16581,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI48",
@@ -16022,7 +16604,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG14",
@@ -16042,7 +16627,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG15",
@@ -16062,7 +16650,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG16",
@@ -16082,7 +16673,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG21",
@@ -16102,7 +16696,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI49",
@@ -16145,6 +16742,9 @@
         "name": "overall",
         "description": "Composite Performance Score: Percentage of denominator-eligible patients for whom a cumulative score of 100% of blood conservation strategies was met"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -16165,7 +16765,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI51",
@@ -16185,7 +16788,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI42",
@@ -16205,7 +16811,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI18",
@@ -16225,7 +16834,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI41",
@@ -16245,7 +16857,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI28",
@@ -16265,7 +16880,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI34",
@@ -16285,7 +16903,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI31",
@@ -16305,7 +16926,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI29",
@@ -16325,7 +16949,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI32",
@@ -16345,7 +16972,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI37",
@@ -16365,7 +16995,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI52",
@@ -16385,7 +17018,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPIRE4",
@@ -16405,7 +17041,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPIRE3",
@@ -16425,7 +17064,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPIRE19",
@@ -16445,7 +17087,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPIRE6",
@@ -16465,7 +17110,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPIRE16",
@@ -16485,7 +17133,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPIRE22",
@@ -16505,7 +17156,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPIRE18",
@@ -16525,7 +17179,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPIRE8",
@@ -16545,7 +17202,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPIRE2",
@@ -16565,7 +17225,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPIRE13",
@@ -16585,7 +17248,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "BNS1",
@@ -16605,7 +17271,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CCOME1",
@@ -16625,7 +17294,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CCOME2",
@@ -16645,7 +17317,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CCOME3",
@@ -16665,7 +17340,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CCOME4",
@@ -16685,7 +17363,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CCOME5",
@@ -16705,7 +17386,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE6",
@@ -16725,7 +17409,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE7",
@@ -16745,7 +17432,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE1",
@@ -16765,7 +17455,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE3",
@@ -16785,7 +17478,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE8",
@@ -16805,7 +17501,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE9",
@@ -16825,7 +17524,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE5",
@@ -16845,7 +17547,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE10",
@@ -16865,7 +17570,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE11",
@@ -16885,7 +17593,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE2",
@@ -16905,7 +17616,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE12",
@@ -16925,7 +17639,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CESQIP6",
@@ -16945,7 +17662,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CESQIP4",
@@ -16965,7 +17685,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CESQIP1",
@@ -16985,7 +17708,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CESQIP3",
@@ -17005,7 +17731,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CESQIP5",
@@ -17025,7 +17754,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CESQIP2",
@@ -17045,7 +17777,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CUHSM3",
@@ -17065,7 +17800,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CUHSM4",
@@ -17085,7 +17823,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CUHSM6",
@@ -17105,7 +17846,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CUHSM8",
@@ -17125,7 +17869,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "EPREOP4",
@@ -17145,7 +17892,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "EPREOP9",
@@ -17165,7 +17915,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "EPREOP14",
@@ -17185,7 +17938,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "EPREOP26",
@@ -17205,7 +17961,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "EPREOP27",
@@ -17225,7 +17984,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "FORCE4",
@@ -17245,7 +18007,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "FORCE5",
@@ -17265,7 +18030,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "FORCE9",
@@ -17285,7 +18053,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "FORCE10",
@@ -17305,7 +18076,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "FORCE17",
@@ -17325,7 +18099,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "FORCE18",
@@ -17345,7 +18122,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "FORCE19",
@@ -17365,7 +18145,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "GIQIC15",
@@ -17385,7 +18168,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "GIQIC12",
@@ -17405,7 +18191,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "GIQIC10",
@@ -17425,7 +18214,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHCR4",
@@ -17445,7 +18237,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HF1",
@@ -17465,7 +18260,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HF2",
@@ -17485,7 +18283,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HF3",
@@ -17505,7 +18306,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HF4",
@@ -17525,7 +18329,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HF5",
@@ -17545,7 +18352,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HF6",
@@ -17565,7 +18375,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HF7",
@@ -17585,7 +18398,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HAdv1",
@@ -17605,7 +18421,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HAdv2",
@@ -17625,7 +18444,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S16",
@@ -17645,7 +18467,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S17",
@@ -17665,7 +18490,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S18",
@@ -17685,7 +18513,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S19",
@@ -17705,7 +18536,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S1",
@@ -17725,7 +18559,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S2",
@@ -17745,7 +18582,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S3",
@@ -17765,7 +18605,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S4",
@@ -17785,7 +18628,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S5",
@@ -17805,7 +18651,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S6",
@@ -17825,7 +18674,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S7",
@@ -17845,7 +18697,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S8",
@@ -17865,7 +18720,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S9",
@@ -17885,7 +18743,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S10",
@@ -17905,7 +18766,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S11",
@@ -17925,7 +18789,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S12",
@@ -17945,7 +18812,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S13",
@@ -17965,7 +18835,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "BIVARUS27",
@@ -17985,7 +18858,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "BIVARUS28",
@@ -18005,7 +18881,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "BIVARUS32",
@@ -18025,7 +18904,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "BIVARUS30",
@@ -18045,7 +18927,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "BIVARUS31",
@@ -18065,7 +18950,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MOA1",
@@ -18096,6 +18984,9 @@
         "name": "neck",
         "description": "Percentage of patients receiving manipulative medicine with a QVAS score and treatment adjustment/maintenance for neck pain."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -18116,7 +19007,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MOA 7",
@@ -18136,7 +19030,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MOA 13",
@@ -18156,7 +19053,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MOA 14",
@@ -18176,7 +19076,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MOA 15",
@@ -18196,7 +19099,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MOA 12",
@@ -18216,7 +19122,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MeHC1",
@@ -18236,7 +19145,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ECPR39",
@@ -18256,7 +19168,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ECPR43",
@@ -18287,6 +19202,9 @@
         "name": "urgentcare",
         "description": "In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with a Diagnosis of Chest Pain Where the Provider Ordered Coagulation Studies (PT, PTT, or INR)"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -18307,7 +19225,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ECPR44",
@@ -18327,7 +19248,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ECPR40",
@@ -18347,7 +19271,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ECPR6",
@@ -18367,7 +19294,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ECPR5",
@@ -18387,7 +19317,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ECPR42",
@@ -18407,7 +19340,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ECPR41",
@@ -18427,7 +19363,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ECPR11",
@@ -18447,7 +19386,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ECPR38",
@@ -18467,7 +19409,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HCPR19",
@@ -18487,7 +19432,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HCPR4",
@@ -18507,7 +19455,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HCPR5",
@@ -18527,7 +19478,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HCPR3",
@@ -18547,7 +19501,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HCPR16",
@@ -18567,7 +19524,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HCPR17",
@@ -18587,7 +19547,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HCPR13",
@@ -18607,7 +19570,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HCPR18",
@@ -18627,7 +19593,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HCPR14",
@@ -18647,7 +19616,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI30",
@@ -18667,7 +19639,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MA1",
@@ -18687,7 +19662,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MA2",
@@ -18707,7 +19685,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED3",
@@ -18727,7 +19708,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MICS1",
@@ -18747,7 +19731,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MICS2",
@@ -18767,7 +19754,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MICS3",
@@ -18787,7 +19777,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MEX1",
@@ -18807,7 +19800,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MEX2",
@@ -18827,7 +19823,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MEX3",
@@ -18847,7 +19846,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MBSAQIP1",
@@ -18867,7 +19869,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MBSAQIP2",
@@ -18887,7 +19892,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MBSAQIP3",
@@ -18907,7 +19915,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MBSAQIP4",
@@ -18927,7 +19938,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MBSAQIP6",
@@ -18947,7 +19961,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MBSAQIP7",
@@ -18967,7 +19984,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MBSAQIP8",
@@ -18987,7 +20007,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC2",
@@ -19007,7 +20030,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC3",
@@ -19027,7 +20053,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC4",
@@ -19047,7 +20076,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC5",
@@ -19067,7 +20099,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC8",
@@ -19087,7 +20122,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC9",
@@ -19107,7 +20145,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC10",
@@ -19127,7 +20168,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC6",
@@ -19147,7 +20191,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC11",
@@ -19167,7 +20214,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC1",
@@ -19187,7 +20237,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC7",
@@ -19207,7 +20260,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC12",
@@ -19227,7 +20283,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC13",
@@ -19247,7 +20306,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC14",
@@ -19267,7 +20329,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC15",
@@ -19287,7 +20352,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MUSIC1",
@@ -19307,7 +20375,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MUSIC6",
@@ -19327,7 +20398,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MUSIC5",
@@ -19347,7 +20421,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MUSIC3",
@@ -19367,7 +20444,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MUSIC2",
@@ -19387,7 +20467,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MUSIC9",
@@ -19407,7 +20490,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MUSIC10",
@@ -19427,7 +20513,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MUSIC11",
@@ -19447,7 +20536,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED5",
@@ -19467,7 +20559,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED9",
@@ -19487,7 +20582,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED7",
@@ -19507,7 +20605,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG12",
@@ -19527,7 +20628,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED4",
@@ -19547,7 +20651,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED16",
@@ -19567,7 +20674,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED13",
@@ -19587,7 +20697,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED14",
@@ -19607,7 +20720,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED12",
@@ -19627,7 +20743,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED15",
@@ -19647,7 +20766,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED11",
@@ -19667,7 +20789,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MNCM1",
@@ -19687,7 +20812,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MNCM2",
@@ -19707,7 +20835,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MNCM3",
@@ -19738,6 +20869,9 @@
         "name": "adult",
         "description": "The percentage of adult (18-50 years of age) patients who had a diagnosis of asthma and whose asthma was optimally controlled during the measurement period as defined by achieving BOTH of the following:\n•Asthma well-controlled as defined by the most recent asthma control tool result available during the measurement period\n•Patient not at elevated risk of exacerbation as defined by less than two emergency department visits and/or hospitalizations due to asthma in the last 12 months"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -19758,7 +20892,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MNCM5",
@@ -19778,7 +20915,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSN6",
@@ -19798,7 +20938,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSN11",
@@ -19818,7 +20961,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSN5",
@@ -19838,7 +20984,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSN10",
@@ -19858,7 +21007,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSN7",
@@ -19878,7 +21030,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSN12",
@@ -19898,7 +21053,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSN8",
@@ -19918,7 +21076,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSN3",
@@ -19938,7 +21099,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSN4",
@@ -19958,7 +21122,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSN9",
@@ -19978,7 +21145,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MHAN1",
@@ -19998,7 +21168,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MHAN2",
@@ -20018,7 +21191,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MHAN3",
@@ -20038,7 +21214,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC15",
@@ -20073,6 +21252,9 @@
         "name": "overall",
         "description": "Percentage of patients who received both a basic ADL and IADL assessment (overall rate)"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -20093,7 +21275,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC14",
@@ -20113,7 +21298,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC7",
@@ -20144,6 +21332,9 @@
         "name": "overall",
         "description": "Percentage of patients with offending medications whose use of offending medications was discontinued or justified."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -20164,7 +21355,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC5",
@@ -20184,7 +21378,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC13",
@@ -20204,7 +21401,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC11",
@@ -20224,7 +21424,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC4",
@@ -20244,7 +21447,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC16",
@@ -20264,7 +21470,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC9",
@@ -20284,7 +21493,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC6",
@@ -20304,7 +21516,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC10",
@@ -20324,7 +21539,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NOF6",
@@ -20344,7 +21562,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NOF7",
@@ -20364,7 +21585,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NOF13",
@@ -20384,7 +21608,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA6",
@@ -20404,7 +21631,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA7",
@@ -20424,7 +21654,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA9",
@@ -20444,7 +21677,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA11",
@@ -20464,7 +21700,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA12",
@@ -20484,7 +21723,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA14",
@@ -20504,7 +21746,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA15",
@@ -20524,7 +21769,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA16",
@@ -20544,7 +21792,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA17",
@@ -20564,7 +21815,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA18",
@@ -20584,7 +21838,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA19",
@@ -20604,7 +21861,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA20",
@@ -20624,7 +21884,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA22",
@@ -20644,7 +21907,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA3",
@@ -20675,6 +21941,9 @@
         "name": "overall",
         "description": "Patient population with improvement in functional status after Follow-up/Patient population with Follow-up."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -20706,6 +21975,9 @@
         "name": "overall",
         "description": "Patient population with improvement in quality of life status after Follow-up/Patient population with Follow-up."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -20737,6 +22009,9 @@
         "name": "overall",
         "description": "Patient population with improvement in satisfaction with care status after Follow-up/Patient population with Follow-up."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -20757,7 +22032,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPAGSC9",
@@ -20777,7 +22055,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPAGSC3",
@@ -20808,6 +22089,9 @@
         "name": "improvement",
         "description": "Patient population with improvement in functional status (at least 10% improvement) from the baseline."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -20828,7 +22112,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPAGSC8",
@@ -20848,7 +22135,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPAGSC4",
@@ -20879,6 +22169,9 @@
         "name": "improvement",
         "description": "Patient population with improvement in Quality of life status from the baseline"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -20910,6 +22203,9 @@
         "name": "improvement",
         "description": "Patient population with improvement in satisfaction with care status from the baseline"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -20941,6 +22237,9 @@
         "name": "improvement",
         "description": "Patient population with improvement in the pain status from the baseline"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -20961,7 +22260,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD7",
@@ -20981,7 +22283,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD6",
@@ -21001,7 +22306,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD4",
@@ -21021,7 +22329,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD5",
@@ -21041,7 +22352,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD22",
@@ -21061,7 +22375,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD3",
@@ -21081,7 +22398,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD19",
@@ -21101,7 +22421,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD12",
@@ -21121,7 +22444,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD20",
@@ -21141,7 +22467,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD2",
@@ -21161,7 +22490,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD11",
@@ -21181,7 +22513,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD8",
@@ -21201,7 +22536,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD9",
@@ -21221,7 +22559,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD21",
@@ -21241,7 +22582,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD1",
@@ -21261,7 +22605,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD10",
@@ -21281,7 +22628,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD14",
@@ -21301,7 +22651,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD17",
@@ -21321,7 +22674,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD16",
@@ -21341,7 +22697,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD15",
@@ -21361,7 +22720,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD13",
@@ -21381,7 +22743,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NNEPTN1",
@@ -21412,6 +22777,9 @@
         "name": "18",
         "description": "Percentage of patients age 18 years and older screened for substance use using an evidence based standardized tool within the measurement year."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -21432,7 +22800,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NNEPTN3",
@@ -21452,7 +22823,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NNEPTN4",
@@ -21472,7 +22846,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OEIS1",
@@ -21492,7 +22869,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OEIS2",
@@ -21512,7 +22892,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OEIS3",
@@ -21532,7 +22915,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OEIS4",
@@ -21552,7 +22938,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OEIS5",
@@ -21572,7 +22961,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OEIS6",
@@ -21592,7 +22984,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ONSQIR15",
@@ -21612,7 +23007,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ONSQIR16",
@@ -21632,7 +23030,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ONSQIR17",
@@ -21652,7 +23053,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ONSQIR6",
@@ -21672,7 +23076,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ONSQIR18",
@@ -21692,7 +23099,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ONSQIR19",
@@ -21712,7 +23122,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ONSQIR20",
@@ -21732,7 +23145,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "WCHQ32",
@@ -21752,7 +23168,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "WCHQ10",
@@ -21772,7 +23191,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "WCHQ9",
@@ -21792,7 +23214,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "WCHQ13",
@@ -21812,7 +23237,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "WCHQ15",
@@ -21832,7 +23260,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCPin1",
@@ -21852,7 +23283,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCPin2",
@@ -21872,7 +23306,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCPin3",
@@ -21892,7 +23329,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCPin4",
@@ -21912,7 +23352,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET8",
@@ -21932,7 +23375,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET32",
@@ -21952,7 +23398,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET13",
@@ -21972,7 +23421,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET14",
@@ -21992,7 +23444,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET31",
@@ -22012,7 +23467,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET33",
@@ -22032,7 +23490,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET27",
@@ -22052,7 +23513,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET28",
@@ -22072,7 +23536,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET29",
@@ -22092,7 +23559,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET30",
@@ -22112,7 +23582,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET24",
@@ -22132,7 +23605,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc1",
@@ -22152,7 +23628,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc2",
@@ -22172,7 +23651,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc3",
@@ -22192,7 +23674,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc4",
@@ -22212,7 +23697,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc5",
@@ -22232,7 +23720,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc6",
@@ -22252,7 +23743,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc33",
@@ -22272,7 +23766,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc34",
@@ -22292,7 +23789,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc35",
@@ -22312,7 +23812,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc53",
@@ -22332,7 +23835,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc54",
@@ -22352,7 +23858,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PP1",
@@ -22387,6 +23896,9 @@
         "name": "diuretics",
         "description": "Annual monitoring for patients on diuretics: At least one serum potassium and a serum creatinine therapeutic monitoring test in the measurement year."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -22407,7 +23919,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "QOPI5",
@@ -22427,7 +23942,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "QOPI11",
@@ -22447,7 +23965,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "QOPI15",
@@ -22467,7 +23988,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "QUANTUM41",
@@ -22487,7 +24011,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "QUANTUM31",
@@ -22507,7 +24034,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "QUANTUM37",
@@ -22527,7 +24057,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "QUANTUM42",
@@ -22547,7 +24080,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "QUANTUM51",
@@ -22567,7 +24103,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAO8",
@@ -22587,7 +24126,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAO9",
@@ -22607,7 +24149,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAO10",
@@ -22627,7 +24172,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAO11",
@@ -22647,7 +24195,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR11",
@@ -22667,7 +24218,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR12",
@@ -22687,7 +24241,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR13",
@@ -22707,7 +24264,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR14",
@@ -22727,7 +24287,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR15",
@@ -22747,7 +24310,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RCOIR1",
@@ -22767,7 +24333,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RCOIR2",
@@ -22787,7 +24356,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RCOIR3",
@@ -22807,7 +24379,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RCOIR4",
@@ -22827,7 +24402,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RCOIR5",
@@ -22847,7 +24425,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RCOIR6",
@@ -22867,7 +24448,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RCOIR7",
@@ -22887,7 +24471,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RCOIR8",
@@ -22907,7 +24494,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RCOIR9",
@@ -22927,7 +24517,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RCOIR10",
@@ -22947,7 +24540,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR1",
@@ -22967,7 +24563,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR2",
@@ -22987,7 +24586,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR4",
@@ -23007,7 +24609,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR5",
@@ -23027,7 +24632,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR9",
@@ -23047,7 +24655,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR16",
@@ -23067,7 +24678,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR17",
@@ -23087,7 +24701,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR18",
@@ -23107,7 +24724,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ICLOPS15",
@@ -23138,6 +24758,9 @@
         "name": "withexcess",
         "description": "the percentage of discharges with excess days where clinician provided the required feedback AND where excess days numbered less than 3, out of the total number of discharges with excess days."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -23169,6 +24792,9 @@
         "name": "withoutfollowup",
         "description": "the percentage of discharges without subsequent office visits within 7 days where clinician provided required feedback AND where re-admission within 30 days did not occur, out of the total number of all-cause discharges for patients aged 18 years and older."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -23204,6 +24830,9 @@
         "name": "overall",
         "description": "The difference between Performance Rate 1 and Performance Rate 2, divided by the total denominator.  Performance Rate 3 is the final performance rate for this measure."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -23239,6 +24868,9 @@
         "name": "overall",
         "description": "The difference between Performance Rate 1 and Performance Rate 2, divided by the total denominator.  Performance Rate 3 is the final performance rate for this measure."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -23259,7 +24891,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RHI4",
@@ -23294,6 +24929,9 @@
         "name": "overall",
         "description": "The difference between Performance Rate 1 and Performance Rate 2, divided by the total denominator.  Performance Rate 3 is the final performance rate for this measure."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -23314,7 +24952,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RHI6",
@@ -23334,7 +24975,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RHI7",
@@ -23354,7 +24998,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SCG1",
@@ -23374,7 +25021,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SCG2",
@@ -23394,7 +25044,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SCG3",
@@ -23414,7 +25067,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SCG4",
@@ -23434,7 +25090,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SCG05",
@@ -23454,7 +25113,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SDPAD1",
@@ -23474,7 +25136,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SDPAD2",
@@ -23494,7 +25159,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SDPAD3",
@@ -23514,7 +25182,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SDPAD4",
@@ -23534,7 +25205,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "STS1",
@@ -23554,7 +25228,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "STS3",
@@ -23574,7 +25251,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "STS5",
@@ -23594,7 +25274,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "STS7",
@@ -23614,7 +25297,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SMX1",
@@ -23634,7 +25320,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SMX2",
@@ -23654,7 +25343,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SMX3",
@@ -23674,7 +25366,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SMX4",
@@ -23694,7 +25389,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AJRR4",
@@ -23714,7 +25412,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AJRR2",
@@ -23734,7 +25435,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AJRR3",
@@ -23754,7 +25458,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AJRR1",
@@ -23774,7 +25481,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASBS10",
@@ -23794,7 +25504,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASBS1",
@@ -23814,7 +25527,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASBS7",
@@ -23834,7 +25550,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NIPM4",
@@ -23854,7 +25573,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NIPM5",
@@ -23874,7 +25596,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NIPM6",
@@ -23894,7 +25619,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NIPM8",
@@ -23914,7 +25642,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NIPM1",
@@ -23934,7 +25665,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NIPM9",
@@ -23954,7 +25688,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NIPM3",
@@ -23974,7 +25711,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NIPM2",
@@ -23994,7 +25734,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NIPM7",
@@ -24014,7 +25757,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CAP1",
@@ -24034,7 +25780,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CAP2",
@@ -24054,7 +25803,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CAP3",
@@ -24074,7 +25826,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CAP4",
@@ -24094,7 +25849,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CAP5",
@@ -24114,7 +25872,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CAP6",
@@ -24134,7 +25895,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SPINEIQ1",
@@ -24154,7 +25918,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SPINEIQ2",
@@ -24174,7 +25941,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SPINEIQ3",
@@ -24194,7 +25964,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OBERD22",
@@ -24214,7 +25987,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OBERD23",
@@ -24234,7 +26010,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OBERD24",
@@ -24254,7 +26033,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OBERD12",
@@ -24274,7 +26056,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OBERD25",
@@ -24294,7 +26079,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CDR5",
@@ -24314,7 +26102,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CDR9",
@@ -24334,7 +26125,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CDR8",
@@ -24354,7 +26148,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "USWR15",
@@ -24393,6 +26190,9 @@
         "name": "overall",
         "description": "The average of the three risk stratified buckets which will be the performance rate in the XML submitted."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -24413,7 +26213,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "USWR20",
@@ -24433,7 +26236,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "USWR22",
@@ -24453,7 +26259,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "USWR13",
@@ -24488,6 +26297,9 @@
         "name": "overall",
         "description": "Percentage of patients undergoing HBOT with vital signs taken and those with diabetes had a blood glucose check."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -24508,7 +26320,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CDR7",
@@ -24528,7 +26343,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CDR10",
@@ -24548,7 +26366,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CDR6",
@@ -24587,6 +26408,9 @@
         "name": "overall",
         "description": "The average of the three risk stratified buckets which will be the performance rate in the XML submitted."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -24607,7 +26431,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "WCQIC16",
@@ -24627,6 +26454,9 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   }
 ]

--- a/measures/measures-data.xml
+++ b/measures/measures-data.xml
@@ -10537,6 +10537,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAAAI5</measureId>
@@ -10556,6 +10557,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAAAI6</measureId>
@@ -10575,6 +10577,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAAAI8</measureId>
@@ -10594,6 +10597,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAAAI9</measureId>
@@ -10613,6 +10617,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAAAI11</measureId>
@@ -10632,6 +10637,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAAAI12</measureId>
@@ -10651,6 +10657,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAAAI17</measureId>
@@ -10670,6 +10677,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAAAI18</measureId>
@@ -10689,6 +10697,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAAAI19</measureId>
@@ -10727,6 +10736,7 @@ Rate 3: Total patients prescribed long-term control medication</description>
       <name>overall</name>
       <description>Total patients prescribed long-term control medication</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAD1</measureId>
@@ -10748,6 +10758,7 @@ Rate 3: Total patients prescribed long-term control medication</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAD2</measureId>
@@ -10769,6 +10780,7 @@ Rate 3: Total patients prescribed long-term control medication</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAD3</measureId>
@@ -10790,6 +10802,7 @@ Rate 3: Total patients prescribed long-term control medication</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAD4</measureId>
@@ -10811,6 +10824,7 @@ Rate 3: Total patients prescribed long-term control medication</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAD5</measureId>
@@ -10832,6 +10846,7 @@ Rate 3: Total patients prescribed long-term control medication</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ARCO11</measureId>
@@ -10853,6 +10868,7 @@ HOQR is a quality data-reporting program, implemented by CMS for outpatient hosp
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ARCO12</measureId>
@@ -10872,6 +10888,7 @@ HOQR is a quality data-reporting program, implemented by CMS for outpatient hosp
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ARCO13</measureId>
@@ -10912,6 +10929,7 @@ Rate 4: The percent of ischemic stroke patients with an LDL greater than or equa
       <name>LDL</name>
       <description>The percent of ischemic stroke patients with an LDL greater than or equal to 100 mg/dL, OR LDL not measured, OR who were on a lipid-lowering medication prior to hospital arrival who were prescribed statin medication at hospital discharge</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ARCO3</measureId>
@@ -10931,6 +10949,7 @@ Rate 4: The percent of ischemic stroke patients with an LDL greater than or equa
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NOF12</measureId>
@@ -10950,6 +10969,7 @@ Rate 4: The percent of ischemic stroke patients with an LDL greater than or equa
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ARCO7</measureId>
@@ -10969,6 +10989,7 @@ Rate 4: The percent of ischemic stroke patients with an LDL greater than or equa
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACR7</measureId>
@@ -10988,6 +11009,7 @@ Rate 4: The percent of ischemic stroke patients with an LDL greater than or equa
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ARCO14</measureId>
@@ -11007,6 +11029,7 @@ Rate 4: The percent of ischemic stroke patients with an LDL greater than or equa
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ARCO10</measureId>
@@ -11026,6 +11049,7 @@ Rate 4: The percent of ischemic stroke patients with an LDL greater than or equa
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACCCath1</measureId>
@@ -11047,6 +11071,7 @@ This measure evaluates the occurrence of stroke as an outcome of a percutaneous 
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACCCath2</measureId>
@@ -11068,6 +11093,7 @@ This measure evaluates the occurrence of the new need for dialysis as an outcome
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACCCath3</measureId>
@@ -11093,6 +11119,7 @@ This measure evaluates the occurrence of vascular site injury requiring treatmen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACCCath4</measureId>
@@ -11114,6 +11141,7 @@ This measure evaluates the occurrence of cardiac tamponade as an outcome of a pe
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACCCath5</measureId>
@@ -11135,6 +11163,7 @@ This measure reflects the processes of care and current guidelines associated wi
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACCCath6</measureId>
@@ -11154,6 +11183,7 @@ This measure reflects the processes of care and current guidelines associated wi
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACCCath8</measureId>
@@ -11175,6 +11205,7 @@ This metric evaluates the process of care associated with the multi-society guid
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACCCath9</measureId>
@@ -11194,6 +11225,7 @@ This metric evaluates the process of care associated with the multi-society guid
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACCCath13</measureId>
@@ -11213,6 +11245,7 @@ This metric evaluates the process of care associated with the multi-society guid
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAN4</measureId>
@@ -11232,6 +11265,7 @@ This metric evaluates the process of care associated with the multi-society guid
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAN9</measureId>
@@ -11251,6 +11285,7 @@ This metric evaluates the process of care associated with the multi-society guid
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAN10</measureId>
@@ -11270,6 +11305,7 @@ This metric evaluates the process of care associated with the multi-society guid
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAN1</measureId>
@@ -11291,6 +11327,7 @@ when seen for an initial evaluation for distal symmetric polyneuropathy.</descri
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAN2</measureId>
@@ -11312,6 +11349,7 @@ when seen for an initial evaluation for distal symmetric polyneuropathy.</descri
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAN5</measureId>
@@ -11332,6 +11370,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAN11</measureId>
@@ -11351,6 +11390,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAN8</measureId>
@@ -11371,6 +11411,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS1</measureId>
@@ -11390,6 +11431,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS2</measureId>
@@ -11409,6 +11451,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS3</measureId>
@@ -11428,6 +11471,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS4</measureId>
@@ -11447,6 +11491,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS5</measureId>
@@ -11466,6 +11511,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS6</measureId>
@@ -11485,6 +11531,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS7</measureId>
@@ -11504,6 +11551,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS8</measureId>
@@ -11523,6 +11571,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS9</measureId>
@@ -11542,6 +11591,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS10</measureId>
@@ -11561,6 +11611,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS11</measureId>
@@ -11580,6 +11631,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS13</measureId>
@@ -11599,6 +11651,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS16</measureId>
@@ -11618,6 +11671,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS17</measureId>
@@ -11637,6 +11691,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS18</measureId>
@@ -11656,6 +11711,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS19</measureId>
@@ -11675,6 +11731,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS20</measureId>
@@ -11694,6 +11751,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS21</measureId>
@@ -11713,6 +11771,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS22</measureId>
@@ -11732,6 +11791,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS23</measureId>
@@ -11751,6 +11811,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS24</measureId>
@@ -11770,6 +11831,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS25</measureId>
@@ -11789,6 +11851,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>IRIS26</measureId>
@@ -11808,6 +11871,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>Q415</measureId>
@@ -11827,6 +11891,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>Q416</measureId>
@@ -11847,6 +11912,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP21</measureId>
@@ -11867,6 +11933,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP22</measureId>
@@ -11886,6 +11953,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP24</measureId>
@@ -11905,6 +11973,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP25</measureId>
@@ -11924,6 +11993,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP26</measureId>
@@ -11943,6 +12013,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP27</measureId>
@@ -11962,6 +12033,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP28</measureId>
@@ -11981,6 +12053,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP29</measureId>
@@ -12000,6 +12073,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP30</measureId>
@@ -12019,6 +12093,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP31</measureId>
@@ -12038,6 +12113,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP32</measureId>
@@ -12066,6 +12142,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP33</measureId>
@@ -12094,6 +12171,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP35</measureId>
@@ -12122,6 +12200,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP36</measureId>
@@ -12150,6 +12229,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP37</measureId>
@@ -12178,6 +12258,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP38</measureId>
@@ -12206,6 +12287,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP39</measureId>
@@ -12234,6 +12316,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP40</measureId>
@@ -12261,6 +12344,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP41</measureId>
@@ -12288,6 +12372,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP43</measureId>
@@ -12315,6 +12400,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP44</measureId>
@@ -12342,6 +12428,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP45</measureId>
@@ -12369,6 +12456,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP46</measureId>
@@ -12396,6 +12484,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP47</measureId>
@@ -12423,6 +12512,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP48</measureId>
@@ -12442,6 +12532,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACEP49</measureId>
@@ -12461,6 +12552,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACPGR1</measureId>
@@ -12480,6 +12572,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>PPRNET20</measureId>
@@ -12499,6 +12592,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACPGR2</measureId>
@@ -12518,6 +12612,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACPGR3</measureId>
@@ -12537,6 +12632,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>Q408</measureId>
@@ -12556,6 +12652,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>Q414</measureId>
@@ -12575,6 +12672,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad26</measureId>
@@ -12596,6 +12694,7 @@ Inverse measure</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad2</measureId>
@@ -12615,6 +12714,7 @@ Inverse measure</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad1</measureId>
@@ -12634,6 +12734,7 @@ Inverse measure</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad23</measureId>
@@ -12654,6 +12755,7 @@ as positive (Lung-RADS Category 3 or 4).</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad21</measureId>
@@ -12676,6 +12778,7 @@ or 4) and result in a tissue diagnosis of cancer within
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad22</measureId>
@@ -12698,6 +12801,7 @@ months.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad31</measureId>
@@ -12717,6 +12821,7 @@ months.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad32</measureId>
@@ -12736,6 +12841,7 @@ months.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad33</measureId>
@@ -12755,6 +12861,7 @@ months.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad30</measureId>
@@ -12776,6 +12883,7 @@ Inverse measure</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad28</measureId>
@@ -12797,6 +12905,7 @@ Inverse measure</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad29</measureId>
@@ -12820,6 +12929,7 @@ Inverse measure</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad18</measureId>
@@ -12840,6 +12950,7 @@ Inverse measure</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad25</measureId>
@@ -12861,6 +12972,7 @@ Continuous measure scoring</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad17</measureId>
@@ -12881,6 +12993,7 @@ Continuous measure scoring</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad19</measureId>
@@ -12901,6 +13014,7 @@ Continuous measure scoring</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad15</measureId>
@@ -12922,6 +13036,7 @@ Continuous measure scoring</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad16</measureId>
@@ -12942,6 +13057,7 @@ Continuous measure scoring</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad5</measureId>
@@ -12962,6 +13078,7 @@ Continuous measure scoring</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad3</measureId>
@@ -12984,6 +13101,7 @@ diagnosis of cancer within 12 months (expressed per
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad8</measureId>
@@ -13003,6 +13121,7 @@ diagnosis of cancer within 12 months (expressed per
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad7</measureId>
@@ -13023,6 +13142,7 @@ screening mammography that are node negative</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad6</measureId>
@@ -13045,6 +13165,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACRad27</measureId>
@@ -13064,6 +13185,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACS15</measureId>
@@ -13086,6 +13208,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACS16</measureId>
@@ -13105,6 +13228,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACS17</measureId>
@@ -13124,6 +13248,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACS18</measureId>
@@ -13143,6 +13268,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACS19</measureId>
@@ -13164,6 +13290,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACS20</measureId>
@@ -13187,6 +13314,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACS21</measureId>
@@ -13208,6 +13336,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACS22</measureId>
@@ -13227,6 +13356,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACS23</measureId>
@@ -13246,6 +13376,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>Pinc51</measureId>
@@ -13265,6 +13396,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>APMA1</measureId>
@@ -13284,6 +13416,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CDR2</measureId>
@@ -13303,6 +13436,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASNC1</measureId>
@@ -13322,6 +13456,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASNC2</measureId>
@@ -13341,6 +13476,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASNC3</measureId>
@@ -13360,6 +13496,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASNC4</measureId>
@@ -13379,6 +13516,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASNC13</measureId>
@@ -13399,6 +13537,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASNC14</measureId>
@@ -13419,6 +13558,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASNC17</measureId>
@@ -13438,6 +13578,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASNC18</measureId>
@@ -13458,6 +13599,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASNC19</measureId>
@@ -13477,6 +13619,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASNC20</measureId>
@@ -13497,6 +13640,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASNC21</measureId>
@@ -13516,6 +13660,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASNC22</measureId>
@@ -13535,6 +13680,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASNC23</measureId>
@@ -13554,6 +13700,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASNC24</measureId>
@@ -13573,6 +13720,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASNC25</measureId>
@@ -13592,6 +13740,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CDR1</measureId>
@@ -13611,6 +13760,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASPS5</measureId>
@@ -13630,6 +13780,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASPS6</measureId>
@@ -13649,6 +13800,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AUGS1</measureId>
@@ -13668,6 +13820,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AUGS2</measureId>
@@ -13687,6 +13840,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AUGS3</measureId>
@@ -13706,6 +13860,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AUGS4</measureId>
@@ -13725,6 +13880,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AUGS5</measureId>
@@ -13744,6 +13900,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AUGS6</measureId>
@@ -13763,6 +13920,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AUGS7</measureId>
@@ -13782,6 +13940,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AUGS8</measureId>
@@ -13801,6 +13960,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AUGS9</measureId>
@@ -13820,6 +13980,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQUA5</measureId>
@@ -13839,6 +14000,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQUA6</measureId>
@@ -13858,6 +14020,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQUA12</measureId>
@@ -13877,6 +14040,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQUA3</measureId>
@@ -13896,6 +14060,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQUA8</measureId>
@@ -13915,6 +14080,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQUA4</measureId>
@@ -13934,6 +14100,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQUA11</measureId>
@@ -13953,6 +14120,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQUA10</measureId>
@@ -13972,6 +14140,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MUSIC4</measureId>
@@ -13991,6 +14160,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQUA14</measureId>
@@ -14010,6 +14180,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQUA13</measureId>
@@ -14029,6 +14200,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQUA15</measureId>
@@ -14048,6 +14220,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQUA16</measureId>
@@ -14067,6 +14240,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQUA17</measureId>
@@ -14086,6 +14260,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQUA18</measureId>
@@ -14105,6 +14280,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AHSQC1</measureId>
@@ -14124,6 +14300,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AHSQC2</measureId>
@@ -14143,6 +14320,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AHSQC6</measureId>
@@ -14180,6 +14358,7 @@ Rate 3: Abdominal Wall Reconstruction Surgical Site Occurrence Requiring Procedu
       <name>hernia&gt;10cm</name>
       <description>Abdominal Wall Reconstruction Surgical Site Occurrence Requiring Procedural Intervention within the 30 Day Postoperative Period-Hernia width of &gt;10cm</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AHSQC7</measureId>
@@ -14199,6 +14378,7 @@ Rate 3: Abdominal Wall Reconstruction Surgical Site Occurrence Requiring Procedu
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AHSQC8</measureId>
@@ -14218,6 +14398,7 @@ Rate 3: Abdominal Wall Reconstruction Surgical Site Occurrence Requiring Procedu
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AHSQC9</measureId>
@@ -14249,6 +14430,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
       <name>email</name>
       <description>Ventral Hernia Repair: Pain and Functional Status Assessment-Email engagement completion rate</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ABG28</measureId>
@@ -14268,6 +14450,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ABG29</measureId>
@@ -14287,6 +14470,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ABG30</measureId>
@@ -14306,6 +14490,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ABG31</measureId>
@@ -14325,6 +14510,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ABG32</measureId>
@@ -14344,6 +14530,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ABG33</measureId>
@@ -14363,6 +14550,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ABG34</measureId>
@@ -14382,6 +14570,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ABG1</measureId>
@@ -14401,6 +14590,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQI35</measureId>
@@ -14420,6 +14610,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ABG4</measureId>
@@ -14439,6 +14630,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ABG5</measureId>
@@ -14458,6 +14650,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ABG7</measureId>
@@ -14477,6 +14670,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQI48</measureId>
@@ -14496,6 +14690,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ABG14</measureId>
@@ -14515,6 +14710,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ABG15</measureId>
@@ -14534,6 +14730,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ABG16</measureId>
@@ -14553,6 +14750,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ABG21</measureId>
@@ -14572,6 +14770,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQI49</measureId>
@@ -14618,6 +14817,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
       <name>overall</name>
       <description>Composite Performance Score: Percentage of denominator-eligible patients for whom a cumulative score of 100% of blood conservation strategies was met</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQI50</measureId>
@@ -14637,6 +14837,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQI51</measureId>
@@ -14656,6 +14857,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQI42</measureId>
@@ -14675,6 +14877,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQI18</measureId>
@@ -14694,6 +14897,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQI41</measureId>
@@ -14713,6 +14917,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQI28</measureId>
@@ -14732,6 +14937,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQI34</measureId>
@@ -14751,6 +14957,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQI31</measureId>
@@ -14770,6 +14977,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQI29</measureId>
@@ -14789,6 +14997,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQI32</measureId>
@@ -14808,6 +15017,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQI37</measureId>
@@ -14827,6 +15037,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQI52</measureId>
@@ -14846,6 +15057,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASPIRE4</measureId>
@@ -14865,6 +15077,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASPIRE3</measureId>
@@ -14884,6 +15097,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASPIRE19</measureId>
@@ -14903,6 +15117,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASPIRE6</measureId>
@@ -14922,6 +15137,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASPIRE16</measureId>
@@ -14941,6 +15157,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASPIRE22</measureId>
@@ -14960,6 +15177,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASPIRE18</measureId>
@@ -14979,6 +15197,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASPIRE8</measureId>
@@ -14998,6 +15217,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASPIRE2</measureId>
@@ -15017,6 +15237,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASPIRE13</measureId>
@@ -15036,6 +15257,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>BNS1</measureId>
@@ -15055,6 +15277,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CCOME1</measureId>
@@ -15074,6 +15297,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CCOME2</measureId>
@@ -15093,6 +15317,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CCOME3</measureId>
@@ -15112,6 +15337,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CCOME4</measureId>
@@ -15131,6 +15357,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CCOME5</measureId>
@@ -15150,6 +15377,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CODE6</measureId>
@@ -15169,6 +15397,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CODE7</measureId>
@@ -15188,6 +15417,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CODE1</measureId>
@@ -15207,6 +15437,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CODE3</measureId>
@@ -15226,6 +15457,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CODE8</measureId>
@@ -15245,6 +15477,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CODE9</measureId>
@@ -15264,6 +15497,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CODE5</measureId>
@@ -15283,6 +15517,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CODE10</measureId>
@@ -15302,6 +15537,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CODE11</measureId>
@@ -15321,6 +15557,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CODE2</measureId>
@@ -15340,6 +15577,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CODE12</measureId>
@@ -15359,6 +15597,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CESQIP6</measureId>
@@ -15378,6 +15617,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CESQIP4</measureId>
@@ -15397,6 +15637,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CESQIP1</measureId>
@@ -15416,6 +15657,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CESQIP3</measureId>
@@ -15435,6 +15677,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CESQIP5</measureId>
@@ -15462,6 +15705,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CESQIP2</measureId>
@@ -15502,6 +15746,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CUHSM3</measureId>
@@ -15524,6 +15769,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CUHSM4</measureId>
@@ -15543,6 +15789,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CUHSM6</measureId>
@@ -15562,6 +15809,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CUHSM8</measureId>
@@ -15581,6 +15829,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>EPREOP4</measureId>
@@ -15600,6 +15849,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>EPREOP9</measureId>
@@ -15619,6 +15869,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>EPREOP14</measureId>
@@ -15638,6 +15889,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>EPREOP26</measureId>
@@ -15657,6 +15909,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>EPREOP27</measureId>
@@ -15676,6 +15929,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>FORCE4</measureId>
@@ -15695,6 +15949,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>FORCE5</measureId>
@@ -15714,6 +15969,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>FORCE9</measureId>
@@ -15733,6 +15989,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>FORCE10</measureId>
@@ -15752,6 +16009,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>FORCE17</measureId>
@@ -15771,6 +16029,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>FORCE18</measureId>
@@ -15790,6 +16049,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>FORCE19</measureId>
@@ -15809,6 +16069,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>GIQIC15</measureId>
@@ -15828,6 +16089,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>GIQIC12</measureId>
@@ -15847,6 +16109,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>GIQIC10</measureId>
@@ -15866,6 +16129,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NHCR4</measureId>
@@ -15885,6 +16149,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>HF1</measureId>
@@ -15904,6 +16169,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>HF2</measureId>
@@ -15923,6 +16189,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>HF3</measureId>
@@ -15957,6 +16224,7 @@ Unadjusted measure: Average Shoulder Measure Change Score</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>HF4</measureId>
@@ -15976,6 +16244,7 @@ Unadjusted measure: Average Shoulder Measure Change Score</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>HF5</measureId>
@@ -15995,6 +16264,7 @@ Unadjusted measure: Average Shoulder Measure Change Score</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>HF6</measureId>
@@ -16021,6 +16291,7 @@ Patient’s Knee Measure Change Score: A patient’s change score is calculated 
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>HF7</measureId>
@@ -16040,6 +16311,7 @@ Patient’s Knee Measure Change Score: A patient’s change score is calculated 
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>HAdv1</measureId>
@@ -16059,6 +16331,7 @@ Patient’s Knee Measure Change Score: A patient’s change score is calculated 
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>HAdv2</measureId>
@@ -16078,6 +16351,7 @@ Patient’s Knee Measure Change Score: A patient’s change score is calculated 
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>M2S16</measureId>
@@ -16099,6 +16373,7 @@ Patient’s Knee Measure Change Score: A patient’s change score is calculated 
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>M2S17</measureId>
@@ -16120,6 +16395,7 @@ Patient’s Knee Measure Change Score: A patient’s change score is calculated 
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>M2S18</measureId>
@@ -16140,6 +16416,7 @@ Patient’s Knee Measure Change Score: A patient’s change score is calculated 
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>M2S19</measureId>
@@ -16161,6 +16438,7 @@ Patient’s Knee Measure Change Score: A patient’s change score is calculated 
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>M2S1</measureId>
@@ -16181,6 +16459,7 @@ Supra-Inguinal Bypass, Peripheral Vascular Intervention, Carotid Artery Stent, C
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>M2S2</measureId>
@@ -16201,6 +16480,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>M2S3</measureId>
@@ -16220,6 +16500,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>M2S4</measureId>
@@ -16239,6 +16520,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>M2S5</measureId>
@@ -16258,6 +16540,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>M2S6</measureId>
@@ -16277,6 +16560,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>M2S7</measureId>
@@ -16296,6 +16580,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>M2S8</measureId>
@@ -16315,6 +16600,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>M2S9</measureId>
@@ -16334,6 +16620,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>M2S10</measureId>
@@ -16353,6 +16640,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>M2S11</measureId>
@@ -16372,6 +16660,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>M2S12</measureId>
@@ -16391,6 +16680,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>M2S13</measureId>
@@ -16410,6 +16700,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>BIVARUS27</measureId>
@@ -16436,6 +16727,7 @@ Note: Limiting the composite measure score to the highest response category prov
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>BIVARUS28</measureId>
@@ -16466,6 +16758,7 @@ Bivarus 26: How Likely Are You to Recommend This Physician To Your Family And Fr
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>BIVARUS32</measureId>
@@ -16494,6 +16787,7 @@ Bivarus 26: How Likely Are You to Recommend This Physician To Your Family And Fr
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>BIVARUS30</measureId>
@@ -16521,6 +16815,7 @@ Bivarus 26: How Likely Are You to Recommend This Physician To Your Family And Fr
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>BIVARUS31</measureId>
@@ -16548,6 +16843,7 @@ Bivarus 26: How Likely Are You to Recommend This Physician To Your Family And Fr
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MOA1</measureId>
@@ -16586,6 +16882,7 @@ Rate 2: Percentage of patients receiving manipulative medicine with a QVAS score
       <name>neck</name>
       <description>Percentage of patients receiving manipulative medicine with a QVAS score and treatment adjustment/maintenance for neck pain.</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MOA 2</measureId>
@@ -16607,6 +16904,7 @@ Rate 2: Percentage of patients receiving manipulative medicine with a QVAS score
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MOA 7</measureId>
@@ -16631,6 +16929,7 @@ Measure explanation: Chronic Pain medication prescribed (prescribed for greater 
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MOA 13</measureId>
@@ -16652,6 +16951,7 @@ Measure explanation: Controlled substance agreement (CSA) or opiate agreement (O
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MOA 14</measureId>
@@ -16673,6 +16973,7 @@ Measure explanation: Controlled substance agreement (CSA) or opiate agreement (O
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MOA 15</measureId>
@@ -16694,6 +16995,7 @@ Measure explanation: Pain conditions that can be treated definitively to avoid o
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MOA 12</measureId>
@@ -16717,6 +17019,7 @@ Measure explanation: Spinal stenosis typically is conservatively managed until s
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MeHC1</measureId>
@@ -16736,6 +17039,7 @@ Measure explanation: Spinal stenosis typically is conservatively managed until s
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ECPR39</measureId>
@@ -16755,6 +17059,7 @@ Measure explanation: Spinal stenosis typically is conservatively managed until s
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ECPR43</measureId>
@@ -16785,6 +17090,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
       <name>urgentcare</name>
       <description>In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with a Diagnosis of Chest Pain Where the Provider Ordered Coagulation Studies (PT, PTT, or INR)</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ECPR2</measureId>
@@ -16807,6 +17113,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ECPR44</measureId>
@@ -16829,6 +17136,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ECPR40</measureId>
@@ -16848,6 +17156,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ECPR6</measureId>
@@ -16867,6 +17176,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ECPR5</measureId>
@@ -16886,6 +17196,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ECPR42</measureId>
@@ -16905,6 +17216,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ECPR41</measureId>
@@ -16924,6 +17236,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ECPR11</measureId>
@@ -16946,6 +17259,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ECPR38</measureId>
@@ -16968,6 +17282,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>HCPR19</measureId>
@@ -16991,6 +17306,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>HCPR4</measureId>
@@ -17010,6 +17326,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>HCPR5</measureId>
@@ -17029,6 +17346,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>HCPR3</measureId>
@@ -17048,6 +17366,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>HCPR16</measureId>
@@ -17067,6 +17386,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>HCPR17</measureId>
@@ -17086,6 +17406,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>HCPR13</measureId>
@@ -17105,6 +17426,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>HCPR18</measureId>
@@ -17124,6 +17446,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>HCPR14</measureId>
@@ -17143,6 +17466,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AQI30</measureId>
@@ -17162,6 +17486,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MA1</measureId>
@@ -17181,6 +17506,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MA2</measureId>
@@ -17200,6 +17526,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MIRAMED3</measureId>
@@ -17220,6 +17547,7 @@ procedure.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MICS1</measureId>
@@ -17245,6 +17573,7 @@ Rationale: Understanding a patient’s mental and general physical improvement a
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MICS2</measureId>
@@ -17270,6 +17599,7 @@ Rationale: Understanding the change in a patient’s pain levels from before to 
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MICS3</measureId>
@@ -17295,6 +17625,7 @@ Rationale: Understanding the change in a patient’s function levels from before
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MEX1</measureId>
@@ -17322,6 +17653,7 @@ Rationale: Understanding the change in a patient’s function levels from before
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MEX2</measureId>
@@ -17349,6 +17681,7 @@ INSTRUCTIONS:
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MEX3</measureId>
@@ -17375,6 +17708,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MBSAQIP1</measureId>
@@ -17396,6 +17730,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MBSAQIP2</measureId>
@@ -17415,6 +17750,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MBSAQIP3</measureId>
@@ -17434,6 +17770,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MBSAQIP4</measureId>
@@ -17453,6 +17790,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MBSAQIP6</measureId>
@@ -17472,6 +17810,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MBSAQIP7</measureId>
@@ -17491,6 +17830,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MBSAQIP8</measureId>
@@ -17510,6 +17850,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSSIC2</measureId>
@@ -17529,6 +17870,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSSIC3</measureId>
@@ -17548,6 +17890,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSSIC4</measureId>
@@ -17567,6 +17910,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSSIC5</measureId>
@@ -17586,6 +17930,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSSIC8</measureId>
@@ -17607,6 +17952,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSSIC9</measureId>
@@ -17628,6 +17974,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSSIC10</measureId>
@@ -17649,6 +17996,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSSIC6</measureId>
@@ -17668,6 +18016,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSSIC11</measureId>
@@ -17687,6 +18036,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSSIC1</measureId>
@@ -17706,6 +18056,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSSIC7</measureId>
@@ -17725,6 +18076,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSSIC12</measureId>
@@ -17745,6 +18097,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSSIC13</measureId>
@@ -17766,6 +18119,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSSIC14</measureId>
@@ -17787,6 +18141,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSSIC15</measureId>
@@ -17806,6 +18161,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MUSIC1</measureId>
@@ -17825,6 +18181,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MUSIC6</measureId>
@@ -17844,6 +18201,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MUSIC5</measureId>
@@ -17863,6 +18221,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MUSIC3</measureId>
@@ -17882,6 +18241,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MUSIC2</measureId>
@@ -17901,6 +18261,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MUSIC9</measureId>
@@ -17920,6 +18281,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MUSIC10</measureId>
@@ -17939,6 +18301,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MUSIC11</measureId>
@@ -17958,6 +18321,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MIRAMED5</measureId>
@@ -17977,6 +18341,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MIRAMED9</measureId>
@@ -17996,6 +18361,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MIRAMED7</measureId>
@@ -18015,6 +18381,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ABG12</measureId>
@@ -18034,6 +18401,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MIRAMED4</measureId>
@@ -18053,6 +18421,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MIRAMED16</measureId>
@@ -18072,6 +18441,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MIRAMED13</measureId>
@@ -18091,6 +18461,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MIRAMED14</measureId>
@@ -18110,6 +18481,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MIRAMED12</measureId>
@@ -18129,6 +18501,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MIRAMED15</measureId>
@@ -18149,6 +18522,7 @@ meeting established criteria, notified of need for follow-up from the provider.<
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MIRAMED11</measureId>
@@ -18168,6 +18542,7 @@ meeting established criteria, notified of need for follow-up from the provider.<
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MNCM1</measureId>
@@ -18189,6 +18564,7 @@ meeting established criteria, notified of need for follow-up from the provider.<
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MNCM2</measureId>
@@ -18212,6 +18588,7 @@ meeting established criteria, notified of need for follow-up from the provider.<
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MNCM3</measureId>
@@ -18250,6 +18627,7 @@ Rate 2: The percentage of adult (18-50 years of age) patients who had a diagnosi
 •Asthma well-controlled as defined by the most recent asthma control tool result available during the measurement period
 •Patient not at elevated risk of exacerbation as defined by less than two emergency department visits and/or hospitalizations due to asthma in the last 12 months</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MNCM4</measureId>
@@ -18270,6 +18648,7 @@ Rate 2: The percentage of adult (18-50 years of age) patients who had a diagnosi
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MNCM5</measureId>
@@ -18291,6 +18670,7 @@ On daily aspirin or anti-platelets, unless allowed contraindications or exceptio
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSN6</measureId>
@@ -18310,6 +18690,7 @@ On daily aspirin or anti-platelets, unless allowed contraindications or exceptio
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSN11</measureId>
@@ -18329,6 +18710,7 @@ On daily aspirin or anti-platelets, unless allowed contraindications or exceptio
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSN5</measureId>
@@ -18348,6 +18730,7 @@ On daily aspirin or anti-platelets, unless allowed contraindications or exceptio
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSN10</measureId>
@@ -18367,6 +18750,7 @@ On daily aspirin or anti-platelets, unless allowed contraindications or exceptio
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSN7</measureId>
@@ -18386,6 +18770,7 @@ On daily aspirin or anti-platelets, unless allowed contraindications or exceptio
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSN12</measureId>
@@ -18405,6 +18790,7 @@ On daily aspirin or anti-platelets, unless allowed contraindications or exceptio
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSN8</measureId>
@@ -18425,6 +18811,7 @@ On daily aspirin or anti-platelets, unless allowed contraindications or exceptio
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSN3</measureId>
@@ -18445,6 +18832,7 @@ On daily aspirin or anti-platelets, unless allowed contraindications or exceptio
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSN4</measureId>
@@ -18464,6 +18852,7 @@ On daily aspirin or anti-platelets, unless allowed contraindications or exceptio
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MSN9</measureId>
@@ -18483,6 +18872,7 @@ On daily aspirin or anti-platelets, unless allowed contraindications or exceptio
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MHAN1</measureId>
@@ -18504,6 +18894,7 @@ and transfers from other institutions.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MHAN2</measureId>
@@ -18523,6 +18914,7 @@ and transfers from other institutions.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>MHAN3</measureId>
@@ -18545,6 +18937,7 @@ and transfers from other institutions.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NHBPC15</measureId>
@@ -18583,6 +18976,7 @@ Rate 3: Percentage of patients who received both a basic ADL and IADL assessment
       <name>overall</name>
       <description>Percentage of patients who received both a basic ADL and IADL assessment (overall rate)</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NHBPC2</measureId>
@@ -18602,6 +18996,7 @@ Rate 3: Percentage of patients who received both a basic ADL and IADL assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NHBPC14</measureId>
@@ -18621,6 +19016,7 @@ Rate 3: Percentage of patients who received both a basic ADL and IADL assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NHBPC7</measureId>
@@ -18652,6 +19048,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
       <name>overall</name>
       <description>Percentage of patients with offending medications whose use of offending medications was discontinued or justified.</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NHBPC3</measureId>
@@ -18671,6 +19068,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NHBPC5</measureId>
@@ -18690,6 +19088,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NHBPC13</measureId>
@@ -18709,6 +19108,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NHBPC11</measureId>
@@ -18728,6 +19128,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NHBPC4</measureId>
@@ -18747,6 +19148,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NHBPC16</measureId>
@@ -18766,6 +19168,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NHBPC9</measureId>
@@ -18785,6 +19188,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NHBPC6</measureId>
@@ -18804,6 +19208,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NHBPC10</measureId>
@@ -18823,6 +19228,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NOF6</measureId>
@@ -18842,6 +19248,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NOF7</measureId>
@@ -18861,6 +19268,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NOF13</measureId>
@@ -18880,6 +19288,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPA6</measureId>
@@ -18899,6 +19308,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPA7</measureId>
@@ -18918,6 +19328,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPA9</measureId>
@@ -18937,6 +19348,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPA11</measureId>
@@ -18956,6 +19368,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPA12</measureId>
@@ -18975,6 +19388,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPA14</measureId>
@@ -18994,6 +19408,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPA15</measureId>
@@ -19013,6 +19428,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPA16</measureId>
@@ -19032,6 +19448,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPA17</measureId>
@@ -19051,6 +19468,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPA18</measureId>
@@ -19070,6 +19488,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPA19</measureId>
@@ -19089,6 +19508,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPA20</measureId>
@@ -19108,6 +19528,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPA22</measureId>
@@ -19127,6 +19548,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPA3</measureId>
@@ -19157,6 +19579,7 @@ Rate 2: Patient population with improvement in functional status after Follow-up
       <name>overall</name>
       <description>Patient population with improvement in functional status after Follow-up/Patient population with Follow-up.</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPA4</measureId>
@@ -19187,6 +19610,7 @@ Rate 2: Patient population with improvement in quality of life status after Foll
       <name>overall</name>
       <description>Patient population with improvement in quality of life status after Follow-up/Patient population with Follow-up.</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPA5</measureId>
@@ -19217,6 +19641,7 @@ Rate 2: Patient population with improvement in satisfaction with care status aft
       <name>overall</name>
       <description>Patient population with improvement in satisfaction with care status after Follow-up/Patient population with Follow-up.</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPAGSC6</measureId>
@@ -19236,6 +19661,7 @@ Rate 2: Patient population with improvement in satisfaction with care status aft
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPAGSC9</measureId>
@@ -19255,6 +19681,7 @@ Rate 2: Patient population with improvement in satisfaction with care status aft
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPAGSC3</measureId>
@@ -19285,6 +19712,7 @@ Rate 2: Patient population with improvement in functional status (at least 10% i
       <name>improvement</name>
       <description>Patient population with improvement in functional status (at least 10% improvement) from the baseline.</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPAGSC7</measureId>
@@ -19308,6 +19736,7 @@ Overall Rate = Rate 1</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPAGSC8</measureId>
@@ -19327,6 +19756,7 @@ Overall Rate = Rate 1</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPAGSC4</measureId>
@@ -19357,6 +19787,7 @@ Rate 2: Patient population with improvement in Quality of life status from the b
       <name>improvement</name>
       <description>Patient population with improvement in Quality of life status from the baseline</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPAGSC5</measureId>
@@ -19387,6 +19818,7 @@ Rate 2: Patient population with improvement in satisfaction with care status fro
       <name>improvement</name>
       <description>Patient population with improvement in satisfaction with care status from the baseline</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NPAGSC10</measureId>
@@ -19417,6 +19849,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
       <name>improvement</name>
       <description>Patient population with improvement in the pain status from the baseline</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NHCR5</measureId>
@@ -19436,6 +19869,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD7</measureId>
@@ -19455,6 +19889,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD6</measureId>
@@ -19474,6 +19909,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD4</measureId>
@@ -19493,6 +19929,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD5</measureId>
@@ -19512,6 +19949,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD22</measureId>
@@ -19531,6 +19969,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD3</measureId>
@@ -19550,6 +19989,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD19</measureId>
@@ -19569,6 +20009,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD12</measureId>
@@ -19588,6 +20029,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD20</measureId>
@@ -19607,6 +20049,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD2</measureId>
@@ -19626,6 +20069,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD11</measureId>
@@ -19645,6 +20089,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD8</measureId>
@@ -19664,6 +20109,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD9</measureId>
@@ -19683,6 +20129,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD21</measureId>
@@ -19702,6 +20149,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD1</measureId>
@@ -19721,6 +20169,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD10</measureId>
@@ -19740,6 +20189,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD14</measureId>
@@ -19759,6 +20209,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD17</measureId>
@@ -19778,6 +20229,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD16</measureId>
@@ -19797,6 +20249,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD15</measureId>
@@ -19816,6 +20269,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NJIISMD13</measureId>
@@ -19835,6 +20289,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NNEPTN1</measureId>
@@ -19865,6 +20320,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
       <name>18</name>
       <description>Percentage of patients age 18 years and older screened for substance use using an evidence based standardized tool within the measurement year.</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NNEPTN2</measureId>
@@ -19884,6 +20340,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NNEPTN3</measureId>
@@ -19913,6 +20370,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NNEPTN4</measureId>
@@ -19937,6 +20395,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>OEIS1</measureId>
@@ -19956,6 +20415,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>OEIS2</measureId>
@@ -19975,6 +20435,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>OEIS3</measureId>
@@ -19994,6 +20455,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>OEIS4</measureId>
@@ -20013,6 +20475,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>OEIS5</measureId>
@@ -20032,6 +20495,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>OEIS6</measureId>
@@ -20051,6 +20515,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ONSQIR15</measureId>
@@ -20070,6 +20535,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ONSQIR16</measureId>
@@ -20089,6 +20555,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ONSQIR17</measureId>
@@ -20108,6 +20575,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ONSQIR6</measureId>
@@ -20127,6 +20595,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ONSQIR18</measureId>
@@ -20146,6 +20615,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ONSQIR19</measureId>
@@ -20165,6 +20635,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ONSQIR20</measureId>
@@ -20184,6 +20655,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>WCHQ32</measureId>
@@ -20205,6 +20677,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>WCHQ10</measureId>
@@ -20225,6 +20698,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>WCHQ9</measureId>
@@ -20245,6 +20719,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>WCHQ13</measureId>
@@ -20267,6 +20742,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>WCHQ15</measureId>
@@ -20286,6 +20762,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACCPin1</measureId>
@@ -20305,6 +20782,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACCPin2</measureId>
@@ -20325,6 +20803,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACCPin3</measureId>
@@ -20344,6 +20823,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ACCPin4</measureId>
@@ -20363,6 +20843,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>PPRNET8</measureId>
@@ -20382,6 +20863,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>PPRNET32</measureId>
@@ -20401,6 +20883,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>PPRNET13</measureId>
@@ -20420,6 +20903,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>PPRNET14</measureId>
@@ -20439,6 +20923,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>PPRNET31</measureId>
@@ -20458,6 +20943,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>PPRNET33</measureId>
@@ -20477,6 +20963,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>PPRNET27</measureId>
@@ -20496,6 +20983,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>PPRNET28</measureId>
@@ -20515,6 +21003,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>PPRNET29</measureId>
@@ -20534,6 +21023,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>PPRNET30</measureId>
@@ -20553,6 +21043,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>PPRNET24</measureId>
@@ -20572,6 +21063,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>Pinc1</measureId>
@@ -20591,6 +21083,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>Pinc2</measureId>
@@ -20610,6 +21103,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>Pinc3</measureId>
@@ -20629,6 +21123,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>Pinc4</measureId>
@@ -20648,6 +21143,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>Pinc5</measureId>
@@ -20667,6 +21163,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>Pinc6</measureId>
@@ -20686,6 +21183,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>Pinc33</measureId>
@@ -20705,6 +21203,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>Pinc34</measureId>
@@ -20724,6 +21223,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>Pinc35</measureId>
@@ -20743,6 +21243,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>Pinc53</measureId>
@@ -20762,6 +21263,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>Pinc54</measureId>
@@ -20781,6 +21283,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>PP1</measureId>
@@ -20816,6 +21319,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
       <name>diuretics</name>
       <description>Annual monitoring for patients on diuretics: At least one serum potassium and a serum creatinine therapeutic monitoring test in the measurement year.</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>PP2</measureId>
@@ -20837,6 +21341,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>QOPI5</measureId>
@@ -20856,6 +21361,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>QOPI11</measureId>
@@ -20875,6 +21381,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>QOPI15</measureId>
@@ -20894,6 +21401,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>QUANTUM41</measureId>
@@ -20913,6 +21421,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>QUANTUM31</measureId>
@@ -20932,6 +21441,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>QUANTUM37</measureId>
@@ -20951,6 +21461,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>QUANTUM42</measureId>
@@ -20970,6 +21481,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>QUANTUM51</measureId>
@@ -20989,6 +21501,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAO8</measureId>
@@ -21014,6 +21527,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAO9</measureId>
@@ -21041,6 +21555,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAO10</measureId>
@@ -21068,6 +21583,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AAO11</measureId>
@@ -21095,6 +21611,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RPAQIR11</measureId>
@@ -21114,6 +21631,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RPAQIR12</measureId>
@@ -21133,6 +21651,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RPAQIR13</measureId>
@@ -21152,6 +21671,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RPAQIR14</measureId>
@@ -21171,6 +21691,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RPAQIR15</measureId>
@@ -21190,6 +21711,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RCOIR1</measureId>
@@ -21215,6 +21737,7 @@ CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RCOIR2</measureId>
@@ -21234,6 +21757,7 @@ CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RCOIR3</measureId>
@@ -21253,6 +21777,7 @@ CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RCOIR4</measureId>
@@ -21272,6 +21797,7 @@ CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RCOIR5</measureId>
@@ -21291,6 +21817,7 @@ CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RCOIR6</measureId>
@@ -21310,6 +21837,7 @@ CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RCOIR7</measureId>
@@ -21329,6 +21857,7 @@ CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RCOIR8</measureId>
@@ -21348,6 +21877,7 @@ CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RCOIR9</measureId>
@@ -21367,6 +21897,7 @@ CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RCOIR10</measureId>
@@ -21386,6 +21917,7 @@ CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RPAQIR1</measureId>
@@ -21405,6 +21937,7 @@ CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RPAQIR2</measureId>
@@ -21424,6 +21957,7 @@ CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RPAQIR4</measureId>
@@ -21443,6 +21977,7 @@ CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RPAQIR5</measureId>
@@ -21462,6 +21997,7 @@ CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RPAQIR9</measureId>
@@ -21481,6 +22017,7 @@ CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RPAQIR16</measureId>
@@ -21500,6 +22037,7 @@ CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RPAQIR17</measureId>
@@ -21519,6 +22057,7 @@ CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RPAQIR18</measureId>
@@ -21538,6 +22077,7 @@ CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ICLOPS15</measureId>
@@ -21568,6 +22108,7 @@ Rate 2: the percentage of discharges with excess days where clinician provided t
       <name>withexcess</name>
       <description>the percentage of discharges with excess days where clinician provided the required feedback AND where excess days numbered less than 3, out of the total number of discharges with excess days.</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ICLOPS17</measureId>
@@ -21598,6 +22139,7 @@ Rate 2: the percentage of discharges without subsequent office visits within 7 d
       <name>withoutfollowup</name>
       <description>the percentage of discharges without subsequent office visits within 7 days where clinician provided required feedback AND where re-admission within 30 days did not occur, out of the total number of all-cause discharges for patients aged 18 years and older.</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RHI1</measureId>
@@ -21635,6 +22177,7 @@ Performance</description>
       <name>overall</name>
       <description>The difference between Performance Rate 1 and Performance Rate 2, divided by the total denominator.  Performance Rate 3 is the final performance rate for this measure.</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RHI2</measureId>
@@ -21672,6 +22215,7 @@ Performance</description>
       <name>overall</name>
       <description>The difference between Performance Rate 1 and Performance Rate 2, divided by the total denominator.  Performance Rate 3 is the final performance rate for this measure.</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RHI3</measureId>
@@ -21691,6 +22235,7 @@ Performance</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RHI4</measureId>
@@ -21728,6 +22273,7 @@ Performance</description>
       <name>overall</name>
       <description>The difference between Performance Rate 1 and Performance Rate 2, divided by the total denominator.  Performance Rate 3 is the final performance rate for this measure.</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RHI5</measureId>
@@ -21747,6 +22293,7 @@ Performance</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RHI6</measureId>
@@ -21766,6 +22313,7 @@ Performance</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>RHI7</measureId>
@@ -21785,6 +22333,7 @@ Performance</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>SCG1</measureId>
@@ -21804,6 +22353,7 @@ Performance</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>SCG2</measureId>
@@ -21823,6 +22373,7 @@ Performance</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>SCG3</measureId>
@@ -21842,6 +22393,7 @@ Performance</description>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>SCG4</measureId>
@@ -21871,6 +22423,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>SCG05</measureId>
@@ -21890,6 +22443,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>SDPAD1</measureId>
@@ -21909,6 +22463,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>SDPAD2</measureId>
@@ -21928,6 +22483,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>SDPAD3</measureId>
@@ -21947,6 +22503,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>SDPAD4</measureId>
@@ -21966,6 +22523,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>STS1</measureId>
@@ -21985,6 +22543,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>STS3</measureId>
@@ -22004,6 +22563,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>STS5</measureId>
@@ -22023,6 +22583,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>STS7</measureId>
@@ -22042,6 +22603,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>SMX1</measureId>
@@ -22061,6 +22623,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>SMX2</measureId>
@@ -22080,6 +22643,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>SMX3</measureId>
@@ -22099,6 +22663,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>SMX4</measureId>
@@ -22118,6 +22683,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AJRR4</measureId>
@@ -22137,6 +22703,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AJRR2</measureId>
@@ -22156,6 +22723,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AJRR3</measureId>
@@ -22175,6 +22743,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>AJRR1</measureId>
@@ -22194,6 +22763,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASBS10</measureId>
@@ -22213,6 +22783,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASBS1</measureId>
@@ -22232,6 +22803,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>ASBS7</measureId>
@@ -22251,6 +22823,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NIPM4</measureId>
@@ -22270,6 +22843,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NIPM5</measureId>
@@ -22289,6 +22863,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NIPM6</measureId>
@@ -22308,6 +22883,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NIPM8</measureId>
@@ -22329,6 +22905,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NIPM1</measureId>
@@ -22348,6 +22925,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NIPM9</measureId>
@@ -22369,6 +22947,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NIPM3</measureId>
@@ -22388,6 +22967,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NIPM2</measureId>
@@ -22407,6 +22987,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>NIPM7</measureId>
@@ -22426,6 +23007,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CAP1</measureId>
@@ -22445,6 +23027,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CAP2</measureId>
@@ -22464,6 +23047,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CAP3</measureId>
@@ -22486,6 +23070,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CAP4</measureId>
@@ -22505,6 +23090,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CAP5</measureId>
@@ -22524,6 +23110,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CAP6</measureId>
@@ -22546,6 +23133,7 @@ assessment
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>SPINEIQ1</measureId>
@@ -22567,6 +23155,7 @@ NOTE: Negative decreases (or increases in pain inference) for a provider's overa
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>SPINEIQ2</measureId>
@@ -22588,6 +23177,7 @@ NOTE: Negative decreases (or increases in pain inference) for a provider's overa
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>nonProportion</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>SPINEIQ3</measureId>
@@ -22607,6 +23197,7 @@ NOTE: Negative decreases (or increases in pain inference) for a provider's overa
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>OBERD22</measureId>
@@ -22626,6 +23217,7 @@ NOTE: Negative decreases (or increases in pain inference) for a provider's overa
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>OBERD23</measureId>
@@ -22645,6 +23237,7 @@ NOTE: Negative decreases (or increases in pain inference) for a provider's overa
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>OBERD24</measureId>
@@ -22664,6 +23257,7 @@ NOTE: Negative decreases (or increases in pain inference) for a provider's overa
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>OBERD12</measureId>
@@ -22683,6 +23277,7 @@ NOTE: Negative decreases (or increases in pain inference) for a provider's overa
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>OBERD25</measureId>
@@ -22702,6 +23297,7 @@ NOTE: Negative decreases (or increases in pain inference) for a provider's overa
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CDR5</measureId>
@@ -22721,6 +23317,7 @@ NOTE: Negative decreases (or increases in pain inference) for a provider's overa
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CDR9</measureId>
@@ -22740,6 +23337,7 @@ NOTE: Negative decreases (or increases in pain inference) for a provider's overa
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CDR8</measureId>
@@ -22759,6 +23357,7 @@ NOTE: Negative decreases (or increases in pain inference) for a provider's overa
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>USWR15</measureId>
@@ -22802,6 +23401,7 @@ Rate 4: The average of the three risk stratified buckets which will be the perfo
       <name>overall</name>
       <description>The average of the three risk stratified buckets which will be the performance rate in the XML submitted.</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>USWR16</measureId>
@@ -22821,6 +23421,7 @@ Rate 4: The average of the three risk stratified buckets which will be the perfo
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>USWR20</measureId>
@@ -22842,6 +23443,7 @@ Using the MNA Short Form algorithm, if a patient at risk of malnutrition has an 
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>USWR22</measureId>
@@ -22863,6 +23465,7 @@ Using the Self-MNA® by Nestlé, if a patient at risk of malnutrition has an MNA
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>USWR13</measureId>
@@ -22901,6 +23504,7 @@ Rate 3: Percentage of patients undergoing HBOT with vital signs taken and those 
       <name>overall</name>
       <description>Percentage of patients undergoing HBOT with vital signs taken and those with diabetes had a blood glucose check.</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CDR3</measureId>
@@ -22920,6 +23524,7 @@ Rate 3: Percentage of patients undergoing HBOT with vital signs taken and those 
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CDR7</measureId>
@@ -22939,6 +23544,7 @@ Rate 3: Percentage of patients undergoing HBOT with vital signs taken and those 
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CDR10</measureId>
@@ -22958,6 +23564,7 @@ Rate 3: Percentage of patients undergoing HBOT with vital signs taken and those 
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>CDR6</measureId>
@@ -23001,6 +23608,7 @@ Rate 4: The average of the three risk stratified buckets which will be the perfo
       <name>overall</name>
       <description>The average of the three risk stratified buckets which will be the performance rate in the XML submitted.</description>
     </strata>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>USWR21</measureId>
@@ -23020,6 +23628,7 @@ Rate 4: The average of the three risk stratified buckets which will be the perfo
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
     <measureId>WCQIC16</measureId>
@@ -23039,5 +23648,6 @@ Rate 4: The average of the three risk stratified buckets which will be the perfo
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
     <metricType>singlePerformanceRate</metricType>
+    <submissionMethod>registry</submissionMethod>
   </measure>
 </measures>

--- a/measures/measures-schema.yaml
+++ b/measures/measures-schema.yaml
@@ -153,7 +153,7 @@ definitions:
           metricType: { enum: [singlePerformanceRate, nonProportion, cahps] }
         }
       }]
-    required: [nationalQualityStrategyDomain, measureType, eMeasureId, nqfEMeasureId, nqfId, isHighPriority, isInverse, primarySteward, measureSets, isRegistryMeasure]
+    required: [nationalQualityStrategyDomain, measureType, eMeasureId, nqfEMeasureId, nqfId, isHighPriority, isInverse, primarySteward, measureSets, submissionMethods, isRegistryMeasure]
 
   performanceStrata:
     type: object

--- a/measures/measures-schema.yaml
+++ b/measures/measures-schema.yaml
@@ -142,6 +142,7 @@ definitions:
       cpcPlusGroup:
         description: CPC+ group which the measure belongs
         type: string
+    # measures with metricType multiPerformanceRate must also have the properties overallAlgorithm and strata; other metricTypes do not
     oneOf: [
       {
         properties: {

--- a/scripts/measures/import-qcdr-measures.js
+++ b/scripts/measures/import-qcdr-measures.js
@@ -147,6 +147,8 @@ const addMultiPerformanceRateDetails = function(newMeasure, record, qcdrStrataNa
 const convertCsvToMeasures = function(records, config, qcdrStrataNamesDataPath) {
   const sourcedFields = config.sourced_fields;
   const constantFields = config.constant_fields;
+  const TRUE_CSV = 'Y';
+  const FALSE_CSV = 'N';
 
   const newMeasures = records.map(function(record) {
     const newMeasure = {};
@@ -175,7 +177,7 @@ const convertCsvToMeasures = function(records, config, qcdrStrataNamesDataPath) 
     const proportion = _.trim(record[17]);
     const continuous = _.trim(record[18]);
     const ratio = _.trim(record[19]);
-    if (proportion === 'Y' && continuous === 'N' && ratio === 'N') {
+    if (proportion === TRUE_CSV && continuous === FALSE_CSV && ratio === FALSE_CSV) {
       // returns an integer if passed string '3', NaN if passed 'N/A'
       const numPerformanceRates = _.parseInt(_.trim(record[11]));
       if (_.isInteger(numPerformanceRates) && numPerformanceRates > 1) {

--- a/scripts/measures/import-qcdr-measures.js
+++ b/scripts/measures/import-qcdr-measures.js
@@ -187,6 +187,8 @@ const convertCsvToMeasures = function(records, config, qcdrStrataNamesDataPath) 
       newMeasure['metricType'] = 'nonProportion';
     }
 
+    newMeasure['submissionMethods'] = ['registry'];
+
     return newMeasure;
   });
 

--- a/staging/measures-data-with-qcdrs.json
+++ b/staging/measures-data-with-qcdrs.json
@@ -11095,7 +11095,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAAAI5",
@@ -11115,7 +11118,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAAAI6",
@@ -11135,7 +11141,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAAAI8",
@@ -11155,7 +11164,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAAAI9",
@@ -11175,7 +11187,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAAAI11",
@@ -11195,7 +11210,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAAAI12",
@@ -11215,7 +11233,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAAAI17",
@@ -11235,7 +11256,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAAAI18",
@@ -11255,7 +11279,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAAAI19",
@@ -11290,6 +11317,9 @@
         "name": "overall",
         "description": "Total patients prescribed long-term control medication"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -11310,7 +11340,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAD2",
@@ -11330,7 +11363,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAD3",
@@ -11350,7 +11386,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAD4",
@@ -11370,7 +11409,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAD5",
@@ -11390,7 +11432,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ARCO11",
@@ -11410,7 +11455,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ARCO12",
@@ -11430,7 +11478,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ARCO13",
@@ -11469,6 +11520,9 @@
         "name": "LDL",
         "description": "The percent of ischemic stroke patients with an LDL greater than or equal to 100 mg/dL, OR LDL not measured, OR who were on a lipid-lowering medication prior to hospital arrival who were prescribed statin medication at hospital discharge"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -11489,7 +11543,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NOF12",
@@ -11509,7 +11566,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ARCO7",
@@ -11529,7 +11589,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACR7",
@@ -11549,7 +11612,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ARCO14",
@@ -11569,7 +11635,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ARCO10",
@@ -11589,7 +11658,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCCath1",
@@ -11609,7 +11681,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCCath2",
@@ -11629,7 +11704,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCCath3",
@@ -11649,7 +11727,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCCath4",
@@ -11669,7 +11750,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCCath5",
@@ -11689,7 +11773,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCCath6",
@@ -11709,7 +11796,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCCath8",
@@ -11729,7 +11819,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCCath9",
@@ -11749,7 +11842,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCCath13",
@@ -11769,7 +11865,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAN4",
@@ -11789,7 +11888,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAN9",
@@ -11809,7 +11911,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAN10",
@@ -11829,7 +11934,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAN1",
@@ -11849,7 +11957,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAN2",
@@ -11869,7 +11980,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAN5",
@@ -11889,7 +12003,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAN11",
@@ -11909,7 +12026,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAN8",
@@ -11929,7 +12049,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS1",
@@ -11949,7 +12072,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS2",
@@ -11969,7 +12095,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS3",
@@ -11989,7 +12118,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS4",
@@ -12009,7 +12141,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS5",
@@ -12029,7 +12164,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS6",
@@ -12049,7 +12187,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS7",
@@ -12069,7 +12210,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS8",
@@ -12089,7 +12233,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS9",
@@ -12109,7 +12256,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS10",
@@ -12129,7 +12279,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS11",
@@ -12149,7 +12302,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS13",
@@ -12169,7 +12325,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS16",
@@ -12189,7 +12348,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS17",
@@ -12209,7 +12371,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS18",
@@ -12229,7 +12394,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS19",
@@ -12249,7 +12417,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS20",
@@ -12269,7 +12440,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS21",
@@ -12289,7 +12463,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS22",
@@ -12309,7 +12486,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS23",
@@ -12329,7 +12509,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS24",
@@ -12349,7 +12532,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS25",
@@ -12369,7 +12555,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "IRIS26",
@@ -12389,7 +12578,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Q415",
@@ -12409,7 +12601,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Q416",
@@ -12429,7 +12624,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP21",
@@ -12449,7 +12647,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP22",
@@ -12469,7 +12670,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP24",
@@ -12489,7 +12693,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP25",
@@ -12509,7 +12716,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP26",
@@ -12529,7 +12739,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP27",
@@ -12549,7 +12762,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP28",
@@ -12569,7 +12785,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP29",
@@ -12589,7 +12808,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP30",
@@ -12609,7 +12831,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP31",
@@ -12629,7 +12854,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP32",
@@ -12649,7 +12877,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP33",
@@ -12669,7 +12900,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP35",
@@ -12689,7 +12923,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP36",
@@ -12709,7 +12946,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP37",
@@ -12729,7 +12969,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP38",
@@ -12749,7 +12992,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP39",
@@ -12769,7 +13015,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP40",
@@ -12789,7 +13038,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP41",
@@ -12809,7 +13061,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP43",
@@ -12829,7 +13084,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP44",
@@ -12849,7 +13107,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP45",
@@ -12869,7 +13130,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP46",
@@ -12889,7 +13153,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP47",
@@ -12909,7 +13176,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP48",
@@ -12929,7 +13199,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACEP49",
@@ -12949,7 +13222,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACPGR1",
@@ -12969,7 +13245,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET20",
@@ -12989,7 +13268,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACPGR2",
@@ -13009,7 +13291,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACPGR3",
@@ -13029,7 +13314,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Q408",
@@ -13049,7 +13337,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Q414",
@@ -13069,7 +13360,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad26",
@@ -13089,7 +13383,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad2",
@@ -13109,7 +13406,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad1",
@@ -13129,7 +13429,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad23",
@@ -13149,7 +13452,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad21",
@@ -13169,7 +13475,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad22",
@@ -13189,7 +13498,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad31",
@@ -13209,7 +13521,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad32",
@@ -13229,7 +13544,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad33",
@@ -13249,7 +13567,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad30",
@@ -13269,7 +13590,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad28",
@@ -13289,7 +13613,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad29",
@@ -13309,7 +13636,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad18",
@@ -13329,7 +13659,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad25",
@@ -13349,7 +13682,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad17",
@@ -13369,7 +13705,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad19",
@@ -13389,7 +13728,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad15",
@@ -13409,7 +13751,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad16",
@@ -13429,7 +13774,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad5",
@@ -13449,7 +13797,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad3",
@@ -13469,7 +13820,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad8",
@@ -13489,7 +13843,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad7",
@@ -13509,7 +13866,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad6",
@@ -13529,7 +13889,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACRad27",
@@ -13549,7 +13912,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACS15",
@@ -13569,7 +13935,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACS16",
@@ -13589,7 +13958,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACS17",
@@ -13609,7 +13981,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACS18",
@@ -13629,7 +14004,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACS19",
@@ -13649,7 +14027,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACS20",
@@ -13669,7 +14050,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACS21",
@@ -13689,7 +14073,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACS22",
@@ -13709,7 +14096,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACS23",
@@ -13729,7 +14119,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc51",
@@ -13749,7 +14142,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "APMA1",
@@ -13769,7 +14165,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CDR2",
@@ -13789,7 +14188,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC1",
@@ -13809,7 +14211,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC2",
@@ -13829,7 +14234,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC3",
@@ -13849,7 +14257,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC4",
@@ -13869,7 +14280,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC13",
@@ -13889,7 +14303,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC14",
@@ -13909,7 +14326,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC17",
@@ -13929,7 +14349,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC18",
@@ -13949,7 +14372,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC19",
@@ -13969,7 +14395,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC20",
@@ -13989,7 +14418,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC21",
@@ -14009,7 +14441,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC22",
@@ -14029,7 +14464,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC23",
@@ -14049,7 +14487,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC24",
@@ -14069,7 +14510,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASNC25",
@@ -14089,7 +14533,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CDR1",
@@ -14109,7 +14556,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPS5",
@@ -14129,7 +14579,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPS6",
@@ -14149,7 +14602,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AUGS1",
@@ -14169,7 +14625,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AUGS2",
@@ -14189,7 +14648,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AUGS3",
@@ -14209,7 +14671,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AUGS4",
@@ -14229,7 +14694,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AUGS5",
@@ -14249,7 +14717,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AUGS6",
@@ -14269,7 +14740,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AUGS7",
@@ -14289,7 +14763,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AUGS8",
@@ -14309,7 +14786,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AUGS9",
@@ -14329,7 +14809,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA5",
@@ -14349,7 +14832,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA6",
@@ -14369,7 +14855,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA12",
@@ -14389,7 +14878,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA3",
@@ -14409,7 +14901,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA8",
@@ -14429,7 +14924,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA4",
@@ -14449,7 +14947,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA11",
@@ -14469,7 +14970,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA10",
@@ -14489,7 +14993,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MUSIC4",
@@ -14509,7 +15016,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA14",
@@ -14529,7 +15039,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA13",
@@ -14549,7 +15062,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA15",
@@ -14569,7 +15085,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA16",
@@ -14589,7 +15108,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA17",
@@ -14609,7 +15131,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQUA18",
@@ -14629,7 +15154,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AHSQC1",
@@ -14649,7 +15177,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AHSQC2",
@@ -14669,7 +15200,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AHSQC6",
@@ -14704,6 +15238,9 @@
         "name": "hernia>10cm",
         "description": "Abdominal Wall Reconstruction Surgical Site Occurrence Requiring Procedural Intervention within the 30 Day Postoperative Period-Hernia width of >10cm"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -14724,7 +15261,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AHSQC8",
@@ -14744,7 +15284,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AHSQC9",
@@ -14775,6 +15318,9 @@
         "name": "email",
         "description": "Ventral Hernia Repair: Pain and Functional Status Assessment-Email engagement completion rate"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -14795,7 +15341,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG29",
@@ -14815,7 +15364,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG30",
@@ -14835,7 +15387,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG31",
@@ -14855,7 +15410,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG32",
@@ -14875,7 +15433,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG33",
@@ -14895,7 +15456,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG34",
@@ -14915,7 +15479,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG1",
@@ -14935,7 +15502,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI35",
@@ -14955,7 +15525,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG4",
@@ -14975,7 +15548,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG5",
@@ -14995,7 +15571,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG7",
@@ -15015,7 +15594,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI48",
@@ -15035,7 +15617,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG14",
@@ -15055,7 +15640,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG15",
@@ -15075,7 +15663,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG16",
@@ -15095,7 +15686,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG21",
@@ -15115,7 +15709,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI49",
@@ -15158,6 +15755,9 @@
         "name": "overall",
         "description": "Composite Performance Score: Percentage of denominator-eligible patients for whom a cumulative score of 100% of blood conservation strategies was met"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -15178,7 +15778,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI51",
@@ -15198,7 +15801,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI42",
@@ -15218,7 +15824,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI18",
@@ -15238,7 +15847,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI41",
@@ -15258,7 +15870,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI28",
@@ -15278,7 +15893,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI34",
@@ -15298,7 +15916,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI31",
@@ -15318,7 +15939,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI29",
@@ -15338,7 +15962,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI32",
@@ -15358,7 +15985,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI37",
@@ -15378,7 +16008,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI52",
@@ -15398,7 +16031,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPIRE4",
@@ -15418,7 +16054,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPIRE3",
@@ -15438,7 +16077,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPIRE19",
@@ -15458,7 +16100,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPIRE6",
@@ -15478,7 +16123,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPIRE16",
@@ -15498,7 +16146,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPIRE22",
@@ -15518,7 +16169,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPIRE18",
@@ -15538,7 +16192,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPIRE8",
@@ -15558,7 +16215,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPIRE2",
@@ -15578,7 +16238,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASPIRE13",
@@ -15598,7 +16261,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "BNS1",
@@ -15618,7 +16284,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CCOME1",
@@ -15638,7 +16307,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CCOME2",
@@ -15658,7 +16330,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CCOME3",
@@ -15678,7 +16353,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CCOME4",
@@ -15698,7 +16376,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CCOME5",
@@ -15718,7 +16399,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE6",
@@ -15738,7 +16422,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE7",
@@ -15758,7 +16445,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE1",
@@ -15778,7 +16468,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE3",
@@ -15798,7 +16491,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE8",
@@ -15818,7 +16514,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE9",
@@ -15838,7 +16537,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE5",
@@ -15858,7 +16560,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE10",
@@ -15878,7 +16583,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE11",
@@ -15898,7 +16606,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE2",
@@ -15918,7 +16629,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CODE12",
@@ -15938,7 +16652,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CESQIP6",
@@ -15958,7 +16675,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CESQIP4",
@@ -15978,7 +16698,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CESQIP1",
@@ -15998,7 +16721,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CESQIP3",
@@ -16018,7 +16744,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CESQIP5",
@@ -16038,7 +16767,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CESQIP2",
@@ -16058,7 +16790,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CUHSM3",
@@ -16078,7 +16813,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CUHSM4",
@@ -16098,7 +16836,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CUHSM6",
@@ -16118,7 +16859,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CUHSM8",
@@ -16138,7 +16882,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "EPREOP4",
@@ -16158,7 +16905,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "EPREOP9",
@@ -16178,7 +16928,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "EPREOP14",
@@ -16198,7 +16951,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "EPREOP26",
@@ -16218,7 +16974,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "EPREOP27",
@@ -16238,7 +16997,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "FORCE4",
@@ -16258,7 +17020,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "FORCE5",
@@ -16278,7 +17043,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "FORCE9",
@@ -16298,7 +17066,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "FORCE10",
@@ -16318,7 +17089,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "FORCE17",
@@ -16338,7 +17112,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "FORCE18",
@@ -16358,7 +17135,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "FORCE19",
@@ -16378,7 +17158,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "GIQIC15",
@@ -16398,7 +17181,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "GIQIC12",
@@ -16418,7 +17204,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "GIQIC10",
@@ -16438,7 +17227,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHCR4",
@@ -16458,7 +17250,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HF1",
@@ -16478,7 +17273,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HF2",
@@ -16498,7 +17296,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HF3",
@@ -16518,7 +17319,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HF4",
@@ -16538,7 +17342,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HF5",
@@ -16558,7 +17365,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HF6",
@@ -16578,7 +17388,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HF7",
@@ -16598,7 +17411,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HAdv1",
@@ -16618,7 +17434,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HAdv2",
@@ -16638,7 +17457,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S16",
@@ -16658,7 +17480,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S17",
@@ -16678,7 +17503,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S18",
@@ -16698,7 +17526,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S19",
@@ -16718,7 +17549,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S1",
@@ -16738,7 +17572,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S2",
@@ -16758,7 +17595,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S3",
@@ -16778,7 +17618,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S4",
@@ -16798,7 +17641,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S5",
@@ -16818,7 +17664,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S6",
@@ -16838,7 +17687,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S7",
@@ -16858,7 +17710,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S8",
@@ -16878,7 +17733,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S9",
@@ -16898,7 +17756,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S10",
@@ -16918,7 +17779,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S11",
@@ -16938,7 +17802,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S12",
@@ -16958,7 +17825,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "M2S13",
@@ -16978,7 +17848,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "BIVARUS27",
@@ -16998,7 +17871,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "BIVARUS28",
@@ -17018,7 +17894,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "BIVARUS32",
@@ -17038,7 +17917,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "BIVARUS30",
@@ -17058,7 +17940,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "BIVARUS31",
@@ -17078,7 +17963,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MOA1",
@@ -17109,6 +17997,9 @@
         "name": "neck",
         "description": "Percentage of patients receiving manipulative medicine with a QVAS score and treatment adjustment/maintenance for neck pain."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -17129,7 +18020,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MOA 7",
@@ -17149,7 +18043,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MOA 13",
@@ -17169,7 +18066,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MOA 14",
@@ -17189,7 +18089,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MOA 15",
@@ -17209,7 +18112,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MOA 12",
@@ -17229,7 +18135,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MeHC1",
@@ -17249,7 +18158,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ECPR39",
@@ -17269,7 +18181,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ECPR43",
@@ -17300,6 +18215,9 @@
         "name": "urgentcare",
         "description": "In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with a Diagnosis of Chest Pain Where the Provider Ordered Coagulation Studies (PT, PTT, or INR)"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -17320,7 +18238,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ECPR44",
@@ -17340,7 +18261,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ECPR40",
@@ -17360,7 +18284,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ECPR6",
@@ -17380,7 +18307,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ECPR5",
@@ -17400,7 +18330,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ECPR42",
@@ -17420,7 +18353,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ECPR41",
@@ -17440,7 +18376,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ECPR11",
@@ -17460,7 +18399,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ECPR38",
@@ -17480,7 +18422,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HCPR19",
@@ -17500,7 +18445,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HCPR4",
@@ -17520,7 +18468,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HCPR5",
@@ -17540,7 +18491,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HCPR3",
@@ -17560,7 +18514,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HCPR16",
@@ -17580,7 +18537,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HCPR17",
@@ -17600,7 +18560,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HCPR13",
@@ -17620,7 +18583,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HCPR18",
@@ -17640,7 +18606,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "HCPR14",
@@ -17660,7 +18629,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AQI30",
@@ -17680,7 +18652,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MA1",
@@ -17700,7 +18675,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MA2",
@@ -17720,7 +18698,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED3",
@@ -17740,7 +18721,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MICS1",
@@ -17760,7 +18744,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MICS2",
@@ -17780,7 +18767,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MICS3",
@@ -17800,7 +18790,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MEX1",
@@ -17820,7 +18813,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MEX2",
@@ -17840,7 +18836,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MEX3",
@@ -17860,7 +18859,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MBSAQIP1",
@@ -17880,7 +18882,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MBSAQIP2",
@@ -17900,7 +18905,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MBSAQIP3",
@@ -17920,7 +18928,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MBSAQIP4",
@@ -17940,7 +18951,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MBSAQIP6",
@@ -17960,7 +18974,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MBSAQIP7",
@@ -17980,7 +18997,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MBSAQIP8",
@@ -18000,7 +19020,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC2",
@@ -18020,7 +19043,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC3",
@@ -18040,7 +19066,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC4",
@@ -18060,7 +19089,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC5",
@@ -18080,7 +19112,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC8",
@@ -18100,7 +19135,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC9",
@@ -18120,7 +19158,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC10",
@@ -18140,7 +19181,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC6",
@@ -18160,7 +19204,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC11",
@@ -18180,7 +19227,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC1",
@@ -18200,7 +19250,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC7",
@@ -18220,7 +19273,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC12",
@@ -18240,7 +19296,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC13",
@@ -18260,7 +19319,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC14",
@@ -18280,7 +19342,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSSIC15",
@@ -18300,7 +19365,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MUSIC1",
@@ -18320,7 +19388,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MUSIC6",
@@ -18340,7 +19411,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MUSIC5",
@@ -18360,7 +19434,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MUSIC3",
@@ -18380,7 +19457,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MUSIC2",
@@ -18400,7 +19480,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MUSIC9",
@@ -18420,7 +19503,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MUSIC10",
@@ -18440,7 +19526,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MUSIC11",
@@ -18460,7 +19549,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED5",
@@ -18480,7 +19572,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED9",
@@ -18500,7 +19595,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED7",
@@ -18520,7 +19618,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ABG12",
@@ -18540,7 +19641,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED4",
@@ -18560,7 +19664,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED16",
@@ -18580,7 +19687,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED13",
@@ -18600,7 +19710,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED14",
@@ -18620,7 +19733,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED12",
@@ -18640,7 +19756,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED15",
@@ -18660,7 +19779,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MIRAMED11",
@@ -18680,7 +19802,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MNCM1",
@@ -18700,7 +19825,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MNCM2",
@@ -18720,7 +19848,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MNCM3",
@@ -18751,6 +19882,9 @@
         "name": "adult",
         "description": "The percentage of adult (18-50 years of age) patients who had a diagnosis of asthma and whose asthma was optimally controlled during the measurement period as defined by achieving BOTH of the following:\n•Asthma well-controlled as defined by the most recent asthma control tool result available during the measurement period\n•Patient not at elevated risk of exacerbation as defined by less than two emergency department visits and/or hospitalizations due to asthma in the last 12 months"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -18771,7 +19905,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MNCM5",
@@ -18791,7 +19928,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSN6",
@@ -18811,7 +19951,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSN11",
@@ -18831,7 +19974,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSN5",
@@ -18851,7 +19997,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSN10",
@@ -18871,7 +20020,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSN7",
@@ -18891,7 +20043,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSN12",
@@ -18911,7 +20066,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSN8",
@@ -18931,7 +20089,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSN3",
@@ -18951,7 +20112,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSN4",
@@ -18971,7 +20135,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MSN9",
@@ -18991,7 +20158,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MHAN1",
@@ -19011,7 +20181,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MHAN2",
@@ -19031,7 +20204,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "MHAN3",
@@ -19051,7 +20227,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC15",
@@ -19086,6 +20265,9 @@
         "name": "overall",
         "description": "Percentage of patients who received both a basic ADL and IADL assessment (overall rate)"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -19106,7 +20288,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC14",
@@ -19126,7 +20311,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC7",
@@ -19157,6 +20345,9 @@
         "name": "overall",
         "description": "Percentage of patients with offending medications whose use of offending medications was discontinued or justified."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -19177,7 +20368,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC5",
@@ -19197,7 +20391,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC13",
@@ -19217,7 +20414,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC11",
@@ -19237,7 +20437,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC4",
@@ -19257,7 +20460,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC16",
@@ -19277,7 +20483,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC9",
@@ -19297,7 +20506,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC6",
@@ -19317,7 +20529,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NHBPC10",
@@ -19337,7 +20552,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NOF6",
@@ -19357,7 +20575,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NOF7",
@@ -19377,7 +20598,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NOF13",
@@ -19397,7 +20621,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA6",
@@ -19417,7 +20644,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA7",
@@ -19437,7 +20667,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA9",
@@ -19457,7 +20690,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA11",
@@ -19477,7 +20713,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA12",
@@ -19497,7 +20736,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA14",
@@ -19517,7 +20759,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA15",
@@ -19537,7 +20782,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA16",
@@ -19557,7 +20805,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA17",
@@ -19577,7 +20828,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA18",
@@ -19597,7 +20851,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA19",
@@ -19617,7 +20874,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA20",
@@ -19637,7 +20897,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA22",
@@ -19657,7 +20920,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPA3",
@@ -19688,6 +20954,9 @@
         "name": "overall",
         "description": "Patient population with improvement in functional status after Follow-up/Patient population with Follow-up."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -19719,6 +20988,9 @@
         "name": "overall",
         "description": "Patient population with improvement in quality of life status after Follow-up/Patient population with Follow-up."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -19750,6 +21022,9 @@
         "name": "overall",
         "description": "Patient population with improvement in satisfaction with care status after Follow-up/Patient population with Follow-up."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -19770,7 +21045,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPAGSC9",
@@ -19790,7 +21068,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPAGSC3",
@@ -19821,6 +21102,9 @@
         "name": "improvement",
         "description": "Patient population with improvement in functional status (at least 10% improvement) from the baseline."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -19841,7 +21125,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPAGSC8",
@@ -19861,7 +21148,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NPAGSC4",
@@ -19892,6 +21182,9 @@
         "name": "improvement",
         "description": "Patient population with improvement in Quality of life status from the baseline"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -19923,6 +21216,9 @@
         "name": "improvement",
         "description": "Patient population with improvement in satisfaction with care status from the baseline"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -19954,6 +21250,9 @@
         "name": "improvement",
         "description": "Patient population with improvement in the pain status from the baseline"
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -19974,7 +21273,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD7",
@@ -19994,7 +21296,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD6",
@@ -20014,7 +21319,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD4",
@@ -20034,7 +21342,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD5",
@@ -20054,7 +21365,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD22",
@@ -20074,7 +21388,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD3",
@@ -20094,7 +21411,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD19",
@@ -20114,7 +21434,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD12",
@@ -20134,7 +21457,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD20",
@@ -20154,7 +21480,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD2",
@@ -20174,7 +21503,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD11",
@@ -20194,7 +21526,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD8",
@@ -20214,7 +21549,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD9",
@@ -20234,7 +21572,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD21",
@@ -20254,7 +21595,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD1",
@@ -20274,7 +21618,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD10",
@@ -20294,7 +21641,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD14",
@@ -20314,7 +21664,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD17",
@@ -20334,7 +21687,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD16",
@@ -20354,7 +21710,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD15",
@@ -20374,7 +21733,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NJIISMD13",
@@ -20394,7 +21756,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NNEPTN1",
@@ -20425,6 +21790,9 @@
         "name": "18",
         "description": "Percentage of patients age 18 years and older screened for substance use using an evidence based standardized tool within the measurement year."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -20445,7 +21813,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NNEPTN3",
@@ -20465,7 +21836,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NNEPTN4",
@@ -20485,7 +21859,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OEIS1",
@@ -20505,7 +21882,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OEIS2",
@@ -20525,7 +21905,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OEIS3",
@@ -20545,7 +21928,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OEIS4",
@@ -20565,7 +21951,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OEIS5",
@@ -20585,7 +21974,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OEIS6",
@@ -20605,7 +21997,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ONSQIR15",
@@ -20625,7 +22020,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ONSQIR16",
@@ -20645,7 +22043,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ONSQIR17",
@@ -20665,7 +22066,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ONSQIR6",
@@ -20685,7 +22089,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ONSQIR18",
@@ -20705,7 +22112,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ONSQIR19",
@@ -20725,7 +22135,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ONSQIR20",
@@ -20745,7 +22158,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "WCHQ32",
@@ -20765,7 +22181,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "WCHQ10",
@@ -20785,7 +22204,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "WCHQ9",
@@ -20805,7 +22227,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "WCHQ13",
@@ -20825,7 +22250,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "WCHQ15",
@@ -20845,7 +22273,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCPin1",
@@ -20865,7 +22296,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCPin2",
@@ -20885,7 +22319,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCPin3",
@@ -20905,7 +22342,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ACCPin4",
@@ -20925,7 +22365,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET8",
@@ -20945,7 +22388,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET32",
@@ -20965,7 +22411,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET13",
@@ -20985,7 +22434,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET14",
@@ -21005,7 +22457,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET31",
@@ -21025,7 +22480,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET33",
@@ -21045,7 +22503,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET27",
@@ -21065,7 +22526,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET28",
@@ -21085,7 +22549,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET29",
@@ -21105,7 +22572,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET30",
@@ -21125,7 +22595,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PPRNET24",
@@ -21145,7 +22618,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc1",
@@ -21165,7 +22641,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc2",
@@ -21185,7 +22664,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc3",
@@ -21205,7 +22687,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc4",
@@ -21225,7 +22710,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc5",
@@ -21245,7 +22733,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc6",
@@ -21265,7 +22756,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc33",
@@ -21285,7 +22779,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc34",
@@ -21305,7 +22802,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc35",
@@ -21325,7 +22825,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc53",
@@ -21345,7 +22848,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "Pinc54",
@@ -21365,7 +22871,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "PP1",
@@ -21400,6 +22909,9 @@
         "name": "diuretics",
         "description": "Annual monitoring for patients on diuretics: At least one serum potassium and a serum creatinine therapeutic monitoring test in the measurement year."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -21420,7 +22932,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "QOPI5",
@@ -21440,7 +22955,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "QOPI11",
@@ -21460,7 +22978,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "QOPI15",
@@ -21480,7 +23001,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "QUANTUM41",
@@ -21500,7 +23024,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "QUANTUM31",
@@ -21520,7 +23047,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "QUANTUM37",
@@ -21540,7 +23070,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "QUANTUM42",
@@ -21560,7 +23093,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "QUANTUM51",
@@ -21580,7 +23116,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAO8",
@@ -21600,7 +23139,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAO9",
@@ -21620,7 +23162,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAO10",
@@ -21640,7 +23185,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AAO11",
@@ -21660,7 +23208,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR11",
@@ -21680,7 +23231,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR12",
@@ -21700,7 +23254,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR13",
@@ -21720,7 +23277,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR14",
@@ -21740,7 +23300,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR15",
@@ -21760,7 +23323,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RCOIR1",
@@ -21780,7 +23346,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RCOIR2",
@@ -21800,7 +23369,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RCOIR3",
@@ -21820,7 +23392,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RCOIR4",
@@ -21840,7 +23415,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RCOIR5",
@@ -21860,7 +23438,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RCOIR6",
@@ -21880,7 +23461,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RCOIR7",
@@ -21900,7 +23484,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RCOIR8",
@@ -21920,7 +23507,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RCOIR9",
@@ -21940,7 +23530,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RCOIR10",
@@ -21960,7 +23553,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR1",
@@ -21980,7 +23576,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR2",
@@ -22000,7 +23599,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR4",
@@ -22020,7 +23622,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR5",
@@ -22040,7 +23645,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR9",
@@ -22060,7 +23668,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR16",
@@ -22080,7 +23691,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR17",
@@ -22100,7 +23714,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RPAQIR18",
@@ -22120,7 +23737,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ICLOPS15",
@@ -22151,6 +23771,9 @@
         "name": "withexcess",
         "description": "the percentage of discharges with excess days where clinician provided the required feedback AND where excess days numbered less than 3, out of the total number of discharges with excess days."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -22182,6 +23805,9 @@
         "name": "withoutfollowup",
         "description": "the percentage of discharges without subsequent office visits within 7 days where clinician provided required feedback AND where re-admission within 30 days did not occur, out of the total number of all-cause discharges for patients aged 18 years and older."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -22217,6 +23843,9 @@
         "name": "overall",
         "description": "The difference between Performance Rate 1 and Performance Rate 2, divided by the total denominator.  Performance Rate 3 is the final performance rate for this measure."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -22252,6 +23881,9 @@
         "name": "overall",
         "description": "The difference between Performance Rate 1 and Performance Rate 2, divided by the total denominator.  Performance Rate 3 is the final performance rate for this measure."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -22272,7 +23904,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RHI4",
@@ -22307,6 +23942,9 @@
         "name": "overall",
         "description": "The difference between Performance Rate 1 and Performance Rate 2, divided by the total denominator.  Performance Rate 3 is the final performance rate for this measure."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -22327,7 +23965,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RHI6",
@@ -22347,7 +23988,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "RHI7",
@@ -22367,7 +24011,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SCG1",
@@ -22387,7 +24034,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SCG2",
@@ -22407,7 +24057,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SCG3",
@@ -22427,7 +24080,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SCG4",
@@ -22447,7 +24103,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SCG05",
@@ -22467,7 +24126,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SDPAD1",
@@ -22487,7 +24149,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SDPAD2",
@@ -22507,7 +24172,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SDPAD3",
@@ -22527,7 +24195,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SDPAD4",
@@ -22547,7 +24218,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "STS1",
@@ -22567,7 +24241,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "STS3",
@@ -22587,7 +24264,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "STS5",
@@ -22607,7 +24287,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "STS7",
@@ -22627,7 +24310,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SMX1",
@@ -22647,7 +24333,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SMX2",
@@ -22667,7 +24356,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SMX3",
@@ -22687,7 +24379,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SMX4",
@@ -22707,7 +24402,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AJRR4",
@@ -22727,7 +24425,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AJRR2",
@@ -22747,7 +24448,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AJRR3",
@@ -22767,7 +24471,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "AJRR1",
@@ -22787,7 +24494,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASBS10",
@@ -22807,7 +24517,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASBS1",
@@ -22827,7 +24540,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "ASBS7",
@@ -22847,7 +24563,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NIPM4",
@@ -22867,7 +24586,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NIPM5",
@@ -22887,7 +24609,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NIPM6",
@@ -22907,7 +24632,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NIPM8",
@@ -22927,7 +24655,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NIPM1",
@@ -22947,7 +24678,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NIPM9",
@@ -22967,7 +24701,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NIPM3",
@@ -22987,7 +24724,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NIPM2",
@@ -23007,7 +24747,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "NIPM7",
@@ -23027,7 +24770,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CAP1",
@@ -23047,7 +24793,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CAP2",
@@ -23067,7 +24816,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CAP3",
@@ -23087,7 +24839,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CAP4",
@@ -23107,7 +24862,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CAP5",
@@ -23127,7 +24885,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CAP6",
@@ -23147,7 +24908,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SPINEIQ1",
@@ -23167,7 +24931,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SPINEIQ2",
@@ -23187,7 +24954,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "nonProportion"
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "SPINEIQ3",
@@ -23207,7 +24977,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OBERD22",
@@ -23227,7 +25000,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OBERD23",
@@ -23247,7 +25023,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OBERD24",
@@ -23267,7 +25046,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OBERD12",
@@ -23287,7 +25069,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "OBERD25",
@@ -23307,7 +25092,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CDR5",
@@ -23327,7 +25115,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CDR9",
@@ -23347,7 +25138,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CDR8",
@@ -23367,7 +25161,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "USWR15",
@@ -23406,6 +25203,9 @@
         "name": "overall",
         "description": "The average of the three risk stratified buckets which will be the performance rate in the XML submitted."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -23426,7 +25226,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "USWR20",
@@ -23446,7 +25249,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "USWR22",
@@ -23466,7 +25272,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "USWR13",
@@ -23501,6 +25310,9 @@
         "name": "overall",
         "description": "Percentage of patients undergoing HBOT with vital signs taken and those with diabetes had a blood glucose check."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -23521,7 +25333,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CDR7",
@@ -23541,7 +25356,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CDR10",
@@ -23561,7 +25379,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "CDR6",
@@ -23600,6 +25421,9 @@
         "name": "overall",
         "description": "The average of the three risk stratified buckets which will be the performance rate in the XML submitted."
       }
+    ],
+    "submissionMethods": [
+      "registry"
     ]
   },
   {
@@ -23620,7 +25444,10 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   },
   {
     "measureId": "WCQIC16",
@@ -23640,6 +25467,9 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate"
+    "metricType": "singlePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
   }
 ]


### PR DESCRIPTION
QCDR measures in measures-data.json should include the submissionmethods field, which should equal ['registry']. This PR fixes that and makes submissionmethods a required field.

Jira: https://jira.cms.gov/browse/QPPA-1350

Tests: passes all tests

Reviewer: @marimiyachi 