### PR TITLE
QPPA-3532: Delete 2019 Benchmarks for Measures that No Longer Exist

### DIFF
--- a/benchmarks/2019.json
+++ b/benchmarks/2019.json
@@ -4554,24 +4554,6 @@
     ]
   },
   {
-    "measureId": "AAD1",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      10.16,
-      18.75,
-      25.13,
-      35.84,
-      43.48,
-      57.08,
-      76.77,
-      100
-    ]
-  },
-  {
     "measureId": "AAD2",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -4587,24 +4569,6 @@
       100,
       100,
       100
-    ]
-  },
-  {
-    "measureId": "AAD3",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      100,
-      1.58,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
     ]
   },
   {
@@ -4644,42 +4608,6 @@
     ]
   },
   {
-    "measureId": "AAN2",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      42.45,
-      46.27,
-      47.03,
-      49.32,
-      52.31,
-      53.47,
-      55.13,
-      59.19
-    ]
-  },
-  {
-    "measureId": "AAN4",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      27.59,
-      41.35,
-      55.96,
-      73.62,
-      84,
-      94.12,
-      98.14,
-      99.74
-    ]
-  },
-  {
     "measureId": "AAN5",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -4716,24 +4644,6 @@
     ]
   },
   {
-    "measureId": "AAO11",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      99.6,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
     "measureId": "AAO8",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -4742,24 +4652,6 @@
     "deciles": [
       0,
       100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ABG1",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      99.98,
       100,
       100,
       100,
@@ -4788,60 +4680,6 @@
     ]
   },
   {
-    "measureId": "ABG21",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      29.34,
-      48.19,
-      62.51,
-      84.87,
-      90.42,
-      95.14,
-      99.77,
-      100
-    ]
-  },
-  {
-    "measureId": "ABG28",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      32.09,
-      44.88,
-      50.16,
-      52.84,
-      58.28,
-      87.26,
-      98.88,
-      100
-    ]
-  },
-  {
-    "measureId": "ABG29",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      44.29,
-      67.23,
-      95.03,
-      99.51,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
     "measureId": "ABG30",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -4860,24 +4698,6 @@
     ]
   },
   {
-    "measureId": "ABG31",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      89.72,
-      98.88,
-      99.67,
-      99.98,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
     "measureId": "ABG7",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -4889,24 +4709,6 @@
       98.63,
       99.29,
       99.83,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ACCPIN3",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
       100,
       100,
       100,
@@ -5022,96 +4824,6 @@
     ]
   },
   {
-    "measureId": "ACRAD3",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      0.18,
-      0.24,
-      0.31,
-      0.43,
-      0.49,
-      0.54,
-      0.62,
-      0.8
-    ]
-  },
-  {
-    "measureId": "ACRAD31",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ACRAD32",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ACRAD33",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ACRAD6",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      20,
-      21.62,
-      23.08,
-      26.09,
-      29.9,
-      32,
-      35.59,
-      37.16
-    ]
-  },
-  {
     "measureId": "AQI48",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5124,96 +4836,6 @@
       94.52,
       99.09,
       99.99,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "AQI50",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      99.14,
-      99.46,
-      99.83,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "AQI51",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      79.31,
-      92.62,
-      96.4,
-      99.35,
-      99.8,
-      99.95,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "AQUA8",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      100,
-      5.13,
-      4.22,
-      3.21,
-      2.63,
-      1.01,
-      0.69,
-      0,
-      0
-    ]
-  },
-  {
-    "measureId": "ASBS1",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      99.16,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ASBS7",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      98.15,
-      98.47,
-      100,
-      100,
-      100,
       100,
       100,
       100
@@ -5580,42 +5202,6 @@
     ]
   },
   {
-    "measureId": "M2S1",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      70.25,
-      77.55,
-      80.47,
-      81.26,
-      81.62,
-      84.57,
-      89.83,
-      92.82
-    ]
-  },
-  {
-    "measureId": "MBSAQIP7",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      100,
-      2.13,
-      1.84,
-      1.28,
-      0.39,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
     "measureId": "MBSAQIP8",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5631,24 +5217,6 @@
       0,
       0,
       0
-    ]
-  },
-  {
-    "measureId": "MUSIC1",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
     ]
   },
   {
@@ -5703,42 +5271,6 @@
       90.54,
       93.1,
       94.59
-    ]
-  },
-  {
-    "measureId": "PPRNET28",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      80,
-      81.81,
-      82.92,
-      84.84,
-      85.95,
-      86.77,
-      91.41,
-      93.08
-    ]
-  },
-  {
-    "measureId": "PPRNET29",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      73.35,
-      78.89,
-      84.41,
-      86.3,
-      88.1,
-      90.89,
-      93.86,
-      96.3
     ]
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/staging/2019/benchmarks/benchmarks.csv
+++ b/staging/2019/benchmarks/benchmarks.csv
@@ -369,29 +369,19 @@ Allergen Immunotherapy Treatment: Allergen Specific Immunoglobulin E (IgE) Sensi
 Documentation of Clinical Response to Allergen Immunotherapy within One Year,AAAAI6,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 Achievement of Projected Effective Dose of Standardized Allergens for Patient Treated With Allergen Immunotherapy for at Least One Year,AAAAI8,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Assessment of Asthma Symptoms Prior to Administration of Allergen Immunotherapy Injection(s),AAAAI9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Psoriasis: Assessment of Psoriasis Disease Activity,AAD1,Registry/QCDR,Process,Y,10.16 - 18.74,18.75 - 25.12,25.13 - 35.83,35.84 - 43.47,43.48 - 57.07,57.08 - 76.76,76.77 - 99.99,100.00,No
 Psoriasis: Screening for Psoriatic Arthritis,AAD2,Registry/QCDR,Process,Y,82.44 - 95.44,95.45 - 99.99,--,--,--,--,--,100.00,Yes
