### PR TITLE
[QPPA-1452] Allow registries to submit EHR-only measures

### DIFF
--- a/measures/measures-data.json
+++ b/measures/measures-data.json
@@ -2304,7 +2304,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "mentalBehavioralHealth",
@@ -2544,7 +2545,8 @@
     "isHighPriority": false,
     "primarySteward": "Physician Consortium for Performance Improvement",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-503f-a1fc-0150-de8350a220c3",
@@ -3061,7 +3063,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "internalMedicine",
@@ -3566,7 +3569,8 @@
     "isHighPriority": false,
     "primarySteward": "Center for Quality Assessment and Improvement in Mental Health",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-503f-a1fc-0150-67942bbc07d7",
@@ -4112,7 +4116,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "obstetricsGynecology",
@@ -4153,7 +4158,8 @@
     "isHighPriority": true,
     "primarySteward": "Physician Consortium for Performance Improvement",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "mentalBehavioralHealth",
@@ -4193,7 +4199,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "pediatrics"
@@ -4232,7 +4239,8 @@
     "isHighPriority": true,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-52fc-3a32-0153-1f39c24d0eef",
@@ -4307,7 +4315,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "obstetricsGynecology",
@@ -4444,7 +4453,8 @@
     "isHighPriority": true,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "allergyImmunology",
@@ -5091,7 +5101,8 @@
     "isHighPriority": false,
     "primarySteward": "Physician Consortium for Performance Improvement",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "neurology",
@@ -5367,7 +5378,8 @@
     "isHighPriority": false,
     "primarySteward": "Minnesota Community Measurement",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "mentalBehavioralHealth"
@@ -5454,7 +5466,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "internalMedicine",
@@ -5686,7 +5699,8 @@
     "isHighPriority": false,
     "primarySteward": "Physician Consortium for Performance Improvement",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "ophthalmology"
@@ -6110,7 +6124,8 @@
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
       "electronicHealthRecord",
-      "cmsWebInterface"
+      "cmsWebInterface",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-51f0-825b-0152-22aae8a21778",
@@ -6224,7 +6239,8 @@
     "isHighPriority": true,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "orthopedicSurgery"
@@ -6264,7 +6280,8 @@
     "isHighPriority": true,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "orthopedicSurgery"
@@ -6304,7 +6321,8 @@
     "isHighPriority": true,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-52fc-3a32-0153-1f3f70ca0eff",
@@ -6890,7 +6908,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "allergyImmunology",
@@ -7150,7 +7169,8 @@
     "isHighPriority": true,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-51f0-825b-0152-227c2f851589",
@@ -7350,7 +7370,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-528a-60ff-0152-8e089ed20376",
@@ -7570,7 +7591,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-51f0-825b-0152-2295c55c16aa",
@@ -9282,7 +9304,8 @@
     "isHighPriority": false,
     "primarySteward": "OptumInsight",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-5223-eb6b-0152-6a1558f51bdc",
@@ -9764,7 +9787,8 @@
     "isHighPriority": false,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "pediatrics"
@@ -11976,7 +12000,8 @@
     "isHighPriority": true,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "orthopedicSurgery",
@@ -12082,7 +12107,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "pediatrics"

--- a/measures/measures-data.xml
+++ b/measures/measures-data.xml
@@ -2223,6 +2223,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isHighPriority>false</isHighPriority>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <measureSet>mentalBehavioralHealth</measureSet>
     <measureSet>pediatrics</measureSet>
     <eMeasureUuid>40280381-51f0-825b-0152-22a639d81762</eMeasureUuid>
@@ -2425,6 +2426,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <isHighPriority>false</isHighPriority>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <eMeasureUuid>40280381-503f-a1fc-0150-de8350a220c3</eMeasureUuid>
     <isRegistryMeasure>false</isRegistryMeasure>
     <measureSpecification>
@@ -2858,6 +2860,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isHighPriority>false</isHighPriority>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <measureSet>internalMedicine</measureSet>
     <measureSet>mentalBehavioralHealth</measureSet>
     <measureSet>generalPracticeFamilyMedicine</measureSet>
@@ -3287,6 +3290,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isHighPriority>false</isHighPriority>
     <primarySteward>Center for Quality Assessment and Improvement in Mental Health</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <eMeasureUuid>40280381-503f-a1fc-0150-67942bbc07d7</eMeasureUuid>
     <isRegistryMeasure>false</isRegistryMeasure>
     <measureSpecification>
