### PR TITLE
QPPA 1435 - Bump Version in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The version has been changed to 1.8.4 in package.json in preparation for publishing 2018 benchmarks.