-Basal Cell Carcinoma/Squamous Cell Carcinoma: Mohs Surgery for Superficial Basal Cell Carcinoma of the Trunk for Immune Competent Patients,AAD3,Registry/QCDR,Process,Y,1.58 - 0.01,--,--,--,--,--,--,0.00,Yes
 Basal Cell Carcinoma/Squamous Cell Carcinoma: Mohs Surgery for Squamous Cell Carcinoma in Situ or Keratoacanthoma Type Squamous Cell Carcinoma 1 cm or Smaller on the Trunk,AAD4,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 Biopsy Reporting Time - Clinician to Patient,AAD5,Registry/QCDR,Process,Y,73.58 - 90.13,90.14 - 98.61,98.62 - 99.99,--,--,--,--,100.00,Yes
 Diabetes/Pre-Diabetes Screening for Patients with DSP,AAN1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 Falls screening,AAN10,Registry/QCDR,Process,Y,3.92 - 11.89,11.90 - 21.87,21.88 - 29.88,29.89 - 55.30,55.31 - 66.67,66.68 - 82.12,82.13 - 90.60,>= 90.61,No
 Overuse of Opioid and Barbiturate Containing Medications for Primary Headache Disorders.,AAN11,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Screening for Unhealthy Alcohol Use,AAN2,Registry/QCDR,Process,Y,42.45 - 46.26,46.27 - 47.02,47.03 - 49.31,49.32 - 52.30,52.31 - 53.46,53.47 - 55.12,55.13 - 59.18,>= 59.19,No
-Screening for Psychiatric or Behavioral Health Disorders,AAN4,Registry/QCDR,Process,Y,27.59 - 41.34,41.35 - 55.95,55.96 - 73.61,73.62 - 83.99,84.00 - 94.11,94.12 - 98.13,98.14 - 99.73,>= 99.74,No
 MEDICATION PRESCRIBED FOR ACUTE MIGRAINE ATTACK,AAN5,Registry/QCDR,Process,Y,14.39 - 17.85,17.86 - 22.94,22.95 - 28.56,28.57 - 33.93,33.94 - 40.19,40.20 - 45.55,45.56 - 53.00,>= 53.01,No
 Exercise and Appropriate Physical Activity Counseling for Patients with MS,AAN8,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 Querying about Symptoms of Autonomic Dysfunction,AAN9,Registry/QCDR,Process,Y,61.54 - 82.60,82.61 - 92.85,92.86 - 94.58,94.59 - 97.49,97.50 - 99.99,--,--,100.00,No
