### PR TITLE
[QPPSF-2880] Add MSPB & TPCC Measures to 2018 Output

### DIFF
--- a/measures/2018/measures-data.json
+++ b/measures/2018/measures-data.json
@@ -47200,6 +47200,34 @@
     "cehrtEligible": false
   },
   {
+    "category": "cost",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "costScore",
+    "title": "Medicare Spending Per Beneficiary (MSPB)",
+    "description": "The Medicare Spending Per Beneficiary (MSPB) measure evaluates solo practitioners and groups on their spending efficiency and is risk-adjusted to account for patients' risk profiles. Solo practitioners and groups are identified by their National Provider Identification (NPI) and Taxpayer Identification Number (TIN) combination. Specifically, the MSPB measure assesses the average spend for Medicare services performed by providers/groups per episode of care. Each episode comprises the period immediately prior to, during, and following a patient's hospital stay.",
+    "measureId": "MSPB_1",
+    "isInverse": true,
+    "overallAlgorithm": "simpleAverage",
+    "submissionMethods": [
+      "administrativeClaims"
+    ]
+  },
+  {
+    "category": "cost",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "costScore",
+    "title": "Total Per Capita Costs (TPCC)",
+    "description": "The Total Per Capita Costs (TPCC) measure is a payment-standardized, annualized, risk-adjusted, and specialty-adjusted measure that evaluates the overall efficiency of care provided to beneficiaries attributed to solo practitioners and groups, as identified by their Medicare Taxpayer Identification Number (TIN)",
+    "measureId": "TPCC_1",
+    "isInverse": true,
+    "overallAlgorithm": "simpleAverage",
+    "submissionMethods": [
+      "administrativeClaims"
+    ]
+  },
+  {
     "measureId": "AAAAI11",
     "title": "Asthma Assessment and Classification",
     "description": "Percentage of patients aged 5 years and older with asthma and documentation of an asthma assessment and classification. National Quality Strategy Domain: Effective Clinical Care Process Measure",

--- a/measures/2018/measures-data.xml
+++ b/measures/2018/measures-data.xml
@@ -42983,6 +42983,30 @@ The program uses a patient-centered and team-based approach, leveraging evidence
     <cehrtEligible>false</cehrtEligible>
   </measure>
   <measure>
+    <category>cost</category>
+    <firstPerformanceYear>2017</firstPerformanceYear>
+    <lastPerformanceYear/>
+    <metricType>costScore</metricType>
+    <title>Medicare Spending Per Beneficiary (MSPB)</title>
+    <description>The Medicare Spending Per Beneficiary (MSPB) measure evaluates solo practitioners and groups on their spending efficiency and is risk-adjusted to account for patients' risk profiles. Solo practitioners and groups are identified by their National Provider Identification (NPI) and Taxpayer Identification Number (TIN) combination. Specifically, the MSPB measure assesses the average spend for Medicare services performed by providers/groups per episode of care. Each episode comprises the period immediately prior to, during, and following a patient's hospital stay.</description>
+    <measureId>MSPB_1</measureId>
+    <isInverse>true</isInverse>
+    <overallAlgorithm>simpleAverage</overallAlgorithm>
+    <submissionMethod>administrativeClaims</submissionMethod>
+  </measure>
+  <measure>
+    <category>cost</category>
+    <firstPerformanceYear>2017</firstPerformanceYear>
+    <lastPerformanceYear/>
+    <metricType>costScore</metricType>
+    <title>Total Per Capita Costs (TPCC)</title>
+    <description>The Total Per Capita Costs (TPCC) measure is a payment-standardized, annualized, risk-adjusted, and specialty-adjusted measure that evaluates the overall efficiency of care provided to beneficiaries attributed to solo practitioners and groups, as identified by their Medicare Taxpayer Identification Number (TIN)</description>
+    <measureId>TPCC_1</measureId>
+    <isInverse>true</isInverse>
+    <overallAlgorithm>simpleAverage</overallAlgorithm>
+    <submissionMethod>administrativeClaims</submissionMethod>
+  </measure>
+  <measure>
     <measureId>AAAAI11</measureId>
     <title>Asthma Assessment and Classification</title>
     <description>Percentage of patients aged 5 years and older with asthma and documentation of an asthma assessment and classification. National Quality Strategy Domain: Effective Clinical Care Process Measure</description>

--- a/scripts/measures/build-measures
+++ b/scripts/measures/build-measures
@@ -12,6 +12,7 @@ currentPerformanceYear=2018
 quality_csv='../../../util/measures/'$currentPerformanceYear'/quality-measures.csv'
 quality_strata='../../../util/measures/'$currentPerformanceYear'/quality-strata.csv'
 quality_measures='../../../staging/'$currentPerformanceYear'/measures-data-quality.json'
+cost_measures='../../../util/measures/'$currentPerformanceYear'/cost-measures.json'
 pi_json='../../../util/measures/'$currentPerformanceYear'/pi-measures.json'
 pi_measures='../../../staging/'$currentPerformanceYear'/measures-data-pi.json'
 ia_csv='../../../util/measures/'$currentPerformanceYear'/ia-measures.csv'
@@ -41,7 +42,7 @@ node scripts/measures/$currentPerformanceYear/enrich-measures-data.js \
 
 # 1. Merge the array/jsonfile-per-measureType into a combined array of all measures
 node scripts/measures/$currentPerformanceYear/merge-measures-data.js \
-	$enriched_quality_measures $pi_measures $ia_measures \
+	$enriched_quality_measures $pi_measures $ia_measures $cost_measures \
 	$final_measures
 
 # import and merge QCDR measures after previous measures have been built, as this has conflict-resolution logic

--- a/util/measures/2018/cost-measures.json
+++ b/util/measures/2018/cost-measures.json
@@ -1,0 +1,30 @@
+[
+  {
+    "category": "cost",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "costScore",
+    "title": "Medicare Spending Per Beneficiary (MSPB)",
+    "description": "The Medicare Spending Per Beneficiary (MSPB) measure evaluates solo practitioners and groups on their spending efficiency and is risk-adjusted to account for patients' risk profiles. Solo practitioners and groups are identified by their National Provider Identification (NPI) and Taxpayer Identification Number (TIN) combination. Specifically, the MSPB measure assesses the average spend for Medicare services performed by providers/groups per episode of care. Each episode comprises the period immediately prior to, during, and following a patient's hospital stay.",
+    "measureId": "MSPB_1",
+    "isInverse": true,
+    "overallAlgorithm": "simpleAverage",
+    "submissionMethods": [
+      "administrativeClaims"
+    ]
+  },
+  {
+    "category": "cost",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "costScore",
+    "title": "Total Per Capita Costs (TPCC)",
+    "description": "The Total Per Capita Costs (TPCC) measure is a payment-standardized, annualized, risk-adjusted, and specialty-adjusted measure that evaluates the overall efficiency of care provided to beneficiaries attributed to solo practitioners and groups, as identified by their Medicare Taxpayer Identification Number (TIN)",
+    "measureId": "TPCC_1",
+    "isInverse": true,
+    "overallAlgorithm": "simpleAverage",
+    "submissionMethods": [
+      "administrativeClaims"
+    ]
+  }
+]


### PR DESCRIPTION
Added MSPB & TPCC cost measures into a new file `util/measures/2018/cost-measures.json`, and integrated that file into the `scripts/measures/build-measures` bash script.