### PR TITLE
[QPPA-2304] Add 2019 historical benchmarks

### DIFF
--- a/benchmarks/2019.json
+++ b/benchmarks/2019.json
@@ -1,1 +1,6530 @@
-[]
+[
+  {
+    "measureId": "100",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "100",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "102",
+    "deciles": [
+      8.2,
+      59.34,
+      75.74,
+      83.91,
+      92,
+      98.31,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "104",
+    "deciles": [
+      23.16,
+      39.65,
+      48.17,
+      55.06,
+      76.23,
+      93.26,
+      99.6,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "107",
+    "deciles": [
+      0.41,
+      1.51,
+      3.57,
+      8.11,
+      17.49,
+      30.29,
+      54.73,
+      77.57,
+      96.67
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "109",
+    "deciles": [
+      56.83,
+      87.28,
+      95.72,
+      98.72,
+      99.89,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "109",
+    "deciles": [
+      8.96,
+      34.62,
+      63.01,
+      86.64,
+      94.38,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "110",
+    "deciles": [
+      5.26,
+      15.5,
+      23.64,
+      31.21,
+      38.66,
+      46.77,
+      56.02,
+      67.5,
+      84.99
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "110",
+    "deciles": [
+      16.81,
+      29.52,
+      41.42,
+      56.32,
+      71.19,
+      82.89,
+      94.15,
+      99.42,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "110",
+    "deciles": [
+      14.29,
+      29.85,
+      41.43,
+      53.85,
+      66.03,
+      76.94,
+      87.81,
+      96.41,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "111",
+    "deciles": [
+      5.97,
+      19.01,
+      31.07,
+      42.71,
+      53.44,
+      62.86,
+      71.82,
+      80.43,
+      90.41
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "111",
+    "deciles": [
+      35.68,
+      49.76,
+      61.11,
+      70.11,
+      77.32,
+      82.96,
+      89.44,
+      95.67,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "111",
+    "deciles": [
+      14.55,
+      30.23,
+      44.53,
+      55.56,
+      63.64,
+      70.43,
+      76.38,
+      83.77,
+      95.45
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "112",
+    "deciles": [
+      7.75,
+      22.28,
+      32.75,
+      42.32,
+      51.06,
+      58.44,
+      65.68,
+      73.44,
+      82.31
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "112",
+    "deciles": [
+      31.94,
+      44.44,
+      52.08,
+      58.45,
+      64.29,
+      70.97,
+      79.85,
+      90.24,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "112",
+    "deciles": [
+      16.44,
+      35.99,
+      48.26,
+      57.58,
+      67.39,
+      75.25,
+      85.31,
+      93.45,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "113",
+    "deciles": [
+      3.7,
+      13.49,
+      24.01,
+      33.97,
+      44.39,
+      54.8,
+      64.01,
+      73.38,
+      83.51
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "113",
+    "deciles": [
+      21.6,
+      36.6,
+      51,
+      62.5,
+      71.23,
+      80,
+      88.64,
+      97.73,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "113",
+    "deciles": [
+      18.6,
+      35.9,
+      49.51,
+      60.83,
+      70.88,
+      80.62,
+      90.41,
+      96.98,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "116",
+    "deciles": [
+      31.48,
+      44.27,
+      57.08,
+      72.03,
+      83.78,
+      90.99,
+      95.57,
+      97.55,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "117",
+    "deciles": [
+      9.09,
+      20.61,
+      32,
+      45.53,
+      66.02,
+      89.12,
+      95.65,
+      98.26,
+      99.73
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "117",
+    "deciles": [
+      42.67,
+      72,
+      96.88,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "117",
+    "deciles": [
+      41.34,
+      77.26,
+      90,
+      95.82,
+      98.49,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "118",
+    "deciles": [
+      72.14,
+      76,
+      78.57,
+      81.08,
+      83.91,
+      86.36,
+      88.73,
+      92.26,
+      98.18
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "119",
+    "deciles": [
+      54.5,
+      67.86,
+      74.8,
+      80,
+      84.14,
+      87.74,
+      91.11,
+      94.63,
+      98.39
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "119",
+    "deciles": [
+      57.78,
+      74.38,
+      82.86,
+      87.71,
+      91.94,
+      97.24,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "122",
+    "deciles": [
+      55.56,
+      67.71,
+      78.11,
+      90,
+      95.93,
+      98.2,
+      99.09,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "126",
+    "deciles": [
+      25.76,
+      66.15,
+      85.23,
+      96.43,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "127",
+    "deciles": [
+      36.42,
+      70.59,
+      92.86,
+      99.46,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "128",
+    "deciles": [
+      17.36,
+      21.15,
+      24.59,
+      28.52,
+      34.21,
+      43.85,
+      60.31,
+      78.25,
+      93.29
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "128",
+    "deciles": [
+      28.47,
+      37.52,
+      47.78,
+      74.48,
+      95.2,
+      99.27,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "128",
+    "deciles": [
+      21.27,
+      34.35,
+      54.26,
+      74.57,
+      90.6,
+      97.56,
+      99.87,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "130",
+    "deciles": [
+      70.38,
+      87.55,
+      93.49,
+      96.29,
+      97.99,
+      99,
+      99.58,
+      99.89,
+      100
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "130",
+    "deciles": [
+      91.9,
+      97.95,
+      99.52,
+      99.92,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "130",
+    "deciles": [
+      16.75,
+      68.06,
+      90.28,
+      97.24,
+      99.51,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "131",
+    "deciles": [
+      51.86,
+      80.57,
+      96.92,
+      99.64,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "131",
+    "deciles": [
+      2.28,
+      15.8,
+      40,
+      62.79,
+      84.06,
+      95.26,
+      99.55,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "134",
+    "deciles": [
+      1.35,
+      4.88,
+      10.18,
+      17.6,
+      28.29,
+      42.3,
+      56.83,
+      73.3,
+      87.5
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "134",
+    "deciles": [
+      0.68,
+      12.94,
+      53.92,
+      80.23,
+      96.99,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "134",
+    "deciles": [
+      0.92,
+      17.11,
+      45.65,
+      73.82,
+      90.06,
+      98.5,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "137",
+    "deciles": [
+      54.87,
+      83.83,
+      94.34,
+      98.8,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "138",
+    "deciles": [
+      24,
+      49.44,
+      63.64,
+      78.26,
+      92.59,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "140",
+    "deciles": [
+      92.5,
+      98.81,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "140",
+    "deciles": [
+      41.67,
+      66,
+      81.96,
+      91.3,
+      96.98,
+      99.57,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "141",
+    "deciles": [
+      97.35,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "141",
+    "deciles": [
+      39.23,
+      73.85,
+      87.5,
+      96.3,
+      99.31,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "143",
+    "deciles": [
+      43.9,
+      77.21,
+      87.79,
+      94.92,
+      97.27,
+      98.35,
+      99.46,
+      100,
+      100
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "143",
+    "deciles": [
+      77.35,
+      90.31,
+      95.4,
+      97.13,
+      98.57,
+      99.26,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "144",
+    "deciles": [
+      10.34,
+      48.64,
+      80.39,
+      89.89,
+      94.34,
+      98.44,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "145",
+    "deciles": [
+      35.94,
+      66.41,
+      82.93,
+      90.91,
+      95.18,
+      97.4,
+      99.07,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "145",
+    "deciles": [
+      42.25,
+      73.1,
+      88.04,
+      94.92,
+      98.16,
+      99.54,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "146",
+    "deciles": [
+      0.65,
+      0.23,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "146",
+    "deciles": [
+      0.72,
+      0.24,
+      0.11,
+      0.04,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "147",
+    "deciles": [
+      50,
+      76.47,
+      87.18,
+      94.06,
+      97.01,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "147",
+    "deciles": [
+      79.56,
+      93.04,
+      97.97,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "154",
+    "deciles": [
+      86.16,
+      96.95,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "154",
+    "deciles": [
+      9.4,
+      28.63,
+      60.82,
+      85,
+      95.97,
+      99.74,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "155",
+    "deciles": [
+      22.13,
+      55.81,
+      84.62,
+      99.21,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "155",
+    "deciles": [
+      31.82,
+      67.86,
+      86.79,
+      95,
+      98.22,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "156",
+    "deciles": [
+      95.09,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "163",
+    "deciles": [
+      2.86,
+      8.2,
+      14.86,
+      23.26,
+      36.21,
+      51.16,
+      64.69,
+      78.49,
+      90.91
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "164",
+    "deciles": [
+      14.29,
+      11.4,
+      9.09,
+      7.69,
+      6.8,
+      5.55,
+      4.28,
+      3.08,
+      1.54
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "165",
+    "deciles": [
+      1.67,
+      0.84,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "166",
+    "deciles": [
+      3.67,
+      2.38,
+      1.79,
+      1.26,
+      0.71,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "167",
+    "deciles": [
+      4.76,
+      3.51,
+      2.7,
+      2.15,
+      1.85,
+      1.28,
+      0.88,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "168",
+    "deciles": [
+      5.21,
+      3.95,
+      3.13,
+      2.63,
+      1.79,
+      1.27,
+      0.87,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "176",
+    "deciles": [
+      20.83,
+      32,
+      48.15,
+      55.56,
+      68.01,
+      80.43,
+      99.04,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "177",
+    "deciles": [
+      25.97,
+      57.23,
+      75,
+      88.24,
+      96.02,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "178",
+    "deciles": [
+      35.26,
+      67.61,
+      81.4,
+      90.59,
+      95.95,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "179",
+    "deciles": [
+      22.52,
+      44.53,
+      67.89,
+      85.31,
+      95.22,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "180",
+    "deciles": [
+      27.43,
+      52.68,
+      75.79,
+      87.96,
+      95.06,
+      99.58,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "181",
+    "deciles": [
+      7.69,
+      55.38,
+      97.32,
+      99.56,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "181",
+    "deciles": [
+      28.85,
+      50.65,
+      66.04,
+      77.78,
+      89.29,
+      96.79,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "182",
+    "deciles": [
+      98,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "185",
+    "deciles": [
+      95,
+      98.57,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "185",
+    "deciles": [
+      33.74,
+      61.64,
+      85,
+      90.54,
+      95.42,
+      98.41,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "187",
+    "deciles": [
+      55.06,
+      88.89,
+      96.49,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "191",
+    "deciles": [
+      67.39,
+      85.25,
+      90.63,
+      93.41,
+      95.59,
+      96.88,
+      97.83,
+      98.78,
+      100
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "191",
+    "deciles": [
+      89.29,
+      94.37,
+      96.88,
+      98.98,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "192",
+    "deciles": [
+      0.41,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "192",
+    "deciles": [
+      1.19,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "195",
+    "deciles": [
+      75.89,
+      91.72,
+      96.23,
+      98.18,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "195",
+    "deciles": [
+      91.01,
+      97.81,
+      99.85,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "204",
+    "deciles": [
+      51.61,
+      64.52,
+      70.97,
+      75.6,
+      79.25,
+      82.5,
+      85.48,
+      88.64,
+      92.52
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "204",
+    "deciles": [
+      80.72,
+      85.71,
+      88.45,
+      90.81,
+      92.68,
+      95,
+      97.89,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "204",
+    "deciles": [
+      34.3,
+      53.39,
+      66.67,
+      77.27,
+      85.44,
+      89.52,
+      94,
+      98.67,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "224",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "225",
+    "deciles": [
+      90.7,
+      99.36,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "225",
+    "deciles": [
+      99.75,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "236",
+    "deciles": [
+      42.76,
+      51.46,
+      56.83,
+      60.95,
+      64.68,
+      68.18,
+      72.01,
+      76.26,
+      82.21
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "236",
+    "deciles": [
+      50.65,
+      58.57,
+      63.98,
+      68.83,
+      73.91,
+      78.57,
+      83.33,
+      88.32,
+      94.89
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "236",
+    "deciles": [
+      37.58,
+      52.41,
+      60.05,
+      65.68,
+      70.62,
+      76.83,
+      84.62,
+      93.4,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "238",
+    "deciles": [
+      13.35,
+      8.04,
+      4.74,
+      2.67,
+      1.31,
+      0.53,
+      0.04,
+      0,
+      0
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "238",
+    "deciles": [
+      4.53,
+      0.68,
+      0.28,
+      0.13,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "239",
+    "deciles": [
+      18.96,
+      26.23,
+      29.52,
+      31.48,
+      32.8,
+      33.86,
+      38.73,
+      47.77,
+      65.53
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "240",
+    "deciles": [
+      4.4,
+      9.3,
+      14.81,
+      20.5,
+      26.68,
+      30.67,
+      37.23,
+      42.42,
+      50.89
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "243",
+    "deciles": [
+      4.17,
+      8.11,
+      11.88,
+      14.63,
+      17.23,
+      20.78,
+      24.32,
+      30.69,
+      44.44
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "249",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "249",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "250",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "250",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "251",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "251",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "254",
+    "deciles": [
+      65.22,
+      74.42,
+      80.95,
+      85.37,
+      88.89,
+      92,
+      95.24,
+      97.67,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "262",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "263",
+    "deciles": [
+      97.04,
+      98.8,
+      99.64,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "264",
+    "deciles": [
+      96.63,
+      97.96,
+      99.22,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "265",
+    "deciles": [
+      26,
+      61.23,
+      83.63,
+      95.65,
+      99.38,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "268",
+    "deciles": [
+      3.57,
+      32,
+      45.35,
+      57.14,
+      78.57,
+      96,
+      99.07,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "276",
+    "deciles": [
+      9.09,
+      41.89,
+      62.07,
+      83.57,
+      96.05,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "277",
+    "deciles": [
+      29.14,
+      69.01,
+      81.03,
+      90.63,
+      99.71,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "278",
+    "deciles": [
+      86.42,
+      95,
+      98.08,
+      99.68,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "279",
+    "deciles": [
+      72.62,
+      90.08,
+      96.27,
+      99.17,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "281",
+    "deciles": [
+      2.94,
+      5.88,
+      12.9,
+      26.09,
+      45,
+      59.26,
+      73.33,
+      88.57,
+      96.77
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "282",
+    "deciles": [
+      13.13,
+      57.14,
+      78.95,
+      95.28,
+      99.13,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "283",
+    "deciles": [
+      25.56,
+      58.14,
+      83.08,
+      96.67,
+      99.82,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "286",
+    "deciles": [
+      26.19,
+      62.86,
+      78.69,
+      89.89,
+      98.21,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "288",
+    "deciles": [
+      23.53,
+      59.26,
+      77.33,
+      89.33,
+      97.54,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "290",
+    "deciles": [
+      63.64,
+      85.09,
+      92.56,
+      96.92,
+      99.23,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "291",
+    "deciles": [
+      77.59,
+      86.49,
+      95,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "293",
+    "deciles": [
+      51.85,
+      67.03,
+      82.95,
+      94.29,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "303",
+    "deciles": [
+      19.5,
+      45.11,
+      70.88,
+      78.77,
+      84.91,
+      91.78,
+      98.8,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "304",
+    "deciles": [
+      34.19,
+      50,
+      72.22,
+      80.3,
+      87.09,
+      95.42,
+      99.12,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "305",
+    "deciles": [
+      0.16,
+      0.31,
+      0.42,
+      0.68,
+      1.03,
+      1.35,
+      2.24,
+      3.85,
+      6.91
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "309",
+    "deciles": [
+      3.3,
+      9.83,
+      16.8,
+      23.66,
+      31.54,
+      39.72,
+      48.31,
+      57.63,
+      72.61
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "310",
+    "deciles": [
+      9.09,
+      16.67,
+      22.31,
+      28.05,
+      33.33,
+      39.13,
+      44.78,
+      53.14,
+      63.78
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "317",
+    "deciles": [
+      12.99,
+      19.56,
+      24.14,
+      28.19,
+      32.31,
+      36.67,
+      42.12,
+      50.7,
+      74.55
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "317",
+    "deciles": [
+      25.37,
+      34.25,
+      45.48,
+      58.49,
+      73.29,
+      89.41,
+      98.07,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "317",
+    "deciles": [
+      16.04,
+      25.75,
+      30.81,
+      35.47,
+      42.57,
+      59.15,
+      83.49,
+      97.32,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "318",
+    "deciles": [
+      1.28,
+      7.24,
+      20.27,
+      36.41,
+      52.25,
+      66.73,
+      78.6,
+      88.51,
+      96.56
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "320",
+    "deciles": [
+      76.32,
+      95.24,
+      97.73,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "320",
+    "deciles": [
+      74.81,
+      85,
+      89.74,
+      93.61,
+      95.95,
+      97.73,
+      98.96,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "322",
+    "deciles": [
+      4.88,
+      1.9,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "323",
+    "deciles": [
+      6.25,
+      2.44,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "324",
+    "deciles": [
+      10.19,
+      6.25,
+      2.01,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "326",
+    "deciles": [
+      57.36,
+      84.13,
+      95.29,
+      98.8,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "326",
+    "deciles": [
+      59.42,
+      69.54,
+      75.11,
+      78.9,
+      83.09,
+      88.17,
+      94.94,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "331",
+    "deciles": [
+      95.7,
+      92.15,
+      87.5,
+      82.88,
+      75.36,
+      64.35,
+      46.67,
+      19.99,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "332",
+    "deciles": [
+      79.01,
+      93.55,
+      96.2,
+      97.59,
+      98.4,
+      99.36,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "333",
+    "deciles": [
+      5.88,
+      2.5,
+      0.9,
+      0.26,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "334",
+    "deciles": [
+      3.45,
+      0.93,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "337",
+    "deciles": [
+      19.05,
+      47.06,
+      60.61,
+      73.63,
+      82.51,
+      90,
+      96.43,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "338",
+    "deciles": [
+      42.5,
+      74.47,
+      78.57,
+      84,
+      87.94,
+      94,
+      97.24,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "340",
+    "deciles": [
+      31.43,
+      48.97,
+      52.86,
+      61.09,
+      82.69,
+      88,
+      92.86,
+      95.92,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "342",
+    "deciles": [
+      87.43,
+      98.78,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "343",
+    "deciles": [
+      23.27,
+      30.32,
+      34.26,
+      38.81,
+      42.08,
+      45.85,
+      50.15,
+      59.2,
+      85.25
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "350",
+    "deciles": [
+      84.68,
+      96,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "351",
+    "deciles": [
+      91.14,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "352",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "353",
+    "deciles": [
+      98.92,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "354",
+    "deciles": [
+      5.19,
+      3.61,
+      3.23,
+      0.73,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "355",
+    "deciles": [
+      5.04,
+      3.15,
+      2.27,
+      1.21,
+      0.4,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "356",
+    "deciles": [
+      8.75,
+      5,
+      3.3,
+      2,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "357",
+    "deciles": [
+      6.45,
+      3.48,
+      2.27,
+      0.93,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "358",
+    "deciles": [
+      3.85,
+      17.29,
+      61.79,
+      91.43,
+      97.64,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "359",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "360",
+    "deciles": [
+      15.91,
+      31.53,
+      61.38,
+      90.55,
+      98.83,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "361",
+    "deciles": [
+      94.04,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "362",
+    "deciles": [
+      98.04,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "363",
+    "deciles": [
+      27.4,
+      94.75,
+      98.17,
+      99.52,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "364",
+    "deciles": [
+      48.28,
+      59.02,
+      93.25,
+      97.65,
+      99.81,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "366",
+    "deciles": [
+      22.58,
+      26.67,
+      30.87,
+      33.96,
+      38.1,
+      46.46,
+      48.84,
+      54.55,
+      65.91
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "367",
+    "deciles": [
+      0.18,
+      0.53,
+      1.35,
+      2.63,
+      2.99,
+      13.54,
+      18.37,
+      40.91,
+      65
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "369",
+    "deciles": [
+      30.69,
+      73.45,
+      78.72,
+      84.35,
+      86.41,
+      89.9,
+      91.43,
+      95.3,
+      96.49
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "370",
+    "deciles": [
+      1.01,
+      2.08,
+      2.7,
+      3.7,
+      4.35,
+      5.32,
+      7.14,
+      8.77,
+      15
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "371",
+    "deciles": [
+      1.33,
+      3.82,
+      6.12,
+      9.09,
+      12.69,
+      16.67,
+      22.09,
+      30.3,
+      43.14
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "373",
+    "deciles": [
+      14.56,
+      22.22,
+      27.86,
+      32.43,
+      36.41,
+      40.54,
+      44.94,
+      50.22,
+      58.54
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "374",
+    "deciles": [
+      2.78,
+      7.63,
+      14.98,
+      26.33,
+      36.74,
+      48.15,
+      60.25,
+      74.44,
+      90.75
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "374",
+    "deciles": [
+      0.53,
+      6.77,
+      8.51,
+      37.84,
+      62.86,
+      82.43,
+      88.89,
+      92.74,
+      99.02
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "375",
+    "deciles": [
+      2.08,
+      5,
+      9.68,
+      15.91,
+      20.31,
+      24.56,
+      34.38,
+      53.42,
+      77.27
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "376",
+    "deciles": [
+      3.45,
+      4.82,
+      8.51,
+      13.1,
+      19.23,
+      27.59,
+      33.33,
+      40.19,
+      63.49
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "378",
+    "deciles": [
+      1.16,
+      0.47,
+      0.09,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "379",
+    "deciles": [
+      0.07,
+      0.32,
+      0.55,
+      0.74,
+      1.09,
+      2.08,
+      3.22,
+      4.9,
+      9.05
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "382",
+    "deciles": [
+      1.3,
+      3.43,
+      7.01,
+      12.47,
+      14.84,
+      20.26,
+      29.01,
+      36.11,
+      51.72
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "383",
+    "deciles": [
+      46.99,
+      58,
+      71.43,
+      86.84,
+      90.01,
+      98.33,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "387",
+    "deciles": [
+      0.3,
+      0.38,
+      0.46,
+      0.59,
+      0.77,
+      1.32,
+      1.41,
+      1.61,
+      2.87
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "388",
+    "deciles": [
+      0.48,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "389",
+    "deciles": [
+      50.53,
+      77.17,
+      90.91,
+      96.97,
+      99.22,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "390",
+    "deciles": [
+      45.24,
+      63.64,
+      80.87,
+      95.45,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "395",
+    "deciles": [
+      96.43,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "395",
+    "deciles": [
+      98.15,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "396",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "397",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "397",
+    "deciles": [
+      50,
+      91.96,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "398",
+    "deciles": [
+      16.67,
+      33.52,
+      59.46,
+      75,
+      96,
+      98.99,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "400",
+    "deciles": [
+      0.71,
+      1.26,
+      1.85,
+      3.23,
+      6.31,
+      16.78,
+      24.11,
+      32.01,
+      74.6
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "402",
+    "deciles": [
+      76.8,
+      86.36,
+      91.18,
+      94.12,
+      96.12,
+      97.59,
+      98.84,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "404",
+    "deciles": [
+      26.99,
+      39.88,
+      50.59,
+      57.25,
+      63,
+      69.75,
+      75.27,
+      82.41,
+      93.38
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "405",
+    "deciles": [
+      23.08,
+      10.26,
+      4.44,
+      0.72,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "405",
+    "deciles": [
+      19.23,
+      12.11,
+      6.67,
+      2.63,
+      0.53,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "406",
+    "deciles": [
+      90,
+      61.9,
+      48,
+      37.5,
+      15.56,
+      2.56,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "406",
+    "deciles": [
+      27.59,
+      14.94,
+      5.97,
+      3.64,
+      0.09,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "407",
+    "deciles": [
+      97.95,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "408",
+    "deciles": [
+      24.53,
+      68.35,
+      91.36,
+      98.49,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "410",
+    "deciles": [
+      13.16,
+      23.08,
+      36.36,
+      50,
+      61.54,
+      72.22,
+      87.5,
+      97.22,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "412",
+    "deciles": [
+      12.04,
+      61.17,
+      88.35,
+      97.44,
+      99.67,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "414",
+    "deciles": [
+      71.01,
+      88.55,
+      98.6,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "415",
+    "deciles": [
+      93.55,
+      96,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "415",
+    "deciles": [
+      56.82,
+      63.41,
+      70,
+      76.19,
+      80.37,
+      83.46,
+      86.49,
+      89.61,
+      98.21
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "416",
+    "deciles": [
+      52.17,
+      46.67,
+      40,
+      35,
+      28.37,
+      22.81,
+      18.75,
+      14.81,
+      9.52
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "419",
+    "deciles": [
+      67.86,
+      74.74,
+      85.71,
+      91.3,
+      95.71,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "424",
+    "deciles": [
+      93.3,
+      98.46,
+      99.52,
+      99.75,
+      99.88,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "425",
+    "deciles": [
+      94.23,
+      97.44,
+      98.49,
+      99.16,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "425",
+    "deciles": [
+      96.06,
+      97.59,
+      98.32,
+      98.74,
+      99.05,
+      99.3,
+      99.51,
+      99.77,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "426",
+    "deciles": [
+      96.12,
+      99.28,
+      99.78,
+      99.94,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "427",
+    "deciles": [
+      88.16,
+      95.18,
+      97.74,
+      99.28,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "430",
+    "deciles": [
+      84.6,
+      93.66,
+      97.18,
+      98.54,
+      99.22,
+      99.64,
+      99.92,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "431",
+    "deciles": [
+      7.85,
+      33.43,
+      49.35,
+      66.12,
+      78.13,
+      87,
+      93.52,
+      97.96,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "435",
+    "deciles": [
+      1.06,
+      2.05,
+      3.03,
+      5.5,
+      12.44,
+      25.82,
+      75.86,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "436",
+    "deciles": [
+      59.06,
+      85.73,
+      94.13,
+      97.46,
+      98.96,
+      99.66,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "436",
+    "deciles": [
+      80.84,
+      93.28,
+      96.97,
+      99.06,
+      99.67,
+      99.92,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "437",
+    "deciles": [
+      2.77,
+      1.32,
+      0.55,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "438",
+    "deciles": [
+      57.5,
+      63.75,
+      71.07,
+      77.12,
+      84.27,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "438",
+    "deciles": [
+      62.07,
+      78.72,
+      91.67,
+      95.65,
+      97.38,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "440",
+    "deciles": [
+      76.2,
+      96.91,
+      98.96,
+      99.88,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "441",
+    "deciles": [
+      26.05,
+      32.4,
+      37.14,
+      40.17,
+      44.04,
+      47.78,
+      50.62,
+      54.36,
+      58.26
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "444",
+    "deciles": [
+      86.15,
+      91.67,
+      96,
+      97.78,
+      98.44,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "445",
+    "deciles": [
+      5.13,
+      3.9,
+      3.16,
+      2.68,
+      2.24,
+      1.72,
+      1.22,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "449",
+    "deciles": [
+      91.8,
+      95.71,
+      98.53,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "450",
+    "deciles": [
+      52.17,
+      90,
+      90.91,
+      93.55,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "453",
+    "deciles": [
+      17.78,
+      15,
+      10.42,
+      9.18,
+      7.99,
+      7.35,
+      7.03,
+      2.38,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "457",
+    "deciles": [
+      20,
+      15.38,
+      15,
+      13.51,
+      11.1,
+      9.64,
+      6.45,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AAD1",
+    "deciles": [
+      3.37,
+      10.16,
+      18.75,
+      25.13,
+      35.84,
+      43.48,
+      57.08,
+      76.77,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AAD2",
+    "deciles": [
+      48.81,
+      82.44,
+      95.45,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AAD3",
+    "deciles": [
+      4.55,
+      1.58,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AAD5",
+    "deciles": [
+      50,
+      73.58,
+      90.14,
+      98.62,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ACR7",
+    "deciles": [
+      16.67,
+      21.19,
+      28.1,
+      34.78,
+      38.17,
+      41.89,
+      46.54,
+      58.88,
+      67.15
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AAN4",
+    "deciles": [
+      15.4,
+      27.59,
+      41.35,
+      58.33,
+      74.07,
+      83.91,
+      94.12,
+      98.14,
+      99.74
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AAN9",
+    "deciles": [
+      23.81,
+      61.54,
+      82.61,
+      92.86,
+      94.59,
+      97.5,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AAN10",
+    "deciles": [
+      1.56,
+      4.09,
+      11.96,
+      22.22,
+      30.43,
+      53.85,
+      65.27,
+      81.95,
+      90.34
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AAN2",
+    "deciles": [
+      31.07,
+      42.45,
+      46.27,
+      47.03,
+      49.32,
+      52.31,
+      53.47,
+      55.13,
+      59.19
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AAN5",
+    "deciles": [
+      10,
+      14.5,
+      16.67,
+      22.41,
+      28.44,
+      32.47,
+      40.2,
+      45.51,
+      53.01
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "IRIS2",
+    "deciles": [
+      76.74,
+      86.96,
+      97.37,
+      99,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ACEP21",
+    "deciles": [
+      41.72,
+      24.61,
+      19.32,
+      15.92,
+      9.05,
+      5.74,
+      3.77,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ACEP22",
+    "deciles": [
+      4.17,
+      8,
+      15,
+      18.96,
+      22.73,
+      26.56,
+      29.47,
+      36.67,
+      50.59
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ACEP24",
+    "deciles": [
+      47.83,
+      55.27,
+      60.23,
+      64.29,
+      68.38,
+      73.25,
+      77.94,
+      80.56,
+      84.77
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ACEP25",
+    "deciles": [
+      57.14,
+      63.89,
+      67.53,
+      71.88,
+      75,
+      78.79,
+      81.82,
+      85.71,
+      90
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ACEP26",
+    "deciles": [
+      50,
+      78.57,
+      81.03,
+      84.44,
+      87.5,
+      90.69,
+      91.94,
+      94.64,
+      96.43
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ACEP27",
+    "deciles": [
+      40,
+      56.25,
+      61.9,
+      70,
+      80.28,
+      85.71,
+      89.29,
+      93.55,
+      96.97
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ACEP28",
+    "deciles": [
+      56.25,
+      72.43,
+      83.73,
+      85.71,
+      88.12,
+      89.74,
+      93.55,
+      94.64,
+      95.51
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ACEP31",
+    "deciles": [
+      30.43,
+      43.04,
+      52,
+      59.09,
+      63.37,
+      69.05,
+      73.08,
+      88.1,
+      91.67
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "PPRNET20",
+    "deciles": [
+      10.28,
+      22.59,
+      37.48,
+      46.74,
+      51,
+      58.52,
+      59.25,
+      63.88,
+      71.52
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ACRad23",
+    "deciles": [
+      27.97,
+      20.97,
+      20.16,
+      18.18,
+      17.45,
+      16,
+      13.75,
+      12.5,
+      9.38
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ACRad31",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ACRad32",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ACRad33",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ACRad5",
+    "deciles": [
+      15.68,
+      13.15,
+      11.8,
+      10.26,
+      8.63,
+      7.43,
+      6.46,
+      4.29,
+      2.03
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ACRad3",
+    "deciles": [
+      0.12,
+      0.18,
+      0.24,
+      0.31,
+      0.43,
+      0.49,
+      0.54,
+      0.62,
+      0.8
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ACRad6",
+    "deciles": [
+      16.67,
+      20,
+      21.62,
+      23.08,
+      26.09,
+      29.9,
+      32,
+      35.59,
+      37.16
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AQUA5",
+    "deciles": [
+      6.82,
+      3.6,
+      2.94,
+      2.27,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AQUA6",
+    "deciles": [
+      9.09,
+      6.84,
+      3.25,
+      0.31,
+      0.09,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AQUA8",
+    "deciles": [
+      9.22,
+      5.13,
+      4.22,
+      3.21,
+      2.63,
+      1.01,
+      0.69,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ABG28",
+    "deciles": [
+      7.74,
+      32.09,
+      44.88,
+      50.16,
+      52.84,
+      58.28,
+      87.26,
+      98.88,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ABG29",
+    "deciles": [
+      32.02,
+      44.29,
+      67.23,
+      95.03,
+      99.51,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ABG30",
+    "deciles": [
+      44.68,
+      76.64,
+      93.47,
+      97.6,
+      99.06,
+      99.67,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ABG31",
+    "deciles": [
+      44.96,
+      89.72,
+      98.88,
+      99.67,
+      99.98,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ABG1",
+    "deciles": [
+      99.94,
+      99.98,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AQI35",
+    "deciles": [
+      0.04,
+      0.02,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ABG4",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ABG5",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ABG7",
+    "deciles": [
+      95.48,
+      97.85,
+      98.63,
+      99.29,
+      99.83,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AQI48",
+    "deciles": [
+      21.99,
+      55.23,
+      60.03,
+      94.52,
+      99.09,
+      99.99,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ABG14",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ABG15",
+    "deciles": [
+      0.02,
+      0.01,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ABG16",
+    "deciles": [
+      37.5,
+      56.01,
+      61.15,
+      72.27,
+      77.97,
+      82.25,
+      89.41,
+      94.19,
+      99.84
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ABG21",
+    "deciles": [
+      7.5,
+      29.34,
+      48.19,
+      62.51,
+      84.87,
+      90.42,
+      95.14,
+      99.77,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AQI50",
+    "deciles": [
+      96.77,
+      99.14,
+      99.46,
+      99.83,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AQI51",
+    "deciles": [
+      14.37,
+      79.31,
+      92.62,
+      96.4,
+      99.35,
+      99.8,
+      99.95,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AQI28",
+    "deciles": [
+      99.9,
+      99.97,
+      99.99,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AQI34",
+    "deciles": [
+      0.48,
+      0.08,
+      0.03,
+      0.01,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AQI31",
+    "deciles": [
+      99.79,
+      0.51,
+      0.14,
+      0.04,
+      0.02,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AQI29",
+    "deciles": [
+      73.66,
+      89.11,
+      94.23,
+      96.97,
+      98.2,
+      98.94,
+      99.78,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AQI32",
+    "deciles": [
+      99.1,
+      99.93,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AQI37",
+    "deciles": [
+      99.18,
+      99.83,
+      99.97,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "EPREOP9",
+    "deciles": [
+      99.26,
+      99.65,
+      99.77,
+      99.84,
+      99.91,
+      99.96,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "EPREOP14",
+    "deciles": [
+      0.01,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "EPREOP27",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "GIQIC15",
+    "deciles": [
+      50,
+      61.11,
+      71.43,
+      76.1,
+      79.2,
+      83.67,
+      87.13,
+      90.24,
+      93.75
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "GIQIC12",
+    "deciles": [
+      76.98,
+      83.71,
+      87.92,
+      90.18,
+      91.83,
+      93.52,
+      95.01,
+      96.58,
+      98.15
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "GIQIC10",
+    "deciles": [
+      16.98,
+      31.25,
+      52.35,
+      61.54,
+      66.78,
+      81.36,
+      90.91,
+      98.91,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "NHCR4",
+    "deciles": [
+      6.32,
+      12.5,
+      19.38,
+      23.67,
+      33.99,
+      40.34,
+      49.39,
+      68.21,
+      80.3
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "M2S1",
+    "deciles": [
+      66.43,
+      70.25,
+      77.55,
+      80.47,
+      81.26,
+      81.62,
+      84.57,
+      89.83,
+      92.82
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ECPR39",
+    "deciles": [
+      77.05,
+      83.33,
+      84.78,
+      87.18,
+      88.45,
+      90.91,
+      92.68,
+      94.44,
+      96.99
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ECPR43",
+    "deciles": [
+      23.35,
+      16.1,
+      11.69,
+      9.64,
+      7.79,
+      6.06,
+      4.94,
+      3.94,
+      0.63
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "MIRAMED3",
+    "deciles": [
+      99.86,
+      99.91,
+      99.98,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "MBSAQIP2",
+    "deciles": [
+      4.92,
+      3.85,
+      2.99,
+      2.17,
+      1.94,
+      1.5,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "MBSAQIP3",
+    "deciles": [
+      1.41,
+      0.46,
+      0.39,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "MBSAQIP4",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "MBSAQIP6",
+    "deciles": [
+      1.67,
+      1.45,
+      1.01,
+      0.46,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "MBSAQIP7",
+    "deciles": [
+      3.85,
+      2.13,
+      1.84,
+      1.28,
+      0.39,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "MBSAQIP8",
+    "deciles": [
+      0.46,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "MUSIC1",
+    "deciles": [
+      99.18,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "MUSIC2",
+    "deciles": [
+      1.59,
+      0.86,
+      0.76,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "MIRAMED5",
+    "deciles": [
+      99.24,
+      99.84,
+      99.93,
+      99.96,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "MIRAMED9",
+    "deciles": [
+      89.38,
+      93.75,
+      95.21,
+      97.04,
+      98.01,
+      98.63,
+      99.35,
+      99.81,
+      99.92
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "MIRAMED7",
+    "deciles": [
+      99.95,
+      99.98,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "MIRAMED4",
+    "deciles": [
+      99.98,
+      99.98,
+      99.97,
+      99.96,
+      99.95,
+      99.94,
+      99.92,
+      99.84,
+      99.74
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ACCPin1",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ACCPin2",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ACCPin3",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ACCPin4",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "PPRNET8",
+    "deciles": [
+      24.6,
+      27.68,
+      36.19,
+      41.6,
+      47.91,
+      50.62,
+      59.09,
+      67.68,
+      74.61
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "PPRNET32",
+    "deciles": [
+      1.18,
+      18.26,
+      26.79,
+      47.27,
+      56.42,
+      61.66,
+      66.12,
+      72.26,
+      75.07
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "PPRNET13",
+    "deciles": [
+      44.68,
+      62.5,
+      64.86,
+      70.59,
+      73.33,
+      76.05,
+      80.19,
+      84.24,
+      89.06
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "PPRNET14",
+    "deciles": [
+      60.29,
+      72.62,
+      77.22,
+      82.86,
+      87.3,
+      89.87,
+      90.54,
+      93.1,
+      94.59
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "PPRNET31",
+    "deciles": [
+      74.16,
+      82.72,
+      84.18,
+      85.54,
+      87.25,
+      90.71,
+      92.16,
+      93.93,
+      96.2
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "PPRNET33",
+    "deciles": [
+      45.52,
+      50.51,
+      54.55,
+      55.59,
+      57.8,
+      60.15,
+      65.25,
+      72.39,
+      81.63
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "PPRNET27",
+    "deciles": [
+      85.71,
+      88.57,
+      90.44,
+      91.4,
+      93.18,
+      96.77,
+      97.62,
+      98.84,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "PPRNET28",
+    "deciles": [
+      74.73,
+      80,
+      81.81,
+      82.92,
+      84.84,
+      85.95,
+      86.77,
+      91.41,
+      93.08
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "PPRNET29",
+    "deciles": [
+      68.74,
+      73.35,
+      78.89,
+      84.41,
+      86.3,
+      88.1,
+      90.89,
+      93.86,
+      96.3
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "PPRNET30",
+    "deciles": [
+      94.87,
+      96.03,
+      96.62,
+      97.54,
+      97.8,
+      97.92,
+      98.39,
+      98.9,
+      99.38
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AAO8",
+    "deciles": [
+      99.7,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AAO9",
+    "deciles": [
+      99.61,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AAO10",
+    "deciles": [
+      85.71,
+      94.65,
+      97.83,
+      99.28,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "AAO11",
+    "deciles": [
+      98.49,
+      99.6,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "RPAQIR11",
+    "deciles": [
+      0.93,
+      0.58,
+      0.26,
+      0.07,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "RPAQIR12",
+    "deciles": [
+      1.59,
+      0.99,
+      0.73,
+      0.54,
+      0.39,
+      0,
+      0,
+      0,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "RPAQIR13",
+    "deciles": [
+      86.51,
+      92.85,
+      94.07,
+      94.95,
+      95.87,
+      97.28,
+      97.89,
+      99.21,
+      99.77
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "RCOIR7",
+    "deciles": [
+      29.27,
+      37.04,
+      40.22,
+      44.53,
+      60,
+      63.64,
+      66.67,
+      69.23,
+      75
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "RCOIR9",
+    "deciles": [
+      99.86,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "STS1",
+    "deciles": [
+      10,
+      8.26,
+      6.96,
+      5.88,
+      4.62,
+      3.49,
+      2.73,
+      1.83,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "STS3",
+    "deciles": [
+      25,
+      21.21,
+      14.29,
+      9.09,
+      7.45,
+      5,
+      4.76,
+      2.7,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "STS5",
+    "deciles": [
+      11.86,
+      8,
+      5.88,
+      5.26,
+      4.08,
+      3.45,
+      3.03,
+      1.61,
+      0
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "STS7",
+    "deciles": [
+      1,
+      2.73,
+      6.56,
+      22.78,
+      51.52,
+      70,
+      83.78,
+      92.48,
+      99.17
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ASBS1",
+    "deciles": [
+      97.3,
+      99.16,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "ASBS7",
+    "deciles": [
+      94.44,
+      98.15,
+      98.47,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "NIPM1",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "001",
+    "deciles": [
+      93.48,
+      77.14,
+      60.78,
+      48.48,
+      38.89,
+      31.59,
+      25.87,
+      20.55,
+      14.71
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "001",
+    "deciles": [
+      65.12,
+      44.44,
+      29.03,
+      19.51,
+      14.71,
+      11.11,
+      8.33,
+      5.56,
+      2.78
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "001",
+    "deciles": [
+      86.27,
+      68.31,
+      50.62,
+      37.5,
+      28.69,
+      20,
+      13.59,
+      9.02,
+      2.7
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "005",
+    "deciles": [
+      66.2,
+      74.19,
+      78.57,
+      82.14,
+      85.19,
+      87.93,
+      90.91,
+      93.75,
+      97.73
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "005",
+    "deciles": [
+      81.48,
+      93.33,
+      96.97,
+      98.41,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "006",
+    "deciles": [
+      76.01,
+      84.13,
+      88,
+      90.67,
+      92.86,
+      95.1,
+      97.09,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "007",
+    "deciles": [
+      70.91,
+      76.74,
+      80.31,
+      83.18,
+      85.29,
+      87.16,
+      89.74,
+      91.92,
+      94.87
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "007",
+    "deciles": [
+      89.74,
+      96.17,
+      98.12,
+      99.77,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "008",
+    "deciles": [
+      71.88,
+      80.49,
+      85.62,
+      88.98,
+      91.3,
+      93.05,
+      94.74,
+      96.35,
+      100
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "008",
+    "deciles": [
+      88,
+      95.45,
+      98.06,
+      99.29,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "009",
+    "deciles": [
+      7.96,
+      16.67,
+      31.07,
+      42.19,
+      53.16,
+      71.74,
+      82.79,
+      88.89,
+      94.44
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "012",
+    "deciles": [
+      63.75,
+      79.11,
+      86.58,
+      90.62,
+      93.88,
+      96.32,
+      98.02,
+      99.11,
+      100
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "012",
+    "deciles": [
+      95.12,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "012",
+    "deciles": [
+      86,
+      96.47,
+      99.17,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "014",
+    "deciles": [
+      96.69,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "014",
+    "deciles": [
+      47.84,
+      76.54,
+      89.81,
+      96.54,
+      99.71,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "018",
+    "deciles": [
+      40.77,
+      56.85,
+      65.38,
+      71.63,
+      77.55,
+      82.66,
+      87.86,
+      92.84,
+      97.66
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "019",
+    "deciles": [
+      15.12,
+      33.9,
+      47.62,
+      57.89,
+      67.03,
+      75.37,
+      82.49,
+      90.03,
+      96
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "019",
+    "deciles": [
+      98.04,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "019",
+    "deciles": [
+      38.89,
+      70.29,
+      84.42,
+      92.73,
+      98.57,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "021",
+    "deciles": [
+      68.97,
+      99.17,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "021",
+    "deciles": [
+      89.57,
+      98.67,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "023",
+    "deciles": [
+      96.67,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "023",
+    "deciles": [
+      94.51,
+      98.68,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "024",
+    "deciles": [
+      21.05,
+      32.35,
+      63.64,
+      92.31,
+      96.21,
+      97.62,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "024",
+    "deciles": [
+      7.51,
+      26.32,
+      45.1,
+      55.32,
+      60.21,
+      70,
+      80.56,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "039",
+    "deciles": [
+      19.35,
+      32.79,
+      42.37,
+      49.01,
+      55.91,
+      62.55,
+      70.69,
+      82.89,
+      95.5
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "039",
+    "deciles": [
+      3.84,
+      11.38,
+      22.44,
+      34.72,
+      45.26,
+      58.11,
+      67.98,
+      78.46,
+      88.24
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "043",
+    "deciles": [
+      96.74,
+      98.45,
+      99,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "044",
+    "deciles": [
+      75,
+      90.35,
+      95.9,
+      97.39,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "046",
+    "deciles": [
+      86.21,
+      95.74,
+      98.41,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "046",
+    "deciles": [
+      82.14,
+      94.24,
+      97.63,
+      99.93,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "047",
+    "deciles": [
+      12.59,
+      50.32,
+      82.61,
+      92.89,
+      97.46,
+      99.31,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "047",
+    "deciles": [
+      4.79,
+      24.33,
+      45.02,
+      65.75,
+      82.17,
+      91.9,
+      97.32,
+      99.72,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "048",
+    "deciles": [
+      1.15,
+      3.88,
+      13.86,
+      72.41,
+      96.69,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "048",
+    "deciles": [
+      3.19,
+      12.22,
+      31.75,
+      52.37,
+      70.45,
+      84.27,
+      95.11,
+      99.51,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "050",
+    "deciles": [
+      88,
+      97.3,
+      98.88,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "050",
+    "deciles": [
+      30.23,
+      47.22,
+      60,
+      68.99,
+      75.64,
+      85.5,
+      92.59,
+      99.66,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "051",
+    "deciles": [
+      14.29,
+      38.1,
+      77.27,
+      92.45,
+      98.76,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "051",
+    "deciles": [
+      11.67,
+      25,
+      45.45,
+      60.43,
+      75.76,
+      86.46,
+      93.83,
+      99.36,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "052",
+    "deciles": [
+      68.75,
+      90.14,
+      98.15,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "052",
+    "deciles": [
+      75.9,
+      90.16,
+      95.22,
+      96.49,
+      98.86,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "065",
+    "deciles": [
+      69.57,
+      80.95,
+      88.37,
+      91.77,
+      93.88,
+      95.61,
+      96.88,
+      98.22,
+      100
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "065",
+    "deciles": [
+      82.05,
+      91.49,
+      95.02,
+      97.03,
+      97.85,
+      98.7,
+      99.2,
+      99.75,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "066",
+    "deciles": [
+      13.04,
+      36.71,
+      60.05,
+      72.41,
+      78.38,
+      83.33,
+      87.63,
+      91.43,
+      94.59
+    ],
+    "submissionMethod": "electronicHealthRecord",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "066",
+    "deciles": [
+      54.55,
+      64.57,
+      69.61,
+      75.42,
+      81.75,
+      85.51,
+      87.96,
+      91.78,
+      97.55
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "067",
+    "deciles": [
+      4,
+      8,
+      12.5,
+      22.73,
+      28.53,
+      34.62,
+      78.79,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "069",
+    "deciles": [
+      34.78,
+      42.86,
+      47.5,
+      64.52,
+      66.67,
+      71.43,
+      71.88,
+      76.92,
+      92.31
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "070",
+    "deciles": [
+      8,
+      16.67,
+      23.21,
+      32.26,
+      35.95,
+      67.86,
+      95.45,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "076",
+    "deciles": [
+      84.62,
+      95.24,
+      98.61,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "076",
+    "deciles": [
+      82.94,
+      95.67,
+      99.09,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "091",
+    "deciles": [
+      19.21,
+      43.36,
+      86.61,
+      93.22,
+      99.66,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "091",
+    "deciles": [
+      53.81,
+      67.34,
+      78.77,
+      86.34,
+      91.33,
+      95.24,
+      97.37,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "093",
+    "deciles": [
+      47.02,
+      89.12,
+      93.51,
+      96.36,
+      97.83,
+      99.93,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "093",
+    "deciles": [
+      42.86,
+      63.16,
+      77.36,
+      83.97,
+      89.66,
+      93.33,
+      96.15,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "099",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "claims",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  },
+  {
+    "measureId": "099",
+    "deciles": [
+      99.03,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "submissionMethod": "registry",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019
+  }
+]


### PR DESCRIPTION
Adding the 2019 historical benchmarks as generated from prod data on 12/18/2018, using the 2018 measures data in lieu of the incomplete 2019 measures data (no QCDRs yet).

```drun benchmarks-20181217 node tools/create-benchmarks/calculate-deciles.js --year 2019 --historical --verbose --keep-historical-qcdrs --exclude-test-tins --write json,csv 2>&1 | tee /tmp/deciles_20181218_1200.log```

[ ] Approved by Tim
[ ] Approved by Sarah

Jira ticket: https://jira.cms.gov/browse/QPPA-2304
Reviewer: TBD