-Otitis Media with Effusion: Avoidance of Topical Intranasal Corticosteroids,AAO11,Registry/QCDR,Process,Y,99.60 - 99.99,--,--,--,--,--,--,100.00,Yes
 Otitis Media with Effusion: Antihistamines or Decongestants – Avoidance of Inappropriate Use,AAO8,Registry/QCDR,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Intra-operative anesthesia safety,ABG1,Registry/QCDR,Outcome,Y,99.98 - 99.99,--,--,--,--,--,--,100.00,Yes
 Patient Experience Survey,ABG12,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 Planned use of difficult airway equipment,ABG16,Registry/QCDR,Process,Y,56.01 - 61.14,61.15 - 72.26,72.27 - 77.96,77.97 - 82.24,82.25 - 89.40,89.41 - 94.18,94.19 - 99.83,>= 99.84,No
-Pre-operative OSA assessment,ABG21,Registry/QCDR,Process,Y,29.34 - 48.18,48.19 - 62.50,62.51 - 84.86,84.87 - 90.41,90.42 - 95.13,95.14 - 99.76,99.77 - 99.99,100.00,No
-Pre-Operative Screening for GERD,ABG28,Registry/QCDR,Process,Y,32.09 - 44.87,44.88 - 50.15,50.16 - 52.83,52.84 - 58.27,58.28 - 87.25,87.26 - 98.87,98.88 - 99.99,100.00,No
-Pre-Operative Screening for Glaucoma,ABG29,Registry/QCDR,Process,Y,44.29 - 67.22,67.23 - 95.02,95.03 - 99.50,99.51 - 99.99,--,--,--,100.00,Yes
 Pre-Operative Screening for PONV Risk,ABG30,Registry/QCDR,Process,Y,76.64 - 93.46,93.47 - 97.59,97.60 - 99.05,99.06 - 99.66,99.67 - 99.99,--,--,100.00,Yes
-Pre-Operative Screening for Excessive Alcohol and Recreational Drug Use,ABG31,Registry/QCDR,Process,Y,89.72 - 98.87,98.88 - 99.66,99.67 - 99.97,99.98 - 99.99,--,--,--,100.00,Yes
 Pain Related Quality of Life Interference,ABG32,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Lower Body Functional Impairment (LBI),ABG33,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Mood Assessment Screening and treatment,ABG34,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
@@ -405,7 +395,6 @@ STEMI patients receiving immediate PCI within 90 minutes.,ACCCATH5,Registry/QCDR
 ACE-I or ARB prescribed at discharge for patients with an ejection fraction < 40% who had a PCI during the episode of care.,ACCCATH6,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 Percutaneous Coronary Intervention (PCI): Post-procedural Optimal Medical Therapy,ACCCATH8,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 PCI procedures that were inappropriate for patients with Acute Coronary Syndrome (ACS).,ACCCATH9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-HF: Patient Self Care Education,ACCPIN3,Registry/QCDR,Process,Y,--,--,--,--,--,--,--,100.00,Yes
 Coagulation Studies in Patients Presenting with Chest Pain with No Coagulopathy or Bleeding,ACEP21,Registry/QCDR,Process,Y,24.61 - 19.33,19.32 - 15.93,15.92 - 9.06,9.05 - 5.75,5.74 - 3.78,3.77 - 0.01,--,0.00,No
 Appropriate Emergency Department Utilization of CT for Pulmonary Embolism,ACEP22,Registry/QCDR,Process,Y,8.00 - 14.99,15.00 - 18.95,18.96 - 22.72,22.73 - 26.55,26.56 - 29.46,29.47 - 36.66,36.67 - 50.58,>= 50.59,No
 Pregnancy Test for Female Abdominal Pain Patients,ACEP24,Registry/QCDR,Process,Y,55.27 - 60.22,60.23 - 64.28,64.29 - 68.37,68.38 - 73.24,73.25 - 77.93,77.94 - 80.55,80.56 - 84.76,>= 84.77,No
