### PR TITLE
QPPSF-3067: Fix 2018 EMA specialty sets for dermatology and neurosurgical

### DIFF
--- a/clinical-clusters/2018/clinical-clusters.json
+++ b/clinical-clusters/2018/clinical-clusters.json
@@ -90,15 +90,6 @@
         ]
       },
       {
-        "name": "neurosurgical",
-        "measureIds": [
-          "021",
-          "023",
-          "130",
-          "226"
-        ]
-      },
-      {
         "name": "generalOncology",
         "measureIds": [
           "047",
@@ -128,10 +119,10 @@
         ]
       },
       {
-        "name": "anesthesiology",
+        "name": "dermatology",
         "measureIds": [
-          "076",
           "130",
+          "226",
           "317"
         ]
       },
@@ -143,6 +134,15 @@
           "130",
           "226",
           "317"
+        ]
+      },
+      {
+        "name": "neurosurgical",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226"
         ]
       }
     ]
@@ -161,15 +161,6 @@
           "130",
           "226",
           "317"
-        ]
-      },
-      {
-        "name": "neurosurgical",
-        "measureIds": [
-          "021",
-          "023",
-          "130",
-          "226"
         ]
       },
       {
@@ -217,6 +208,15 @@
           "130",
           "226",
           "317"
+        ]
+      },
+      {
+        "name": "neurosurgical",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226"
         ]
       }
     ],
@@ -269,10 +269,10 @@
         ]
       },
       {
-        "name": "anesthesiology",
+        "name": "dermatology",
         "measureIds": [
-          "076",
           "130",
+          "226",
           "317"
         ]
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/scripts/clinical-clusters/ema-clinical-cluster-builder.js
+++ b/scripts/clinical-clusters/ema-clinical-cluster-builder.js
@@ -35,14 +35,15 @@ const specialSpecialtySetRelations = {
     registry: []
   },
   2018: {
-    claims: [{
-      name: 'anesthesiology', action: 'replace', measureIds: ['076', '130', '317']
-    }, {
-      name: 'rheumatology', action: 'add', measureIds: ['047', '128', '130', '226', '317']
-    }],
-    registry: [{
-      name: 'dentistry', action: 'remove', measureIds: ['378', '379']
-    }]
+    claims: [
+      { name: 'anesthesiology', action: 'replace', measureIds: ['076', '130', '317'] },
+      { name: 'dermatology', action: 'replace', measureIds: ['130', '226', '317'] },
+      { name: 'rheumatology', action: 'add', measureIds: ['047', '128', '130', '226', '317'] },
+      { name: 'neurosurgical', action: 'replace', measureIds: ['021', '023', '130', '226'] }
+    ],
+    registry: [
+      { name: 'dentistry', action: 'remove', measureIds: ['378', '379'] }
+    ]
   }
 };
 


### PR DESCRIPTION
The metadata for two claims specialty sets were incorrect (dermatology and neurosurgical), as a result the scoring engine was not reporting these groups of measures as EMA eligible.

https://jira.cms.gov/browse/QPPSF-3067
https://confluence.cms.gov/display/QPPPRACTICE/2018+EMA+Logic+and+Set

```
      { name: 'dermatology', measureIds: ['130', '226', '317'] },
      { name: 'neurosurgical', measureIds: ['021', '023', '130', '226'] }
```