### PR TITLE
QPPSF-5346 - Clinical Cluster Fixes

### DIFF
--- a/clinical-clusters/2019/clinical-clusters.json
+++ b/clinical-clusters/2019/clinical-clusters.json
@@ -143,33 +143,6 @@
           "317"
         ]
       }
-    ],
-    "clinicalClusters": [
-      {
-        "name": "lungCare",
-        "measureIds": [
-          "130"
-        ]
-      },
-      {
-        "name": "generalCare",
-        "measureIds": [
-          "130"
-        ]
-      },
-      {
-        "name": "preventiveCare",
-        "measureIds": [
-          "130",
-          "317"
-        ]
-      },
-      {
-        "name": "colonoscopyCare",
-        "measureIds": [
-          "130"
-        ]
-      }
     ]
   },
   {
@@ -224,14 +197,6 @@
           "317"
         ]
       }
-    ],
-    "clinicalClusters": [
-      {
-        "name": "generalCare",
-        "measureIds": [
-          "226"
-        ]
-      }
     ]
   },
   {
@@ -265,23 +230,6 @@
         "measureIds": [
           "130",
           "226",
-          "317"
-        ]
-      }
-    ],
-    "clinicalClusters": [
-      {
-        "name": "generalCare",
-        "measureIds": [
-          "130",
-          "226",
-          "317"
-        ]
-      },
-      {
-        "name": "preventiveCare",
-        "measureIds": [
-          "130",
           "317"
         ]
       }
@@ -522,7 +470,8 @@
         "measureIds": [
           "130",
           "226",
-          "134"
+          "134",
+          "317"
         ]
       }
     ]
@@ -592,6 +541,7 @@
       {
         "name": "diabeticCare",
         "measureIds": [
+          "001",
           "117",
           "128"
         ]
@@ -706,10 +656,7 @@
         "name": "pathology",
         "measureIds": [
           "249",
-          "250",
-          "395",
-          "396",
-          "397"
+          "250"
         ]
       }
     ]
@@ -736,10 +683,7 @@
         "name": "pathology",
         "measureIds": [
           "249",
-          "250",
-          "395",
-          "396",
-          "397"
+          "250"
         ]
       }
     ]
@@ -762,16 +706,6 @@
       }
     ],
     "clinicalClusters": [
-      {
-        "name": "pathology",
-        "measureIds": [
-          "249",
-          "250",
-          "395",
-          "396",
-          "397"
-        ]
-      },
       {
         "name": "pathologyLungCancer",
         "measureIds": [
@@ -800,16 +734,6 @@
     ],
     "clinicalClusters": [
       {
-        "name": "pathology",
-        "measureIds": [
-          "249",
-          "250",
-          "395",
-          "396",
-          "397"
-        ]
-      },
-      {
         "name": "pathologyLungCancer",
         "measureIds": [
           "395",
@@ -824,18 +748,6 @@
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
     "specialtySets": [
-      {
-        "name": "pathology",
-        "measureIds": [
-          "249",
-          "250",
-          "395",
-          "396",
-          "397"
-        ]
-      }
-    ],
-    "clinicalClusters": [
       {
         "name": "pathology",
         "measureIds": [
@@ -887,32 +799,9 @@
       {
         "name": "diabeticCare",
         "measureIds": [
+          "001",
           "117",
-          "001"
-        ]
-      }
-    ]
-  },
-  {
-    "measureId": "117",
-    "submissionMethod": "claims",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "clinicalClusters": [
-      {
-        "name": "diabeticCare",
-        "measureIds": [
-          "117"
-        ]
-      },
-      {
-        "name": "eyeCare",
-        "measureIds": [
-          "012",
-          "014",
-          "019",
-          "117",
-          "141"
+          "128"
         ]
       }
     ]
@@ -926,8 +815,9 @@
       {
         "name": "lungCare",
         "measureIds": [
-          "130",
-          "051"
+          "051",
+          "052",
+          "130"
         ]
       }
     ]
@@ -941,8 +831,9 @@
       {
         "name": "lungCare",
         "measureIds": [
-          "130",
-          "052"
+          "051",
+          "052",
+          "130"
         ]
       }
     ]
@@ -1451,46 +1342,37 @@
     ]
   },
   {
-    "measureId": "130",
+    "measureId": "398",
     "submissionMethod": "registry",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
     "clinicalClusters": [
       {
-        "name": "chronicObstructivePulmonaryDiseaseCopdCare",
+        "name": "asthmaCare",
         "measureIds": [
-          "130"
-        ]
-      },
-      {
-        "name": "osteoporosisCare",
-        "measureIds": [
-          "130"
-        ]
-      },
-      {
-        "name": "coronaryDiseaseCare",
-        "measureIds": [
-          "130"
-        ]
-      },
-      {
-        "name": "heartFailureCare",
-        "measureIds": [
-          "130"
-        ]
-      },
-      {
-        "name": "colonoscopyCare",
-        "measureIds": [
+          "110",
           "130",
-          "425"
+          "226",
+          "398",
+          "444"
         ]
-      },
+      }
+    ]
+  },
+  {
+    "measureId": "444",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
       {
-        "name": "preventiveCare",
+        "name": "asthmaCare",
         "measureIds": [
-          "130"
+          "110",
+          "130",
+          "226",
+          "398",
+          "444"
         ]
       }
     ]
@@ -1605,26 +1487,6 @@
           "130",
           "226",
           "024"
-        ]
-      }
-    ]
-  },
-  {
-    "measureId": "226",
-    "submissionMethod": "registry",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "clinicalClusters": [
-      {
-        "name": "osteoporosisCare",
-        "measureIds": [
-          "226"
-        ]
-      },
-      {
-        "name": "coronaryDiseaseCare",
-        "measureIds": [
-          "226"
         ]
       }
     ]
@@ -2417,7 +2279,8 @@
       {
         "name": "palliativeCare",
         "measureIds": [
-          "047"
+          "047",
+          "134"
         ]
       }
     ]