@@ -427,13 +416,7 @@ Appropriate venous access for hemodialysis,ACRAD26,Registry/QCDR,Intermediate Ou
 Uterine artery embolization technique: Documentation of angiographic endpoints and interrogation of ovarian arteries,ACRAD27,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 Rate of early peristomal infection following fluoroscopically guided gastrostomy tube placement,ACRAD28,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Rate of percutaneous nephrostomy tube replacement within 30 days secondary to dislodgement,ACRAD29,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Screening Mammography Cancer Detection Rate (CDR),ACRAD3,Registry/QCDR,Outcome,Y,0.18 - 0.23,0.24 - 0.30,0.31 - 0.42,0.43 - 0.48,0.49 - 0.53,0.54 - 0.61,0.62 - 0.79,>= 0.80,No
 Rate of Inadequate Percutaneous Image-Guided Biopsy,ACRAD30,Registry/QCDR,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--
-Percent of CT Abdomen-pelvis exams with contrast (single phase scan) for which Dose Length Product is at or below the size-specific diagnostic reference level.,ACRAD31,Registry/QCDR,Outcome,Y,--,--,--,--,--,--,--,100.00,Yes
-Percent of CT Chest exams without contrast (single phase scan) for which Dose Length Product is at or below the size-specific diagnostic reference level.,ACRAD32,Registry/QCDR,Outcome,Y,--,--,--,--,--,--,--,100.00,Yes
-Percent of CT Head/Brain exams without contrast (single phase scan) for which Dose Length Product is at or below the size-specific diagnostic reference level,ACRAD33,Registry/QCDR,Outcome,Y,--,--,--,--,--,--,--,100.00,Yes
-"Screening Mammography Positive Predictive Value 2 (PPV2 - Biopsy
-Recommended)",ACRAD6,Registry/QCDR,Outcome,Y,20.00 - 21.61,21.62 - 23.07,23.08 - 26.08,26.09 - 29.89,29.90 - 31.99,32.00 - 35.58,35.59 - 37.15,>= 37.16,No
 Screening Mammography Node Negativity Rate,ACRAD7,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Screening Mammography Minimal Cancer Rate,ACRAD8,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Preoperative Composite,ACS15,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
@@ -462,8 +445,6 @@ Coronary Artery Bypass Graft (CABG): Stroke - INVERSE MEASURE,AQI41,Registry/QCD
 Coronary Artery Bypass Graft (CABG): Post-Operative Renal Failure - INVERSE MEASURE,AQI42,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Anesthesia: Patient Experience Survey,AQI48,Registry/QCDR,Process,Y,55.23 - 60.02,60.03 - 94.51,94.52 - 99.08,99.09 - 99.98,99.99 - 99.99,--,--,100.00,Yes
 Adherence to Blood Conservation Guidelines for Cardiac Operations using Cardiopulmonary Bypass (CPB) – Composite,AQI49,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Application of Lung-Protective Ventilation during General Anesthesia,AQI50,Registry/QCDR,Intermediate Outcome,Y,99.14 - 99.45,99.46 - 99.82,99.83 - 99.99,--,--,--,--,100.00,Yes
-Assessment of Patients for Obstructive Sleep Apnea,AQI51,Registry/QCDR,Process,Y,79.31 - 92.61,92.62 - 96.39,96.40 - 99.34,99.35 - 99.79,99.80 - 99.94,99.95 - 99.99,--,100.00,Yes
 Treatment of Hyperglycemia with Insulin,AQI52,Registry/QCDR,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--
 Prostate Cancer: Patient Report of Urinary function after treatment,AQUA10,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Prostate Cancer: Patient Report of Sexual function after treatment,AQUA11,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
@@ -476,7 +457,6 @@ Non-Muscle Invasive Bladder Cancer: Initiation of BCG 3 months of diagnosis of h
 Non-Muscle Invasive Bladder Cancer: Early surveillance cystoscopy within 4 months of initial diagnosis,AQUA18,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 Cryptorchidism: Inappropriate use of scrotal/groin ultrasound on boys,AQUA3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 Hypogonadism: Testosterone lab ordered/reported within 6 months of starting testosterone replacement,AQUA4,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Hospital re-admissions/complications within 30 days of TRUS Biopsy,AQUA8,Registry/QCDR,Outcome,Y,5.13 - 4.23,4.22 - 3.22,3.21 - 2.64,2.63 - 1.02,1.01 - 0.70,0.69 - 0.01,--,0.00,Yes
 Risk Standardized Mortality Rate within 30 days following Trauma Operation,ARCO10,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Head CT or MRI Scan Results for Acute Ischemic Stroke or Hemorrhagic Stroke Patients who Received Head CT or MRI Scan Interpretation within 45 minutes of ED Arrival,ARCO11,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 Venous Thromboembolism (VTE) Prophylaxis,ARCO12,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
