### PR TITLE
Feature/QPPQS-735 add missing cpc plus measure

### DIFF
--- a/measures/measures-data.json
+++ b/measures/measures-data.json
@@ -4471,6 +4471,7 @@
     ],
     "eMeasureUuid": "40280381-5118-2f4e-0151-59fb81bf1055",
     "isRegistryMeasure": false,
+    "cpcPlusGroup": "C",
     "measureSpecification": {
       "registry": "https://ecqi.healthit.gov/system/files/ecqm/measures/CMS50v5.html"
     }

--- a/measures/measures-data.xml
+++ b/measures/measures-data.xml
@@ -4068,6 +4068,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <measureSet>plasticSurgery</measureSet>
     <eMeasureUuid>40280381-5118-2f4e-0151-59fb81bf1055</eMeasureUuid>
     <isRegistryMeasure>false</isRegistryMeasure>
+    <cpcPlusGroup>C</cpcPlusGroup>
     <measureSpecification>
       <registry>https://ecqi.healthit.gov/system/files/ecqm/measures/CMS50v5.html</registry>
     </measureSpecification>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.0.0-alpha.15",
+  "version": "1.0.0-alpha.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "acorn": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
+      "integrity": "sha1-kRy1PgNoB88Pp3jcXTcPvYZCRtc=",
       "dev": true
     },
     "acorn-jsx": {
@@ -245,7 +245,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "cli-cursor": {
@@ -287,7 +287,7 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
       "dev": true
     },
     "concat-map": {
@@ -432,7 +432,7 @@
     "es-abstract": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
-      "integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
+      "integrity": "sha1-aQgpoHyuNrIi5/2bdcDQVz6yUic=",
       "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
@@ -581,7 +581,7 @@
     "eslint-module-utils": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
-      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "integrity": "sha1-q67IJBd2E7ipWymWOeG2+s9HNEk=",
       "dev": true,
       "requires": {
         "debug": "2.6.8",
@@ -647,7 +647,7 @@
     "eslint-plugin-react": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.4.0.tgz",
-      "integrity": "sha512-tvjU9u3VqmW2vVuYnE8Qptq+6ji4JltjOjJ9u7VAOxVYkUkyBZWRvNYKbDv5fN+L6wiA+4we9+qQahZ0m63XEA==",
+      "integrity": "sha1-MAqVhhuXKcCH02LdZKvMNRp0Nko=",
       "dev": true,
       "requires": {
         "doctrine": "2.0.0",
@@ -685,7 +685,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
       "dev": true
     },
     "esquery": {
@@ -812,7 +812,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
     "functional-red-black-tree": {
@@ -824,7 +824,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -837,7 +837,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
       "dev": true
     },
     "globby": {
@@ -911,13 +911,13 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs=",
       "dev": true
     },
     "ignore": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
-      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
+      "integrity": "sha1-xOcVRV9gc6jX5drnLS/J1xZj26Y=",
       "dev": true
     },
     "imurmurhash": {
@@ -1084,7 +1084,7 @@
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -1094,7 +1094,7 @@
     "jschardet": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
-      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
+      "integrity": "sha1-xRn2KfhrOlvtuliojTETCe7Al/k=",
       "dev": true
     },
     "json-schema-traverse": {
@@ -1265,7 +1265,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
@@ -1280,7 +1280,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -1303,7 +1303,7 @@
     "mocha": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -1381,7 +1381,7 @@
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
       "dev": true,
       "requires": {
         "encoding": "0.1.12",
@@ -1585,7 +1585,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "dev": true,
       "requires": {
         "asap": "2.0.6"
@@ -1641,7 +1641,7 @@
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -1690,7 +1690,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -1723,18 +1723,18 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
     },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
       "dev": true
     },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
       "dev": true
     },
     "setimmediate": {
@@ -1806,7 +1806,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
@@ -1816,7 +1816,7 @@
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
       "requires": {
         "safe-buffer": "5.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.0.0-alpha.22",
+  "version": "1.0.0-alpha.23",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/scripts/measures/enrich-measures-data.js
+++ b/scripts/measures/enrich-measures-data.js
@@ -102,7 +102,7 @@ function enrichStratifications(measures) {
       const stratification = stratifications.find(stratum => stratum.eMeasureId === measure.eMeasureId);
       if (stratification) {
         measure.strata.forEach(subPopulation => {
-          const mapping = stratification.mapping.find(map =>
+          const mapping = stratification.strataMaps.find(map =>
             map.numeratorUuid === subPopulation.eMeasureUuids.numeratorUuid);
           if (mapping) {
             subPopulation.eMeasureUuids.strata = mapping.strata;

--- a/util/measures/cpc+-measure-groups.json
+++ b/util/measures/cpc+-measure-groups.json
@@ -1,5 +1,5 @@
 {
   "A": ["CMS122v5", "CMS159v5", "CMS165v5"],
   "B": ["CMS137v5", "CMS139v5", "CMS149v5", "CMS156v5"],
-  "C": ["CMS50v5", "CMS124v5", "CMS125v5", "CMS130v5", "CMS131v5", "CMS138v5", "CMS166v6"]
+  "C": ["CMS124v5", "CMS125v5", "CMS130v5", "CMS131v5", "CMS138v5", "CMS166v6", "CMS50v5"]
 }

--- a/util/measures/cpc+-measure-groups.json
+++ b/util/measures/cpc+-measure-groups.json
@@ -1,5 +1,5 @@
 {
   "A": ["CMS122v5", "CMS159v5", "CMS165v5"],
   "B": ["CMS137v5", "CMS139v5", "CMS149v5", "CMS156v5"],
-  "C": ["CMS124v5", "CMS125v5", "CMS130v5", "CMS131v5", "CMS138v5", "CMS166v6"]
+  "C": ["CMS50v5", "CMS124v5", "CMS125v5", "CMS130v5", "CMS131v5", "CMS138v5", "CMS166v6"]
 }


### PR DESCRIPTION
- Adding measure CMS50v5 (Quality ID: 374) as one of the required measures in group 3 (C)
- Rebuilt measures-data.json by running `build:measures` npm script
- Fixed typo in `scripts/measures/build-measures` which fixed the `build:measures` npm script
- Bump package version to 1.0.0-alpha.23