### PR TITLE
feature/QPPSF-4438-DMCompositeDownloadLink

### DIFF
--- a/measures/2018/measures-data.json
+++ b/measures/2018/measures-data.json
@@ -47822,7 +47822,7 @@
     "isToppedOutByProgram": false,
     "isRegistryMeasure": false,
     "measureSpecification": {
-      "cmsWebInterface": "https://www.cms.gov/Medicare/Quality-Payment-Program/Resource-Library/2018-Web-Interface-Measures-and-supporting-documents/Web-Interface-Measures/2018_WI_DM.pdf"
+      "cmsWebInterface": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Web-Interface-Measures/2018_WI_DM.pdf"
     }
   },
   {

--- a/measures/2018/measures-data.xml
+++ b/measures/2018/measures-data.xml
@@ -43484,7 +43484,7 @@ The program uses a patient-centered and team-based approach, leveraging evidence
     <isToppedOutByProgram>false</isToppedOutByProgram>
     <isRegistryMeasure>false</isRegistryMeasure>
     <measureSpecification>
-      <cmsWebInterface>https://www.cms.gov/Medicare/Quality-Payment-Program/Resource-Library/2018-Web-Interface-Measures-and-supporting-documents/Web-Interface-Measures/2018_WI_DM.pdf</cmsWebInterface>
+      <cmsWebInterface>https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Web-Interface-Measures/2018_WI_DM.pdf</cmsWebInterface>
     </measureSpecification>
   </measure>
   <measure>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.19.2",
+  "version": "1.20.0",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/util/measures/2018/manually-added-measures.json
+++ b/util/measures/2018/manually-added-measures.json
@@ -56,7 +56,7 @@
     "isToppedOutByProgram": false,
     "isRegistryMeasure": false,
     "measureSpecification": {
-      "cmsWebInterface": "https://www.cms.gov/Medicare/Quality-Payment-Program/Resource-Library/2018-Web-Interface-Measures-and-supporting-documents/Web-Interface-Measures/2018_WI_DM.pdf"
+      "cmsWebInterface": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Web-Interface-Measures/2018_WI_DM.pdf"
     }
   }
 ]


### PR DESCRIPTION
https://jira.cms.gov/browse/QPPSF-4438
Fixing wrong url for DM-Composite
#### Motivation for change

Fixing wrong url for DM-Composite

#### What is being changed

I am not 100% positive these are all the changes that are needed for this.

the DM composite download url

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [ ] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [ ] Unit tests added/passing
* [ ] Verified working locally

##### Associated JIRA tickets:
https://jira.cms.gov/browse/QPPSF-4438