### PR TITLE
Add instructions for using npm version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ We also use Travis CI to run tests on every branch.
 
 ## Versioning, publishing, and creating new releases
 
-1. Bump the `version` in `package.json` when making changes to `measures/$YEAR/measures-data.json` or `benchmarks/$YEAR.json`. You can also choose to bump the version when making changes elsewhere.
+1. Bump the `version` using `npm version <patch | minor | major>` when making changes to `measures/$YEAR/measures-data.json` or `benchmarks/$YEAR.json`. You can also choose to bump the version when making changes elsewhere.
 
 2. Publish a new version after bumping the version number:
 ```


### PR DESCRIPTION
Rather than manually updating package.json and package-lock.json.
Previously the version in package-lock.json was getting out of date from
package.json.

`npm version` takes one argument, one of: patch, minor, or major. It
will update the version number in package.json and package-lock.json and
commit the changes in a git commit.