### PR TITLE
QPPA-1132: Changing metricType for measure 321 from singlePerformanceRate to cahps

### DIFF
--- a/measures/measures-data.json
+++ b/measures/measures-data.json
@@ -3670,7 +3670,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "singlePerformanceRate",
+    "metricType": "cahps",
     "title": "CAHPS for MIPS Clinician/Group Survey",
     "description": "<br/><ul><li> Getting timely care, appointments, and information;\n</li><li> How well providers Communicate;\n</li><li> Patient's Rating of Provider;\n</li><li> Access to Specialists;\n</li><li> Health Promotion & Education;\n</li><li> Shared Decision Making;\n</li><li> Health Status/Functional Status;\n</li><li> Courteous and Helpful Office Staff;\n</li><li> Care Coordination;\n</li><li> Between Visit Communication;\n</li><li> Helping Your to Take Medication as Directed; and\n</li><li> Stewardship of Patient Resources</li></ul>",
     "nationalQualityStrategyDomain": "PCCEO",

--- a/measures/measures-data.xml
+++ b/measures/measures-data.xml
@@ -3376,7 +3376,7 @@ b. Percentage of patients who remained on an antidepressant medication for at le
     <category>quality</category>
     <firstPerformanceYear>2017</firstPerformanceYear>
     <lastPerformanceYear/>
-    <metricType>singlePerformanceRate</metricType>
+    <metricType>cahps</metricType>
     <title>CAHPS for MIPS Clinician/Group Survey</title>
     <description>&lt;br/&gt;&lt;ul&gt;&lt;li&gt; Getting timely care, appointments, and information;
 &lt;/li&gt;&lt;li&gt; How well providers Communicate;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/staging/measures-data-with-qcdrs.json
+++ b/staging/measures-data-with-qcdrs.json
@@ -3452,7 +3452,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "singlePerformanceRate",
+    "metricType": "cahps",
     "title": "CAHPS for MIPS Clinician/Group Survey",
     "description": "<br/><ul><li> Getting timely care, appointments, and information;\n</li><li> How well providers Communicate;\n</li><li> Patient's Rating of Provider;\n</li><li> Access to Specialists;\n</li><li> Health Promotion & Education;\n</li><li> Shared Decision Making;\n</li><li> Health Status/Functional Status;\n</li><li> Courteous and Helpful Office Staff;\n</li><li> Care Coordination;\n</li><li> Between Visit Communication;\n</li><li> Helping Your to Take Medication as Directed; and\n</li><li> Stewardship of Patient Resources</li></ul>",
     "nationalQualityStrategyDomain": "PCCEO",

--- a/staging/measures-data.json
+++ b/staging/measures-data.json
@@ -3398,7 +3398,7 @@
     "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
-    "metricType": "singlePerformanceRate",
+    "metricType": "cahps",
     "title": "CAHPS for MIPS Clinician/Group Survey",
     "description": "<br/><ul><li> Getting timely care, appointments, and information;\n</li><li> How well providers Communicate;\n</li><li> Patient's Rating of Provider;\n</li><li> Access to Specialists;\n</li><li> Health Promotion & Education;\n</li><li> Shared Decision Making;\n</li><li> Health Status/Functional Status;\n</li><li> Courteous and Helpful Office Staff;\n</li><li> Care Coordination;\n</li><li> Between Visit Communication;\n</li><li> Helping Your to Take Medication as Directed; and\n</li><li> Stewardship of Patient Resources</li></ul>",
     "nationalQualityStrategyDomain": "PCCEO",


### PR DESCRIPTION
Measure 321 is the aggregate measure for CAHPS and currently has a metric type of 'singlePerformanceRate'. The aggregate value for CAHPS score will be a percentage (just like the individual CAHPS measurements) so we should use the CAHPS metric type for 321 as well. This PR changes that metricType for measure 321.

Also updating the version number to be `1.0.5` so it can be published and consumed by downstream services.

Reviewers: @kencheeto @lamroger 