### PR TITLE
QPPA-3603 Update README for 2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,7 @@
 
 ## Quality Payment Program Measures Data Repository
 
-This repository hosts measures data for QPP and supports functionality to import
-measures data as an NPM module. All 2018 quality, PI (Promoting Interoperability, 
-formerly ACI), and IA measures were added as of 
-[release 1.1.3](https://github.com/CMSgov/qpp-measures-data/releases/tag/1.1.3). QCDR measures will be added later in 2018.
-
-This is the v2 source of truth for QPP measures data. The previous measures data API is no longer available (qpp.cms.gov/api). The transition to using qpp-measures-data as a
+This is the source of truth for QPP measures data. The previous measures data API is no longer available (qpp.cms.gov/api). The transition to using qpp-measures-data as a
 source of truth for CMS is ongoing and this data may be subject to
 modifications. Stability in the API contract for
 qpp-measures-data is prioritized but not guaranteed.


### PR DESCRIPTION
Removed introductory paragraph with the reference to when measures will be added in 2018. Removed a reference to versioning in the introductory paragraph to clarify that the repo is the source of truth.

Include any related JIRA issue keys in the PR title, eg `QPPA-1234 Add measures x, y, and z`.

#### Motivation for change

Updating repo introductory language for 2020. 

#### What is being changed

Removed introductory paragraph with references to 2018. Removed version reference to clarify that the repo is the source of truth for QPP measures data. 

#### Release checklist:
Review for any additional updates that might be needed to clarify the README

* [X] Documentation updated

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-3603