@@ -3764,6 +3768,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isHighPriority>false</isHighPriority>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <measureSet>obstetricsGynecology</measureSet>
     <measureSet>generalPracticeFamilyMedicine</measureSet>
     <eMeasureUuid>40280381-51f0-825b-0152-229bdcab1702</eMeasureUuid>
@@ -3800,6 +3805,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isHighPriority>true</isHighPriority>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <measureSet>mentalBehavioralHealth</measureSet>
     <measureSet>pediatrics</measureSet>
     <eMeasureUuid>40280381-503f-a1fc-0151-11602d4d2909</eMeasureUuid>
@@ -3834,6 +3840,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isHighPriority>false</isHighPriority>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <measureSet>pediatrics</measureSet>
     <eMeasureUuid>40280381-52fc-3a32-0153-1a4ba57f0b8a</eMeasureUuid>
     <isRegistryMeasure>false</isRegistryMeasure>
@@ -3867,6 +3874,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isHighPriority>true</isHighPriority>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <eMeasureUuid>40280381-52fc-3a32-0153-1f39c24d0eef</eMeasureUuid>
     <isRegistryMeasure>false</isRegistryMeasure>
     <measureSpecification>
@@ -3929,6 +3937,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isHighPriority>false</isHighPriority>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <measureSet>obstetricsGynecology</measureSet>
     <measureSet>pediatrics</measureSet>
     <eMeasureUuid>40280381-51f0-825b-0152-22b52da917ba</eMeasureUuid>
@@ -4045,6 +4054,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isHighPriority>true</isHighPriority>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <measureSet>allergyImmunology</measureSet>
     <measureSet>cardiology</measureSet>
     <measureSet>dermatology</measureSet>
@@ -4595,6 +4605,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isHighPriority>false</isHighPriority>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <measureSet>neurology</measureSet>
     <measureSet>mentalBehavioralHealth</measureSet>
     <eMeasureUuid>40280381-52fc-3a32-0153-1a401cc10b57</eMeasureUuid>
@@ -4829,6 +4840,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <isHighPriority>false</isHighPriority>
     <primarySteward>Minnesota Community Measurement</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <measureSet>mentalBehavioralHealth</measureSet>
     <overallAlgorithm>weightedAverage</overallAlgorithm>
     <eMeasureUuid>40280381-503f-a1fc-0150-afe320c01761</eMeasureUuid>
@@ -4905,6 +4917,7 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
     <isHighPriority>false</isHighPriority>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <measureSet>internalMedicine</measureSet>
     <measureSet>generalPracticeFamilyMedicine</measureSet>
     <eMeasureUuid>40280381-51f0-825b-0152-229b7b2f16f9</eMeasureUuid>
@@ -5103,6 +5116,7 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
     <isHighPriority>false</isHighPriority>
     <primarySteward>Physician Consortium for Performance Improvement</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <measureSet>ophthalmology</measureSet>
     <eMeasureUuid>40280381-52fc-3a32-0153-1a4838b80b79</eMeasureUuid>
     <isRegistryMeasure>false</isRegistryMeasure>
@@ -5462,6 +5476,7 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
     <submissionMethod>cmsWebInterface</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <eMeasureUuid>40280381-51f0-825b-0152-22aae8a21778</eMeasureUuid>
     <isRegistryMeasure>false</isRegistryMeasure>
     <cpcPlusGroup>B</cpcPlusGroup>
@@ -5563,6 +5578,7 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
     <isHighPriority>true</isHighPriority>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <measureSet>orthopedicSurgery</measureSet>
     <eMeasureUuid>40280381-51f0-825b-0152-227617db152e</eMeasureUuid>
     <isRegistryMeasure>false</isRegistryMeasure>
@@ -5597,6 +5613,7 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
     <isHighPriority>true</isHighPriority>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <measureSet>orthopedicSurgery</measureSet>
     <eMeasureUuid>40280381-51f0-825b-0152-227ce2c81597</eMeasureUuid>
     <isRegistryMeasure>false</isRegistryMeasure>
@@ -5631,6 +5648,7 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
     <isHighPriority>true</isHighPriority>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <eMeasureUuid>40280381-52fc-3a32-0153-1f3f70ca0eff</eMeasureUuid>
     <isRegistryMeasure>false</isRegistryMeasure>
     <measureSpecification>
