### PR TITLE
Fix CMS160v6 uuid

### DIFF
--- a/measures/2018/measures-data.json
+++ b/measures/2018/measures-data.json
@@ -32480,7 +32480,7 @@
       }
     ],
     "cpcPlusGroup": "Other_Measure",
-    "eMeasureUuid": "40280381-503f-a1fc-0150-afe320c01761"
+    "eMeasureUuid": "40280382-5b4d-eebc-015b-5e87add90267"
   },
   {
     "title": "Maternal Depression Screening",
@@ -44112,7 +44112,7 @@
     "nqfEMeasureId": null,
     "nqfId": null,
     "measureId": "441",
-    "description": "The IVD All-or-None Measure is one outcome measure (optimal control). The measure contains four goals. All four goals within a measure must be reached in order to meet that measure. The numerator for the all-or-none measure should be collected from the organization's total IVD denominator. All-or-None Outcome Measure (Optimal Control) - Using the IVD denominator optimal results include:\n- Most recent blood pressure (BP) measurement is less than 140/90 mm Hg -- And\n- Most recent tobacco status is Tobacco Free -- And\n- Daily Aspirin or Other Antiplatelet Unless Contraindicated -- And\n- Statin Use Unless Contraindicated",
+    "description": "The IVD All-or-None Measure is one outcome measure (optimal control). The measure contains four goals. All four goals within a measure must be reached in order to meet that measure. The numerator for the all-or-none measure should be collected from the organization's total IVD denominator. All-or-None Outcome Measure (Optimal Control) - Using the IVD denominator optimal results include:\r- Most recent blood pressure (BP) measurement is less than 140/90 mm Hg -- And\r- Most recent tobacco status is Tobacco Free -- And\r- Daily Aspirin or Other Antiplatelet Unless Contraindicated -- And\r- Statin Use Unless Contraindicated",
     "nationalQualityStrategyDomain": "Effective Clinical Care",
     "measureType": "intermediateOutcome",
     "primarySteward": "Wisconsin Collaborative for Healthcare Quality",

--- a/measures/2018/measures-data.xml
+++ b/measures/2018/measures-data.xml
@@ -29071,7 +29071,7 @@ A retinal or dilated eye exam by an eye care professional in the measurement per
       </eMeasureUuids>
     </strata>
     <cpcPlusGroup>Other_Measure</cpcPlusGroup>
-    <eMeasureUuid>40280381-503f-a1fc-0150-afe320c01761</eMeasureUuid>
+    <eMeasureUuid>40280382-5b4d-eebc-015b-5e87add90267</eMeasureUuid>
   </measure>
   <measure>
     <title>Maternal Depression Screening</title>
@@ -40030,11 +40030,7 @@ If a follow-up blood pressure reading is not recorded during the measurement yea
     <nqfEMeasureId/>
     <nqfId/>
     <measureId>441</measureId>
-    <description>The IVD All-or-None Measure is one outcome measure (optimal control). The measure contains four goals. All four goals within a measure must be reached in order to meet that measure. The numerator for the all-or-none measure should be collected from the organization's total IVD denominator. All-or-None Outcome Measure (Optimal Control) - Using the IVD denominator optimal results include:
-    - Most recent blood pressure (BP) measurement is less than 140/90 mm Hg -- And
-    - Most recent tobacco status is Tobacco Free -- And
-    - Daily Aspirin or Other Antiplatelet Unless Contraindicated -- And
-    - Statin Use Unless Contraindicated</description>
+    <description>The IVD All-or-None Measure is one outcome measure (optimal control). The measure contains four goals. All four goals within a measure must be reached in order to meet that measure. The numerator for the all-or-none measure should be collected from the organization's total IVD denominator. All-or-None Outcome Measure (Optimal Control) - Using the IVD denominator optimal results include:&#xD;- Most recent blood pressure (BP) measurement is less than 140/90 mm Hg -- And&#xD;- Most recent tobacco status is Tobacco Free -- And&#xD;- Daily Aspirin or Other Antiplatelet Unless Contraindicated -- And&#xD;- Statin Use Unless Contraindicated</description>
     <nationalQualityStrategyDomain>Effective Clinical Care</nationalQualityStrategyDomain>
     <measureType>intermediateOutcome</measureType>
     <primarySteward>Wisconsin Collaborative for Healthcare Quality</primarySteward>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/staging/2018/measures-data-quality.json
+++ b/staging/2018/measures-data-quality.json
@@ -8301,7 +8301,7 @@
     "nqfEMeasureId": null,
     "nqfId": null,
     "measureId": "441",
-    "description": "The IVD All-or-None Measure is one outcome measure (optimal control). The measure contains four goals. All four goals within a measure must be reached in order to meet that measure. The numerator for the all-or-none measure should be collected from the organization's total IVD denominator. All-or-None Outcome Measure (Optimal Control) - Using the IVD denominator optimal results include:\n- Most recent blood pressure (BP) measurement is less than 140/90 mm Hg -- And\n- Most recent tobacco status is Tobacco Free -- And\n- Daily Aspirin or Other Antiplatelet Unless Contraindicated -- And\n- Statin Use Unless Contraindicated",
+    "description": "The IVD All-or-None Measure is one outcome measure (optimal control). The measure contains four goals. All four goals within a measure must be reached in order to meet that measure. The numerator for the all-or-none measure should be collected from the organization's total IVD denominator. All-or-None Outcome Measure (Optimal Control) - Using the IVD denominator optimal results include:\r- Most recent blood pressure (BP) measurement is less than 140/90 mm Hg -- And\r- Most recent tobacco status is Tobacco Free -- And\r- Daily Aspirin or Other Antiplatelet Unless Contraindicated -- And\r- Statin Use Unless Contraindicated",
     "nationalQualityStrategyDomain": "Effective Clinical Care",
     "measureType": "intermediateOutcome",
     "primarySteward": "Wisconsin Collaborative for Healthcare Quality",

--- a/util/measures/2018/enriched-measures-data-quality.json
+++ b/util/measures/2018/enriched-measures-data-quality.json
@@ -32480,7 +32480,7 @@
       }
     ],
     "cpcPlusGroup": "Other_Measure",