@@ -2431,6 +2294,7 @@
       {
         "name": "palliativeCare",
         "measureIds": [
+          "047",
           "134"
         ]
       }
@@ -2493,23 +2357,8 @@
       {
         "name": "preventiveCare",
         "measureIds": [
+          "130",
           "317"
-        ]
-      }
-    ]
-  },
-  {
-    "measureId": "110",
-    "submissionMethod": "registry",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "clinicalClusters": [
-      {
-        "name": "immunizationCare",
-        "measureIds": [
-          "110",
-          "111",
-          "474"
         ]
       }
     ]
@@ -2524,24 +2373,7 @@
         "name": "immunizationCare",
         "measureIds": [
           "110",
-          "111",
-          "474"
-        ]
-      }
-    ]
-  },
-  {
-    "measureId": "474",
-    "submissionMethod": "registry",
-    "firstPerformanceYear": 2019,
-    "lastPerformanceYear": null,
-    "clinicalClusters": [
-      {
-        "name": "immunizationCare",
-        "measureIds": [
-          "110",
-          "111",
-          "474"
+          "111"
         ]
       }
     ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.31.4",
+  "version": "1.31.5",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/scripts/clinical-clusters/ema-clinical-cluster-builder.js
+++ b/scripts/clinical-clusters/ema-clinical-cluster-builder.js
@@ -91,15 +91,15 @@ const specialClusterRelations = {
     claims: [
       {measureId: '130', optionals: []},
       {measureId: '317', optionals: []},
-      {measureId: '117', optionals: []},
+      {measureId: '117', optionals: ['001', '128']},
       {measureId: '226', optionals: []},
       {measureId: '112', optionals: ['113']},
       {measureId: '113', optionals: ['112']}
     ],
     registry: [
-      {measureId: '110', optionals: []},
-      {measureId: '130', optionals: []},
-      {measureId: '226', optionals: []},
+      {measureId: '110', optionals: ['398', '444', '111']},
+      {measureId: '130', optionals: ['024', '418']},
+      {measureId: '226', optionals: ['024', '418']},
       {measureId: '424', optionals: []},
       {measureId: '430', optionals: []},
       {measureId: '317', optionals: []},
@@ -123,13 +123,16 @@ const specialClusterRelations = {
     claims: [
       {measureId: '112', optionals: ['113']},
       {measureId: '113', optionals: ['112']},
-      {measureId: '117', optionals: ['001', '128']},
-      {measureId: '130', optionals: ['051', '052']},
-      {measureId: '130', optionals: ['134']},
-      {measureId: '130', optionals: ['425']}
+      {measureId: '117', optionals: []},
+      {measureId: '130', optionals: []},
+      {measureId: '226', optionals: []},
+      {measureId: '317', optionals: []}
     ],
     registry: [
       {measureId: '047', optionals: ['342']},
+      {measureId: '110', optionals: []},
+      {measureId: '130', optionals: []},
+      {measureId: '226', optionals: []},
       {measureId: '134', optionals: ['342']},
       {measureId: '051', optionals: ['052']},
       {measureId: '052', optionals: ['051']},

--- a/scripts/clinical-clusters/ema-clinical-cluster-builder.js
+++ b/scripts/clinical-clusters/ema-clinical-cluster-builder.js
@@ -91,15 +91,15 @@ const specialClusterRelations = {
     claims: [
       {measureId: '130', optionals: []},
       {measureId: '317', optionals: []},
-      {measureId: '117', optionals: ['001', '128']},
+      {measureId: '117', optionals: []},
       {measureId: '226', optionals: []},
       {measureId: '112', optionals: ['113']},
       {measureId: '113', optionals: ['112']}
     ],
     registry: [
-      {measureId: '110', optionals: ['398', '444', '111']},
-      {measureId: '130', optionals: ['024', '418']},
-      {measureId: '226', optionals: ['024', '418']},
+      {measureId: '110', optionals: []},
+      {measureId: '130', optionals: []},
+      {measureId: '226', optionals: []},
       {measureId: '424', optionals: []},
       {measureId: '430', optionals: []},
       {measureId: '317', optionals: []},

--- a/util/clinical-clusters/2019/ClaimsClinical_Cluster.csv
+++ b/util/clinical-clusters/2019/ClaimsClinical_Cluster.csv
@@ -13,9 +13,6 @@ EmergencyCare,255
 "Ear,Nose,&ThroatCare",93
 Pathology,249
 Pathology,250
-Pathology,395
-Pathology,396
-Pathology,397
 AppropriateFollow-UpImaging,405
 AppropriateFollow-UpImaging,406
 EyeCare,12

--- a/util/clinical-clusters/2019/RegistryClinicalCluster.csv
+++ b/util/clinical-clusters/2019/RegistryClinicalCluster.csv
@@ -4,6 +4,11 @@ Diabetes Mellitus Foot Care,127
 Chronic Obstructive Pulmonary Disease (COPD) Care,51
 Chronic Obstructive Pulmonary Disease (COPD) Care,52
 Chronic Obstructive Pulmonary Disease (COPD) Care,130
+Asthma Care,110
+Asthma Care,130
+Asthma Care,226
+Asthma Care,398
+Asthma Care,444
 Hematology Care,67
 Hematology Care,68
 Hematology Care,69
@@ -80,7 +85,6 @@ Preventive Care,130
 Preventive Care,317
 Immunization Care,110
 Immunization Care,111
-Immunization Care,474
 Parkinson's Disease,290
 Parkinson's Disease,291
 Parkinsons Disease,293


### PR DESCRIPTION
#### Motivation for change

- Added missing Asthma Care for registry clinical cluster.
- Removed 395, 396, 397 from Pathology claims clinical cluster.
- Updated optional measures 117, 130, 226, 317 for claims clinical clusters.
- Updated optional measures 110, 130, 226 for registry clinical clusters.

#### What is being changed

- Added missing Asthma Care for registry clinical cluster.
- Removed 395, 396, 397 from Pathology claims clinical cluster.
- Updated optional measures 117, 130, 226, 317 for claims clinical clusters.
- Updated optional measures 110, 130, 226 for registry clinical clusters.

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [x] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [x] Documentation updated
* [x] Unit tests added/passing
* [x] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-5346

@harrisj @lamroger @sheldon-b @kyeah @shebryant @KyleApfel @NateTheGreatt @Jpec07 @bijujoseph