@@ -6128,6 +6146,7 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
     <isHighPriority>false</isHighPriority>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <measureSet>allergyImmunology</measureSet>
     <measureSet>pediatrics</measureSet>
     <eMeasureUuid>40280381-51f0-825b-0152-2273af5a150b</eMeasureUuid>
@@ -6355,6 +6374,7 @@ If a follow-up blood pressure reading is not recorded during the measurement yea
     <isHighPriority>true</isHighPriority>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <eMeasureUuid>40280381-51f0-825b-0152-227c2f851589</eMeasureUuid>
     <isRegistryMeasure>false</isRegistryMeasure>
     <measureSpecification>
@@ -6526,6 +6546,7 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <isHighPriority>false</isHighPriority>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <eMeasureUuid>40280381-528a-60ff-0152-8e089ed20376</eMeasureUuid>
     <overallAlgorithm>simpleAverage</overallAlgorithm>
     <isRegistryMeasure>false</isRegistryMeasure>
@@ -6718,6 +6739,7 @@ b. Percentage of patients who initiated treatment and who had two or more additi
     <isHighPriority>false</isHighPriority>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <eMeasureUuid>40280381-51f0-825b-0152-2295c55c16aa</eMeasureUuid>
     <isRegistryMeasure>false</isRegistryMeasure>
     <measureSpecification>
@@ -8157,6 +8179,7 @@ This measure is reported as three rates stratified by age group:
     <isHighPriority>false</isHighPriority>
     <primarySteward>OptumInsight</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <eMeasureUuid>40280381-5223-eb6b-0152-6a1558f51bdc</eMeasureUuid>
     <isRegistryMeasure>false</isRegistryMeasure>
     <measureSpecification>
@@ -8581,6 +8604,7 @@ Normal Parameters:       Age 18 years and older BMI =&gt; 18.5 and &lt; 25 kg/m2
     <isHighPriority>false</isHighPriority>
     <primarySteward>Centers for Medicare &amp; Medicaid Services</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <measureSet>pediatrics</measureSet>
     <eMeasureUuid>40280381-52fc-3a32-0153-1f6962df0f9c</eMeasureUuid>
     <isRegistryMeasure>false</isRegistryMeasure>
@@ -10434,6 +10458,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <isHighPriority>true</isHighPriority>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <measureSet>orthopedicSurgery</measureSet>
     <measureSet>physicalMedicine</measureSet>
     <measureSet>generalPracticeFamilyMedicine</measureSet>
@@ -10527,6 +10552,7 @@ b. Percentage of patients who were ordered at least two different high-risk medi
     <isHighPriority>false</isHighPriority>
     <primarySteward>National Committee for Quality Assurance</primarySteward>
     <submissionMethod>electronicHealthRecord</submissionMethod>
+    <submissionMethod>registry</submissionMethod>
     <measureSet>pediatrics</measureSet>
     <eMeasureUuid>40280381-51f0-825b-0152-22b695b217dc</eMeasureUuid>
     <overallAlgorithm>simpleAverage</overallAlgorithm>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.0.0-alpha.25",
+  "version": "1.0.0-alpha.26",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/scripts/measures/archived/scripts/add-registry-submission-method.js
+++ b/scripts/measures/archived/scripts/add-registry-submission-method.js
@@ -1,10 +1,10 @@
 const fs = require('fs');
 
-stagingMeasuresDataPath = './staging/measures-data.json';
-stagingMeasuresString = fs.readFileSync(stagingMeasuresDataPath, 'utf-8');
-stagingMeasures = JSON.parse(stagingMeasuresString);
+const stagingMeasuresDataPath = './staging/measures-data.json';
+const stagingMeasuresString = fs.readFileSync(stagingMeasuresDataPath, 'utf-8');
+const stagingMeasures = JSON.parse(stagingMeasuresString);
 
