### PR TITLE
QPPA-3147: Remove Nonprop Measures from 2018 Benchmarks

### DIFF
--- a/benchmarks/2018.json
+++ b/benchmarks/2018.json
@@ -4518,6 +4518,24 @@
     ]
   },
   {
+    "measureId": "CAHPS_11",
+    "benchmarkYear": 2016,
+    "performanceYear": 2018,
+    "submissionMethod": "certifiedSurveyVendor",
+    "isToppedOut": false,
+    "deciles": [
+      0,
+      23.16,
+      24.31,
+      25.14,
+      26.18,
+      27.41,
+      28.94,
+      30.78,
+      35.52
+    ]
+  },
+  {
     "measureId": "CAHPS_2",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -4597,13 +4615,13 @@
     "isToppedOut": false,
     "deciles": [
       0,
-      83.70,
+      83.7,
       84.61,
       85.58,
-      86.10,
+      86.1,
       86.68,
-      87.30,
-      87.90,
+      87.3,
+      87.9,
       88.88
     ]
   },
@@ -4621,26 +4639,8 @@
       93.07,
       93.55,
       92.24,
-      94.70,
+      94.7,
       95.17
-    ]
-  },
-  {
-    "measureId": "CAHPS_11",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
-    "submissionMethod": "certifiedSurveyVendor",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      23.16,
-      24.31,
-      25.14,
-      26.18,
-      27.41,
-      28.94,
-      30.78,
-      35.52
     ]
   },
   {
@@ -4767,24 +4767,6 @@
       59.27,
       60.58,
       62.76
-    ]
-  },
-  {
-    "measureId": "ECPR11",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      100,
-      5.94,
-      5.65,
-      5.34,
-      5.09,
-      4.67,
-      4.41,
-      4.15,
-      3.63
     ]
   },
   {
@@ -5001,78 +4983,6 @@
       21.57,
       27.38,
       33.33
-    ]
-  },
-  {
-    "measureId": "PINC2",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      100,
-      18.18,
-      16.67,
-      16.22,
-      14.71,
-      13.79,
-      12.2,
-      10.34,
-      6.67
-    ]
-  },
-  {
-    "measureId": "PINC3",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      100,
-      19.23,
-      15.94,
-      15,
-      12.88,
-      11.11,
-      9.76,
-      8.33,
-      5.56
-    ]
-  },
-  {
-    "measureId": "PINC5",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      100,
-      4.76,
-      3.6,
-      3.33,
-      2.56,
-      1.61,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "measureId": "PINC6",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      100,
-      13.04,
-      11.11,
-      9.62,
-      8.77,
-      7.5,
-      5.16,
-      4.55,
-      3.33
     ]
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/staging/2018/benchmarks/benchmarks.csv
+++ b/staging/2018/benchmarks/benchmarks.csv
@@ -1,4 +1,4 @@
-Table 2: Updated MIPS Benchmark Results Using DY2016 and PY2018 Logic ,,,,,,,,,,,,,
+Table 2: Updated MIPS Benchmark Results Using DY2016 and PY2018 Logic,,,,,,,,,,,,,
 ,,,,,,,,,,,,,
 Measure_Name,Measure_ID,Submission_Method,Measure_Type,Benchmark,Decile 3,Decile 4,Decile 5,Decile 6,Decile 7,Decile 8,Decile 9,Decile 10,Topped Out
 Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,Claims, Intermediate Outcome,Y,33.33 - 23.54,23.53 - 18.25,18.24 - 14.30,14.29 - 11.55,11.54 -  8.90,8.89 -  6.26,6.25 -  3.34,<=  3.33,No