@@ -484,9 +464,7 @@ Ischemic stroke patients management -,ARCO13,Registry/QCDR,Process,N,--,--,--,--
 Gout: ULT Therapy,ARCO14,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 Antipsychotic Use in Persons with Dementia,ARCO3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 Laboratory Investigation for Secondary Causes of Fracture,ARCO7,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Surgeon assessment for hereditary cause of breast cancer,ASBS1,Registry/QCDR,Process,Y,99.16 - 99.99,--,--,--,--,--,--,100.00,Yes
 Management of the axilla in breast cancer patients undergoing breast conserving surgery with a positive sentinel node biopsy,ASBS10,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Unplanned 30 day re-operation after mastectomy,ASBS7,Registry/QCDR,Outcome,Y,98.15 - 98.46,98.47 - 99.99,--,--,--,--,--,100.00,Yes
 Cardiac Stress Nuclear Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low Risk Surgery Patients,ASNC1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 SPECT-MPI studies meeting appropriate use criteria,ASNC13,Registry/QCDR,Efficiency,N,--,--,--,--,--,--,--,--,--
 PET-MPI studies meeting appropriate use criteria,ASNC14,Registry/QCDR,Efficiency,N,--,--,--,--,--,--,--,--,--
@@ -611,7 +589,6 @@ Acquired Involutional Entropion -  Normalized Lid Position After Surgical Repai
 Amblyopia - Interocular Visual Acuity,IRIS7,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Surgical Esotropia - Postoperative Alignment,IRIS8,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Diabetic Retinopathy - Documentation of the Presence or Absence of Macular Edema and the Level of Severity of Retinopathy,IRIS9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Procedures with statin and antiplatelet agents prescribed at discharge,M2S1,Registry/QCDR,Process,Y,70.25 - 77.54,77.55 - 80.46,80.47 - 81.25,81.26 - 81.61,81.62 - 84.56,84.57 - 89.82,89.83 - 92.81,>= 92.82,No
 Survival at least 9 months after elective repair of small thoracic aortic aneurysms,M2S10,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Imaging-based maximum aortic diameter assessed at least 9 months following Endovascular AAA Repair procedures,M2S11,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 Survival at least 9 months after elective repair Endovascular AAA Repair of small abdominal aortic aneurysms,M2S12,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
@@ -630,7 +607,6 @@ Ipsilateral stroke-free survival assessed at least 9 months following isolated C
 Imaging-based maximum aortic diameter assessed at least 9 months following Thoracic and Complex EVAR procedures,M2S9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 Case Delay,MA1,Registry/QCDR,Efficiency,N,--,--,--,--,--,--,--,--,--
 Corneal Abrasion,MA2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-"Risk standardized rate of patients who experienced postoperative nausea, vomiting or fluid/electrolyte/nutritional depletion within 30 days",MBSAQIP7,Registry/QCDR,Outcome,Y,2.13 - 1.85,1.84 - 1.29,1.28 - 0.40,0.39 - 0.01,--,--,--,0.00,Yes
 Risk standardized rate of patients who experienced extended length of stay (> 7 days),MBSAQIP8,Registry/QCDR,Outcome,Y,--,--,--,--,--,--,--,0.00,Yes
 Hemoglobin A1c Test for Pediatric Patients,MEHC1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 Heel Pain Treatment Outcomes for Adults,MEX1,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
@@ -673,7 +649,6 @@ Percent same-day ambulation,MSSIC6,Registry/QCDR,Process,N,--,--,--,--,--,--,--,
 Rate of use of Pre-op skin preparation/wash,MSSIC7,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
 Percent of patients achieving MCID for back or neck pain,MSSIC8,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Percent of patients achieving MCID for leg or arm pain,MSSIC9,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Prostate Biopsy Antibiotic Compliance,MUSIC1,Registry/QCDR,Process,Y,--,--,--,--,--,--,--,100.00,Yes
 Prostate Cancer: Confirmation Testing in low risk AS eligible patients,MUSIC10,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Prostate Cancer: Follow-Up Testing for patients on active surveillance for at least 30 months,MUSIC11,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
 Prostate Cancer: Avoidance of Overuse of CT Scan for Staging Low Risk Prostate Cancer Patients,MUSIC3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
