### PR TITLE
QPPA-1588: Updating metricType of measureId 458 (ACR) to be 'cost'

### DIFF
--- a/measures/measures-data.json
+++ b/measures/measures-data.json
@@ -2872,7 +2872,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "cost",
+    "metricType": "costScore",
     "title": "All-cause Hospital Readmission",
     "description": "The 30-day All-Cause Hospital Readmission measure is a risk-standardized readmission rate for beneficiaries age 65 or older who were hospitalized at a short-stay acute care hospital and experienced an unplanned readmission for any cause to an acute care hospital within 30 days of discharge.",
     "nationalQualityStrategyDomain": "CCC",

--- a/measures/measures-data.json
+++ b/measures/measures-data.json
@@ -2872,7 +2872,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "singlePerformanceRate",
+    "metricType": "cost",
     "title": "All-cause Hospital Readmission",
     "description": "The 30-day All-Cause Hospital Readmission measure is a risk-standardized readmission rate for beneficiaries age 65 or older who were hospitalized at a short-stay acute care hospital and experienced an unplanned readmission for any cause to an acute care hospital within 30 days of discharge.",
     "nationalQualityStrategyDomain": "CCC",

--- a/measures/measures-data.xml
+++ b/measures/measures-data.xml
@@ -2696,7 +2696,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>cost</metricType>
+    <metricType>costScore</metricType>
     <title>All-cause Hospital Readmission</title>
     <description>The 30-day All-Cause Hospital Readmission measure is a risk-standardized readmission rate for beneficiaries age 65 or older who were hospitalized at a short-stay acute care hospital and experienced an unplanned readmission for any cause to an acute care hospital within 30 days of discharge.</description>
     <nationalQualityStrategyDomain>CCC</nationalQualityStrategyDomain>

--- a/measures/measures-data.xml
+++ b/measures/measures-data.xml
@@ -2696,7 +2696,7 @@ b. Percentage of children who remained on ADHD medication for at least 210 days 
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>cost</metricType>
     <title>All-cause Hospital Readmission</title>
     <description>The 30-day All-Cause Hospital Readmission measure is a risk-standardized readmission rate for beneficiaries age 65 or older who were hospitalized at a short-stay acute care hospital and experienced an unplanned readmission for any cause to an acute care hospital within 30 days of discharge.</description>
     <nationalQualityStrategyDomain>CCC</nationalQualityStrategyDomain>

--- a/measures/measures-schema.yaml
+++ b/measures/measures-schema.yaml
@@ -17,7 +17,7 @@ definitions:
         enum: [ia, quality, aci, cost]
       metricType:
         description: Type of measurement that the measure requires in order to attest.
-        enum: [boolean, proportion, singlePerformanceRate, multiPerformanceRate, registrySinglePerformanceRate, registryMultiPerformanceRate, nonProportion, cahps]
+        enum: [boolean, proportion, singlePerformanceRate, multiPerformanceRate, registrySinglePerformanceRate, registryMultiPerformanceRate, nonProportion, cahps, cost]
       firstPerformanceYear:
         description: Year in which the measure was introduced.
         type: integer
@@ -151,7 +151,7 @@ definitions:
         required: [overallAlgorithm, strata]
       },{
         properties: {
-          metricType: { enum: [singlePerformanceRate, nonProportion, cahps, registrySinglePerformanceRate] }
+          metricType: { enum: [singlePerformanceRate, nonProportion, cahps, registrySinglePerformanceRate, cost] }
         }
       }]
     required: [nationalQualityStrategyDomain, measureType, eMeasureId, nqfEMeasureId, nqfId, isHighPriority, isInverse, primarySteward, measureSets, submissionMethods, isRegistryMeasure]

--- a/measures/measures-schema.yaml
+++ b/measures/measures-schema.yaml
@@ -17,7 +17,7 @@ definitions:
         enum: [ia, quality, aci, cost]
       metricType:
         description: Type of measurement that the measure requires in order to attest.
-        enum: [boolean, proportion, singlePerformanceRate, multiPerformanceRate, registrySinglePerformanceRate, registryMultiPerformanceRate, nonProportion, cahps, cost]
+        enum: [boolean, proportion, singlePerformanceRate, multiPerformanceRate, registrySinglePerformanceRate, registryMultiPerformanceRate, nonProportion, cahps, costScore]
       firstPerformanceYear:
         description: Year in which the measure was introduced.
         type: integer
@@ -151,7 +151,7 @@ definitions:
         required: [overallAlgorithm, strata]
       },{
         properties: {
-          metricType: { enum: [singlePerformanceRate, nonProportion, cahps, registrySinglePerformanceRate, cost] }
+          metricType: { enum: [singlePerformanceRate, nonProportion, cahps, registrySinglePerformanceRate, costScore] }
         }
       }]
     required: [nationalQualityStrategyDomain, measureType, eMeasureId, nqfEMeasureId, nqfId, isHighPriority, isInverse, primarySteward, measureSets, submissionMethods, isRegistryMeasure]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/staging/measures-data-with-qcdrs.json
+++ b/staging/measures-data-with-qcdrs.json
@@ -2730,7 +2730,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "singlePerformanceRate",
+    "metricType": "cost",
     "title": "All-cause Hospital Readmission",
     "description": "The 30-day All-Cause Hospital Readmission measure is a risk-standardized readmission rate for beneficiaries age 65 or older who were hospitalized at a short-stay acute care hospital and experienced an unplanned readmission for any cause to an acute care hospital within 30 days of discharge.",
     "nationalQualityStrategyDomain": "CCC",

--- a/staging/measures-data-with-qcdrs.json
+++ b/staging/measures-data-with-qcdrs.json
@@ -2730,7 +2730,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "cost",
+    "metricType": "costScore",
     "title": "All-cause Hospital Readmission",
     "description": "The 30-day All-Cause Hospital Readmission measure is a risk-standardized readmission rate for beneficiaries age 65 or older who were hospitalized at a short-stay acute care hospital and experienced an unplanned readmission for any cause to an acute care hospital within 30 days of discharge.",
     "nationalQualityStrategyDomain": "CCC",

--- a/staging/measures-data.json
+++ b/staging/measures-data.json
@@ -2698,7 +2698,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "singlePerformanceRate",
+    "metricType": "cost",
     "title": "All-cause Hospital Readmission",
     "description": "The 30-day All-Cause Hospital Readmission measure is a risk-standardized readmission rate for beneficiaries age 65 or older who were hospitalized at a short-stay acute care hospital and experienced an unplanned readmission for any cause to an acute care hospital within 30 days of discharge.",
     "nationalQualityStrategyDomain": "CCC",

--- a/staging/measures-data.json
+++ b/staging/measures-data.json
@@ -2698,7 +2698,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "cost",
+    "metricType": "costScore",
     "title": "All-cause Hospital Readmission",
     "description": "The 30-day All-Cause Hospital Readmission measure is a risk-standardized readmission rate for beneficiaries age 65 or older who were hospitalized at a short-stay acute care hospital and experienced an unplanned readmission for any cause to an acute care hospital within 30 days of discharge.",
     "nationalQualityStrategyDomain": "CCC",


### PR DESCRIPTION
In QPPA-1588, we'll be adding a new database table to store data for cost-related measures, like ACR (even though ACR is technically a quality measure) and future cost measures. This PR changes the `metricType` of ACR, which is measure 458, to be `cost` and updates our schemas to expect this as a valid `metricType`.

Note -- I'm wondering if it'll be confusing if we have a `metricType` of `cost` if we're eventually also going to have a `category` of `cost`. Should we name the `metricType` something else to save that confusion? ` But what...?