@@ -70,19 +70,19 @@ Osteoarthritis (OA): Function and Pain Assessment,109,Registry/QCDR,Process,Y,15
 Preventive Care and Screening: Influenza Immunization,110,Claims,Process,Y,23.29 - 33.13,33.14 - 46.93,46.94 - 62.62,62.63 - 74.35,74.36 - 86.05,86.06 - 97.34,97.35 - 99.99,100,No
 Preventive Care and Screening: Influenza Immunization,110,EHR,Process,Y,14.55 - 21.83,21.84 - 29.00,29.01 - 35.99,36.00 - 43.53,43.54 - 52.13,52.14 - 63.12,63.13 - 78.42,>= 78.43,No
 Preventive Care and Screening: Influenza Immunization,110,Registry/QCDR,Process,Y,26.89 - 40.48,40.49 - 49.99,50.00 - 57.06,57.07 - 64.78,64.79 - 73.07,73.08 - 82.70,82.71 - 96.43,>= 96.44,No
-Preventive Care and Screening: Influenza Immunization,110,cmsWebInterface,Process,Y, --, 30.00 - 39.99, 40.00 - 49.99, 50.00 - 59.99, 60.00 - 69.99, 70.00 - 79.99, 80.00 - 89.99,>= 90.00,No
+Preventive Care and Screening: Influenza Immunization,110,cmsWebInterface,Process,Y, --,30.00 - 39.99,40.00 - 49.99,50.00 - 59.99,60.00 - 69.99,70.00 - 79.99,80.00 - 89.99,>= 90.00,No
 Pneumococcal Vaccination Status for Older Adults,111,Claims,Process,Y,44.78 - 55.87,55.88 - 65.57,65.58 - 73.27,73.28 - 80.67,80.68 - 87.34,87.35 - 93.84,93.85 - 99.68,>= 99.69,No
 Pneumococcal Vaccination Status for Older Adults,111,EHR,Process,Y,15.40 - 25.61,25.62 - 37.30,37.31 - 47.48,47.49 - 56.46,56.47 - 65.52,65.53 - 75.08,75.09 - 85.70,>= 85.71,No
 Pneumococcal Vaccination Status for Older Adults,111,Registry/QCDR,Process,Y,29.93 - 45.27,45.28 - 55.09,55.10 - 62.58,62.59 - 69.99,70.00 - 76.96,76.97 - 83.99,84.00 - 92.88,>= 92.89,No
-Pneumococcal Vaccination Status for Older Adults,111,cmsWebInterface,Process,Y, --, 30.00 - 39.99, 40.00 - 49.99, 50.00 - 59.99, 60.00 - 69.99, 70.00 - 79.99, 80.00 - 89.99,>= 90.00,No
+Pneumococcal Vaccination Status for Older Adults,111,cmsWebInterface,Process,Y, --,30.00 - 39.99,40.00 - 49.99,50.00 - 59.99,60.00 - 69.99,70.00 - 79.99,80.00 - 89.99,>= 90.00,No
 Breast Cancer Screening,112,Claims,Process,Y,33.68 - 45.35,45.36 - 53.21,53.22 - 60.28,60.29 - 67.83,67.84 - 76.55,76.56 - 89.23,89.24 - 99.99,100,No
 Breast Cancer Screening,112,EHR,Process,Y,19.19 - 31.97,31.98 - 40.58,40.59 - 48.40,48.41 - 55.73,55.74 - 63.12,63.13 - 70.05,70.06 - 78.94,>= 78.95,No
 Breast Cancer Screening,112,Registry/QCDR,Process,Y,38.69 - 52.53,52.54 - 60.13,60.14 - 65.18,65.19 - 70.17,70.18 - 76.01,76.02 - 82.72,82.73 - 92.04,>= 92.05,No
