### PR TITLE
Update cms347v1

### DIFF
--- a/measures/2018/measures-data.json
+++ b/measures/2018/measures-data.json
@@ -44044,7 +44044,42 @@
       "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/measures/cms347v1"
     },
     "cpcPlusGroup": "Other_Measure",
-    "eMeasureUuid": "40280382-5b4d-eebc-015b-8245e0fa06b7"
+    "eMeasureUuid": "40280382-5b4d-eebc-015b-8245e0fa06b7",
+    "strata": [
+      {
+        "name": "clinicalASCVD",
+        "description": "Patients aged ≥ 21 years at the beginning of the measurement period with clinical ASCVD diagnosis",
+        "eMeasureUuids": {
+          "initialPopulationUuid": "B5249FB8-86D2-4633-BCF8-705EAAA35F04",
+          "denominatorUuid": "CC35FC48-FA75-4E8C-8949-BC2B4D152F72",
+          "numeratorUuid": "53656F0F-97C7-4537-907E-4C8D836A5853",
+          "denominatorExclusionUuid": "6C1F017F-F0C4-4346-B823-0BC24E3BFA9C",
+          "denominatorExceptionUuid": "F13A488B-6F7F-45E3-8216-1A7A679ADBFD"
+        }
+      },
+      {
+        "name": "familialPureHypercholesterolemia",
+        "description": "Patients aged ≥ 21 years at the beginning of the measurement period who have ever had a fasting or direct laboratory result of LDL-C ≥ 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial or pure hypercholesterolemia",
+        "eMeasureUuids": {
+          "initialPopulationUuid": "F1948A70-E9EE-427F-9D1F-9489B902DFAB",
+          "denominatorUuid": "C44EA250-22FE-4FF1-835B-BD718A9E71FA",
+          "numeratorUuid": "632ECBD0-8C77-40E9-AE21-795891D5CD64",
+          "denominatorExclusionUuid": "C5AA9EF4-FC68-4844-A45A-4985E81DA8A1",
+          "denominatorExceptionUuid": "B55F6B97-ABF6-4F44-90C5-D02D99DE55DA"
+        }
+      },
+      {
+        "name": "highLdlcResultsDiabetes",
+        "description": "Patients aged 40 to 75 years at the beginning of the measurement period with Type 1 or Type 2 diabetes and with an LDL-C result of 70–189 mg/dL recorded as the highest fasting or direct laboratory test result in the measurement year or during the two years prior to the beginning of the measurement period",
+        "eMeasureUuids": {
+          "initialPopulationUuid": "E44CE0A2-A08E-48CC-B022-5B54F808FB61",
+          "denominatorUuid": "01B3E154-5F42-4905-BDDD-E2A34B8C1DB2",
+          "numeratorUuid": "5E64B1E4-1F1A-4B3B-B148-5044F6B30760",
+          "denominatorExclusionUuid": "1354D37B-998F-434E-8039-99F6CCC987FD",
+          "denominatorExceptionUuid": "3D0BD8CB-CB77-407A-A367-080F53D880DD"
+        }
+      }
+    ]
   },
   {
     "title": "Age Appropriate Screening Colonoscopy",

--- a/measures/2018/measures-data.json
+++ b/measures/2018/measures-data.json
@@ -44058,7 +44058,7 @@
         }
       },
       {
-        "name": "familialPureHypercholesterolemia",
+        "name": ">21Familial",
         "description": "Patients aged ≥ 21 years at the beginning of the measurement period who have ever had a fasting or direct laboratory result of LDL-C ≥ 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial or pure hypercholesterolemia",
         "eMeasureUuids": {
           "initialPopulationUuid": "F1948A70-E9EE-427F-9D1F-9489B902DFAB",
@@ -44069,7 +44069,7 @@
         }
       },
       {
-        "name": "highLdlcResultsDiabetes",
+        "name": "between40And75",
         "description": "Patients aged 40 to 75 years at the beginning of the measurement period with Type 1 or Type 2 diabetes and with an LDL-C result of 70–189 mg/dL recorded as the highest fasting or direct laboratory test result in the measurement year or during the two years prior to the beginning of the measurement period",
         "eMeasureUuids": {
           "initialPopulationUuid": "E44CE0A2-A08E-48CC-B022-5B54F808FB61",

--- a/measures/2018/measures-data.xml
+++ b/measures/2018/measures-data.xml
@@ -39983,7 +39983,7 @@ If a follow-up blood pressure reading is not recorded during the measurement yea
       </eMeasureUuids>
     </strata>
     <strata>
-      <name>familialPureHypercholesterolemia</name>
+      <name>&gt;21Familial</name>
       <description>Patients aged ≥ 21 years at the beginning of the measurement period who have ever had a fasting or direct laboratory result of LDL-C ≥ 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial or pure hypercholesterolemia</description>
       <eMeasureUuids>
         <initialPopulationUuid>F1948A70-E9EE-427F-9D1F-9489B902DFAB</initialPopulationUuid>
@@ -39994,7 +39994,7 @@ If a follow-up blood pressure reading is not recorded during the measurement yea
       </eMeasureUuids>
     </strata>
     <strata>
-      <name>highLdlcResultsDiabetes</name>
+      <name>between40And75</name>
       <description>Patients aged 40 to 75 years at the beginning of the measurement period with Type 1 or Type 2 diabetes and with an LDL-C result of 70–189 mg/dL recorded as the highest fasting or direct laboratory test result in the measurement year or during the two years prior to the beginning of the measurement period</description>
       <eMeasureUuids>
         <initialPopulationUuid>E44CE0A2-A08E-48CC-B022-5B54F808FB61</initialPopulationUuid>

--- a/measures/2018/measures-data.xml
+++ b/measures/2018/measures-data.xml
@@ -39971,6 +39971,39 @@ If a follow-up blood pressure reading is not recorded during the measurement yea
     </measureSpecification>
     <cpcPlusGroup>Other_Measure</cpcPlusGroup>
     <eMeasureUuid>40280382-5b4d-eebc-015b-8245e0fa06b7</eMeasureUuid>
+    <strata>
+      <name>clinicalASCVD</name>
+      <description>Patients aged ≥ 21 years at the beginning of the measurement period with clinical ASCVD diagnosis</description>
+      <eMeasureUuids>
+        <initialPopulationUuid>B5249FB8-86D2-4633-BCF8-705EAAA35F04</initialPopulationUuid>
+        <denominatorUuid>CC35FC48-FA75-4E8C-8949-BC2B4D152F72</denominatorUuid>
+        <numeratorUuid>53656F0F-97C7-4537-907E-4C8D836A5853</numeratorUuid>
+        <denominatorExclusionUuid>6C1F017F-F0C4-4346-B823-0BC24E3BFA9C</denominatorExclusionUuid>
+        <denominatorExceptionUuid>F13A488B-6F7F-45E3-8216-1A7A679ADBFD</denominatorExceptionUuid>
+      </eMeasureUuids>
+    </strata>
+    <strata>
+      <name>familialPureHypercholesterolemia</name>
+      <description>Patients aged ≥ 21 years at the beginning of the measurement period who have ever had a fasting or direct laboratory result of LDL-C ≥ 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial or pure hypercholesterolemia</description>
+      <eMeasureUuids>
+        <initialPopulationUuid>F1948A70-E9EE-427F-9D1F-9489B902DFAB</initialPopulationUuid>
+        <denominatorUuid>C44EA250-22FE-4FF1-835B-BD718A9E71FA</denominatorUuid>
+        <numeratorUuid>632ECBD0-8C77-40E9-AE21-795891D5CD64</numeratorUuid>
+        <denominatorExclusionUuid>C5AA9EF4-FC68-4844-A45A-4985E81DA8A1</denominatorExclusionUuid>
+        <denominatorExceptionUuid>B55F6B97-ABF6-4F44-90C5-D02D99DE55DA</denominatorExceptionUuid>
+      </eMeasureUuids>
+    </strata>
+    <strata>
+      <name>highLdlcResultsDiabetes</name>
+      <description>Patients aged 40 to 75 years at the beginning of the measurement period with Type 1 or Type 2 diabetes and with an LDL-C result of 70–189 mg/dL recorded as the highest fasting or direct laboratory test result in the measurement year or during the two years prior to the beginning of the measurement period</description>
+      <eMeasureUuids>
+        <initialPopulationUuid>E44CE0A2-A08E-48CC-B022-5B54F808FB61</initialPopulationUuid>
+        <denominatorUuid>01B3E154-5F42-4905-BDDD-E2A34B8C1DB2</denominatorUuid>
+        <numeratorUuid>5E64B1E4-1F1A-4B3B-B148-5044F6B30760</numeratorUuid>
+        <denominatorExclusionUuid>1354D37B-998F-434E-8039-99F6CCC987FD</denominatorExclusionUuid>
+        <denominatorExceptionUuid>3D0BD8CB-CB77-407A-A367-080F53D880DD</denominatorExceptionUuid>
+      </eMeasureUuids>
+    </strata>
   </measure>
   <measure>
     <title>Age Appropriate Screening Colonoscopy</title>

--- a/util/measures/2018/enriched-measures-data-quality.json
+++ b/util/measures/2018/enriched-measures-data-quality.json
@@ -44044,7 +44044,42 @@
       "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/measures/cms347v1"
     },
     "cpcPlusGroup": "Other_Measure",
-    "eMeasureUuid": "40280382-5b4d-eebc-015b-8245e0fa06b7"
+    "eMeasureUuid": "40280382-5b4d-eebc-015b-8245e0fa06b7",
+    "strata": [
+      {
+        "name": "clinicalASCVD",
+        "description": "Patients aged ≥ 21 years at the beginning of the measurement period with clinical ASCVD diagnosis",
+        "eMeasureUuids": {
+          "initialPopulationUuid": "B5249FB8-86D2-4633-BCF8-705EAAA35F04",
+          "denominatorUuid": "CC35FC48-FA75-4E8C-8949-BC2B4D152F72",
+          "numeratorUuid": "53656F0F-97C7-4537-907E-4C8D836A5853",
+          "denominatorExclusionUuid": "6C1F017F-F0C4-4346-B823-0BC24E3BFA9C",
+          "denominatorExceptionUuid": "F13A488B-6F7F-45E3-8216-1A7A679ADBFD"
+        }
+      },
+      {
+        "name": "familialPureHypercholesterolemia",
+        "description": "Patients aged ≥ 21 years at the beginning of the measurement period who have ever had a fasting or direct laboratory result of LDL-C ≥ 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial or pure hypercholesterolemia",
+        "eMeasureUuids": {
+          "initialPopulationUuid": "F1948A70-E9EE-427F-9D1F-9489B902DFAB",
+          "denominatorUuid": "C44EA250-22FE-4FF1-835B-BD718A9E71FA",
+          "numeratorUuid": "632ECBD0-8C77-40E9-AE21-795891D5CD64",
+          "denominatorExclusionUuid": "C5AA9EF4-FC68-4844-A45A-4985E81DA8A1",
+          "denominatorExceptionUuid": "B55F6B97-ABF6-4F44-90C5-D02D99DE55DA"
+        }
+      },
+      {
+        "name": "highLdlcResultsDiabetes",
+        "description": "Patients aged 40 to 75 years at the beginning of the measurement period with Type 1 or Type 2 diabetes and with an LDL-C result of 70–189 mg/dL recorded as the highest fasting or direct laboratory test result in the measurement year or during the two years prior to the beginning of the measurement period",
+        "eMeasureUuids": {
+          "initialPopulationUuid": "E44CE0A2-A08E-48CC-B022-5B54F808FB61",
+          "denominatorUuid": "01B3E154-5F42-4905-BDDD-E2A34B8C1DB2",
+          "numeratorUuid": "5E64B1E4-1F1A-4B3B-B148-5044F6B30760",
+          "denominatorExclusionUuid": "1354D37B-998F-434E-8039-99F6CCC987FD",
+          "denominatorExceptionUuid": "3D0BD8CB-CB77-407A-A367-080F53D880DD"
+        }
+      }
+    ]
   },
   {
     "title": "Age Appropriate Screening Colonoscopy",

--- a/util/measures/2018/enriched-measures-data-quality.json
+++ b/util/measures/2018/enriched-measures-data-quality.json
@@ -44058,7 +44058,7 @@
         }
       },
       {
-        "name": "familialPureHypercholesterolemia",
+        "name": ">21Familial",
         "description": "Patients aged ≥ 21 years at the beginning of the measurement period who have ever had a fasting or direct laboratory result of LDL-C ≥ 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial or pure hypercholesterolemia",
         "eMeasureUuids": {
           "initialPopulationUuid": "F1948A70-E9EE-427F-9D1F-9489B902DFAB",
@@ -44069,7 +44069,7 @@
         }
       },
       {
-        "name": "highLdlcResultsDiabetes",
+        "name": "between40And75",
         "description": "Patients aged 40 to 75 years at the beginning of the measurement period with Type 1 or Type 2 diabetes and with an LDL-C result of 70–189 mg/dL recorded as the highest fasting or direct laboratory test result in the measurement year or during the two years prior to the beginning of the measurement period",
         "eMeasureUuids": {
           "initialPopulationUuid": "E44CE0A2-A08E-48CC-B022-5B54F808FB61",

--- a/util/measures/2018/manually-created-missing-measures.json
+++ b/util/measures/2018/manually-created-missing-measures.json
@@ -105,7 +105,7 @@
 	{
 		"eMeasureId": "CMS347v1",
 		"metricType": "singlePerformanceRate",
-		"eMeasureUuid": "40280382-5b4d-eebc-015b-8245e0fa06b7"
+		"eMeasureUuid": "40280382-5b4d-eebc-015b-8245e0fa06b7",
 		"strata": [
 			{
 				"name" : "clinicalASCVD",

--- a/util/measures/2018/manually-created-missing-measures.json
+++ b/util/measures/2018/manually-created-missing-measures.json
@@ -119,7 +119,7 @@
 				}
 			},
 			{
-				"name" : "familialPureHypercholesterolemia",
+				"name" : ">21Familial",
 				"description": "Patients aged ≥ 21 years at the beginning of the measurement period who have ever had a fasting or direct laboratory result of LDL-C ≥ 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial or pure hypercholesterolemia",
 				"eMeasureUuids": {
 					"initialPopulationUuid": "F1948A70-E9EE-427F-9D1F-9489B902DFAB",
@@ -130,7 +130,7 @@
 				}
 			},
 			{
-				"name" : "highLdlcResultsDiabetes",
+				"name" : "between40And75",
 				"description": "Patients aged 40 to 75 years at the beginning of the measurement period with Type 1 or Type 2 diabetes and with an LDL-C result of 70–189 mg/dL recorded as the highest fasting or direct laboratory test result in the measurement year or during the two years prior to the beginning of the measurement period",
 				"eMeasureUuids": {
 					"initialPopulationUuid": "E44CE0A2-A08E-48CC-B022-5B54F808FB61",

--- a/util/measures/2018/manually-created-missing-measures.json
+++ b/util/measures/2018/manually-created-missing-measures.json
@@ -106,5 +106,40 @@
 		"eMeasureId": "CMS347v1",
 		"metricType": "singlePerformanceRate",
 		"eMeasureUuid": "40280382-5b4d-eebc-015b-8245e0fa06b7"
+		"strata": [
+			{
+				"name" : "clinicalASCVD",
+				"description": "Patients aged ≥ 21 years at the beginning of the measurement period with clinical ASCVD diagnosis",
+				"eMeasureUuids": {
+					"initialPopulationUuid": "B5249FB8-86D2-4633-BCF8-705EAAA35F04",
+					"denominatorUuid": "CC35FC48-FA75-4E8C-8949-BC2B4D152F72",
+					"numeratorUuid": "53656F0F-97C7-4537-907E-4C8D836A5853",
+					"denominatorExclusionUuid": "6C1F017F-F0C4-4346-B823-0BC24E3BFA9C",
+					"denominatorExceptionUuid": "F13A488B-6F7F-45E3-8216-1A7A679ADBFD"
+				}
+			},
+			{
+				"name" : "familialPureHypercholesterolemia",
+				"description": "Patients aged ≥ 21 years at the beginning of the measurement period who have ever had a fasting or direct laboratory result of LDL-C ≥ 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial or pure hypercholesterolemia",
+				"eMeasureUuids": {
+					"initialPopulationUuid": "F1948A70-E9EE-427F-9D1F-9489B902DFAB",
+					"denominatorUuid": "C44EA250-22FE-4FF1-835B-BD718A9E71FA",
+					"numeratorUuid": "632ECBD0-8C77-40E9-AE21-795891D5CD64",
+					"denominatorExclusionUuid": "C5AA9EF4-FC68-4844-A45A-4985E81DA8A1",
+					"denominatorExceptionUuid": "B55F6B97-ABF6-4F44-90C5-D02D99DE55DA"
+				}
+			},
+			{
+				"name" : "highLdlcResultsDiabetes",
+				"description": "Patients aged 40 to 75 years at the beginning of the measurement period with Type 1 or Type 2 diabetes and with an LDL-C result of 70–189 mg/dL recorded as the highest fasting or direct laboratory test result in the measurement year or during the two years prior to the beginning of the measurement period",
+				"eMeasureUuids": {
+					"initialPopulationUuid": "E44CE0A2-A08E-48CC-B022-5B54F808FB61",
+					"denominatorUuid": "01B3E154-5F42-4905-BDDD-E2A34B8C1DB2",
+					"numeratorUuid": "5E64B1E4-1F1A-4B3B-B148-5044F6B30760",
+					"denominatorExclusionUuid": "1354D37B-998F-434E-8039-99F6CCC987FD",
+					"denominatorExceptionUuid": "3D0BD8CB-CB77-407A-A367-080F53D880DD"
+				}
+			}
+		]
 	}
 ]


### PR DESCRIPTION
- This adds a a set of GUIDs that are required for the Conversion Tools Team (see https://ecqi.healthit.gov/system/files/2018_CMS_QRDA_III_Eligible_Clinicians_and_EP_IG_v2_508.pdf#page=100).
- These guids are used to identify which strata are to be combined.
- This change has been verified by Krista Hammons from Mathematica. Please talk to @sarahnw for any details about this change.