### PR TITLE
QPPSF-4331 - Fixed Clinical Cluster Exception for missing 2019 clusters

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,8 +52,14 @@ exports.getMeasuresSchema = function(performanceYear = 2017) {
  * @return {Array<ClinicalCluster>}
  */
 exports.getClinicalClusterData = function(performanceYear = 2017) {
-  return JSON.parse(
-    fs.readFileSync(path.join(__dirname, 'clinical-clusters', performanceYear.toString(), 'clinical-clusters.json')));
+  let clusterData = [];
+  try {
+    clusterData = JSON.parse(
+      fs.readFileSync(path.join(__dirname, 'clinical-clusters', performanceYear.toString(), 'clinical-clusters.json')));
+  } catch (e) {
+    console.log('QPP measures data not found for year: ' + performanceYear + ' --> ' + e);
+  }
+  return clusterData;
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.18.0",
+  "version": "1.18.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.18.2",
+  "version": "1.18.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.18.2",
+  "version": "1.18.1",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/test/clinical-clusters/clinical-clusters-spec.js
+++ b/test/clinical-clusters/clinical-clusters-spec.js
@@ -3,7 +3,6 @@ const assert = chai.assert;
 const main = require('./../../index');
 
 describe('clinical cluster functionality', () => {
-
   it('can load clinical cluster data', () => {
     const data = main.getClinicalClusterData();
     assert.isArray(data);

--- a/test/clinical-clusters/clinical-clusters-spec.js
+++ b/test/clinical-clusters/clinical-clusters-spec.js
@@ -3,6 +3,7 @@ const assert = chai.assert;
 const main = require('./../../index');
 
 describe('clinical cluster functionality', () => {
+
   it('can load clinical cluster data', () => {
     const data = main.getClinicalClusterData();
     assert.isArray(data);
@@ -56,5 +57,10 @@ describe('clinical cluster functionality', () => {
       .filter(c => c.clinicalClusters && c.clinicalClusters.find(c => c.name === 'acuteOtitisExterna'))
       .map(c => c.clinicalClusters[0].measureIds);
     assert.deepEqual(measuresIds, [ [ '091', '093' ], [ '091', '093' ] ]);
+  });
+
+  it('Should handel missing years gracefully', () => {
+    const data = main.getClinicalClusterData(2000);
+    assert.deepEqual(data, []);
   });
 });


### PR DESCRIPTION
Fixed Clinical Cluster Exception for missing 2019 clusters

#### Motivation for change

Currently receiving error for 2019 Clinical Cluster which will be added later. Discussed with @bijujoseph we decided it would be best that the measures data return an empty array instead of throwing an exception for years that are not found. 

#### What is being changed

Modified index.js... exports.getClinicalClusterData(performanceYear = 2017) to return an empty array for years not found.

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [ ] [Package version updated](../CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [x] Unit tests added/passing
* [x] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPSF-4331

Reviewers:

@kalvinwang @KyleApfel @bijujoseph @sheldon-b @kyeah @shebryant 
