### PR TITLE
Update QPP Measures Data Version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/test/measures/2018/measures-data-spec.js
+++ b/test/measures/2018/measures-data-spec.js
@@ -28,7 +28,7 @@ describe(year + ' measures data json', function() {
       assert.deepEqual(measure.substitutes, ['PI_PHCDRR_2']);
     });
 
-    it.only('contains proper metadata', () => {
+    it('contains proper metadata', () => {
       const generated = {};
       measuresData
         .filter(m => m.category === 'pi')


### PR DESCRIPTION
New changes were introduced in previous PR, #177, that require a version bump. This PR updates the version.