### PR TITLE
Fix Measure PI EP 2 metric type - PI_EP_2 should be a proportion measure

### DIFF
--- a/measures/2019/measures-data.json
+++ b/measures/2019/measures-data.json
@@ -43582,7 +43582,7 @@
     "title": "Query of the Prescription Drug Monitoring Program (PDMP)",
     "description": "For at least one Schedule II opioid electronically prescribed using CEHRT during the performance period, the MIPS eligible clinician uses data from CEHRT to conduct a query of a Prescription Drug Monitoring Program (PDMP) for prescription drug history, except where prohibited and in accordance with applicable law.",
     "isRequired": false,
-    "metricType": "boolean",
+    "metricType": "proportion",
     "firstPerformanceYear": 2019,
     "lastPerformanceYear": null,
     "weight": 5,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.32.1",
+  "version": "1.32.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.32.2",
+  "version": "1.32.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.32.3",
+  "version": "1.32.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.32.2",
+  "version": "1.32.3",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.32.3",
+  "version": "1.32.2",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.32.1",
+  "version": "1.32.2",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",


### PR DESCRIPTION

#### Motivation for change

PI_EP_2 should be a proportion measure as per https://confluence.cms.gov/pages/viewpage.action?spaceKey=QPPPRACTICE&title=Promoting+Interoperability

#### What is being changed

changing metric type of PI measure PI_EP_2 from `boolean` to `proportion`

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [X] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [X] Documentation updated
* [X] Unit tests added/passing
* [X] Verified working locally

##### Associated JIRA tickets:
* N/A