@@ -784,8 +759,6 @@ Follow-Up After Hospitalization for Schizophrenia (7- and 30-day),PP2,Registry/Q
 Chronic Kidney Disease (CKD): eGFR Monitoring,PPRNET13,Registry/QCDR,Process,Y,62.50 - 64.85,64.86 - 70.58,70.59 - 73.32,73.33 - 76.04,76.05 - 80.18,80.19 - 84.23,84.24 - 89.05,>= 89.06,No
 Chronic Kidney Disease (CKD): Hemoglobin Monitoring,PPRNET14,Registry/QCDR,Process,Y,72.62 - 77.21,77.22 - 82.85,82.86 - 87.29,87.30 - 89.86,89.87 - 90.53,90.54 - 93.09,93.10 - 94.58,>= 94.59,No
 Appropriate Treatment for Adults with Upper Respiratory Infection,PPRNET24,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-NSAID or Cox 2 Inhibitor Use in Patients with Heart Failure (HF) or Chronic Kidney Disease (CKD),PPRNET28,Registry/QCDR,Process,Y,80.00 - 81.80,81.81 - 82.91,82.92 - 84.83,84.84 - 85.94,85.95 - 86.76,86.77 - 91.40,91.41 - 93.07,>= 93.08,No
-Monitoring Serum Creatinine,PPRNET29,Registry/QCDR,Process,Y,73.35 - 78.88,78.89 - 84.40,84.41 - 86.29,86.30 - 88.09,88.10 - 90.88,90.89 - 93.85,93.86 - 96.29,>= 96.30,No
 Screening for Type 2 Diabetes,PPRNET31,Registry/QCDR,Process,Y,82.72 - 84.17,84.18 - 85.53,85.54 - 87.24,87.25 - 90.70,90.71 - 92.15,92.16 - 93.92,93.93 - 96.19,>= 96.20,No
 Screening for albuminuria in patients at risk for CKD (DM and/or HTN),PPRNET32,Registry/QCDR,Process,Y,18.26 - 26.78,26.79 - 47.26,47.27 - 56.41,56.42 - 61.65,61.66 - 66.11,66.12 - 72.25,72.26 - 75.06,>= 75.07,No
 Avoiding Use of CNS Depressants in Patients on Long-Term Opioids,PPRNET33,Registry/QCDR,Process,Y,50.51 - 54.54,54.55 - 55.58,55.59 - 57.79,57.80 - 60.14,60.15 - 65.24,65.25 - 72.38,72.39 - 81.62,>= 81.63,No