-Breast Cancer Screening,112,cmsWebInterface,Process,Y, --, 30.00 - 39.99, 40.00 - 49.99, 50.00 - 59.99, 60.00 - 69.99, 70.00 - 79.99, 80.00 - 89.99,>= 90.00,No
+Breast Cancer Screening,112,cmsWebInterface,Process,Y, --,30.00 - 39.99,40.00 - 49.99,50.00 - 59.99,60.00 - 69.99,70.00 - 79.99,80.00 - 89.99,>= 90.00,No
 Colorectal Cancer Screening,113,Claims,Process,Y,32.69 - 43.68,43.69 - 55.15,55.16 - 66.09,66.10 - 77.36,77.37 - 86.63,86.64 - 94.51,94.52 - 99.99,100,No
 Colorectal Cancer Screening,113,EHR,Process,Y,12.61 - 23.91,23.92 - 34.31,34.32 - 44.54,44.55 - 54.09,54.10 - 63.63,63.64 - 73.09,73.10 - 83.14,>= 83.15,No
 Colorectal Cancer Screening,113,Registry/QCDR,Process,Y,37.55 - 53.00,53.01 - 59.91,59.92 - 66.20,66.21 - 73.07,73.08 - 79.48,79.49 - 86.42,86.43 - 93.81,>= 93.82,No
-Colorectal Cancer Screening,113,cmsWebInterface,Process,Y, --, 30.00 - 39.99, 40.00 - 49.99, 50.00 - 59.99, 60.00 - 69.99, 70.00 - 79.99, 80.00 - 89.99,>= 90.00,No
+Colorectal Cancer Screening,113,cmsWebInterface,Process,Y, --,30.00 - 39.99,40.00 - 49.99,50.00 - 59.99,60.00 - 69.99,70.00 - 79.99,80.00 - 89.99,>= 90.00,No
 Avoidance of Antibiotic Treatment in Adults With Acute Bronchitis,116,Registry/QCDR,Process,Y,23.90 - 30.87,30.88 - 38.77,38.78 - 58.80,58.81 - 99.99,--,--,--,100,No
 Diabetes: Eye Exam,117,Claims,Process,Y,88.98 - 98.44,98.45 - 99.99,--,--,--,--,--,100,Yes
 Diabetes: Eye Exam,117,EHR,Process,Y,84.83 - 92.85,92.86 - 95.32,95.33 - 96.96,96.97 - 98.19,98.20 - 99.17,99.18 - 99.82,99.83 - 99.99,100,Yes
@@ -96,7 +96,7 @@ Adult Kidney Disease: Blood Pressure Management,122,Registry/QCDR, Intermediate 
 Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,Claims,Process,Y,43.20 - 48.42,48.43 - 58.92,58.93 - 83.56,83.57 - 96.60,96.61 - 99.53,99.54 - 99.99,--,100,No
 Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,EHR,Process,Y,28.22 - 31.92,31.93 - 35.34,35.35 - 38.76,38.77 - 42.88,42.89 - 49.18,49.19 - 64.83,64.84 - 85.93,>= 85.94,No
 Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,Registry/QCDR,Process,Y,45.12 - 52.05,52.06 - 59.99,60.00 - 68.74,68.75 - 77.77,77.78 - 86.07,86.08 - 92.85,92.86 - 99.42,>= 99.43,No
-Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,cmsWebInterface,Process,Y, --, 30.00 - 39.99, 40.00 - 49.99, 50.00 - 59.99, 60.00 - 69.99, 70.00 - 79.99, 80.00 - 89.99,>= 90.00,No
+Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,cmsWebInterface,Process,Y, --,30.00 - 39.99,40.00 - 49.99,50.00 - 59.99,60.00 - 69.99,70.00 - 79.99,80.00 - 89.99,>= 90.00,No
 Documentation of Current Medications in the Medical Record,130,Claims,Process,Y,97.20 - 99.23,99.24 - 99.79,99.80 - 99.99,--,--,--,--,100,Yes
 Documentation of Current Medications in the Medical Record,130,EHR,Process,Y,86.25 - 91.91,91.92 - 94.85,94.86 - 96.69,96.70 - 97.98,97.99 - 98.87,98.88 - 99.54,99.55 - 99.95,>= 99.96,Yes
 Documentation of Current Medications in the Medical Record,130,Registry/QCDR,Process,Y,77.08 - 90.22,90.23 - 95.97,95.98 - 98.60,98.61 - 99.69,99.70 - 99.99,--,--,100,Yes
