### PR TITLE
increase test timeout for link checking

### DIFF
--- a/test/measures/measures-specification-spec.js
+++ b/test/measures/measures-specification-spec.js
@@ -28,8 +28,8 @@ function checkUrl(s) {
 // this will run once a day on travis
 if (process.env.TRAVIS_EVENT_TYPE === 'cron') {
   it('has valid specification links', function() {
-    this.timeout(12000); // 8 seconds timeout.
-    this.retries(3); // retry for transient failures
+    this.timeout(12000);
+    this.retries(3); // retry for transient network failures
 
     const specs = [];
     const measures = measuresData.getMeasuresData();

--- a/test/measures/measures-specification-spec.js
+++ b/test/measures/measures-specification-spec.js
@@ -28,7 +28,7 @@ function checkUrl(s) {
 // this will run once a day on travis
 if (process.env.TRAVIS_EVENT_TYPE === 'cron') {
   it('has valid specification links', function() {
-    this.timeout(8000); // 8 seconds timeout.
+    this.timeout(12000); // 8 seconds timeout.
     this.retries(3); // retry for transient failures
 
     const specs = [];


### PR DESCRIPTION
the test we merged recently to check that the measure specification links are valid failed because of a timeout, so I'm increasing the timeout here by 50%.

this test only runs on CI during cron runs, once a day.

failing run here:
https://travis-ci.org/CMSgov/qpp-measures-data/jobs/412016666