### PR TITLE
Removed EMA Preventive Care cluster for measure 317 in 2018

### DIFF
--- a/clinical-clusters/2018/clinical-clusters.json
+++ b/clinical-clusters/2018/clinical-clusters.json
@@ -2457,21 +2457,6 @@
     ]
   },
   {
-    "measureId": "317",
-    "submissionMethod": "registry",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "clinicalClusters": [
-      {
-        "name": "preventiveCare",
-        "measureIds": [
-          "130",
-          "317"
-        ]
-      }
-    ]
-  },
-  {
     "measureId": "111",
     "submissionMethod": "registry",
     "firstPerformanceYear": 2017,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/scripts/clinical-clusters/ema-clinical-cluster-builder.js
+++ b/scripts/clinical-clusters/ema-clinical-cluster-builder.js
@@ -96,6 +96,7 @@ const specialClusterRelations = {
       {measureId: '226', optionals: []},
       {measureId: '424', optionals: []},
       {measureId: '430', optionals: []},
+      {measureId: '317', optionals: []},
       {measureId: '051', optionals: ['052']},
       {measureId: '052', optionals: ['051']},
       {measureId: '398', optionals: ['444']},

--- a/test/clinical-clusters/clinical-clusters-spec.js
+++ b/test/clinical-clusters/clinical-clusters-spec.js
@@ -25,6 +25,18 @@ describe('clinical cluster functionality', () => {
     assert.equal(1, clusters.length);
   });
 
+  it('measures in 130 and 317 are ignored completely for EMA', () => {
+    const data = main.getClinicalClusterData();
+    ['130', '317'].forEach((measureId) => {
+      let clusters = data.filter(c => c.measureId === measureId && c.submissionMethod === 'registry');
+      assert.isArray(clusters);
+      assert.equal(0, clusters.length);
+      clusters = data.filter(c => c.measureId === measureId && c.submissionMethod === 'claims');
+      assert.isArray(clusters);
+      assert.equal(1, clusters.length);
+    });
+  });
+
   it('measures in specialClusterRelations has measureIds without optionals', () => {
     // registry 051 and 052 should only have 130 in their clinicalCluster for registry
     const data = main.getClinicalClusterData();

--- a/test/clinical-clusters/clinical-clusters-spec.js
+++ b/test/clinical-clusters/clinical-clusters-spec.js
@@ -28,7 +28,6 @@ describe('clinical cluster functionality', () => {
   it('cluster for measure 317 in 2018 should exist only for claims and not registry', () => {
     const data = main.getClinicalClusterData(2018);
     let clusters = data.filter(c => c.measureId === '317' && c.submissionMethod === 'registry');
-    console.log(JSON.stringify(data));
     assert.isArray(clusters);
     assert.equal(0, clusters.length);
     clusters = data.filter(c => c.measureId === '317' && c.submissionMethod === 'claims');

--- a/test/clinical-clusters/clinical-clusters-spec.js
+++ b/test/clinical-clusters/clinical-clusters-spec.js
@@ -25,16 +25,15 @@ describe('clinical cluster functionality', () => {
     assert.equal(1, clusters.length);
   });
 
-  it('measures in 130 and 317 are ignored completely for EMA', () => {
-    const data = main.getClinicalClusterData();
-    ['130', '317'].forEach((measureId) => {
-      let clusters = data.filter(c => c.measureId === measureId && c.submissionMethod === 'registry');
-      assert.isArray(clusters);
-      assert.equal(0, clusters.length);
-      clusters = data.filter(c => c.measureId === measureId && c.submissionMethod === 'claims');
-      assert.isArray(clusters);
-      assert.equal(1, clusters.length);
-    });
+  it('cluster for measure 317 in 2018 should exist only for claims and not registry', () => {
+    const data = main.getClinicalClusterData(2018);
+    let clusters = data.filter(c => c.measureId === '317' && c.submissionMethod === 'registry');
+    console.log(JSON.stringify(data));
+    assert.isArray(clusters);
+    assert.equal(0, clusters.length);
+    clusters = data.filter(c => c.measureId === '317' && c.submissionMethod === 'claims');
+    assert.isArray(clusters);
+    assert.equal(1, clusters.length);
   });
 
   it('measures in specialClusterRelations has measureIds without optionals', () => {


### PR DESCRIPTION
### Summary

Removed registry Preventive Care cluster for measure 317 in 2018, that was falsely identifying measures 130, 317 as EMA Cluster

### Test Plan

Things that have to pass; these are things that the reviewer(s) should be able to reproduce:

* [X] Verified Working locally
* [X] Unit tested
* [X] Integration tests pass
* [ ] Documented (technical doc and/or business requirements doc)

* Ticket - https://jira.cms.gov/browse/QPPSF-4286

Reviewers:

@kalvinwang @KyleApfel @bijujoseph @sheldon-b @kyeah 
