### PR TITLE
QPPA-3530: Remove Y2 Entries From 2019 Benchmarks

### DIFF
--- a/benchmarks/2019.json
+++ b/benchmarks/2019.json
@@ -5221,8 +5221,8 @@
   },
   {
     "measureId": "CAHPS_1",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [
@@ -5239,8 +5239,8 @@
   },
   {
     "measureId": "CAHPS_11",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [
@@ -5257,8 +5257,8 @@
   },
   {
     "measureId": "CAHPS_2",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [
@@ -5275,8 +5275,8 @@
   },
   {
     "measureId": "CAHPS_3",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [
@@ -5293,8 +5293,8 @@
   },
   {
     "measureId": "CAHPS_5",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [
@@ -5311,8 +5311,8 @@
   },
   {
     "measureId": "CAHPS_6",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [
@@ -5329,8 +5329,8 @@
   },
   {
     "measureId": "CAHPS_8",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [
@@ -5347,8 +5347,8 @@
   },
   {
     "measureId": "CAHPS_9",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [
@@ -5365,8 +5365,8 @@
   },
   {
     "measureId": "CAHPS_ACO_1",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [
@@ -5383,8 +5383,8 @@
   },
   {
     "measureId": "CAHPS_ACO_2",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [
@@ -5401,8 +5401,8 @@
   },
   {
     "measureId": "CAHPS_ACO_3",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [
@@ -5419,8 +5419,8 @@
   },
   {
     "measureId": "CAHPS_ACO_34",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [
@@ -5437,8 +5437,8 @@
   },
   {
     "measureId": "CAHPS_ACO_4",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [
@@ -5455,8 +5455,8 @@
   },
   {
     "measureId": "CAHPS_ACO_5",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [
@@ -5473,8 +5473,8 @@
   },
   {
     "measureId": "CAHPS_ACO_6",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.32.1",
+  "version": "1.33.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.32.1",
+  "version": "1.33.0",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/staging/2019/benchmarks/json/002_benchmarks_aco_cahps.json
+++ b/staging/2019/benchmarks/json/002_benchmarks_aco_cahps.json
@@ -1,8 +1,8 @@
 [
   {
     "measureId": "CAHPS_ACO_1",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [
@@ -19,8 +19,8 @@
   },
   {
     "measureId": "CAHPS_ACO_2",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [
@@ -37,8 +37,8 @@
   },
   {
     "measureId": "CAHPS_ACO_3",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [
@@ -55,8 +55,8 @@
   },
   {
     "measureId": "CAHPS_ACO_4",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [
@@ -73,8 +73,8 @@
   },
   {
     "measureId": "CAHPS_ACO_5",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [
@@ -91,8 +91,8 @@
   },
   {
     "measureId": "CAHPS_ACO_6",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [
@@ -109,8 +109,8 @@
   },
   {
     "measureId": "CAHPS_ACO_34",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "certifiedSurveyVendor",
     "isToppedOut": false,
     "deciles": [

--- a/staging/2019/benchmarks/json/003_benchmarks_cahps.json
+++ b/staging/2019/benchmarks/json/003_benchmarks_cahps.json
@@ -1,8 +1,8 @@
 [	
 	{
 	  "measureId": "CAHPS_1",
-	  "benchmarkYear": 2016,
-	  "performanceYear": 2018,
+	  "benchmarkYear": 2017,
+	  "performanceYear": 2019,
 	  "submissionMethod": "certifiedSurveyVendor",
 	  "isToppedOut": false,
 	  "deciles": [
@@ -19,8 +19,8 @@
 	},
 	{
 	  "measureId": "CAHPS_2",
-	  "benchmarkYear": 2016,
-	  "performanceYear": 2018,
+	  "benchmarkYear": 2017,
+	  "performanceYear": 2019,
 	  "submissionMethod": "certifiedSurveyVendor",
 	  "isToppedOut": false,
 	  "deciles": [
@@ -37,8 +37,8 @@
 	},
 	{
 	  "measureId": "CAHPS_3",
-	  "benchmarkYear": 2016,
-	  "performanceYear": 2018,
+	  "benchmarkYear": 2017,
+	  "performanceYear": 2019,
 	  "submissionMethod": "certifiedSurveyVendor",
 	  "isToppedOut": false,
 	  "deciles": [
@@ -55,8 +55,8 @@
 	},
 	{
 	  "measureId": "CAHPS_5",
-	  "benchmarkYear": 2016,
-	  "performanceYear": 2018,
+	  "benchmarkYear": 2017,
+	  "performanceYear": 2019,
 	  "submissionMethod": "certifiedSurveyVendor",
 	  "isToppedOut": false,
 	  "deciles": [
@@ -73,8 +73,8 @@
 	},
 	{
 	  "measureId": "CAHPS_6",
-	  "benchmarkYear": 2016,
-	  "performanceYear": 2018,
+	  "benchmarkYear": 2017,
+	  "performanceYear": 2019,
 	  "submissionMethod": "certifiedSurveyVendor",
 	  "isToppedOut": false,
 	  "deciles": [
@@ -91,8 +91,8 @@
 	},
 	{
 	  "measureId": "CAHPS_8",
-	  "benchmarkYear": 2016,
-	  "performanceYear": 2018,
+	  "benchmarkYear": 2017,
+	  "performanceYear": 2019,
 	  "submissionMethod": "certifiedSurveyVendor",
 	  "isToppedOut": false,
 	  "deciles": [
@@ -109,8 +109,8 @@
 	},
 	{
 	  "measureId": "CAHPS_9",
-	  "benchmarkYear": 2016,
-	  "performanceYear": 2018,
+	  "benchmarkYear": 2017,
+	  "performanceYear": 2019,
 	  "submissionMethod": "certifiedSurveyVendor",
 	  "isToppedOut": false,
 	  "deciles": [
@@ -127,8 +127,8 @@
 	},
 	{
 	  "measureId": "CAHPS_11",
-	  "benchmarkYear": 2016,
-	  "performanceYear": 2018,
+	  "benchmarkYear": 2017,
+	  "performanceYear": 2019,
 	  "submissionMethod": "certifiedSurveyVendor",
 	  "isToppedOut": false,
 	  "deciles": [


### PR DESCRIPTION
#### Motivation for change

There are 15 entries in the 2019 benchmarks file that show `"performanceYear": 2018`. All entries in this file should be 2019.

#### What is being changed

JSON files from 2018 CAHPS benchmarks had been uploaded into the 2019 directory because the benchmarks were not changing from 2018 to 2019. However, the `benchmarkYear` and the `performanceYear` were not made current which resulted in comprising 2019 benchmarks with inaccurate data. The files in question where updated to use `benchmarkYear` 2017 and `performanceYear` 2019. 

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [x] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [x] Unit tests added/passing
* [ ] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-3530
