### PR TITLE
QPPSF-3108 - Add ACO CAHPS Benchmarks 2018

### DIFF
--- a/benchmarks/2018.json
+++ b/benchmarks/2018.json
@@ -4826,5 +4826,124 @@
       85.67,
       92.31
     ]
+  },
+  {
+    "measureId": "CAHPS_ACO_1",
+    "benchmarkYear": 2016,
+    "performanceYear": 2018,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      30,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "CAHPS_ACO_2",
+    "benchmarkYear": 2016,
+    "performanceYear": 2018,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      30,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "CAHPS_ACO_3",
+    "benchmarkYear": 2016,
+    "performanceYear": 2018,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      30,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "CAHPS_ACO_4",
+    "benchmarkYear": 2016,
+    "performanceYear": 2018,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      30,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "CAHPS_ACO_5",
+    "benchmarkYear": 2016,
+    "performanceYear": 2018,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      54.18,
+      54.18,
+      55.48,
+      56.72,
+      57.95,
+      59.39,
+      60.99,
+      63.44
+    ]
+  },
+  {
+    "measureId": "CAHPS_ACO_6",
+    "benchmarkYear": 2016,
+    "performanceYear": 2018,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      54.75,
+      54.75,
+      55.97,
+      57.05,
+      58.1,
+      59.27,
+      60.58,
+      62.76
+    ]
+  },
+  {
+    "measureId": "CAHPS_ACO_34",
+    "benchmarkYear": 2016,
+    "performanceYear": 2018,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      24.25,
+      24.25,
+      25.57,
+      26.74,
+      28.12,
+      29.43,
+      31.08,
+      33.43
+    ]
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/staging/2018/benchmarks/json/002_benchmarks_aco_cahps.json
+++ b/staging/2018/benchmarks/json/002_benchmarks_aco_cahps.json
@@ -1,0 +1,121 @@
+[
+  {
+    "measureId": "CAHPS_ACO_1",
+    "benchmarkYear": 2016,
+    "performanceYear": 2018,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      30,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "CAHPS_ACO_2",
+    "benchmarkYear": 2016,
+    "performanceYear": 2018,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      30,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "CAHPS_ACO_3",
+    "benchmarkYear": 2016,
+    "performanceYear": 2018,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      30,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "CAHPS_ACO_4",
+    "benchmarkYear": 2016,
+    "performanceYear": 2018,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      30,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "CAHPS_ACO_5",
+    "benchmarkYear": 2016,
+    "performanceYear": 2018,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      54.18,
+      54.18,
+      55.48,
+      56.72,
+      57.95,
+      59.39,
+      60.99,
+      63.44
+    ]
+  },
+  {
+    "measureId": "CAHPS_ACO_6",
+    "benchmarkYear": 2016,
+    "performanceYear": 2018,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      54.75,
+      54.75,
+      55.97,
+      57.05,
+      58.1,
+      59.27,
+      60.58,
+      62.76
+    ]
+  },
+  {
+    "measureId": "CAHPS_ACO_34",
+    "benchmarkYear": 2016,
+    "performanceYear": 2018,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      24.25,
+      24.25,
+      25.57,
+      26.74,
+      28.12,
+      29.43,
+      31.08,
+      33.43
+    ]
+  }
+]


### PR DESCRIPTION
# Summary
Adding ACO CAHPS Benchmarks for 2018 measures.

# Tickets
[QPPSF-3108](https://jira.cms.gov/browse/QPPSF-3108)