--- a/staging/2019/benchmarks/json/benchmarks.json
+++ b/staging/2019/benchmarks/json/benchmarks.json
@@ -4536,24 +4536,6 @@
     ]
   },
   {
-    "measureId": "AAD1",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      10.16,
-      18.75,
-      25.13,
-      35.84,
-      43.48,
-      57.08,
-      76.77,
-      100
-    ]
-  },
-  {
     "measureId": "AAD2",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -4569,24 +4551,6 @@
       100,
       100,
       100
-    ]
-  },
-  {
-    "measureId": "AAD3",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      100,
-      1.58,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
     ]
   },
   {
@@ -4626,42 +4590,6 @@
     ]
   },
   {
-    "measureId": "AAN2",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      42.45,
-      46.27,
-      47.03,
-      49.32,
-      52.31,
-      53.47,
-      55.13,
-      59.19
-    ]
-  },
-  {
-    "measureId": "AAN4",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      27.59,
-      41.35,
-      55.96,
-      73.62,
-      84,
-      94.12,
-      98.14,
-      99.74
-    ]
-  },
-  {
     "measureId": "AAN5",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -4698,24 +4626,6 @@
     ]
   },
   {
-    "measureId": "AAO11",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      99.6,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
     "measureId": "AAO8",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -4724,24 +4634,6 @@
     "deciles": [
       0,
       100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ABG1",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      99.98,
       100,
       100,
       100,
@@ -4770,60 +4662,6 @@
     ]
   },
   {
-    "measureId": "ABG21",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      29.34,
-      48.19,
-      62.51,
-      84.87,
-      90.42,
-      95.14,
-      99.77,
-      100
-    ]
-  },
-  {
-    "measureId": "ABG28",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      32.09,
-      44.88,
-      50.16,
-      52.84,
-      58.28,
-      87.26,
-      98.88,
-      100
-    ]
-  },
-  {
-    "measureId": "ABG29",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      44.29,
-      67.23,
-      95.03,
-      99.51,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
     "measureId": "ABG30",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -4842,24 +4680,6 @@
     ]
   },
   {
-    "measureId": "ABG31",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      89.72,
-      98.88,
-      99.67,
-      99.98,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
     "measureId": "ABG7",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -4871,24 +4691,6 @@
       98.63,
       99.29,
       99.83,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ACCPIN3",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
       100,
       100,
       100,
@@ -5004,96 +4806,6 @@
     ]
   },
   {
-    "measureId": "ACRAD3",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      0.18,
-      0.24,
-      0.31,
-      0.43,
-      0.49,
-      0.54,
-      0.62,
-      0.8
-    ]
-  },
-  {
-    "measureId": "ACRAD31",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ACRAD32",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ACRAD33",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ACRAD6",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      20,
-      21.62,
-      23.08,
-      26.09,
-      29.9,
-      32,
-      35.59,
-      37.16
-    ]
-  },
-  {
     "measureId": "AQI48",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5106,96 +4818,6 @@
       94.52,
       99.09,
       99.99,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "AQI50",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      99.14,
-      99.46,
-      99.83,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "AQI51",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      79.31,
-      92.62,
-      96.4,
-      99.35,
-      99.8,
-      99.95,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "AQUA8",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      100,
-      5.13,
-      4.22,
-      3.21,
-      2.63,
-      1.01,
-      0.69,
-      0,
-      0
-    ]
-  },
-  {
-    "measureId": "ASBS1",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      99.16,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ASBS7",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      98.15,
-      98.47,
-      100,
-      100,
-      100,
       100,
       100,
       100
@@ -5292,42 +4914,6 @@
     ]
   },
   {
-    "measureId": "M2S1",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      70.25,
-      77.55,
-      80.47,
-      81.26,
-      81.62,
-      84.57,
-      89.83,
-      92.82
-    ]
-  },
-  {
-    "measureId": "MBSAQIP7",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      100,
-      2.13,
-      1.84,
-      1.28,
-      0.39,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
     "measureId": "MBSAQIP8",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5343,24 +4929,6 @@
       0,
       0,
       0
-    ]
-  },
-  {
-    "measureId": "MUSIC1",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
     ]
   },
   {
@@ -5415,42 +4983,6 @@
       90.54,
       93.1,
       94.59
-    ]
-  },
-  {
-    "measureId": "PPRNET28",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      80,
-      81.81,
-      82.92,
-      84.84,
-      85.95,
-      86.77,
-      91.41,
-      93.08
-    ]
-  },
-  {
-    "measureId": "PPRNET29",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      73.35,
-      78.89,
-      84.41,
-      86.3,
-      88.1,
-      90.89,
-      93.86,
-      96.3
     ]
   },
   {


### PR DESCRIPTION
#### Motivation for change

Get /api/submissions/public/benchmarks?measureId=AAD3 returns a 422 error with the message "Invalid value: AAD3 for filter parameter: measureId." Yet this entry can be found in the 2019 benchmark file: https://raw.githubusercontent.com/CMSgov/qpp-measures-data/master/benchmarks/2019.json. The error occurs for a total of 26 measure ids.

#### What is being changed

After looking at the measureIds for which the error is occurring, it was determined that the specific ids are no longer valid ids for Y3. Therefore, data for measures with these ids was deleted from `benchmarks.csv` and the script to build benchmarks was run again, resulting in the removal of benchmarks for these ids in the 2019 benchmark JSON. Ultimately, the 422 error is and should be returned, because the measureIds are invalid.

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [x] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [x] Unit tests added/passing
* [ ] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-3532