### PR TITLE
QPPSF-4346 Clinical Cluster Updates

### DIFF
--- a/clinical-clusters/2018/clinical-clusters.json
+++ b/clinical-clusters/2018/clinical-clusters.json
@@ -219,17 +219,6 @@
           "226"
         ]
       }
-    ],
-    "clinicalClusters": [
-      {
-        "name": "generalCare",
-        "measureIds": [
-          "130",
-          "226",
-          "134",
-          "317"
-        ]
-      }
     ]
   },
   {
@@ -707,22 +696,6 @@
   },
   {
     "measureId": "001",
-    "submissionMethod": "claims",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "clinicalClusters": [
-      {
-        "name": "diabeticCare",
-        "measureIds": [
-          "001",
-          "117",
-          "128"
-        ]
-      }
-    ]
-  },
-  {
-    "measureId": "117",
     "submissionMethod": "claims",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
@@ -2378,22 +2351,6 @@
   },
   {
     "measureId": "047",
-    "submissionMethod": "registry",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "clinicalClusters": [
-      {
-        "name": "palliativeCare",
-        "measureIds": [
-          "047",
-          "134",
-          "342"
-        ]
-      }
-    ]
-  },
-  {
-    "measureId": "134",
     "submissionMethod": "registry",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/scripts/clinical-clusters/ema-clinical-cluster-builder.js
+++ b/scripts/clinical-clusters/ema-clinical-cluster-builder.js
@@ -87,6 +87,8 @@ const specialClusterRelations = {
     claims: [
       {measureId: '130', optionals: []},
       {measureId: '317', optionals: []},
+      {measureId: '117', optionals: []},
+      {measureId: '226', optionals: []},
       {measureId: '112', optionals: ['113']},
       {measureId: '113', optionals: ['112']}
     ],
@@ -97,6 +99,7 @@ const specialClusterRelations = {
       {measureId: '424', optionals: []},
       {measureId: '430', optionals: []},
       {measureId: '317', optionals: []},
+      {measureId: '134', optionals: []},
       {measureId: '051', optionals: ['052']},
       {measureId: '052', optionals: ['051']},
       {measureId: '398', optionals: ['444']},

--- a/test/clinical-clusters/clinical-clusters-spec.js
+++ b/test/clinical-clusters/clinical-clusters-spec.js
@@ -49,6 +49,30 @@ describe('clinical cluster functionality', () => {
     assert.deepEqual(['130', '052'], cluster052.clinicalClusters[0].measureIds);
   });
 
+  it('cluster for measure 134 and 47 in 2018 should not exist only for registry', () => {
+    const data = main.getClinicalClusterData(2018);
+    ['134', '47'].forEach((m) => {
+      const clusters = data.filter(c => c.measureId === m && c.submissionMethod === 'registry');
+      assert.isArray(clusters);
+      assert.equal(0, clusters.length);
+    });
+  });
+
+  it('cluster for measure 1 and 117 in 2018 should not exist only for claims', () => {
+    const data = main.getClinicalClusterData(2018);
+    ['1', '117'].forEach((m) => {
+      const clusters = data.filter(c => c.measureId === m && c.submissionMethod === 'claims');
+      assert.isArray(clusters);
+      assert.equal(0, clusters.length);
+    });
+  });
+
+  it('clinical cluster for measure 226 in 2018 should not exist only for claims', () => {
+    const data = main.getClinicalClusterData(2018);
+    const clusters = data.filter(c => c.measureId === '226' && c.submissionMethod === 'claims');
+    assert.equal(undefined, clusters.clinicalClusters);
+  });
+
   it('Cluster input files are processed properly', () => {
     // registry Acute Otitis Externa should have 91 and 93
     const data = main.getClinicalClusterData();


### PR DESCRIPTION
Update/fix Claims and Registry Clinical Clusters as per BA spread sheet

#### Motivation for change

 update/fix Claims and Registry Clinical Clusters as per BA spread sheet

#### What is being changed

After comparison between current clinical cluster data and proposed clinical cluster changes, we have identified the following measures need to be removed from 2018 Registry clinical clusters, 134 and 47 (Palliative Care) , and Claims Clinical Clusters 117, 1 (Diabetic Care), and 226 (General Care)

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [x] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [x] Unit tests added/passing
* [x] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPSF-4346

@sheldon-b @kalvinwang @KyleApfel @bijujoseph @kyeah @shebryant