@@ -105,7 +105,7 @@ Pain Assessment and Follow-Up,131,Registry/QCDR,Process,Y,20.00 - 49.79,49.80 - 
 Preventive Care and Screening: Screening for Clinical Depression and Follow-Up Plan,134,Claims,Process,Y,17.13 - 29.27,29.28 - 65.00,65.01 - 91.46,91.47 - 99.34,99.35 - 99.99,--,--,100,No
 Preventive Care and Screening: Screening for Clinical Depression and Follow-Up Plan,134,EHR,Process,Y,0.51 -  1.29,1.30 -  5.09,5.10 - 12.51,12.52 - 25.60,25.61 - 42.30,42.31 - 64.36,64.37 - 83.73,>= 83.74,No
 Preventive Care and Screening: Screening for Clinical Depression and Follow-Up Plan,134,Registry/QCDR,Process,Y,28.44 - 53.24,53.25 - 62.81,62.82 - 71.15,71.16 - 79.90,79.91 - 88.69,88.70 - 96.42,96.43 - 99.99,100,No
-Preventive Care and Screening: Screening for Clinical Depression and Follow-Up Plan,134,cmsWebInterface,Process,Y, --, 30.00 - 39.99, 40.00 - 49.99, 50.00 - 59.99, 60.00 - 69.99, 70.00 - 79.99, 80.00 - 89.99,>= 90.00,No
+Preventive Care and Screening: Screening for Clinical Depression and Follow-Up Plan,134,cmsWebInterface,Process,Y, --,30.00 - 39.99,40.00 - 49.99,50.00 - 59.99,60.00 - 69.99,70.00 - 79.99,80.00 - 89.99,>= 90.00,No
 Melanoma: Continuity of Care - Recall System,137,Registry/QCDR,Structure,Y,87.50 - 93.64,93.65 - 96.96,96.97 - 99.99,--,--,--,--,100,No
 Melanoma: Coordination of Care,138,Registry/QCDR,Process,Y,52.38 - 78.97,78.98 - 88.88,88.89 - 95.54,95.55 - 99.99,--,--,--,100,Yes
 Age-Related Macular Degeneration (AMD): Counseling on Antioxidant Supplement,140,Claims,Process,Y,97.33 - 99.99,--,--,--,--,--,--,100,Yes
@@ -155,7 +155,7 @@ Radiology: Stenosis Measurement in Carotid Imaging Reports,195,Registry/QCDR,Pro
 Ischemic Vascular Disease (IVD): Use of Aspirin or Another Antiplatelet,204,Claims,Process,Y,83.87 - 86.90,86.91 - 89.00,89.01 - 90.90,90.91 - 92.65,92.66 - 94.58,94.59 - 97.01,97.02 - 99.99,100,No
 Ischemic Vascular Disease (IVD): Use of Aspirin or Another Antiplatelet,204,EHR,Process,Y,53.33 - 61.75,61.76 - 68.32,68.33 - 73.23,73.24 - 77.10,77.11 - 80.60,80.61 - 83.91,83.92 - 87.92,>= 87.93,No
 Ischemic Vascular Disease (IVD): Use of Aspirin or Another Antiplatelet,204,Registry/QCDR,Process,Y,76.89 - 81.70,81.71 - 84.61,84.62 - 87.16,87.17 - 89.51,89.52 - 91.87,91.88 - 94.89,94.90 - 99.99,100,No
