### PR TITLE
QPPSF-3743 topped out benchmarks for 2018 fix

### DIFF
--- a/benchmarks/2018.json
+++ b/benchmarks/2018.json
@@ -313,7 +313,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -403,7 +403,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -817,7 +817,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -835,7 +835,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -979,7 +979,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -1015,7 +1015,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -1033,7 +1033,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -1807,7 +1807,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -2509,7 +2509,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -2545,7 +2545,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -2689,7 +2689,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -2707,7 +2707,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -2743,7 +2743,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -2761,7 +2761,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -2797,7 +2797,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -3463,7 +3463,7 @@
     "isToppedOut": true,
     "deciles": [
       100,
-      100,
+      0,
       0,
       0,
       0,
@@ -3517,7 +3517,7 @@
     "isToppedOut": true,
     "deciles": [
       100,
-      100,
+      0,
       0,
       0,
       0,
@@ -3967,7 +3967,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/scripts/benchmarks/format-benchmark-record.js
+++ b/scripts/benchmarks/format-benchmark-record.js
@@ -124,11 +124,11 @@ const formatDecileGenerator = function(record) {
     if (!definedPredecessor &&
       definedSuccessor &&
       nextIndex === array.length) {
-      if (isInverseMeasure && (index === 1 || index === 2)) {
+      if (isInverseMeasure && (index === 1)) {
         return 100;
       } else if (isInverseMeasure) {
         return 0;
-      } else if (index === 1 || index === 2) {
+      } else if (index === 1) {
         return 0;
       } else {
         return 100;

--- a/staging/2018/benchmarks/json/003_benchmarks_updates.json
+++ b/staging/2018/benchmarks/json/003_benchmarks_updates.json
@@ -313,7 +313,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -403,7 +403,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -817,7 +817,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -835,7 +835,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -979,7 +979,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -1015,7 +1015,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -1033,7 +1033,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -1807,7 +1807,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -2509,7 +2509,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -2545,7 +2545,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -2689,7 +2689,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -2707,7 +2707,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -2743,7 +2743,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -2761,7 +2761,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -2797,7 +2797,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,
@@ -3463,7 +3463,7 @@
     "isToppedOut": true,
     "deciles": [
       100,
-      100,
+      0,
       0,
       0,
       0,
@@ -3517,7 +3517,7 @@
     "isToppedOut": true,
     "deciles": [
       100,
-      100,
+      0,
       0,
       0,
       0,
@@ -3967,7 +3967,7 @@
     "isToppedOut": true,
     "deciles": [
       0,
-      0,
+      100,
       100,
       100,
       100,

--- a/test/scripts/benchmarks/format-benchmark-record-spec.js
+++ b/test/scripts/benchmarks/format-benchmark-record-spec.js
@@ -210,7 +210,7 @@ describe('formatBenchmarkRecord', function() {
           assert.equal(benchmark.submissionMethod, 'claims', 'submissionMethod');
           assert.equal(benchmark.benchmarkYear, 2016, 'benchmarkYear');
           assert.equal(benchmark.performanceYear, 2018, 'performanceYear');
-          assert.deepEqual(benchmark.deciles, [0, 0, 100, 100, 100, 100, 100, 100, 100], 'deciles');
+          assert.deepEqual(benchmark.deciles, [0, 100, 100, 100, 100, 100, 100, 100, 100], 'deciles');
         });
       });
     });
@@ -300,7 +300,7 @@ describe('formatBenchmarkRecord', function() {
           assert.equal(benchmark.submissionMethod, 'registry', 'submissionMethod');
           assert.equal(benchmark.benchmarkYear, 2016, 'benchmarkYear');
           assert.equal(benchmark.performanceYear, 2018, 'performanceYear');
-          assert.deepEqual(benchmark.deciles, [100, 100, 0, 0, 0, 0, 0, 0, 0], 'deciles');
+          assert.deepEqual(benchmark.deciles, [100, 0, 0, 0, 0, 0, 0, 0, 0], 'deciles');
         });
       });
 


### PR DESCRIPTION
Fix for benchmarks for measures where deciles should be `[100, 0, 0, 0, 0, 0, 0, 0, 0]` (inverse) or `[0, 100, 100, 100, 100, 100, 100, 100, 100]` (regular)

- Updated `scripts/benchmarks/format-benchmark-record.js` so future runs of the `parse-benchmarks-data.js` script produce the correct output

This change affects benchmarks for the following measures/submission methods in 2018:
```
[
    ["019", "claims"],
    ["023", "claims"],
    ["067", "registry"],
    ["069", "registry"],
    ["099", "claims"],
    ["100", "claims"],
    ["100", "registry"],
    ["141", "claims"],
    ["224", "registry"],
    ["225", "registry"],
    ["249", "claims"],
    ["249", "registry"],
    ["251", "claims"],
    ["251", "registry"],
    ["262", "registry"],
    ["378", "electronicHealthRecord"],
    ["388", "registry"],
    ["427", "registry"]
]
```

Related Tickets:
https://jira.cms.gov/browse/QPPSF-3743
