### PR TITLE
[QPPA-1447] Update metricTypes for qcdr measures

### DIFF
--- a/measures/measures-data.json
+++ b/measures/measures-data.json
@@ -12082,7 +12082,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12105,7 +12105,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12128,7 +12128,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12151,7 +12151,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12174,7 +12174,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12197,7 +12197,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12220,7 +12220,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12243,7 +12243,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12266,7 +12266,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12289,7 +12289,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -12327,7 +12327,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12350,7 +12350,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12373,7 +12373,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12396,7 +12396,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12419,7 +12419,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12442,7 +12442,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12465,7 +12465,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12488,7 +12488,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "sumNumerators",
     "strata": [
       {
@@ -12530,7 +12530,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12576,7 +12576,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12599,7 +12599,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12622,7 +12622,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12645,7 +12645,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12668,7 +12668,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12691,7 +12691,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12714,7 +12714,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12737,7 +12737,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12760,7 +12760,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12783,7 +12783,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12806,7 +12806,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12829,7 +12829,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12852,7 +12852,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12875,7 +12875,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12898,7 +12898,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12921,7 +12921,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12944,7 +12944,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12967,7 +12967,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12990,7 +12990,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13013,7 +13013,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13036,7 +13036,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13059,7 +13059,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13082,7 +13082,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13105,7 +13105,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13128,7 +13128,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13151,7 +13151,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13174,7 +13174,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13197,7 +13197,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13220,7 +13220,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13243,7 +13243,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13266,7 +13266,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13289,7 +13289,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13312,7 +13312,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13335,7 +13335,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13358,7 +13358,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13381,7 +13381,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13404,7 +13404,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13427,7 +13427,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13450,7 +13450,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13473,7 +13473,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13496,7 +13496,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13519,7 +13519,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13542,7 +13542,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13565,7 +13565,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13588,7 +13588,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13611,7 +13611,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13634,7 +13634,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13657,7 +13657,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13680,7 +13680,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13703,7 +13703,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13726,7 +13726,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13749,7 +13749,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13772,7 +13772,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13795,7 +13795,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13818,7 +13818,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13841,7 +13841,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14186,7 +14186,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14209,7 +14209,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14232,7 +14232,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14255,7 +14255,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14278,7 +14278,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14301,7 +14301,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14324,7 +14324,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14347,7 +14347,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14370,7 +14370,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14393,7 +14393,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14416,7 +14416,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14439,7 +14439,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14462,7 +14462,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14485,7 +14485,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14508,7 +14508,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14531,7 +14531,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14554,7 +14554,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14577,7 +14577,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14600,7 +14600,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14623,7 +14623,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14784,7 +14784,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14807,7 +14807,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14830,7 +14830,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14853,7 +14853,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14876,7 +14876,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14899,7 +14899,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14922,7 +14922,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14945,7 +14945,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14968,7 +14968,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14991,7 +14991,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15014,7 +15014,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15037,7 +15037,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15060,7 +15060,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15083,7 +15083,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15106,7 +15106,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15129,7 +15129,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15152,7 +15152,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15175,7 +15175,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15198,7 +15198,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15221,7 +15221,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15244,7 +15244,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15267,7 +15267,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15290,7 +15290,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15313,7 +15313,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15336,7 +15336,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15359,7 +15359,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15382,7 +15382,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15405,7 +15405,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15428,7 +15428,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15451,7 +15451,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15474,7 +15474,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15497,7 +15497,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15520,7 +15520,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15543,7 +15543,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15566,7 +15566,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15589,7 +15589,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15612,7 +15612,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15635,7 +15635,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15658,7 +15658,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15681,7 +15681,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15704,7 +15704,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15727,7 +15727,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15750,7 +15750,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15773,7 +15773,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15796,7 +15796,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15819,7 +15819,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15842,7 +15842,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15865,7 +15865,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15888,7 +15888,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15911,7 +15911,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15934,7 +15934,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15957,7 +15957,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15980,7 +15980,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16003,7 +16003,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16026,7 +16026,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16049,7 +16049,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16072,7 +16072,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16095,7 +16095,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16118,7 +16118,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16141,7 +16141,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16164,7 +16164,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16187,7 +16187,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16210,7 +16210,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -16248,7 +16248,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16271,7 +16271,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16294,7 +16294,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -16328,7 +16328,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16351,7 +16351,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16374,7 +16374,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16397,7 +16397,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16420,7 +16420,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16443,7 +16443,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16466,7 +16466,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16489,7 +16489,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16512,7 +16512,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16535,7 +16535,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16558,7 +16558,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16581,7 +16581,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16604,7 +16604,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16627,7 +16627,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16650,7 +16650,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16673,7 +16673,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16696,7 +16696,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16719,7 +16719,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -16765,7 +16765,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16788,7 +16788,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16811,7 +16811,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16834,7 +16834,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16857,7 +16857,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16880,7 +16880,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16903,7 +16903,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16926,7 +16926,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16949,7 +16949,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16972,7 +16972,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16995,7 +16995,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17018,7 +17018,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17041,7 +17041,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17064,7 +17064,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17087,7 +17087,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17110,7 +17110,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17133,7 +17133,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17156,7 +17156,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17179,7 +17179,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17202,7 +17202,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17225,7 +17225,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17248,7 +17248,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17271,7 +17271,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17294,7 +17294,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17317,7 +17317,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17340,7 +17340,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17363,7 +17363,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17386,7 +17386,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17409,7 +17409,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17432,7 +17432,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17455,7 +17455,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17478,7 +17478,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17501,7 +17501,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17524,7 +17524,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17547,7 +17547,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17570,7 +17570,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17593,7 +17593,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17616,7 +17616,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17639,7 +17639,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17662,7 +17662,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17685,7 +17685,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17708,7 +17708,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17731,7 +17731,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17754,7 +17754,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17777,7 +17777,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17800,7 +17800,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17823,7 +17823,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17846,7 +17846,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17869,7 +17869,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17892,7 +17892,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17915,7 +17915,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17938,7 +17938,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17961,7 +17961,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17984,7 +17984,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18168,7 +18168,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18191,7 +18191,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18214,7 +18214,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18237,7 +18237,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18421,7 +18421,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18444,7 +18444,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18467,7 +18467,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18490,7 +18490,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18513,7 +18513,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18536,7 +18536,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18559,7 +18559,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18582,7 +18582,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18605,7 +18605,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18628,7 +18628,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18651,7 +18651,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18674,7 +18674,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18697,7 +18697,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18720,7 +18720,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18743,7 +18743,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18766,7 +18766,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18789,7 +18789,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18812,7 +18812,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18835,7 +18835,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18858,7 +18858,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18881,7 +18881,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18904,7 +18904,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18927,7 +18927,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18950,7 +18950,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18973,7 +18973,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "weightedAverage",
     "strata": [
       {
@@ -19007,7 +19007,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19030,7 +19030,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19053,7 +19053,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19076,7 +19076,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19099,7 +19099,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19122,7 +19122,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19145,7 +19145,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19168,7 +19168,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19191,7 +19191,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -19271,7 +19271,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19340,7 +19340,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19363,7 +19363,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19524,7 +19524,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19547,7 +19547,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19570,7 +19570,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19593,7 +19593,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19616,7 +19616,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19639,7 +19639,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19685,7 +19685,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19708,7 +19708,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19731,7 +19731,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -19765,7 +19765,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -19799,7 +19799,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -19833,7 +19833,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19856,7 +19856,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19879,7 +19879,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20063,7 +20063,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20086,7 +20086,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20109,7 +20109,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20132,7 +20132,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20155,7 +20155,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20178,7 +20178,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20201,7 +20201,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20224,7 +20224,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20247,7 +20247,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20270,7 +20270,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20293,7 +20293,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20316,7 +20316,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20339,7 +20339,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20362,7 +20362,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20385,7 +20385,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20408,7 +20408,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20431,7 +20431,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20454,7 +20454,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20477,7 +20477,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20500,7 +20500,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20523,7 +20523,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20546,7 +20546,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20569,7 +20569,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20592,7 +20592,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20615,7 +20615,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20638,7 +20638,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20661,7 +20661,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20684,7 +20684,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20707,7 +20707,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20730,7 +20730,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20753,7 +20753,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20776,7 +20776,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20799,7 +20799,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20822,7 +20822,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20845,7 +20845,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20868,7 +20868,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20891,7 +20891,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "weightedAverage",
     "strata": [
       {
@@ -20925,7 +20925,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20948,7 +20948,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21247,7 +21247,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21270,7 +21270,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -21308,7 +21308,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21331,7 +21331,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21354,7 +21354,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -21388,7 +21388,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21411,7 +21411,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21434,7 +21434,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21457,7 +21457,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21480,7 +21480,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21503,7 +21503,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21526,7 +21526,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21549,7 +21549,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21572,7 +21572,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21595,7 +21595,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21618,7 +21618,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21641,7 +21641,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21664,7 +21664,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21710,7 +21710,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21733,7 +21733,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21756,7 +21756,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21779,7 +21779,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21802,7 +21802,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21825,7 +21825,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21848,7 +21848,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21871,7 +21871,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21894,7 +21894,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21917,7 +21917,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21940,7 +21940,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21963,7 +21963,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -21997,7 +21997,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -22031,7 +22031,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -22065,7 +22065,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22088,7 +22088,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22111,7 +22111,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -22168,7 +22168,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22191,7 +22191,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -22225,7 +22225,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -22259,7 +22259,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -22293,7 +22293,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22316,7 +22316,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22339,7 +22339,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22362,7 +22362,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22385,7 +22385,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22408,7 +22408,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22431,7 +22431,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22454,7 +22454,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22477,7 +22477,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22500,7 +22500,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22523,7 +22523,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22546,7 +22546,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22569,7 +22569,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22592,7 +22592,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22615,7 +22615,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22638,7 +22638,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22661,7 +22661,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22684,7 +22684,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22707,7 +22707,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22730,7 +22730,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22753,7 +22753,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22776,7 +22776,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22799,7 +22799,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "weightedAverage",
     "strata": [
       {
@@ -22833,7 +22833,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22856,7 +22856,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22879,7 +22879,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22902,7 +22902,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22925,7 +22925,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22948,7 +22948,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22971,7 +22971,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22994,7 +22994,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23017,7 +23017,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23040,7 +23040,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23063,7 +23063,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23086,7 +23086,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23109,7 +23109,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23132,7 +23132,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23155,7 +23155,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23178,7 +23178,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23201,7 +23201,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23224,7 +23224,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23247,7 +23247,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23270,7 +23270,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23293,7 +23293,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23316,7 +23316,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23339,7 +23339,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23362,7 +23362,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23385,7 +23385,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23408,7 +23408,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23431,7 +23431,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23454,7 +23454,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23477,7 +23477,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23500,7 +23500,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23523,7 +23523,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23546,7 +23546,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23569,7 +23569,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23592,7 +23592,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23615,7 +23615,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23638,7 +23638,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23868,7 +23868,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23891,7 +23891,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23914,7 +23914,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "sumNumerators",
     "strata": [
       {
@@ -23952,7 +23952,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23975,7 +23975,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23998,7 +23998,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24021,7 +24021,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24044,7 +24044,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24067,7 +24067,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24090,7 +24090,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24113,7 +24113,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24136,7 +24136,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24159,7 +24159,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24182,7 +24182,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24205,7 +24205,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24228,7 +24228,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24251,7 +24251,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24274,7 +24274,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24297,7 +24297,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24320,7 +24320,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24343,7 +24343,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24366,7 +24366,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "weightedAverage",
     "strata": [
       {
@@ -24404,7 +24404,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24427,7 +24427,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24450,7 +24450,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24473,7 +24473,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24496,7 +24496,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24519,7 +24519,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24542,7 +24542,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24565,7 +24565,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24588,7 +24588,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24611,7 +24611,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24634,7 +24634,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24657,7 +24657,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24680,7 +24680,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24703,7 +24703,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24726,7 +24726,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24749,7 +24749,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24772,7 +24772,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24795,7 +24795,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "weightedAverage",
     "strata": [
       {
@@ -24829,7 +24829,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "weightedAverage",
     "strata": [
       {
@@ -24863,7 +24863,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -24901,7 +24901,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -24939,7 +24939,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24962,7 +24962,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -25000,7 +25000,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25023,7 +25023,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25046,7 +25046,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25069,7 +25069,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25092,7 +25092,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25115,7 +25115,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25138,7 +25138,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25161,7 +25161,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25184,7 +25184,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25207,7 +25207,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25230,7 +25230,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25253,7 +25253,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25276,7 +25276,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25299,7 +25299,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25322,7 +25322,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25345,7 +25345,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25368,7 +25368,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25391,7 +25391,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25414,7 +25414,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25437,7 +25437,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25460,7 +25460,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25483,7 +25483,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25506,7 +25506,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25529,7 +25529,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25552,7 +25552,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25575,7 +25575,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25598,7 +25598,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25621,7 +25621,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25644,7 +25644,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25667,7 +25667,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25690,7 +25690,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25713,7 +25713,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25736,7 +25736,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25759,7 +25759,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25782,7 +25782,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25805,7 +25805,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25828,7 +25828,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25851,7 +25851,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25874,7 +25874,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25897,7 +25897,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25920,7 +25920,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25943,7 +25943,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -26012,7 +26012,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -26035,7 +26035,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -26058,7 +26058,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -26081,7 +26081,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -26104,7 +26104,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -26127,7 +26127,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -26150,7 +26150,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -26173,7 +26173,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -26196,7 +26196,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -26219,7 +26219,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -26261,7 +26261,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -26284,7 +26284,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -26307,7 +26307,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -26330,7 +26330,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -26368,7 +26368,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -26391,7 +26391,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -26414,7 +26414,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -26437,7 +26437,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -26479,7 +26479,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -26502,7 +26502,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]

--- a/measures/measures-data.xml
+++ b/measures/measures-data.xml
@@ -10536,7 +10536,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -10556,7 +10556,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -10576,7 +10576,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -10596,7 +10596,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -10616,7 +10616,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -10636,7 +10636,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -10656,7 +10656,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -10676,7 +10676,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -10696,7 +10696,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -10722,7 +10722,7 @@ Rate 3: Total patients prescribed long-term control medication</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>ICS</name>
@@ -10757,7 +10757,7 @@ Rate 3: Total patients prescribed long-term control medication</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -10779,7 +10779,7 @@ Rate 3: Total patients prescribed long-term control medication</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -10801,7 +10801,7 @@ Rate 3: Total patients prescribed long-term control medication</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -10823,7 +10823,7 @@ Rate 3: Total patients prescribed long-term control medication</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -10845,7 +10845,7 @@ Rate 3: Total patients prescribed long-term control medication</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -10867,7 +10867,7 @@ HOQR is a quality data-reporting program, implemented by CMS for outpatient hosp
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -10887,7 +10887,7 @@ HOQR is a quality data-reporting program, implemented by CMS for outpatient hosp
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -10911,7 +10911,7 @@ Rate 4: The percent of ischemic stroke patients with an LDL greater than or equa
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>sumNumerators</overallAlgorithm>
     <strata>
       <name>antithrombotic</name>
@@ -10948,7 +10948,7 @@ Rate 4: The percent of ischemic stroke patients with an LDL greater than or equa
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -10988,7 +10988,7 @@ Rate 4: The percent of ischemic stroke patients with an LDL greater than or equa
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11008,7 +11008,7 @@ Rate 4: The percent of ischemic stroke patients with an LDL greater than or equa
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11028,7 +11028,7 @@ Rate 4: The percent of ischemic stroke patients with an LDL greater than or equa
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11048,7 +11048,7 @@ Rate 4: The percent of ischemic stroke patients with an LDL greater than or equa
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11070,7 +11070,7 @@ This measure evaluates the occurrence of stroke as an outcome of a percutaneous 
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11092,7 +11092,7 @@ This measure evaluates the occurrence of the new need for dialysis as an outcome
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11118,7 +11118,7 @@ This measure evaluates the occurrence of vascular site injury requiring treatmen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11140,7 +11140,7 @@ This measure evaluates the occurrence of cardiac tamponade as an outcome of a pe
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11162,7 +11162,7 @@ This measure reflects the processes of care and current guidelines associated wi
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11182,7 +11182,7 @@ This measure reflects the processes of care and current guidelines associated wi
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11204,7 +11204,7 @@ This metric evaluates the process of care associated with the multi-society guid
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11224,7 +11224,7 @@ This metric evaluates the process of care associated with the multi-society guid
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11244,7 +11244,7 @@ This metric evaluates the process of care associated with the multi-society guid
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11264,7 +11264,7 @@ This metric evaluates the process of care associated with the multi-society guid
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11284,7 +11284,7 @@ This metric evaluates the process of care associated with the multi-society guid
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11304,7 +11304,7 @@ This metric evaluates the process of care associated with the multi-society guid
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11326,7 +11326,7 @@ when seen for an initial evaluation for distal symmetric polyneuropathy.</descri
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11348,7 +11348,7 @@ when seen for an initial evaluation for distal symmetric polyneuropathy.</descri
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11369,7 +11369,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11389,7 +11389,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11410,7 +11410,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11430,7 +11430,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11450,7 +11450,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11470,7 +11470,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11490,7 +11490,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11510,7 +11510,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11530,7 +11530,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11550,7 +11550,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11570,7 +11570,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11590,7 +11590,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11610,7 +11610,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11630,7 +11630,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11650,7 +11650,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11670,7 +11670,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11690,7 +11690,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11710,7 +11710,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11730,7 +11730,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11750,7 +11750,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11770,7 +11770,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11790,7 +11790,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11810,7 +11810,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11830,7 +11830,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11850,7 +11850,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11870,7 +11870,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11890,7 +11890,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11911,7 +11911,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11932,7 +11932,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11952,7 +11952,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11972,7 +11972,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -11992,7 +11992,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12012,7 +12012,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12032,7 +12032,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12052,7 +12052,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12072,7 +12072,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12092,7 +12092,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12112,7 +12112,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12531,7 +12531,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12551,7 +12551,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12571,7 +12571,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12591,7 +12591,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12611,7 +12611,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12631,7 +12631,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12651,7 +12651,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12671,7 +12671,7 @@ recommended medication for acute migraine attacks within the 12 month measuremen
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12693,7 +12693,7 @@ Inverse measure</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12713,7 +12713,7 @@ Inverse measure</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12733,7 +12733,7 @@ Inverse measure</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12754,7 +12754,7 @@ as positive (Lung-RADS Category 3 or 4).</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12777,7 +12777,7 @@ or 4) and result in a tissue diagnosis of cancer within
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12800,7 +12800,7 @@ months.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12820,7 +12820,7 @@ months.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12840,7 +12840,7 @@ months.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12860,7 +12860,7 @@ months.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12882,7 +12882,7 @@ Inverse measure</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12904,7 +12904,7 @@ Inverse measure</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -12928,7 +12928,7 @@ Inverse measure</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13077,7 +13077,7 @@ Continuous measure scoring</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13100,7 +13100,7 @@ diagnosis of cancer within 12 months (expressed per
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13120,7 +13120,7 @@ diagnosis of cancer within 12 months (expressed per
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13141,7 +13141,7 @@ screening mammography that are node negative</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13164,7 +13164,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13184,7 +13184,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13207,7 +13207,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13227,7 +13227,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13247,7 +13247,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13267,7 +13267,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13289,7 +13289,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13313,7 +13313,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13335,7 +13335,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13355,7 +13355,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13375,7 +13375,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13395,7 +13395,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13415,7 +13415,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13435,7 +13435,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13455,7 +13455,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13475,7 +13475,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13495,7 +13495,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13515,7 +13515,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13536,7 +13536,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13557,7 +13557,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13577,7 +13577,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13598,7 +13598,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13618,7 +13618,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13639,7 +13639,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13659,7 +13659,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13679,7 +13679,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13699,7 +13699,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13719,7 +13719,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13739,7 +13739,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13759,7 +13759,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13779,7 +13779,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13799,7 +13799,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13819,7 +13819,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13839,7 +13839,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13859,7 +13859,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13879,7 +13879,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13899,7 +13899,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13919,7 +13919,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13939,7 +13939,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13959,7 +13959,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13979,7 +13979,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -13999,7 +13999,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14019,7 +14019,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14039,7 +14039,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14059,7 +14059,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14079,7 +14079,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14099,7 +14099,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14119,7 +14119,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14139,7 +14139,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14159,7 +14159,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14179,7 +14179,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14199,7 +14199,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14219,7 +14219,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14239,7 +14239,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14259,7 +14259,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14279,7 +14279,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14299,7 +14299,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14319,7 +14319,7 @@ diagnosis of cancer within 12 months. Note: Recommendation for biopsy may be mad
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14344,7 +14344,7 @@ Rate 3: Abdominal Wall Reconstruction Surgical Site Occurrence Requiring Procedu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>hernia</name>
@@ -14377,7 +14377,7 @@ Rate 3: Abdominal Wall Reconstruction Surgical Site Occurrence Requiring Procedu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14397,7 +14397,7 @@ Rate 3: Abdominal Wall Reconstruction Surgical Site Occurrence Requiring Procedu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14420,7 +14420,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>overall</name>
@@ -14449,7 +14449,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14469,7 +14469,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14489,7 +14489,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14509,7 +14509,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14529,7 +14529,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14549,7 +14549,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14569,7 +14569,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14589,7 +14589,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14609,7 +14609,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14629,7 +14629,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14649,7 +14649,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14669,7 +14669,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14689,7 +14689,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14709,7 +14709,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14729,7 +14729,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14749,7 +14749,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14769,7 +14769,7 @@ Rate 2: Ventral Hernia Repair: Pain and Functional Status Assessment-Email engag
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14795,7 +14795,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>lysine</name>
@@ -14836,7 +14836,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14856,7 +14856,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14876,7 +14876,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14896,7 +14896,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14916,7 +14916,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14936,7 +14936,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14956,7 +14956,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14976,7 +14976,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -14996,7 +14996,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15016,7 +15016,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15036,7 +15036,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15056,7 +15056,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15076,7 +15076,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15096,7 +15096,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15116,7 +15116,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15136,7 +15136,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15156,7 +15156,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15176,7 +15176,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15196,7 +15196,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15216,7 +15216,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15236,7 +15236,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15256,7 +15256,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15276,7 +15276,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15296,7 +15296,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15316,7 +15316,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15336,7 +15336,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15356,7 +15356,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15376,7 +15376,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15396,7 +15396,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15416,7 +15416,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15436,7 +15436,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15456,7 +15456,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15476,7 +15476,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15496,7 +15496,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15516,7 +15516,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15536,7 +15536,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15556,7 +15556,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15576,7 +15576,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15596,7 +15596,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15616,7 +15616,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15636,7 +15636,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15656,7 +15656,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15676,7 +15676,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15704,7 +15704,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15745,7 +15745,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15768,7 +15768,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15788,7 +15788,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15808,7 +15808,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15828,7 +15828,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15848,7 +15848,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15868,7 +15868,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15888,7 +15888,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15908,7 +15908,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -15928,7 +15928,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16088,7 +16088,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16108,7 +16108,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16128,7 +16128,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16148,7 +16148,7 @@ Rate 5: Composite Performance Score: Percentage of denominator-eligible patients
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16330,7 +16330,7 @@ Patient’s Knee Measure Change Score: A patient’s change score is calculated 
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16350,7 +16350,7 @@ Patient’s Knee Measure Change Score: A patient’s change score is calculated 
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16372,7 +16372,7 @@ Patient’s Knee Measure Change Score: A patient’s change score is calculated 
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16394,7 +16394,7 @@ Patient’s Knee Measure Change Score: A patient’s change score is calculated 
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16415,7 +16415,7 @@ Patient’s Knee Measure Change Score: A patient’s change score is calculated 
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16437,7 +16437,7 @@ Patient’s Knee Measure Change Score: A patient’s change score is calculated 
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16458,7 +16458,7 @@ Supra-Inguinal Bypass, Peripheral Vascular Intervention, Carotid Artery Stent, C
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16479,7 +16479,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16499,7 +16499,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16519,7 +16519,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16539,7 +16539,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16559,7 +16559,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16579,7 +16579,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16599,7 +16599,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16619,7 +16619,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16639,7 +16639,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16659,7 +16659,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16679,7 +16679,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16699,7 +16699,7 @@ after Infra-Inguinal Bypass for intermittent claudication.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16726,7 +16726,7 @@ Note: Limiting the composite measure score to the highest response category prov
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16757,7 +16757,7 @@ Bivarus 26: How Likely Are You to Recommend This Physician To Your Family And Fr
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16786,7 +16786,7 @@ Bivarus 26: How Likely Are You to Recommend This Physician To Your Family And Fr
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16814,7 +16814,7 @@ Bivarus 26: How Likely Are You to Recommend This Physician To Your Family And Fr
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16842,7 +16842,7 @@ Bivarus 26: How Likely Are You to Recommend This Physician To Your Family And Fr
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16872,7 +16872,7 @@ Rate 2: Percentage of patients receiving manipulative medicine with a QVAS score
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>weightedAverage</overallAlgorithm>
     <strata>
       <name>back</name>
@@ -16903,7 +16903,7 @@ Rate 2: Percentage of patients receiving manipulative medicine with a QVAS score
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16928,7 +16928,7 @@ Measure explanation: Chronic Pain medication prescribed (prescribed for greater 
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16950,7 +16950,7 @@ Measure explanation: Controlled substance agreement (CSA) or opiate agreement (O
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16972,7 +16972,7 @@ Measure explanation: Controlled substance agreement (CSA) or opiate agreement (O
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -16994,7 +16994,7 @@ Measure explanation: Pain conditions that can be treated definitively to avoid o
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17018,7 +17018,7 @@ Measure explanation: Spinal stenosis typically is conservatively managed until s
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17038,7 +17038,7 @@ Measure explanation: Spinal stenosis typically is conservatively managed until s
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17058,7 +17058,7 @@ Measure explanation: Spinal stenosis typically is conservatively managed until s
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17080,7 +17080,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>overall</name>
@@ -17155,7 +17155,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17215,7 +17215,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17235,7 +17235,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17385,7 +17385,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17405,7 +17405,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17425,7 +17425,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17445,7 +17445,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17465,7 +17465,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17485,7 +17485,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17525,7 +17525,7 @@ Rate 2: In Urgent Care (UC), Percentage of Patients Aged 18 Years and Older with
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17546,7 +17546,7 @@ procedure.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17573,7 +17573,7 @@ Rate 2: The overall percentage of patients that improve their general health sco
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>postsurvey</name>
@@ -17609,7 +17609,7 @@ Rate 2: The overall percentage of patients that improve their pain scores beyond
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>postsurvey</name>
@@ -17645,7 +17645,7 @@ Rate 2: The overall percentage of patients that improve their function scores be
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>postsurvey</name>
@@ -17682,7 +17682,7 @@ Rate 2: The overall percentage of patients that improve their function scores be
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17710,7 +17710,7 @@ INSTRUCTIONS:
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17737,7 +17737,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17899,7 +17899,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17919,7 +17919,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17939,7 +17939,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17959,7 +17959,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -17981,7 +17981,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18003,7 +18003,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18025,7 +18025,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18045,7 +18045,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18065,7 +18065,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18085,7 +18085,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18105,7 +18105,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18126,7 +18126,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18148,7 +18148,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18170,7 +18170,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18190,7 +18190,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18210,7 +18210,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18230,7 +18230,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18250,7 +18250,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18270,7 +18270,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18290,7 +18290,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18310,7 +18310,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18330,7 +18330,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18350,7 +18350,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18370,7 +18370,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18390,7 +18390,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18410,7 +18410,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18430,7 +18430,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18450,7 +18450,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18470,7 +18470,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18490,7 +18490,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18510,7 +18510,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18530,7 +18530,7 @@ This measure is to be reported a minimum of once per reporting period for eligib
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18551,7 +18551,7 @@ meeting established criteria, notified of need for follow-up from the provider.<
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18571,7 +18571,7 @@ meeting established criteria, notified of need for follow-up from the provider.<
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18593,7 +18593,7 @@ meeting established criteria, notified of need for follow-up from the provider.<
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18617,7 +18617,7 @@ meeting established criteria, notified of need for follow-up from the provider.<
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18643,7 +18643,7 @@ Rate 2: The percentage of adult (18-50 years of age) patients who had a diagnosi
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>weightedAverage</overallAlgorithm>
     <strata>
       <name>pediatric</name>
@@ -18677,7 +18677,7 @@ Rate 2: The percentage of adult (18-50 years of age) patients who had a diagnosi
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18699,7 +18699,7 @@ On daily aspirin or anti-platelets, unless allowed contraindications or exceptio
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18966,7 +18966,7 @@ and transfers from other institutions.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -18992,7 +18992,7 @@ Rate 3: Percentage of patients who received both a basic ADL and IADL assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>ADL</name>
@@ -19025,7 +19025,7 @@ Rate 3: Percentage of patients who received both a basic ADL and IADL assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19045,7 +19045,7 @@ Rate 3: Percentage of patients who received both a basic ADL and IADL assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19068,7 +19068,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>reviewed</name>
@@ -19097,7 +19097,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19117,7 +19117,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19137,7 +19137,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19157,7 +19157,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19177,7 +19177,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19197,7 +19197,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19217,7 +19217,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19237,7 +19237,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19257,7 +19257,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19277,7 +19277,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19297,7 +19297,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19317,7 +19317,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19337,7 +19337,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19377,7 +19377,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19397,7 +19397,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19417,7 +19417,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19437,7 +19437,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19457,7 +19457,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19477,7 +19477,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19497,7 +19497,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19517,7 +19517,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19537,7 +19537,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19557,7 +19557,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19577,7 +19577,7 @@ Rate 2: Percentage of patients with offending medications whose use of offending
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19599,7 +19599,7 @@ Rate 2: Patient population with improvement in functional status after Follow-up
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>baseline</name>
@@ -19630,7 +19630,7 @@ Rate 2: Patient population with improvement in quality of life status after Foll
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>baseline</name>
@@ -19661,7 +19661,7 @@ Rate 2: Patient population with improvement in satisfaction with care status aft
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>baseline</name>
@@ -19690,7 +19690,7 @@ Rate 2: Patient population with improvement in satisfaction with care status aft
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19710,7 +19710,7 @@ Rate 2: Patient population with improvement in satisfaction with care status aft
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19732,7 +19732,7 @@ Rate 2: Patient population with improvement in functional status (at least 10% i
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>overall</name>
@@ -19785,7 +19785,7 @@ Overall Rate = Rate 1</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19807,7 +19807,7 @@ Rate 2: Patient population with improvement in Quality of life status from the b
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>overall</name>
@@ -19838,7 +19838,7 @@ Rate 2: Patient population with improvement in satisfaction with care status fro
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>overall</name>
@@ -19869,7 +19869,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>overall</name>
@@ -19898,7 +19898,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19918,7 +19918,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19938,7 +19938,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19958,7 +19958,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19978,7 +19978,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -19998,7 +19998,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20018,7 +20018,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20038,7 +20038,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20058,7 +20058,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20078,7 +20078,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20098,7 +20098,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20118,7 +20118,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20138,7 +20138,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20158,7 +20158,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20178,7 +20178,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20198,7 +20198,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20218,7 +20218,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20238,7 +20238,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20258,7 +20258,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20278,7 +20278,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20298,7 +20298,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20318,7 +20318,7 @@ Rate 2: Patient population with improvement in the pain status from the baseline
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20340,7 +20340,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>weightedAverage</overallAlgorithm>
     <strata>
       <name>12to18</name>
@@ -20369,7 +20369,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20399,7 +20399,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20424,7 +20424,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20444,7 +20444,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20464,7 +20464,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20484,7 +20484,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20504,7 +20504,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20524,7 +20524,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20544,7 +20544,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20564,7 +20564,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20584,7 +20584,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20604,7 +20604,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20624,7 +20624,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20644,7 +20644,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20664,7 +20664,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20684,7 +20684,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20706,7 +20706,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20727,7 +20727,7 @@ Rate 2: Percentage of patients age 18 years and older screened for substance use
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20748,7 +20748,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20771,7 +20771,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20791,7 +20791,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20811,7 +20811,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20832,7 +20832,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20852,7 +20852,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20872,7 +20872,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20892,7 +20892,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20912,7 +20912,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20932,7 +20932,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20952,7 +20952,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20972,7 +20972,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -20992,7 +20992,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21012,7 +21012,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21032,7 +21032,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21052,7 +21052,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21072,7 +21072,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21092,7 +21092,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21292,7 +21292,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21312,7 +21312,7 @@ All or None Process Measure (Optimal Testing) composite of two A1C’s, one Kidn
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21335,7 +21335,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>sumNumerators</overallAlgorithm>
     <strata>
       <name>ace</name>
@@ -21370,7 +21370,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21390,7 +21390,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21410,7 +21410,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21430,7 +21430,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21450,7 +21450,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21470,7 +21470,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21490,7 +21490,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21510,7 +21510,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21530,7 +21530,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21556,7 +21556,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21584,7 +21584,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21612,7 +21612,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21640,7 +21640,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21660,7 +21660,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21680,7 +21680,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21700,7 +21700,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21720,7 +21720,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21740,7 +21740,7 @@ Rate 3: Annual monitoring for patients on diuretics: At least one serum potassiu
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21768,7 +21768,7 @@ Rate 3: CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>weightedAverage</overallAlgorithm>
     <strata>
       <name>CKD3</name>
@@ -21801,7 +21801,7 @@ Rate 3: CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21821,7 +21821,7 @@ Rate 3: CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21841,7 +21841,7 @@ Rate 3: CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21861,7 +21861,7 @@ Rate 3: CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21881,7 +21881,7 @@ Rate 3: CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21901,7 +21901,7 @@ Rate 3: CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21921,7 +21921,7 @@ Rate 3: CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21941,7 +21941,7 @@ Rate 3: CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21961,7 +21961,7 @@ Rate 3: CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -21981,7 +21981,7 @@ Rate 3: CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22001,7 +22001,7 @@ Rate 3: CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22021,7 +22021,7 @@ Rate 3: CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22041,7 +22041,7 @@ Rate 3: CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22061,7 +22061,7 @@ Rate 3: CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22081,7 +22081,7 @@ Rate 3: CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22101,7 +22101,7 @@ Rate 3: CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22121,7 +22121,7 @@ Rate 3: CKD 5 Patients with 8 or more visits/yr.</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22143,7 +22143,7 @@ Rate 2: the percentage of discharges with excess days where clinician provided t
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>weightedAverage</overallAlgorithm>
     <strata>
       <name>withoutexcess</name>
@@ -22174,7 +22174,7 @@ Rate 2: the percentage of discharges without subsequent office visits within 7 d
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>weightedAverage</overallAlgorithm>
     <strata>
       <name>withfollowup</name>
@@ -22206,7 +22206,7 @@ Performance Rate 3: The difference between Performance Rate 1 and Performance Ra
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>&lt;9</name>
@@ -22244,7 +22244,7 @@ Performance Rate 3: The difference between Performance Rate 1 and Performance Ra
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>&gt;=160</name>
@@ -22279,7 +22279,7 @@ Performance</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22302,7 +22302,7 @@ Performance Rate 3: The difference between Performance Rate 1 and Performance Ra
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>decreased</name>
@@ -22337,7 +22337,7 @@ Performance</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22357,7 +22357,7 @@ Performance</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22377,7 +22377,7 @@ Performance</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22397,7 +22397,7 @@ Performance</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22417,7 +22417,7 @@ Performance</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22437,7 +22437,7 @@ Performance</description>
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22467,7 +22467,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22487,7 +22487,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22507,7 +22507,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22527,7 +22527,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22547,7 +22547,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22567,7 +22567,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22587,7 +22587,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22607,7 +22607,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22627,7 +22627,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22647,7 +22647,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22667,7 +22667,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22687,7 +22687,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22707,7 +22707,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22727,7 +22727,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22747,7 +22747,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22767,7 +22767,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22787,7 +22787,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22807,7 +22807,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22827,7 +22827,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22847,7 +22847,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22867,7 +22867,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22887,7 +22887,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22907,7 +22907,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22927,7 +22927,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22949,7 +22949,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22969,7 +22969,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -22991,7 +22991,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23011,7 +23011,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23031,7 +23031,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23051,7 +23051,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23071,7 +23071,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23091,7 +23091,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23114,7 +23114,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23134,7 +23134,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23154,7 +23154,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23177,7 +23177,7 @@ assessment
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23241,7 +23241,7 @@ NOTE: Negative decreases (or increases in pain inference) for a provider's overa
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23261,7 +23261,7 @@ NOTE: Negative decreases (or increases in pain inference) for a provider's overa
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23281,7 +23281,7 @@ NOTE: Negative decreases (or increases in pain inference) for a provider's overa
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23301,7 +23301,7 @@ NOTE: Negative decreases (or increases in pain inference) for a provider's overa
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23321,7 +23321,7 @@ NOTE: Negative decreases (or increases in pain inference) for a provider's overa
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23341,7 +23341,7 @@ NOTE: Negative decreases (or increases in pain inference) for a provider's overa
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23361,7 +23361,7 @@ NOTE: Negative decreases (or increases in pain inference) for a provider's overa
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23381,7 +23381,7 @@ NOTE: Negative decreases (or increases in pain inference) for a provider's overa
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23401,7 +23401,7 @@ NOTE: Negative decreases (or increases in pain inference) for a provider's overa
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23428,7 +23428,7 @@ Rate 4: The average of the three risk stratified buckets which will be the perfo
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>bucket1</name>
@@ -23465,7 +23465,7 @@ Rate 4: The average of the three risk stratified buckets which will be the perfo
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23487,7 +23487,7 @@ Using the MNA Short Form algorithm, if a patient at risk of malnutrition has an 
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23509,7 +23509,7 @@ Using the Self-MNA® by Nestlé, if a patient at risk of malnutrition has an MNA
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23535,7 +23535,7 @@ Rate 3: Percentage of patients undergoing HBOT with vital signs taken and those 
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>vital</name>
@@ -23568,7 +23568,7 @@ Rate 3: Percentage of patients undergoing HBOT with vital signs taken and those 
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23588,7 +23588,7 @@ Rate 3: Percentage of patients undergoing HBOT with vital signs taken and those 
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23608,7 +23608,7 @@ Rate 3: Percentage of patients undergoing HBOT with vital signs taken and those 
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23635,7 +23635,7 @@ Rate 4: The average of the three risk stratified buckets which will be the perfo
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>multiPerformanceRate</metricType>
+    <metricType>registryMultiPerformanceRate</metricType>
     <overallAlgorithm>overallStratumOnly</overallAlgorithm>
     <strata>
       <name>bucket1</name>
@@ -23672,7 +23672,7 @@ Rate 4: The average of the three risk stratified buckets which will be the perfo
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
   <measure>
@@ -23692,7 +23692,7 @@ Rate 4: The average of the three risk stratified buckets which will be the perfo
     <nqfEMeasureId/>
     <nqfId/>
     <isRegistryMeasure>true</isRegistryMeasure>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>registrySinglePerformanceRate</metricType>
     <submissionMethod>registry</submissionMethod>
   </measure>
 </measures>

--- a/measures/measures-schema.yaml
+++ b/measures/measures-schema.yaml
@@ -17,7 +17,7 @@ definitions:
         enum: [ia, quality, aci, cost]
       metricType:
         description: Type of measurement that the measure requires in order to attest.
-        enum: [boolean, proportion, singlePerformanceRate, multiPerformanceRate, nonProportion, cahps]
+        enum: [boolean, proportion, singlePerformanceRate, multiPerformanceRate, registrySinglePerformanceRate, registryMultiPerformanceRate, nonProportion, cahps]
       firstPerformanceYear:
         description: Year in which the measure was introduced.
         type: integer
@@ -146,12 +146,12 @@ definitions:
     oneOf: [
       {
         properties: {
-          metricType: { enum: [multiPerformanceRate] }
+          metricType: { enum: [multiPerformanceRate, registryMultiPerformanceRate] }
         },
         required: [overallAlgorithm, strata]
       },{
         properties: {
-          metricType: { enum: [singlePerformanceRate, nonProportion, cahps] }
+          metricType: { enum: [singlePerformanceRate, nonProportion, cahps, registrySinglePerformanceRate] }
         }
       }]
     required: [nationalQualityStrategyDomain, measureType, eMeasureId, nqfEMeasureId, nqfId, isHighPriority, isInverse, primarySteward, measureSets, submissionMethods, isRegistryMeasure]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.0.0-alpha.21",
+  "version": "1.0.0-alpha.22",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/staging/measures-data-with-qcdrs.json
+++ b/staging/measures-data-with-qcdrs.json
@@ -11095,7 +11095,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11118,7 +11118,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11141,7 +11141,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11164,7 +11164,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11187,7 +11187,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11210,7 +11210,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11233,7 +11233,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11256,7 +11256,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11279,7 +11279,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11302,7 +11302,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -11340,7 +11340,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11363,7 +11363,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11386,7 +11386,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11409,7 +11409,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11432,7 +11432,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11455,7 +11455,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11478,7 +11478,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11501,7 +11501,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "sumNumerators",
     "strata": [
       {
@@ -11543,7 +11543,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11589,7 +11589,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11612,7 +11612,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11635,7 +11635,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11658,7 +11658,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11681,7 +11681,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11704,7 +11704,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11727,7 +11727,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11750,7 +11750,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11773,7 +11773,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11796,7 +11796,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11819,7 +11819,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11842,7 +11842,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11865,7 +11865,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11888,7 +11888,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11911,7 +11911,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11934,7 +11934,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11957,7 +11957,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -11980,7 +11980,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12003,7 +12003,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12026,7 +12026,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12049,7 +12049,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12072,7 +12072,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12095,7 +12095,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12118,7 +12118,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12141,7 +12141,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12164,7 +12164,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12187,7 +12187,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12210,7 +12210,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12233,7 +12233,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12256,7 +12256,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12279,7 +12279,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12302,7 +12302,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12325,7 +12325,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12348,7 +12348,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12371,7 +12371,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12394,7 +12394,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12417,7 +12417,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12440,7 +12440,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12463,7 +12463,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12486,7 +12486,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12509,7 +12509,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12532,7 +12532,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12555,7 +12555,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12578,7 +12578,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12601,7 +12601,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12624,7 +12624,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12647,7 +12647,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12670,7 +12670,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12693,7 +12693,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12716,7 +12716,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12739,7 +12739,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12762,7 +12762,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12785,7 +12785,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12808,7 +12808,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12831,7 +12831,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -12854,7 +12854,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13199,7 +13199,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13222,7 +13222,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13245,7 +13245,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13268,7 +13268,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13291,7 +13291,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13314,7 +13314,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13337,7 +13337,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13360,7 +13360,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13383,7 +13383,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13406,7 +13406,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13429,7 +13429,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13452,7 +13452,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13475,7 +13475,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13498,7 +13498,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13521,7 +13521,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13544,7 +13544,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13567,7 +13567,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13590,7 +13590,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13613,7 +13613,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13636,7 +13636,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13797,7 +13797,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13820,7 +13820,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13843,7 +13843,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13866,7 +13866,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13889,7 +13889,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13912,7 +13912,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13935,7 +13935,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13958,7 +13958,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -13981,7 +13981,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14004,7 +14004,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14027,7 +14027,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14050,7 +14050,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14073,7 +14073,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14096,7 +14096,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14119,7 +14119,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14142,7 +14142,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14165,7 +14165,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14188,7 +14188,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14211,7 +14211,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14234,7 +14234,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14257,7 +14257,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14280,7 +14280,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14303,7 +14303,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14326,7 +14326,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14349,7 +14349,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14372,7 +14372,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14395,7 +14395,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14418,7 +14418,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14441,7 +14441,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14464,7 +14464,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14487,7 +14487,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14510,7 +14510,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14533,7 +14533,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14556,7 +14556,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14579,7 +14579,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14602,7 +14602,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14625,7 +14625,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14648,7 +14648,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14671,7 +14671,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14694,7 +14694,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14717,7 +14717,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14740,7 +14740,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14763,7 +14763,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14786,7 +14786,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14809,7 +14809,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14832,7 +14832,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14855,7 +14855,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14878,7 +14878,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14901,7 +14901,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14924,7 +14924,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14947,7 +14947,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14970,7 +14970,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -14993,7 +14993,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15016,7 +15016,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15039,7 +15039,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15062,7 +15062,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15085,7 +15085,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15108,7 +15108,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15131,7 +15131,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15154,7 +15154,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15177,7 +15177,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15200,7 +15200,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15223,7 +15223,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -15261,7 +15261,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15284,7 +15284,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15307,7 +15307,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -15341,7 +15341,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15364,7 +15364,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15387,7 +15387,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15410,7 +15410,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15433,7 +15433,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15456,7 +15456,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15479,7 +15479,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15502,7 +15502,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15525,7 +15525,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15548,7 +15548,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15571,7 +15571,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15594,7 +15594,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15617,7 +15617,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15640,7 +15640,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15663,7 +15663,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15686,7 +15686,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15709,7 +15709,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15732,7 +15732,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -15778,7 +15778,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15801,7 +15801,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15824,7 +15824,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15847,7 +15847,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15870,7 +15870,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15893,7 +15893,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15916,7 +15916,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15939,7 +15939,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15962,7 +15962,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -15985,7 +15985,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16008,7 +16008,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16031,7 +16031,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16054,7 +16054,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16077,7 +16077,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16100,7 +16100,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16123,7 +16123,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16146,7 +16146,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16169,7 +16169,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16192,7 +16192,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16215,7 +16215,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16238,7 +16238,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16261,7 +16261,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16284,7 +16284,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16307,7 +16307,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16330,7 +16330,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16353,7 +16353,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16376,7 +16376,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16399,7 +16399,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16422,7 +16422,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16445,7 +16445,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16468,7 +16468,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16491,7 +16491,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16514,7 +16514,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16537,7 +16537,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16560,7 +16560,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16583,7 +16583,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16606,7 +16606,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16629,7 +16629,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16652,7 +16652,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16675,7 +16675,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16698,7 +16698,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16721,7 +16721,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16744,7 +16744,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16767,7 +16767,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16790,7 +16790,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16813,7 +16813,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16836,7 +16836,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16859,7 +16859,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16882,7 +16882,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16905,7 +16905,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16928,7 +16928,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16951,7 +16951,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16974,7 +16974,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -16997,7 +16997,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17181,7 +17181,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17204,7 +17204,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17227,7 +17227,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17250,7 +17250,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17434,7 +17434,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17457,7 +17457,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17480,7 +17480,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17503,7 +17503,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17526,7 +17526,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17549,7 +17549,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17572,7 +17572,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17595,7 +17595,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17618,7 +17618,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17641,7 +17641,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17664,7 +17664,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17687,7 +17687,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17710,7 +17710,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17733,7 +17733,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17756,7 +17756,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17779,7 +17779,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17802,7 +17802,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17825,7 +17825,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17848,7 +17848,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17871,7 +17871,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17894,7 +17894,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17917,7 +17917,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17940,7 +17940,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17963,7 +17963,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -17986,7 +17986,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "weightedAverage",
     "strata": [
       {
@@ -18020,7 +18020,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18043,7 +18043,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18066,7 +18066,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18089,7 +18089,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18112,7 +18112,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18135,7 +18135,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18158,7 +18158,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18181,7 +18181,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18204,7 +18204,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -18284,7 +18284,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18353,7 +18353,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18376,7 +18376,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18537,7 +18537,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18560,7 +18560,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18583,7 +18583,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18606,7 +18606,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18629,7 +18629,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18652,7 +18652,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18698,7 +18698,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18721,7 +18721,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18744,7 +18744,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -18778,7 +18778,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -18812,7 +18812,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -18846,7 +18846,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18869,7 +18869,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -18892,7 +18892,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19076,7 +19076,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19099,7 +19099,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19122,7 +19122,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19145,7 +19145,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19168,7 +19168,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19191,7 +19191,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19214,7 +19214,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19237,7 +19237,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19260,7 +19260,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19283,7 +19283,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19306,7 +19306,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19329,7 +19329,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19352,7 +19352,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19375,7 +19375,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19398,7 +19398,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19421,7 +19421,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19444,7 +19444,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19467,7 +19467,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19490,7 +19490,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19513,7 +19513,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19536,7 +19536,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19559,7 +19559,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19582,7 +19582,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19605,7 +19605,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19628,7 +19628,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19651,7 +19651,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19674,7 +19674,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19697,7 +19697,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19720,7 +19720,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19743,7 +19743,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19766,7 +19766,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19789,7 +19789,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19812,7 +19812,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19835,7 +19835,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19858,7 +19858,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19881,7 +19881,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19904,7 +19904,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "weightedAverage",
     "strata": [
       {
@@ -19938,7 +19938,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -19961,7 +19961,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20260,7 +20260,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20283,7 +20283,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -20321,7 +20321,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20344,7 +20344,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20367,7 +20367,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -20401,7 +20401,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20424,7 +20424,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20447,7 +20447,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20470,7 +20470,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20493,7 +20493,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20516,7 +20516,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20539,7 +20539,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20562,7 +20562,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20585,7 +20585,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20608,7 +20608,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20631,7 +20631,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20654,7 +20654,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20677,7 +20677,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20723,7 +20723,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20746,7 +20746,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20769,7 +20769,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20792,7 +20792,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20815,7 +20815,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20838,7 +20838,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20861,7 +20861,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20884,7 +20884,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20907,7 +20907,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20930,7 +20930,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20953,7 +20953,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -20976,7 +20976,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -21010,7 +21010,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -21044,7 +21044,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -21078,7 +21078,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21101,7 +21101,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21124,7 +21124,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -21181,7 +21181,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21204,7 +21204,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -21238,7 +21238,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -21272,7 +21272,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -21306,7 +21306,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21329,7 +21329,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21352,7 +21352,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21375,7 +21375,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21398,7 +21398,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21421,7 +21421,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21444,7 +21444,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21467,7 +21467,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21490,7 +21490,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21513,7 +21513,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21536,7 +21536,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21559,7 +21559,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21582,7 +21582,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21605,7 +21605,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21628,7 +21628,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21651,7 +21651,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21674,7 +21674,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21697,7 +21697,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21720,7 +21720,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21743,7 +21743,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21766,7 +21766,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21789,7 +21789,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21812,7 +21812,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "weightedAverage",
     "strata": [
       {
@@ -21846,7 +21846,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21869,7 +21869,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21892,7 +21892,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21915,7 +21915,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21938,7 +21938,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21961,7 +21961,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -21984,7 +21984,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22007,7 +22007,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22030,7 +22030,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22053,7 +22053,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22076,7 +22076,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22099,7 +22099,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22122,7 +22122,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22145,7 +22145,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22168,7 +22168,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22191,7 +22191,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22214,7 +22214,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22237,7 +22237,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22260,7 +22260,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22283,7 +22283,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22306,7 +22306,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22329,7 +22329,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22352,7 +22352,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22375,7 +22375,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22398,7 +22398,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22421,7 +22421,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22444,7 +22444,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22467,7 +22467,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22490,7 +22490,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22513,7 +22513,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22536,7 +22536,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22559,7 +22559,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22582,7 +22582,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22605,7 +22605,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22628,7 +22628,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22651,7 +22651,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22881,7 +22881,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22904,7 +22904,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22927,7 +22927,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "sumNumerators",
     "strata": [
       {
@@ -22965,7 +22965,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -22988,7 +22988,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23011,7 +23011,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23034,7 +23034,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23057,7 +23057,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23080,7 +23080,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23103,7 +23103,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23126,7 +23126,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23149,7 +23149,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23172,7 +23172,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23195,7 +23195,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23218,7 +23218,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23241,7 +23241,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23264,7 +23264,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23287,7 +23287,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23310,7 +23310,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23333,7 +23333,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23356,7 +23356,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23379,7 +23379,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "weightedAverage",
     "strata": [
       {
@@ -23417,7 +23417,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23440,7 +23440,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23463,7 +23463,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23486,7 +23486,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23509,7 +23509,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23532,7 +23532,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23555,7 +23555,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23578,7 +23578,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23601,7 +23601,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23624,7 +23624,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23647,7 +23647,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23670,7 +23670,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23693,7 +23693,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23716,7 +23716,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23739,7 +23739,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23762,7 +23762,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23785,7 +23785,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23808,7 +23808,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "weightedAverage",
     "strata": [
       {
@@ -23842,7 +23842,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "weightedAverage",
     "strata": [
       {
@@ -23876,7 +23876,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -23914,7 +23914,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -23952,7 +23952,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -23975,7 +23975,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -24013,7 +24013,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24036,7 +24036,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24059,7 +24059,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24082,7 +24082,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24105,7 +24105,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24128,7 +24128,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24151,7 +24151,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24174,7 +24174,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24197,7 +24197,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24220,7 +24220,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24243,7 +24243,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24266,7 +24266,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24289,7 +24289,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24312,7 +24312,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24335,7 +24335,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24358,7 +24358,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24381,7 +24381,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24404,7 +24404,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24427,7 +24427,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24450,7 +24450,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24473,7 +24473,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24496,7 +24496,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24519,7 +24519,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24542,7 +24542,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24565,7 +24565,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24588,7 +24588,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24611,7 +24611,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24634,7 +24634,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24657,7 +24657,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24680,7 +24680,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24703,7 +24703,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24726,7 +24726,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24749,7 +24749,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24772,7 +24772,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24795,7 +24795,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24818,7 +24818,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24841,7 +24841,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24864,7 +24864,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24887,7 +24887,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24910,7 +24910,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24933,7 +24933,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -24956,7 +24956,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25025,7 +25025,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25048,7 +25048,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25071,7 +25071,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25094,7 +25094,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25117,7 +25117,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25140,7 +25140,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25163,7 +25163,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25186,7 +25186,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25209,7 +25209,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25232,7 +25232,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -25274,7 +25274,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25297,7 +25297,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25320,7 +25320,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25343,7 +25343,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -25381,7 +25381,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25404,7 +25404,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25427,7 +25427,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25450,7 +25450,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "multiPerformanceRate",
+    "metricType": "registryMultiPerformanceRate",
     "overallAlgorithm": "overallStratumOnly",
     "strata": [
       {
@@ -25492,7 +25492,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]
@@ -25515,7 +25515,7 @@
     "nqfId": null,
     "measureSets": [],
     "isRegistryMeasure": true,
-    "metricType": "singlePerformanceRate",
+    "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
     ]


### PR DESCRIPTION
Updates qcdr measures with `isRegistryMeasure === true` to use new metric types `registrySinglePerformanceRate` and `registryMultiPerformanceRate`

Steps:
* Write and run script to update staging file
* Updated `measures/measures-schema.yaml`
* Run `./scripts/measures/build-measures`

Changes:
* Updated staging file for qcdr measures
* Updated measures-data.json and measures-data.xml
* Updated measures-schema.yaml with new metric types

```javascript
const fs = require('fs');

qcdrMeasuresDataPath = './staging/measures-data-with-qcdrs.json';
qcdrMeasuresString = fs.readFileSync(qcdrMeasuresDataPath, 'utf-8');
qcdrMeasures = JSON.parse(qcdrMeasuresString);

updatedMeasures = [];
qcdrMeasures.forEach((measure) => {
  if (measure.isRegistryMeasure === true) {
    if (measure.metricType === 'singlePerformanceRate') {
      measure.metricType = 'registrySinglePerformanceRate';
    } else if (measure.metricType === 'multiPerformanceRate') {
      measure.metricType = 'registryMultiPerformanceRate'
    }
  }
  updatedMeasures.push(measure);
});

updatedMeasuresJson = JSON.stringify(updatedMeasures, null, 2);
fs.writeFileSync(qcdrMeasuresDataPath, updatedMeasuresJson);
```

Testing:
* measures data is valid
```
⇒  cat measures/measures-data.json | node scripts/validate-data.js measures
Valid!
```
* By inspection, number of measures updated is equal to number of measures where `isRegistryMeasure: true` ("isRegistryMeasure": true - 610 matches, isRegistryMeasure and nonProportion metricType - 78 matches, isRegistryMeasure and regisrySinglePerformanceRate or registryMultiplePerformanceRate metricTypes - 532 measures)