-Ischemic Vascular Disease (IVD): Use of Aspirin or Another Antiplatelet,204,cmsWebInterface,Process,Y, --, 30.00 - 39.99, 40.00 - 49.99, 50.00 - 59.99, 60.00 - 69.99, 70.00 - 79.99, 80.00 - 89.99,>= 90.00,No
+Ischemic Vascular Disease (IVD): Use of Aspirin or Another Antiplatelet,204,cmsWebInterface,Process,Y, --,30.00 - 39.99,40.00 - 49.99,50.00 - 59.99,60.00 - 69.99,70.00 - 79.99,80.00 - 89.99,>= 90.00,No
 "HIV/AIDS: Sexually Transmitted Disease Screening for Chlamydia, Gonorrhea, and Syphilis",205,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 Functional Status Change for Patients with Knee Impairments,217,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Functional Status Change for Patients with Hip Impairments,218,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
@@ -170,7 +170,7 @@ Radiology: Reminder System for Screening Mammograms,225,Registry/QCDR,Structure,
 Controlling High Blood Pressure,236,Claims, Intermediate Outcome,Y,58.02 - 63.90,63.91 - 68.36,68.37 - 72.91,72.92 - 76.91,76.92 - 81.65,81.66 - 86.95,86.96 - 94.06,>= 94.07,No
 Controlling High Blood Pressure,236,EHR, Intermediate Outcome,Y,51.10 - 56.51,56.52 - 60.77,60.78 - 64.28,64.29 - 67.46,67.47 - 70.93,70.94 - 74.88,74.89 - 80.42,>= 80.43,No
 Controlling High Blood Pressure,236,Registry/QCDR, Intermediate Outcome,Y,56.36 - 62.91,62.92 - 67.53,67.54 - 70.68,70.69 - 73.78,73.79 - 77.45,77.46 - 82.12,82.13 - 88.58,>= 88.59,No
-Controlling High Blood Pressure,236,cmsWebInterface, Intermediate Outcome,Y, --, 30.00 - 39.99, 40.00 - 49.99, 50.00 - 59.99, 60.00 - 69.99, 70.00 - 79.99, 80.00 - 89.99,>= 90.00,No
+Controlling High Blood Pressure,236,cmsWebInterface, Intermediate Outcome,Y, --,30.00 - 39.99,40.00 - 49.99,50.00 - 59.99,60.00 - 69.99,70.00 - 79.99,80.00 - 89.99,>= 90.00,No
 Use of High-Risk Medications in the Elderly,238,EHR,Process,Y,12.02 -  6.84,6.83 -  3.53,3.52 -  1.50,1.49 -  0.49,0.48 -  0.01,--,--,0,Yes
 Use of High-Risk Medications in the Elderly,238,Registry/QCDR,Process,Y,11.54 -  7.33,7.32 -  4.11,4.10 -  1.94,1.93 -  0.77,0.76 -  0.24,0.23 -  0.01,--,0,Yes
 Weight Assessment and Counseling for Nutrition and Physical Activity for Children and Adolescents,239,EHR,Process,Y,21.69 - 26.09,26.10 - 28.86,28.87 - 30.47,30.48 - 31.76,31.77 - 32.65,32.66 - 33.32,33.33 - 40.77,>= 40.78,No
@@ -221,7 +221,7 @@ Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up D
 Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,EHR,Process,Y,16.53 - 20.40,20.41 - 23.94,23.95 - 26.93,26.94 - 29.99,30.00 - 33.32,33.33 - 37.61,37.62 - 45.98,>= 45.99,No
 Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,Registry/QCDR,Process,Y,35.65 - 51.15,51.16 - 64.21,64.22 - 71.25,71.26 - 76.46,76.47 - 81.40,81.41 - 88.06,88.07 - 97.68,>= 97.69,No
 Falls: Screening for Future Fall Risk,318,EHR,Process,Y,9.14 - 20.16,20.17 - 33.70,33.71 - 48.36,48.37 - 65.67,65.68 - 81.76,81.77 - 93.39,93.40 - 98.80,>= 98.81,No
