### PR TITLE
Bump version to 1.31.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.31.3",
+  "version": "1.31.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.31.3",
+  "version": "1.31.4",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",


### PR DESCRIPTION
#### Motivation for change

Both #291 and #293 bumped the version to 1.31.3 but only one of those changes were included when 1.31.3 was published to npm. This resulted in only one of the features being released into PROD when we were expecting both of them to go out.

#### What is being changed

Bumps the qpp-measures-data repo to 1.31.4 so we can publish the measure 370 change without overriding the version of 1.31.3 that is already deployed to PROD.

#### Future work

The ticket QPPA-3525 is for a feature enabler to add CI to qpp-measures-data. That CI would have helped avoid this scenario and others like it but allowing us to utilize automation for more quality checks and process steps.

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [x] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)