### PR TITLE
Update CMS22v7 UUIDs

### DIFF
--- a/measures/2019/measures-data.json
+++ b/measures/2019/measures-data.json
@@ -28422,6 +28422,19 @@
       "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2019_Measure_317_MedicarePartBClaims.pdf",
       "electronicHealthRecord": "https://ecqi.healthit.gov/system/files/ecqm/measures/CMS22v7.html"
     },
+    "eMeasureUuid": "40280382-610b-e7a4-0161-9a3a392c37d5",
+    "strata": [
+      {
+        "description": "Patients who were screened for high blood pressure AND have a recommended follow-up plan documented, as indicated if the blood pressure is pre-hypertensive or hypertensive",
+        "eMeasureUuids": {
+          "initialPopulationUuid": "D019FA53-2049-43D9-B006-E4AB7DA01878",
+          "denominatorUuid": "75FDA064-6A0C-463E-84B2-B307A1F8959F",
+          "numeratorUuid": "54790C8F-7C20-4261-B895-39E915B73F42",
+          "denominatorExceptionUuid": "0EA1313C-BCF6-4526-9AD6-365E8A400805",
+          "denominatorExclusionUuid": "72097A3E-8090-486C-ABCD-9419C9A04291"
+        }
+      }
+    ],
     "eligibilityOptions": [
       {
         "minAge": 18,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.31.4",
+  "version": "1.31.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.31.8",
+  "version": "1.31.9",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/scripts/measures/2019/get-strata-uuids-from-ecqm-zip.js
+++ b/scripts/measures/2019/get-strata-uuids-from-ecqm-zip.js
@@ -157,10 +157,6 @@ Promise.all(
         console.warn('WARNING: CMS160v7 has one numerator but two initial populations and needs to be added manually - see /tmp/ecqm/EC_CMS160v7_NQF0712_Dep_PHQ9.zip');
         return;
       }
-      if (emeasureid === '22') {
-        console.warn('WARNING: CMS22v7 does not contain a strata and does not need uuids');
-        return;
-      }
       if (emeasureid === '347') {
         console.warn('WARNING: CMS347v2 does not contain a strata and does not need uuids');
         return;

--- a/util/measures/2019/enriched-measures-data-quality.json
+++ b/util/measures/2019/enriched-measures-data-quality.json
@@ -28422,6 +28422,19 @@
       "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2019_Measure_317_MedicarePartBClaims.pdf",
       "electronicHealthRecord": "https://ecqi.healthit.gov/system/files/ecqm/measures/CMS22v7.html"
     },
+    "eMeasureUuid": "40280382-610b-e7a4-0161-9a3a392c37d5",
+    "strata": [
+      {
+        "description": "Patients who were screened for high blood pressure AND have a recommended follow-up plan documented, as indicated if the blood pressure is pre-hypertensive or hypertensive",
+        "eMeasureUuids": {
+          "initialPopulationUuid": "D019FA53-2049-43D9-B006-E4AB7DA01878",
+          "denominatorUuid": "75FDA064-6A0C-463E-84B2-B307A1F8959F",
+          "numeratorUuid": "54790C8F-7C20-4261-B895-39E915B73F42",
+          "denominatorExceptionUuid": "0EA1313C-BCF6-4526-9AD6-365E8A400805",
+          "denominatorExclusionUuid": "72097A3E-8090-486C-ABCD-9419C9A04291"
+        }
+      }
+    ],
     "eligibilityOptions": [
       {
         "minAge": 18,

--- a/util/measures/2019/generated-ecqm-data.json
+++ b/util/measures/2019/generated-ecqm-data.json
@@ -579,6 +579,23 @@
     "metricType": "singlePerformanceRate"
   },
   {
+    "eMeasureId": "CMS22v7",
+    "eMeasureUuid": "40280382-610b-e7a4-0161-9a3a392c37d5",
+    "strata": [
+      {
+        "description": "Patients who were screened for high blood pressure AND have a recommended follow-up plan documented, as indicated if the blood pressure is pre-hypertensive or hypertensive",
+        "eMeasureUuids": {
+          "initialPopulationUuid": "D019FA53-2049-43D9-B006-E4AB7DA01878",
+          "denominatorUuid": "75FDA064-6A0C-463E-84B2-B307A1F8959F",
+          "numeratorUuid": "54790C8F-7C20-4261-B895-39E915B73F42",
+          "denominatorExceptionUuid": "0EA1313C-BCF6-4526-9AD6-365E8A400805",
+          "denominatorExclusionUuid": "72097A3E-8090-486C-ABCD-9419C9A04291"
+        }
+      }
+    ],
+    "metricType": "singlePerformanceRate"
+  },
+  {
     "eMeasureId": "CMS249v1",
     "eMeasureUuid": "40280382-6258-7581-0162-92de53e31699",
     "strata": [


### PR DESCRIPTION
#### Motivation for change

CMS22v7 was missing UUID's associated with the 2019 IG here: https://ecqi.healthit.gov/system/files/2019_CMS_QRDA_III_Eligible_Clinicians_and_EP_IG-508.pdf

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [x] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [x] Documentation updated
* [x] Unit tests added/passing
* [x] Verified working locally

##### Associated JIRA tickets:
No ticket, this was found by @StevenSzeliga. CMS22v7 was being skipped and needed to be included.