-Falls: Screening for Future Fall Risk,318,cmsWebInterface,Process,Y, --, 43.42 - 50.41, 50.42 - 58.44, 58.45 - 65.99, 66.00 - 73.38, 73.39 - 81.78, 81.79 - 90.72,>= 90.73,No
+Falls: Screening for Future Fall Risk,318,cmsWebInterface,Process,Y, --,43.42 - 50.41,50.42 - 58.44,58.45 - 65.99,66.00 - 73.38,73.39 - 81.78,81.79 - 90.72,>= 90.73,No
 Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients,320,Claims,Process,Y,91.51 - 96.40,96.41 - 99.99,--,--,--,--,--,100,Yes
 Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients,320,Registry/QCDR,Process,Y,87.30 - 91.48,91.49 - 94.25,94.26 - 96.21,96.22 - 98.68,98.69 - 99.99,--,--,100,Yes
 Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low Risk Surgery Patients,322,Registry/QCDR,Efficiency,Y,3.45 -  0.93,0.92 -  0.01,--,--,--,--,--,0,Yes
@@ -557,7 +557,7 @@ Infection Control Practices for Open Interventional Pain Procedures,AQI58,Regist
 Multimodal Pain Management,AQI59,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 New Corneal Injury Not Diagnosed Prior to Discharge,AQI60,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Cryptorchidism: Inappropriate use of scrotal/groin ultrasound on boys,AQUA3,Registry/QCDR,Cost/Resource Use,N,--,--,--,--,--,--,--,--,--
-Hospital re-admissions / complications within 30 days of TRUS Biopsy,AQUA8,Registry/QCDR,Outcome,Y,  4.00 -  3.24,  3.23 -  2.21,  2.20 -  1.70,  1.69 -  1.34,  1.33 -  0.01,--,--,0,Yes
+Hospital re-admissions / complications within 30 days of TRUS Biopsy,AQUA8,Registry/QCDR,Outcome,Y,4.00 -  3.24,3.23 -  2.21,2.20 -  1.70,1.69 -  1.34,1.33 -  0.01,--,--,0,Yes
 Benign Prostate Hyperplasia: IPSS improvement after diagnosis,AQUA12,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Stress Urinary Incontinence (SUI): Revision surgery within 12 months of incontinence procedure,AQUA13,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Stones: Repeat Shock Wave Lithotripsy (SWL) within 6 months of treatment,AQUA14,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
@@ -701,7 +701,6 @@ CureOneMelBRAFTTP,CURE11,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Door to Diagnostic Evaluation by a Provider ?Adult Emergency Department (ED) Patients,ECPR2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Mean Time from Emergency Department (ED) Arrival to ED Departure for Discharged Lower Acuity ED Patients,ECPR5,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Mean Time from Emergency Department (ED) Arrival to ED Departure for Discharged Higher Acuity ED Patients,ECPR6,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Three Day All Cause Return ED Visit Rate ?All Patients,ECPR11,Registry/QCDR,Outcome,Y,5.94 -  5.66,5.65 -  5.35,5.34 -  5.10,5.09 -  4.68,4.67 -  4.42,4.41 -  4.16,4.15 -  3.64,<=  3.63,No
 Avoid Head CT for Patients with Uncomplicated Syncope,ECPR39,Registry/QCDR,Process,Y,65.22 - 73.99,74.00 - 77.49,77.50 - 80.64,80.65 - 84.37,84.38 - 86.46,86.47 - 89.28,89.29 - 92.76,>= 92.77,No
 Pain Management for Long Bone Fracture,ECPR40,Registry/QCDR,Process,Y,91.67 - 92.97,92.98 - 93.74,93.75 - 95.44,95.45 - 96.42,96.43 - 97.95,97.96 - 99.99,--,100,Yes
 Coagulation Studies in Patients Presenting with Chest Pain with No Coagulopathy or Bleeding,ECPR41,Registry/QCDR,Process,Y,55.22 - 67.88,67.89 - 74.73,74.74 - 84.81,84.82 - 86.89,86.90 - 90.57,90.58 - 98.27,98.28 - 99.04,>= 99.05,No