-updatedMeasures = [];
+const updatedMeasures = [];
 stagingMeasures.forEach((measure) => {
   // if it's an ecqm measure and it allows 'electronicHealthRecord'
   // submissions but not 'registry' submissions already, add 'registry' to the list.
@@ -16,5 +16,5 @@ stagingMeasures.forEach((measure) => {
   updatedMeasures.push(measure);
 });
 
-updatedMeasuresJson = JSON.stringify(updatedMeasures, null, 2);
+const updatedMeasuresJson = JSON.stringify(updatedMeasures, null, 2);
 fs.writeFileSync(stagingMeasuresDataPath, updatedMeasuresJson);

--- a/scripts/measures/archived/scripts/add-registry-submission-method.js
+++ b/scripts/measures/archived/scripts/add-registry-submission-method.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+
+stagingMeasuresDataPath = './staging/measures-data.json';
+stagingMeasuresString = fs.readFileSync(stagingMeasuresDataPath, 'utf-8');
+stagingMeasures = JSON.parse(stagingMeasuresString);
+
+updatedMeasures = [];
+stagingMeasures.forEach((measure) => {
+  // if it's an ecqm measure and it allows 'electronicHealthRecord'
+  // submissions but not 'registry' submissions already, add 'registry' to the list.
+  if (measure.eMeasureUuid && measure.submissionMethods.includes('electronicHealthRecord')) {
+    if (!measure.submissionMethods.includes('registry')) {
+      measure.submissionMethods.push('registry');
+    }
+  }
+  updatedMeasures.push(measure);
+});
+
+updatedMeasuresJson = JSON.stringify(updatedMeasures, null, 2);
+fs.writeFileSync(stagingMeasuresDataPath, updatedMeasuresJson);

--- a/staging/measures-data-with-qcdrs.json
+++ b/staging/measures-data-with-qcdrs.json
@@ -2215,7 +2215,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "mentalBehavioralHealth",
@@ -2434,7 +2435,8 @@
     "isHighPriority": false,
     "primarySteward": "Physician Consortium for Performance Improvement",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-503f-a1fc-0150-de8350a220c3",
@@ -2907,7 +2909,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "internalMedicine",
@@ -3364,7 +3367,8 @@
     "isHighPriority": false,
     "primarySteward": "Center for Quality Assessment and Improvement in Mental Health",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-503f-a1fc-0150-67942bbc07d7",
@@ -3863,7 +3867,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "obstetricsGynecology",
@@ -3900,7 +3905,8 @@
     "isHighPriority": true,
     "primarySteward": "Physician Consortium for Performance Improvement",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "mentalBehavioralHealth",
@@ -3937,7 +3943,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "pediatrics"
@@ -3973,7 +3980,8 @@
     "isHighPriority": true,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-52fc-3a32-0153-1f39c24d0eef",
@@ -4038,7 +4046,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "obstetricsGynecology",
@@ -4161,7 +4170,8 @@
     "isHighPriority": true,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "allergyImmunology",
@@ -4747,7 +4757,8 @@
     "isHighPriority": false,
     "primarySteward": "Physician Consortium for Performance Improvement",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "neurology",
@@ -4999,7 +5010,8 @@
     "isHighPriority": false,
     "primarySteward": "Minnesota Community Measurement",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "mentalBehavioralHealth"
@@ -5078,7 +5090,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "internalMedicine",
@@ -5289,7 +5302,8 @@
     "isHighPriority": false,
     "primarySteward": "Physician Consortium for Performance Improvement",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "ophthalmology"
@@ -5673,7 +5687,8 @@
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
       "electronicHealthRecord",
-      "cmsWebInterface"
+      "cmsWebInterface",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-51f0-825b-0152-22aae8a21778",
@@ -5775,7 +5790,8 @@
     "isHighPriority": true,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "orthopedicSurgery"
@@ -5812,7 +5828,8 @@
     "isHighPriority": true,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "orthopedicSurgery"
@@ -5849,7 +5866,8 @@
     "isHighPriority": true,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-52fc-3a32-0153-1f3f70ca0eff",
@@ -6384,7 +6402,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "allergyImmunology",
@@ -6623,7 +6642,8 @@
     "isHighPriority": true,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-51f0-825b-0152-227c2f851589",
@@ -6800,7 +6820,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-528a-60ff-0152-8e089ed20376",
@@ -6997,7 +7018,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-51f0-825b-0152-2295c55c16aa",
@@ -8546,7 +8568,8 @@
     "isHighPriority": false,
     "primarySteward": "OptumInsight",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-5223-eb6b-0152-6a1558f51bdc",
@@ -8982,7 +9005,8 @@
     "isHighPriority": false,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "pediatrics"
@@ -10981,7 +11005,8 @@
     "isHighPriority": true,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "orthopedicSurgery",
@@ -11068,7 +11093,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "pediatrics"

--- a/staging/measures-data.json
+++ b/staging/measures-data.json
@@ -2200,7 +2200,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "mentalBehavioralHealth",
@@ -2412,7 +2413,8 @@
     "isHighPriority": false,
     "primarySteward": "Physician Consortium for Performance Improvement",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-503f-a1fc-0150-de8350a220c3"
@@ -2870,7 +2872,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "internalMedicine",
@@ -3313,7 +3316,8 @@
     "isHighPriority": false,
     "primarySteward": "Center for Quality Assessment and Improvement in Mental Health",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-503f-a1fc-0150-67942bbc07d7"
@@ -3797,7 +3801,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "obstetricsGynecology",
@@ -3833,7 +3838,8 @@
     "isHighPriority": true,
     "primarySteward": "Physician Consortium for Performance Improvement",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "mentalBehavioralHealth",
@@ -3869,7 +3875,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "pediatrics"
@@ -3904,7 +3911,8 @@
     "isHighPriority": true,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-52fc-3a32-0153-1f39c24d0eef"
@@ -3967,7 +3975,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "obstetricsGynecology",
@@ -4086,7 +4095,8 @@
     "isHighPriority": true,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "allergyImmunology",
@@ -4655,7 +4665,8 @@
     "isHighPriority": false,
     "primarySteward": "Physician Consortium for Performance Improvement",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "neurology",
@@ -4900,7 +4911,8 @@
     "isHighPriority": false,
     "primarySteward": "Minnesota Community Measurement",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "mentalBehavioralHealth"
@@ -4977,7 +4989,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "internalMedicine",
@@ -5182,7 +5195,8 @@
     "isHighPriority": false,
     "primarySteward": "Physician Consortium for Performance Improvement",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "ophthalmology"
@@ -5555,7 +5569,8 @@
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
       "electronicHealthRecord",
-      "cmsWebInterface"
+      "cmsWebInterface",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-51f0-825b-0152-22aae8a21778"
@@ -5654,7 +5669,8 @@
     "isHighPriority": true,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "orthopedicSurgery"
@@ -5690,7 +5706,8 @@
     "isHighPriority": true,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "orthopedicSurgery"
@@ -5726,7 +5743,8 @@
     "isHighPriority": true,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-52fc-3a32-0153-1f3f70ca0eff"
@@ -6244,7 +6262,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "allergyImmunology",
@@ -6476,7 +6495,8 @@
     "isHighPriority": true,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-51f0-825b-0152-227c2f851589"
@@ -6648,7 +6668,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-528a-60ff-0152-8e089ed20376",
@@ -6839,7 +6860,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-51f0-825b-0152-2295c55c16aa"
@@ -8339,7 +8361,8 @@
     "isHighPriority": false,
     "primarySteward": "OptumInsight",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [],
     "eMeasureUuid": "40280381-5223-eb6b-0152-6a1558f51bdc"
@@ -8765,7 +8788,8 @@
     "isHighPriority": false,
     "primarySteward": "Centers for Medicare & Medicaid Services",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "pediatrics"
@@ -10700,7 +10724,8 @@
     "isHighPriority": true,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "orthopedicSurgery",
@@ -10785,7 +10810,8 @@
     "isHighPriority": false,
     "primarySteward": "National Committee for Quality Assurance",
     "submissionMethods": [
-      "electronicHealthRecord"
+      "electronicHealthRecord",
+      "registry"
     ],
     "measureSets": [
       "pediatrics"

--- a/test/measures/measures-data-spec.js
+++ b/test/measures/measures-data-spec.js
@@ -146,5 +146,16 @@ describe('measures data json', function() {
         assert.deepEqual(generated, actual);
       });
     });
+
+    describe('eCQMeasures', () => {
+      it('all eCQM measures permitting electronicHealthRecord submission method also permit registry submission method', () => {
+        const eCQMeasures = measuresData.filter(m => m.eMeasureUuid !== undefined);
+        eCQMeasures.forEach(m => {
+          if (m.submissionMethods.includes('electronicHealthRecord')) {
+            assert.isTrue(m.submissionMethods.includes('registry'));
+          }
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
[QPPA-1452] Allow registries to submit EHR-only measures

Adds "registry" submission method to measures with an eMeasureUuid and already permitting the electronicHealthRecord submission method. This PR includes the script used to generate the changes but archives it since it doesn't need to be run more than once.

Test plan:
* [x] Unit tested
* [x] Running `npm run build:measures` doesn't make any changes^
* [x] `/measures/measures-data.json` is valid

^ I ran `npm run build:measures` once to generate `/measures/measures-data.json` and `/measures/measures-data.xml` using the updated stagin-data.json but additional executions do not make any changes