-    "eMeasureUuid": "40280381-503f-a1fc-0150-afe320c01761"
+    "eMeasureUuid": "40280382-5b4d-eebc-015b-5e87add90267"
   },
   {
     "title": "Maternal Depression Screening",
@@ -44112,7 +44112,7 @@
     "nqfEMeasureId": null,
     "nqfId": null,
     "measureId": "441",
-    "description": "The IVD All-or-None Measure is one outcome measure (optimal control). The measure contains four goals. All four goals within a measure must be reached in order to meet that measure. The numerator for the all-or-none measure should be collected from the organization's total IVD denominator. All-or-None Outcome Measure (Optimal Control) - Using the IVD denominator optimal results include:\n- Most recent blood pressure (BP) measurement is less than 140/90 mm Hg -- And\n- Most recent tobacco status is Tobacco Free -- And\n- Daily Aspirin or Other Antiplatelet Unless Contraindicated -- And\n- Statin Use Unless Contraindicated",
+    "description": "The IVD All-or-None Measure is one outcome measure (optimal control). The measure contains four goals. All four goals within a measure must be reached in order to meet that measure. The numerator for the all-or-none measure should be collected from the organization's total IVD denominator. All-or-None Outcome Measure (Optimal Control) - Using the IVD denominator optimal results include:\r- Most recent blood pressure (BP) measurement is less than 140/90 mm Hg -- And\r- Most recent tobacco status is Tobacco Free -- And\r- Daily Aspirin or Other Antiplatelet Unless Contraindicated -- And\r- Statin Use Unless Contraindicated",
     "nationalQualityStrategyDomain": "Effective Clinical Care",
     "measureType": "intermediateOutcome",
     "primarySteward": "Wisconsin Collaborative for Healthcare Quality",

--- a/util/measures/2018/manually-created-missing-measures.json
+++ b/util/measures/2018/manually-created-missing-measures.json
@@ -31,7 +31,7 @@
 		"eMeasureId": "CMS160v6",
 		"overallAlgorithm": "weightedAverage",
 		"metricType": "multiPerformanceRate",
-		"eMeasureUuid": "40280381-503f-a1fc-0150-afe320c01761",
+		"eMeasureUuid": "40280382-5b4d-eebc-015b-5e87add90267",
 		"strata": [
 			{
 				"name": "4MonthsOfEnd",


### PR DESCRIPTION
- The 2018 UUID for eMeasure CMS160v6 had an old UUID from 2017.
- This PR updates the 2018 eMeasureUuid for CMS160v6 to the correct value from the 2018 Implementation Guide.
- The UUID was updated in `util/measures/2018/manually-created-missing-measures.json` and used in the `build-measures.sh`  into `measures/2018/measures-data.json` 
- The description was update to use `\r` instead of `/n` that seems to be included from a separate change.