@@ -964,11 +963,7 @@ Advance Care Planning in Stage 4 Disease,PIMSH1,Registry/QCDR,Process,N,--,--,--
 Utilization of GCSF in Metastatic Colon Cancer,PIMSH2,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 Combination chemotherapy is recommended or administered within 4 months (120 days) of diagnosis for women under 70 with AJCC T1cN0M0 or Stage IB-III hormone receptor negative breast cancer,PIMSH3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 30 day Readmission for Acute Myocardial Infarction,PINC1,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-30 day Readmission for Heart Failure,PINC2,Registry/QCDR,Outcome,Y,18.18 - 16.68,16.67 - 16.23,16.22 - 14.72,14.71 - 13.80,13.79 - 12.21,12.20 - 10.35,10.34 -  6.68,<=  6.67,No
-30 day Readmission for Pneumonia,PINC3,Registry/QCDR,Outcome,Y,19.23 - 15.95,15.94 - 15.01,15.00 - 12.89,12.88 - 11.12,11.11 -  9.77,9.76 -  8.34,8.33 -  5.57,<=  5.56,No
 30 day Mortality for Acute Myocardial Infarction,PINC4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-30 day Mortality for Heart Failure,PINC5,Registry/QCDR,Outcome,Y,4.76 -  3.61,3.60 -  3.34,3.33 -  2.57,2.56 -  1.62,1.61 -  0.01,--,--,0,Yes
-30 day Mortality for Pneumonia,PINC6,Registry/QCDR,Outcome,Y,13.04 - 11.12,11.11 -  9.63,9.62 -  8.78,8.77 -  7.51,7.50 -  5.17,5.16 -  4.56,4.55 -  3.34,<=  3.33,Yes
 Risk-Adjusted Average Length of Inpatient Hospital Stay for Acute Myocardial Infarction (AMI),PINC33,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Risk-Adjusted Average Length of Inpatient Hospital Stay for Heart Failure (HF),PINC34,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Risk-Adjusted Average Length of Inpatient Hospital Stay for Pneumonia (PN),PINC35,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--

--- a/staging/2018/benchmarks/json/003_benchmarks_cahps.json
+++ b/staging/2018/benchmarks/json/003_benchmarks_cahps.json
@@ -1,0 +1,146 @@
+[	
+	{
+	  "measureId": "CAHPS_1",
+	  "benchmarkYear": 2016,
+	  "performanceYear": 2018,
+	  "submissionMethod": "certifiedSurveyVendor",
+	  "isToppedOut": false,
+	  "deciles": [
+	    0,
+	    81.4,
+	    82.64,
+	    83.82,
+	    84.88,
+	    85.83,
+	    87.12,
+	    88.07,
+	    89.22
+	  ]
+	},
+	{
+	  "measureId": "CAHPS_2",
+	  "benchmarkYear": 2016,
+	  "performanceYear": 2018,
+	  "submissionMethod": "certifiedSurveyVendor",
+	  "isToppedOut": false,
+	  "deciles": [
+	    0,
+	    91.77,
+	    92.44,
+	    92.94,
+	    93.51,
+	    94.18,
+	    94.77,
+	    94.99,
+	    95.53
+	  ]
+	},
+	{
+	  "measureId": "CAHPS_3",
+	  "benchmarkYear": 2016,
+	  "performanceYear": 2018,
+	  "submissionMethod": "certifiedSurveyVendor",
+	  "isToppedOut": false,
+	  "deciles": [
+	    0,
+	    90.58,
+	    91.2,
+	    91.68,
+	    92.13,
+	    92.63,
+	    93.25,
+	    93.63,
+	    94.13
+	  ]
+	},
+	{
+	  "measureId": "CAHPS_5",
+	  "benchmarkYear": 2016,
+	  "performanceYear": 2018,
+	  "submissionMethod": "certifiedSurveyVendor",
+	  "isToppedOut": false,
+	  "deciles": [
+	    0,
+	    54.94,
+	    56.18,
+	    57.22,
+	    58.36,
+	    60.21,
+	    61.53,
+	    63.37,
+	    65.11
+	  ]
+	},
+	{
+	  "measureId": "CAHPS_6",
+	  "benchmarkYear": 2016,
+	  "performanceYear": 2018,
+	  "submissionMethod": "certifiedSurveyVendor",
+	  "isToppedOut": false,
+	  "deciles": [
+	    0,
+	    57.49,
+	    58.61,
+	    59.63,
+	    60.64,
+	    62,
+	    63.47,
+	    64.98,
+	    66.45
+	  ]
+	},
+	{
+	  "measureId": "CAHPS_8",
+	  "benchmarkYear": 2016,
+	  "performanceYear": 2018,
+	  "submissionMethod": "certifiedSurveyVendor",
+	  "isToppedOut": false,
+	  "deciles": [
+	    0,
+	    83.70,
+	    84.61,
+	    85.58,
+	    86.10,
+	    86.68,
+	    87.30,
+	    87.90,
+	    88.88
+	  ]
+	},
+	{
+	  "measureId": "CAHPS_9",
+	  "benchmarkYear": 2016,
+	  "performanceYear": 2018,
+	  "submissionMethod": "certifiedSurveyVendor",
+	  "isToppedOut": false,
+	  "deciles": [
+	    0,
+	    91.15,
+	    91.76,
+	    92.41,
+	    93.07,
+	    93.55,
+	    92.24,
+	    94.70,
+	    95.17
+	  ]
+	},
+	{
+	  "measureId": "CAHPS_11",
+	  "benchmarkYear": 2016,
+	  "performanceYear": 2018,
+	  "submissionMethod": "certifiedSurveyVendor",
+	  "isToppedOut": false,
+	  "deciles": [
+	    0,
+	    23.16,
+	    24.31,
+	    25.14,
+	    26.18,
+	    27.41,
+	    28.94,
+	    30.78,
+	    35.52
+	  ]
+	}
+]

