### PR TITLE
QPPA-3262: Update Measures Repo Schema

### DIFF
--- a/measures/2018/measures-schema.yaml
+++ b/measures/2018/measures-schema.yaml
@@ -22,7 +22,7 @@ definitions:
       firstPerformanceYear:
         description: Year in which the measure was introduced.
         type: integer
-        default: 2018
+        default: 2017
       lastPerformanceYear:
         description: Year in which the measure was deprecated.
         type: [integer, 'null']

--- a/measures/2019/measures-schema.yaml
+++ b/measures/2019/measures-schema.yaml
@@ -22,7 +22,7 @@ definitions:
       firstPerformanceYear:
         description: Year in which the measure was introduced.
         type: integer
-        default: 2018
+        default: 2017
       lastPerformanceYear:
         description: Year in which the measure was deprecated.
         type: [integer, 'null']
@@ -31,7 +31,7 @@ definitions:
         description: URL link for Measure Specification PDF to download by Submission Method.
         items: { $ref: #/definitions/measureSpecification }
       measureSets:
-        description: PI measures can belong to the transition measure set. Quality measures can belong to multiple measure sets that represent different specialties.
+        description: Quality measures can belong to multiple measure sets that represent different specialties.
         type: array
         items: { $ref: #/definitions/measureSets }
     required: [measureId, title, description, category, metricType, firstPerformanceYear, lastPerformanceYear]
@@ -76,7 +76,10 @@ definitions:
         type: boolean
         default: false
       substitutes:
-        description: Identifiers of other PI measure that can be used instead of the current meausre.
+        description: Identifiers of other PI measures that can be used instead of the current measure.
+        oneOf: [{ $ref: #/definitions/arrayOfStringIdentifiers}]
+      exclusion:
+        description: Identifiers of other PI measures that can be submitted instead of current measure. Cannot submit both current measure and the exclusion measure.
         oneOf: [{ $ref: #/definitions/arrayOfStringIdentifiers}]
     required: [weight, objective, isRequired, isBonus, measureSets]
 

--- a/measures/2019/measures-schema.yaml
+++ b/measures/2019/measures-schema.yaml
@@ -80,7 +80,6 @@ definitions:
         oneOf: [{ $ref: #/definitions/arrayOfStringIdentifiers}]
       exclusion:
         description: Identifiers of other PI measures that can be submitted instead of current measure. Cannot submit both current measure and the exclusion measure.
-        oneOf: [{ $ref: #/definitions/arrayOfStringIdentifiers}]
     required: [weight, objective, isRequired, isBonus, measureSets]
 
   aggregateCostMeasure:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",


### PR DESCRIPTION

#### Motivation for change
A number of small changes are needed for the measures repo.

#### What is being changed
The changes that are included in this PR are as follows:

1. firstPerformanceYear - default is changed from 2018 to 2017
2. measureSets - description is updated to "Quality measures can belong to multiple measure sets that represent different specialties."
3. piMeasure object - field "exclusion" is added, with the description, "Identifiers of other PI measures that can be submitted instead of current measure. Cannot submit both current measure and the exclusion measure."
4. typo is fixed in piMeasure substitutes' description - "Identifiers of other PI measures that can be used instead of the current measure."

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [ ] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [x ] Unit tests added/passing
* [ ] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-3262
