### PR TITLE
upgrade adm-zip to fix vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -28,9 +28,9 @@
       }
     },
     "adm-zip": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
-      "integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E=",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
+      "integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA==",
       "dev": true
     },
     "ajv": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.6.2",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "adm-zip": "^0.4.7",
+    "adm-zip": "0.4.11",
     "ajv": "6.5.0",
     "ajv-keywords": "3.2.0",
     "bluebird": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.6.2",
+  "version": "1.6.1",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<img width="752" alt="screen shot 2018-07-31 at 10 43 41 am" src="https://user-images.githubusercontent.com/279406/43476917-a5286fe0-94ae-11e8-9cb0-472a8ba8eb20.png">

https://nvd.nist.gov/vuln/detail/CVE-2018-1002204

Not a likely attack vector for us since we manually process zip files, but upgrades adm-zip anyway to resolve the sec warning that GitHub displays.