--- a/staging/2018/benchmarks/json/benchmarks.json
+++ b/staging/2018/benchmarks/json/benchmarks.json
@@ -4500,24 +4500,6 @@
     ]
   },
   {
-    "measureId": "ECPR11",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      100,
-      5.94,
-      5.65,
-      5.34,
-      5.09,
-      4.67,
-      4.41,
-      4.15,
-      3.63
-    ]
-  },
-  {
     "measureId": "ECPR39",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -4731,78 +4713,6 @@
       21.57,
       27.38,
       33.33
-    ]
-  },
-  {
-    "measureId": "PINC2",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      100,
-      18.18,
-      16.67,
-      16.22,
-      14.71,
-      13.79,
-      12.2,
-      10.34,
-      6.67
-    ]
-  },
-  {
-    "measureId": "PINC3",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      100,
-      19.23,
-      15.94,
-      15,
-      12.88,
-      11.11,
-      9.76,
-      8.33,
-      5.56
-    ]
-  },
-  {
-    "measureId": "PINC5",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      100,
-      4.76,
-      3.6,
-      3.33,
-      2.56,
-      1.61,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "measureId": "PINC6",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      100,
-      13.04,
-      11.11,
-      9.62,
-      8.77,
-      7.5,
-      5.16,
-      4.55,
-      3.33
     ]
   },
   {


### PR DESCRIPTION
#### Motivation for change

The 2018 historic benchmark file incorrectly contained 5 non-proportion benchmarks. These measures should not have received historic benchmarks because non-proportion measures did not start receiving benchmarks until the 2018 PY (and thus can only be scored against PY benchmarks).

#### What is being changed

The incorrect file  is replaced with a csv without the non-proportion measures, and a new file for cahps benchmarks is added also. It seems that in a previous PR cahps benchmarks were added directly to the 2018.json file, rather than added as a json file in the staging directory in order to ensure that the benchmarks are added each time the build script is run.

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [x] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [x] Unit tests added/passing

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-3147