### PR TITLE
QPPA-3580, QPPA-3536 - Update benchmarks for isToppedOutByProgram, revert decile change, and delete benchmarks for measures that no longer exist

### DIFF
--- a/benchmarks/2019.json
+++ b/benchmarks/2019.json
@@ -5,11 +5,12 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       44.44,
       29.03,
-      19.61,
+      19.51,
       14.71,
       11.11,
       8.33,
@@ -21,36 +22,19 @@
     "measureId": "001",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
-    "submissionMethod": "cmsWebInterface",
-    "isToppedOut": false,
-    "deciles": [
-      100,
-      100,
-      70,
-      60,
-      50,
-      40,
-      30,
-      20,
-      10
-    ]
-  },
-  {
-    "measureId": "001",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       77.14,
-      60.65,
-      48.31,
-      38.72,
-      31.51,
-      25.71,
-      20.45,
-      14.63
+      60.78,
+      48.48,
+      38.89,
+      31.59,
+      25.87,
+      20.55,
+      14.71
     ]
   },
   {
@@ -59,16 +43,17 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
-      68.34,
-      50.65,
+      68.31,
+      50.62,
       37.5,
       28.69,
       20,
-      13.55,
-      9,
-      2.68
+      13.59,
+      9.02,
+      2.7
     ]
   },
   {
@@ -77,16 +62,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      74.1,
+      74.19,
       78.57,
       82.14,
       85.19,
-      87.9,
-      90.84,
-      93.67,
-      97.53
+      87.93,
+      90.91,
+      93.75,
+      97.73
     ]
   },
   {
@@ -95,6 +81,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       93.33,
@@ -113,14 +100,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      84.18,
-      88.04,
-      90.7,
-      92.9,
-      95.12,
-      97.11,
+      84.13,
+      88,
+      90.67,
+      92.86,
+      95.1,
+      97.09,
       100,
       100
     ]
@@ -131,16 +119,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      76.92,
-      80.86,
-      83.33,
-      85.61,
-      87.41,
-      89.9,
-      92,
-      94.93
+      76.74,
+      80.31,
+      83.18,
+      85.29,
+      87.16,
+      89.74,
+      91.92,
+      94.87
     ]
   },
   {
@@ -149,6 +138,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       96.17,
@@ -167,15 +157,16 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      80.77,
-      86,
-      89.4,
+      80.49,
+      85.62,
+      88.98,
       91.3,
-      93.14,
-      94.87,
-      96.43,
+      93.05,
+      94.74,
+      96.35,
       100
     ]
   },
@@ -185,6 +176,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       95.45,
@@ -203,6 +195,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       16.67,
@@ -221,6 +214,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -239,15 +233,16 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      79.84,
-      86.73,
-      90.71,
-      93.95,
-      96.38,
-      98.06,
-      99.12,
+      79.11,
+      86.58,
+      90.62,
+      93.88,
+      96.32,
+      98.02,
+      99.11,
       100
     ]
   },
@@ -257,10 +252,11 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      96.49,
-      99.2,
+      96.47,
+      99.17,
       100,
       100,
       100,
@@ -275,6 +271,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -293,6 +290,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       76.54,
@@ -311,6 +309,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -329,16 +328,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      33.94,
-      47.65,
-      57.95,
-      67.07,
-      75.46,
+      33.9,
+      47.62,
+      57.89,
+      67.03,
+      75.37,
       82.49,
       90.03,
-      96.03
+      96
     ]
   },
   {
@@ -347,6 +347,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       70.29,
@@ -365,6 +366,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       99.17,
@@ -383,9 +385,10 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      98.72,
+      98.67,
       100,
       100,
       100,
@@ -401,6 +404,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -419,9 +423,10 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      98.72,
+      98.68,
       100,
       100,
       100,
@@ -437,6 +442,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       32.35,
@@ -455,13 +461,14 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       26.32,
-      47.37,
+      45.1,
       55.32,
-      62.79,
-      74.07,
+      60.21,
+      70,
       80.56,
       100,
       100
@@ -473,15 +480,16 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      32.81,
-      42.41,
-      49.02,
+      32.79,
+      42.37,
+      49.01,
       55.91,
       62.55,
-      70.71,
-      82.91,
+      70.69,
+      82.89,
       95.5
     ]
   },
@@ -491,16 +499,17 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      11.18,
-      22.42,
-      34.62,
-      45.21,
-      58.05,
+      11.38,
+      22.44,
+      34.72,
+      45.26,
+      58.11,
       67.98,
-      78.69,
-      88.34
+      78.46,
+      88.24
     ]
   },
   {
@@ -509,11 +518,12 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      91.43,
-      96.05,
-      97.56,
+      90.35,
+      95.9,
+      97.39,
       100,
       100,
       100,
@@ -527,6 +537,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       95.74,
@@ -545,6 +556,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       94.24,
@@ -563,13 +575,14 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      50.33,
-      82.64,
+      50.32,
+      82.61,
       92.89,
       97.46,
-      99.3,
+      99.31,
       100,
       100,
       100
@@ -581,14 +594,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      24.26,
-      44.99,
-      65.69,
-      82.13,
+      24.33,
+      45.02,
+      65.75,
+      82.17,
       91.9,
-      97.3,
+      97.32,
       99.72,
       100
     ]
@@ -599,6 +613,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       3.88,
@@ -617,13 +632,14 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      12.2,
+      12.22,
       31.75,
-      51.72,
+      52.37,
       70.45,
-      84.21,
+      84.27,
       95.11,
       99.51,
       100
@@ -635,6 +651,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       97.3,
@@ -653,6 +670,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       47.22,
@@ -671,6 +689,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       38.1,
@@ -689,14 +708,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       25,
-      45.13,
+      45.45,
       60.43,
-      75.7,
-      86.21,
-      93.9,
+      75.76,
+      86.46,
+      93.83,
       99.36,
       100
     ]
@@ -707,6 +727,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       90.14,
@@ -725,6 +746,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       90.16,
@@ -743,13 +765,14 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      81.13,
-      88.47,
-      91.8,
+      80.95,
+      88.37,
+      91.77,
       93.88,
-      95.65,
+      95.61,
       96.88,
       98.22,
       100
@@ -761,6 +784,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       91.49,
@@ -779,15 +803,16 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      36.35,
-      59.84,
-      72.42,
-      78.68,
-      83.49,
-      87.65,
-      91.53,
+      36.71,
+      60.05,
+      72.41,
+      78.38,
+      83.33,
+      87.63,
+      91.43,
       94.59
     ]
   },
@@ -797,6 +822,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       64.57,
@@ -815,6 +841,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       8,
@@ -833,6 +860,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       42.86,
@@ -851,6 +879,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       16.67,
@@ -869,6 +898,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       95.24,
@@ -887,9 +917,10 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      95.66,
+      95.67,
       99.09,
       100,
       100,
@@ -905,6 +936,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       43.36,
@@ -923,12 +955,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       67.34,
-      78.79,
-      86.36,
-      91.35,
+      78.77,
+      86.34,
+      91.33,
       95.24,
       97.37,
       100,
@@ -941,6 +974,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       89.12,
@@ -959,6 +993,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       63.16,
@@ -977,6 +1012,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       59.34,
@@ -995,14 +1031,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      37.38,
+      39.65,
       48.17,
-      54.67,
-      73.25,
-      89.74,
-      97.22,
+      55.06,
+      76.23,
+      93.26,
+      99.6,
       100,
       100
     ]
@@ -1013,6 +1050,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       1.51,
@@ -1031,6 +1069,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       87.28,
@@ -1049,6 +1088,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       34.62,
@@ -1067,34 +1107,17 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       29.52,
-      41.4,
-      56.26,
+      41.42,
+      56.32,
       71.19,
-      82.88,
-      94.16,
-      99.43,
+      82.89,
+      94.15,
+      99.42,
       100
-    ]
-  },
-  {
-    "measureId": "110",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "cmsWebInterface",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      0,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
     ]
   },
   {
@@ -1103,16 +1126,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      15.6,
-      23.83,
-      31.46,
-      38.86,
-      46.96,
-      56.18,
-      67.93,
-      85.2
+      15.5,
+      23.64,
+      31.21,
+      38.66,
+      46.77,
+      56.02,
+      67.5,
+      84.99
     ]
   },
   {
@@ -1121,15 +1145,16 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      29.77,
+      29.85,
       41.43,
       53.85,
       66.03,
       76.94,
-      87.82,
-      96.43,
+      87.81,
+      96.41,
       100
     ]
   },
@@ -1139,15 +1164,16 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      49.75,
+      49.76,
       61.11,
       70.11,
-      77.31,
-      82.95,
-      89.43,
-      95.69,
+      77.32,
+      82.96,
+      89.44,
+      95.67,
       100
     ]
   },
@@ -1157,16 +1183,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       19.01,
-      31.17,
-      42.79,
-      53.45,
-      62.89,
-      71.86,
-      80.49,
-      90.48
+      31.07,
+      42.71,
+      53.44,
+      62.86,
+      71.82,
+      80.43,
+      90.41
     ]
   },
   {
@@ -1175,9 +1202,10 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      30.19,
+      30.23,
       44.53,
       55.56,
       63.64,
@@ -1193,34 +1221,17 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       44.44,
-      52,
-      58.44,
+      52.08,
+      58.45,
       64.29,
       70.97,
-      79.84,
-      90.2,
+      79.85,
+      90.24,
       100
-    ]
-  },
-  {
-    "measureId": "112",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "cmsWebInterface",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      0,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
     ]
   },
   {
@@ -1229,16 +1240,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       22.28,
-      32.84,
-      42.42,
-      51.18,
-      58.54,
-      65.78,
-      73.59,
-      82.42
+      32.75,
+      42.32,
+      51.06,
+      58.44,
+      65.68,
+      73.44,
+      82.31
     ]
   },
   {
@@ -1247,6 +1259,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       35.99,
@@ -1265,14 +1278,15 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      36.43,
-      50.94,
-      62.44,
-      71.19,
+      36.6,
+      51,
+      62.5,
+      71.23,
       80,
-      88.61,
+      88.64,
       97.73,
       100
     ]
@@ -1281,36 +1295,19 @@
     "measureId": "113",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
-    "submissionMethod": "cmsWebInterface",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      0,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
-    ]
-  },
-  {
-    "measureId": "113",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      13.58,
-      24.1,
-      34.09,
-      44.53,
-      54.9,
-      64.16,
-      73.48,
-      83.53
+      13.49,
+      24.01,
+      33.97,
+      44.39,
+      54.8,
+      64.01,
+      73.38,
+      83.51
     ]
   },
   {
@@ -1319,15 +1316,16 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      35.81,
-      49.71,
-      60.91,
-      70.96,
-      80.77,
+      35.9,
+      49.51,
+      60.83,
+      70.88,
+      80.62,
       90.41,
-      97.07,
+      96.98,
       100
     ]
   },
@@ -1337,6 +1335,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       44.27,
@@ -1355,6 +1354,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       72,
@@ -1373,16 +1373,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      20.5,
-      31.82,
-      45.21,
-      65.31,
-      88.91,
-      95.63,
-      98.27,
-      99.74
+      20.61,
+      32,
+      45.53,
+      66.02,
+      89.12,
+      95.65,
+      98.26,
+      99.73
     ]
   },
   {
@@ -1391,9 +1392,10 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      77.42,
+      77.26,
       90,
       95.82,
       98.49,
@@ -1409,6 +1411,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       76,
@@ -1427,16 +1430,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      67.9,
-      75,
-      80.14,
-      84.33,
-      87.86,
-      91.22,
-      94.69,
-      98.42
+      67.86,
+      74.8,
+      80,
+      84.14,
+      87.74,
+      91.11,
+      94.63,
+      98.39
     ]
   },
   {
@@ -1445,6 +1449,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       74.38,
@@ -1463,6 +1468,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       66.15,
@@ -1481,11 +1487,12 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      70.38,
-      93.04,
-      99.47,
+      70.59,
+      92.86,
+      99.46,
       100,
       100,
       100,
@@ -1499,13 +1506,14 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      37.5,
-      47.75,
-      74.42,
-      95.18,
-      99.26,
+      37.52,
+      47.78,
+      74.48,
+      95.2,
+      99.27,
       100,
       100,
       100
@@ -1517,16 +1525,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       21.15,
-      24.58,
-      28.49,
+      24.59,
+      28.52,
       34.21,
-      43.91,
-      60.51,
-      78.43,
-      93.39
+      43.85,
+      60.31,
+      78.25,
+      93.29
     ]
   },
   {
@@ -1535,12 +1544,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      34.52,
+      34.35,
       54.26,
-      74.93,
-      90.61,
+      74.57,
+      90.6,
       97.56,
       99.87,
       100,
@@ -1553,6 +1563,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       97.95,
@@ -1571,14 +1582,15 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      87.63,
-      93.55,
-      96.33,
-      98.02,
-      99.01,
-      99.59,
+      87.55,
+      93.49,
+      96.29,
+      97.99,
+      99,
+      99.58,
       99.89,
       100
     ]
@@ -1589,11 +1601,12 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      68.02,
+      68.06,
       90.28,
-      97.22,
+      97.24,
       99.51,
       100,
       100,
@@ -1607,10 +1620,11 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      80.87,
-      96.98,
+      80.57,
+      96.92,
       99.64,
       100,
       100,
@@ -1625,12 +1639,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      15.61,
+      15.8,
       40,
-      62.81,
-      84.07,
+      62.79,
+      84.06,
       95.26,
       99.55,
       100,
@@ -1643,12 +1658,13 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      12.9,
-      53.56,
-      80.08,
-      96.84,
+      12.94,
+      53.92,
+      80.23,
+      96.99,
       100,
       100,
       100,
@@ -1659,36 +1675,19 @@
     "measureId": "134",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
-    "submissionMethod": "cmsWebInterface",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      0,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
-    ]
-  },
-  {
-    "measureId": "134",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       4.88,
       10.18,
-      17.95,
-      28.57,
-      42.55,
-      57.07,
-      73.47,
-      87.76
+      17.6,
+      28.29,
+      42.3,
+      56.83,
+      73.3,
+      87.5
     ]
   },
   {
@@ -1697,12 +1696,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       17.11,
       45.65,
-      74.07,
-      90.45,
+      73.82,
+      90.06,
       98.5,
       100,
       100,
@@ -1715,9 +1715,10 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      83.84,
+      83.83,
       94.34,
       98.8,
       100,
@@ -1733,6 +1734,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       49.44,
@@ -1751,6 +1753,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -1769,6 +1772,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       73.85,
@@ -1787,12 +1791,13 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      77.24,
-      87.91,
-      94.93,
-      97.3,
+      77.21,
+      87.79,
+      94.92,
+      97.27,
       98.35,
       99.46,
       100,
@@ -1805,13 +1810,14 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      90.26,
-      95.39,
-      97.12,
-      98.55,
-      99.24,
+      90.31,
+      95.4,
+      97.13,
+      98.57,
+      99.26,
       100,
       100,
       100
@@ -1823,6 +1829,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       66.41,
@@ -1841,6 +1848,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       73.1,
@@ -1859,6 +1867,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       0.23,
@@ -1877,6 +1886,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       0.24,
@@ -1895,6 +1905,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       76.47,
@@ -1913,6 +1924,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       93.04,
@@ -1931,9 +1943,10 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      96.94,
+      96.95,
       100,
       100,
       100,
@@ -1949,13 +1962,14 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      28.84,
+      28.63,
       60.82,
       85,
-      96.03,
-      99.9,
+      95.97,
+      99.74,
       100,
       100,
       100
@@ -1967,9 +1981,10 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      55.86,
+      55.81,
       84.62,
       99.21,
       100,
@@ -1985,6 +2000,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       67.86,
@@ -2003,16 +2019,17 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
-      11.09,
+      11.4,
       9.09,
       7.69,
-      6.82,
-      5.69,
-      4.4,
-      3.03,
-      1.52
+      6.8,
+      5.55,
+      4.28,
+      3.08,
+      1.54
     ]
   },
   {
@@ -2021,9 +2038,10 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
-      0.85,
+      0.84,
       0,
       0,
       0,
@@ -2039,12 +2057,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       2.38,
       1.79,
-      1.27,
-      0.81,
+      1.26,
+      0.71,
       0,
       0,
       0,
@@ -2057,13 +2076,14 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
-      3.45,
+      3.51,
       2.7,
-      2.13,
+      2.15,
       1.85,
-      1.3,
+      1.28,
       0.88,
       0,
       0
@@ -2075,14 +2095,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
-      3.9,
+      3.95,
       3.13,
       2.63,
       1.79,
       1.27,
-      0.9,
+      0.87,
       0,
       0
     ]
@@ -2093,14 +2114,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       32,
       48.15,
-      56,
-      69,
-      80.72,
-      100,
+      55.56,
+      68.01,
+      80.43,
+      99.04,
       100,
       100
     ]
@@ -2111,12 +2133,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      53.85,
+      57.23,
       75,
-      88.57,
-      96.6,
+      88.24,
+      96.02,
       100,
       100,
       100,
@@ -2129,12 +2152,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      67.71,
-      81.44,
-      91.11,
-      96.27,
+      67.61,
+      81.4,
+      90.59,
+      95.95,
       100,
       100,
       100,
@@ -2147,12 +2171,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       44.53,
-      67.99,
-      87.8,
-      95.45,
+      67.89,
+      85.31,
+      95.22,
       100,
       100,
       100,
@@ -2165,13 +2190,14 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      51.1,
-      76.41,
-      88.19,
-      95.15,
-      100,
+      52.68,
+      75.79,
+      87.96,
+      95.06,
+      99.58,
       100,
       100,
       100
@@ -2183,6 +2209,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       55.38,
@@ -2201,6 +2228,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       50.65,
@@ -2219,6 +2247,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -2237,6 +2266,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       98.57,
@@ -2255,6 +2285,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       61.64,
@@ -2273,6 +2304,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       88.89,
@@ -2291,15 +2323,16 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      85.71,
-      90.88,
-      93.6,
-      95.64,
-      96.92,
-      97.85,
-      98.8,
+      85.25,
+      90.63,
+      93.41,
+      95.59,
+      96.88,
+      97.83,
+      98.78,
       100
     ]
   },
@@ -2309,6 +2342,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       94.37,
@@ -2327,6 +2361,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       0,
@@ -2345,6 +2380,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       0,
@@ -2363,6 +2399,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       91.72,
@@ -2381,10 +2418,11 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       97.81,
-      99.86,
+      99.85,
       100,
       100,
       100,
@@ -2399,6 +2437,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       99.36,
@@ -2417,6 +2456,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -2435,6 +2475,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       58.57,
@@ -2443,26 +2484,8 @@
       73.91,
       78.57,
       83.33,
-      88.27,
-      94.87
-    ]
-  },
-  {
-    "measureId": "236",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "cmsWebInterface",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      0,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
+      88.32,
+      94.89
     ]
   },
   {
@@ -2471,16 +2494,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       51.46,
-      56.84,
+      56.83,
       60.95,
       64.68,
-      68.21,
-      72.09,
-      76.35,
-      82.28
+      68.18,
+      72.01,
+      76.26,
+      82.21
     ]
   },
   {
@@ -2489,15 +2513,16 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      52.48,
-      60.15,
-      65.73,
-      70.68,
+      52.41,
+      60.05,
+      65.68,
+      70.62,
       76.83,
       84.62,
-      93.62,
+      93.4,
       100
     ]
   },
@@ -2507,14 +2532,15 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
-      8.08,
-      4.78,
-      2.7,
-      1.32,
+      8.04,
+      4.74,
+      2.67,
+      1.31,
       0.53,
-      0.05,
+      0.04,
       0,
       0
     ]
@@ -2525,9 +2551,10 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
-      0.67,
+      0.68,
       0.28,
       0.13,
       0,
@@ -2543,16 +2570,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       26.23,
       29.52,
       31.48,
-      32.83,
-      33.96,
-      38.81,
-      47.93,
-      65.69
+      32.8,
+      33.86,
+      38.73,
+      47.77,
+      65.53
     ]
   },
   {
@@ -2561,6 +2589,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       9.3,
@@ -2579,6 +2608,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       8.11,
@@ -2597,6 +2627,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -2615,6 +2646,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -2633,6 +2665,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -2651,6 +2684,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -2669,6 +2703,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       74.42,
@@ -2687,6 +2722,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -2705,6 +2741,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       97.96,
@@ -2723,12 +2760,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      61.2,
-      83.7,
+      61.23,
+      83.63,
       95.65,
-      99.39,
+      99.38,
       100,
       100,
       100,
@@ -2741,6 +2779,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       32,
@@ -2759,6 +2798,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       69.01,
@@ -2777,6 +2817,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       90.08,
@@ -2795,12 +2836,13 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       5.88,
       12.9,
       26.09,
-      44.84,
+      45,
       59.26,
       73.33,
       88.57,
@@ -2813,6 +2855,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       57.14,
@@ -2831,6 +2874,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       58.14,
@@ -2849,6 +2893,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       62.86,
@@ -2867,6 +2912,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       59.26,
@@ -2885,6 +2931,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       85.09,
@@ -2903,6 +2950,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       86.49,
@@ -2921,6 +2969,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       67.03,
@@ -2939,6 +2988,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       45.11,
@@ -2957,6 +3007,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       50,
@@ -2975,6 +3026,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       0.31,
@@ -2993,15 +3045,16 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      9.84,
-      16.67,
-      23.62,
-      31.5,
-      39.61,
-      48.21,
-      57.61,
+      9.83,
+      16.8,
+      23.66,
+      31.54,
+      39.72,
+      48.31,
+      57.63,
       72.61
     ]
   },
@@ -3011,6 +3064,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       16.67,
@@ -3029,14 +3083,15 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      34.24,
-      45.45,
-      58.45,
-      73.19,
-      89.39,
-      98.05,
+      34.25,
+      45.48,
+      58.49,
+      73.29,
+      89.41,
+      98.07,
       100,
       100
     ]
@@ -3047,16 +3102,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      19.55,
-      24.12,
-      28.15,
-      32.23,
-      36.65,
-      42.2,
-      50.93,
-      75
+      19.56,
+      24.14,
+      28.19,
+      32.31,
+      36.67,
+      42.12,
+      50.7,
+      74.55
     ]
   },
   {
@@ -3065,34 +3121,17 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      25.83,
+      25.75,
       30.81,
       35.47,
-      42.53,
-      59.12,
-      83.33,
-      97.3,
+      42.57,
+      59.15,
+      83.49,
+      97.32,
       100
-    ]
-  },
-  {
-    "measureId": "318",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "cmsWebInterface",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      0,
-      43.42,
-      50.42,
-      58.45,
-      66,
-      73.39,
-      81.79,
-      90.73
     ]
   },
   {
@@ -3101,16 +3140,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      7.25,
-      20.23,
-      36.4,
-      52.26,
-      66.77,
-      78.69,
+      7.24,
+      20.27,
+      36.41,
+      52.25,
+      66.73,
+      78.6,
       88.51,
-      96.55
+      96.56
     ]
   },
   {
@@ -3119,6 +3159,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       95.24,
@@ -3137,14 +3178,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      85.29,
+      85,
       89.74,
-      93.75,
+      93.61,
       95.95,
       97.73,
-      98.98,
+      98.96,
       100,
       100
     ]
@@ -3155,6 +3197,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       1.9,
@@ -3173,6 +3216,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       2.44,
@@ -3191,6 +3235,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       6.25,
@@ -3209,6 +3254,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       84.13,
@@ -3227,14 +3273,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      69.38,
-      75.07,
-      78.84,
-      83.05,
-      87.99,
-      94.86,
+      69.54,
+      75.11,
+      78.9,
+      83.09,
+      88.17,
+      94.94,
       100,
       100
     ]
@@ -3245,6 +3292,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       92.15,
@@ -3263,6 +3311,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       93.55,
@@ -3281,6 +3330,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       2.5,
@@ -3299,6 +3349,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       47.06,
@@ -3317,6 +3368,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       74.47,
@@ -3335,6 +3387,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       48.97,
@@ -3353,6 +3406,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       98.78,
@@ -3371,6 +3425,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       96,
@@ -3389,6 +3444,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -3407,6 +3463,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -3425,6 +3482,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -3443,6 +3501,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       3.61,
@@ -3461,6 +3520,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       3.15,
@@ -3479,6 +3539,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       5,
@@ -3497,11 +3558,12 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       3.48,
       2.27,
-      0.95,
+      0.93,
       0,
       0,
       0,
@@ -3515,6 +3577,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       17.29,
@@ -3533,6 +3596,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       31.53,
@@ -3551,6 +3615,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -3569,6 +3634,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -3587,6 +3653,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       59.02,
@@ -3605,6 +3672,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       26.67,
@@ -3623,15 +3691,16 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      2.04,
-      2.63,
-      3.55,
-      4.24,
-      5.26,
+      2.08,
+      2.7,
+      3.7,
+      4.35,
+      5.32,
       7.14,
-      8.82,
+      8.77,
       15
     ]
   },
@@ -3641,15 +3710,16 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      3.7,
-      6.06,
-      8.96,
-      12.5,
-      16.43,
-      21.74,
-      30.1,
+      3.82,
+      6.12,
+      9.09,
+      12.69,
+      16.67,
+      22.09,
+      30.3,
       43.14
     ]
   },
@@ -3659,16 +3729,36 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      7.62,
-      14.93,
+      7.63,
+      14.98,
       26.33,
-      37.04,
-      48.47,
-      60.32,
-      74.67,
-      90.91
+      36.74,
+      48.15,
+      60.25,
+      74.44,
+      90.75
+    ]
+  },
+  {
+    "measureId": "374",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      6.77,
+      8.51,
+      37.84,
+      62.86,
+      82.43,
+      88.89,
+      92.74,
+      99.02
     ]
   },
   {
@@ -3677,6 +3767,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       5,
@@ -3695,6 +3786,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       4.82,
@@ -3713,10 +3805,11 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
-      0.48,
-      0.1,
+      0.47,
+      0.09,
       0,
       0,
       0,
@@ -3731,6 +3824,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       0.32,
@@ -3749,6 +3843,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       3.43,
@@ -3767,6 +3862,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       58,
@@ -3785,6 +3881,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       0.38,
@@ -3803,6 +3900,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       0,
@@ -3821,6 +3919,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       77.17,
@@ -3839,6 +3938,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       63.64,
@@ -3857,6 +3957,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -3875,6 +3976,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -3893,6 +3995,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -3911,6 +4014,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -3929,6 +4033,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       91.96,
@@ -3947,6 +4052,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       33.52,
@@ -3965,6 +4071,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       1.26,
@@ -3983,6 +4090,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       86.36,
@@ -4001,16 +4109,17 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      40,
+      39.88,
       50.59,
-      57.35,
+      57.25,
       63,
-      69.74,
-      75.25,
-      82.35,
-      93.4
+      69.75,
+      75.27,
+      82.41,
+      93.38
     ]
   },
   {
@@ -4019,6 +4128,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       10.26,
@@ -4037,12 +4147,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
-      12.24,
+      12.11,
       6.67,
       2.63,
-      0.46,
+      0.53,
       0,
       0,
       0,
@@ -4055,6 +4166,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       61.9,
@@ -4073,12 +4185,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
-      14.23,
-      5.8,
-      3.47,
-      0.03,
+      14.94,
+      5.97,
+      3.64,
+      0.09,
       0,
       0,
       0,
@@ -4091,6 +4204,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -4109,6 +4223,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       68.35,
@@ -4127,6 +4242,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       23.08,
@@ -4145,12 +4261,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       61.17,
       88.35,
       97.44,
-      99.63,
+      99.67,
       100,
       100,
       100,
@@ -4163,6 +4280,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       88.55,
@@ -4181,6 +4299,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       96,
@@ -4199,6 +4318,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       63.41,
@@ -4217,6 +4337,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       46.67,
@@ -4235,13 +4356,14 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       98.46,
       99.52,
       99.75,
       99.88,
-      99.99,
+      100,
       100,
       100,
       100
@@ -4253,6 +4375,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       97.44,
@@ -4266,16 +4389,36 @@
     ]
   },
   {
+    "measureId": "425",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      97.59,
+      98.32,
+      98.74,
+      99.05,
+      99.3,
+      99.51,
+      99.77,
+      100
+    ]
+  },
+  {
     "measureId": "430",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       93.66,
       97.18,
-      98.51,
+      98.54,
       99.22,
       99.64,
       99.92,
@@ -4289,12 +4432,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       33.43,
       49.35,
       66.12,
-      78.15,
+      78.13,
       87,
       93.52,
       97.96,
@@ -4307,6 +4451,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       2.05,
@@ -4325,6 +4470,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       85.73,
@@ -4343,11 +4489,12 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       93.28,
-      96.96,
-      99.05,
+      96.97,
+      99.06,
       99.67,
       99.92,
       100,
@@ -4361,6 +4508,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       1.32,
@@ -4377,14 +4525,34 @@
     "measureId": "438",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      69.86,
-      77.18,
-      88.88,
-      96.54,
+      63.75,
+      71.07,
+      77.12,
+      84.27,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "438",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      78.72,
+      91.67,
+      95.65,
+      97.38,
       100,
       100,
       100,
@@ -4397,6 +4565,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       96.91,
@@ -4415,6 +4584,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       32.4,
@@ -4433,6 +4603,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       91.67,
@@ -4451,14 +4622,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       3.9,
-      3.39,
+      3.16,
       2.68,
-      2.25,
-      1.74,
-      1.15,
+      2.24,
+      1.72,
+      1.22,
       0,
       0
     ]
@@ -4469,10 +4641,11 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      94.8,
-      98.15,
+      95.71,
+      98.53,
       100,
       100,
       100,
@@ -4487,12 +4660,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      87.59,
-      90.45,
-      93.2,
-      97.86,
+      90,
+      90.91,
+      93.55,
+      100,
       100,
       100,
       100,
@@ -4505,15 +4679,16 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       15,
       10.42,
       9.18,
-      8.18,
-      7.63,
-      7.3,
-      6.47,
+      7.99,
+      7.35,
+      7.03,
+      2.38,
       0
     ]
   },
@@ -4523,15 +4698,16 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       15.38,
-      15.09,
+      15,
       13.51,
-      12.2,
-      9.7,
+      11.1,
+      9.64,
       6.45,
-      4.32,
+      0,
       0
     ]
   },
@@ -4559,6 +4735,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       10.16,
@@ -4577,6 +4754,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       82.44,
@@ -4595,6 +4773,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       1.58,
@@ -4613,6 +4792,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       73.58,
@@ -4631,16 +4811,17 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      3.92,
-      11.9,
-      21.88,
-      29.89,
-      55.31,
-      66.68,
-      82.13,
-      90.61
+      4.09,
+      11.96,
+      22.22,
+      30.43,
+      53.85,
+      65.27,
+      81.95,
+      90.34
     ]
   },
   {
@@ -4649,6 +4830,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       42.45,
@@ -4667,13 +4849,14 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       27.59,
       41.35,
-      55.96,
-      73.62,
-      84,
+      58.33,
+      74.07,
+      83.91,
       94.12,
       98.14,
       99.74
@@ -4685,15 +4868,16 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      14.39,
-      17.86,
-      22.95,
-      28.57,
-      33.94,
+      14.5,
+      16.67,
+      22.41,
+      28.44,
+      32.47,
       40.2,
-      45.56,
+      45.51,
       53.01
     ]
   },
@@ -4703,6 +4887,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       61.54,
@@ -4721,6 +4906,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       99.6,
@@ -4739,6 +4925,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -4757,6 +4944,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       99.98,
@@ -4775,6 +4963,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       56.01,
@@ -4793,6 +4982,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       29.34,
@@ -4811,6 +5001,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       32.09,
@@ -4829,6 +5020,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       44.29,
@@ -4847,6 +5039,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       76.64,
@@ -4865,6 +5058,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       89.72,
@@ -4883,6 +5077,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       97.85,
@@ -4896,11 +5091,12 @@
     ]
   },
   {
-    "measureId": "ACCPIN3",
+    "measureId": "ACCPin3",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -4919,6 +5115,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       24.61,
@@ -4937,6 +5134,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       8,
@@ -4955,6 +5153,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       55.27,
@@ -4973,6 +5172,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       63.89,
@@ -4991,6 +5191,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       43.04,
@@ -5009,24 +5210,26 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      20.83,
-      24.56,
-      31.82,
-      38.1,
-      41.46,
-      44.62,
-      47.83,
-      65.25
+      21.19,
+      28.1,
+      34.78,
+      38.17,
+      41.89,
+      46.54,
+      58.88,
+      67.15
     ]
   },
   {
-    "measureId": "ACRAD3",
+    "measureId": "ACRad3",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       0.18,
@@ -5040,11 +5243,12 @@
     ]
   },
   {
-    "measureId": "ACRAD31",
+    "measureId": "ACRad31",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -5058,11 +5262,12 @@
     ]
   },
   {
-    "measureId": "ACRAD32",
+    "measureId": "ACRad32",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -5076,11 +5281,12 @@
     ]
   },
   {
-    "measureId": "ACRAD33",
+    "measureId": "ACRad33",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -5094,11 +5300,12 @@
     ]
   },
   {
-    "measureId": "ACRAD6",
+    "measureId": "ACRad6",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       20,
@@ -5117,6 +5324,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       55.23,
@@ -5135,6 +5343,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       99.14,
@@ -5153,6 +5362,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       79.31,
@@ -5171,6 +5381,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       5.13,
@@ -5189,6 +5400,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       99.16,
@@ -5207,6 +5419,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       98.15,
@@ -5495,6 +5708,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       83.33,
@@ -5513,6 +5727,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       31.25,
@@ -5531,14 +5746,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      83.72,
+      83.71,
       87.92,
-      90.2,
-      91.86,
+      90.18,
+      91.83,
       93.52,
-      95.06,
+      95.01,
       96.58,
       98.15
     ]
@@ -5549,6 +5765,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       61.11,
@@ -5567,6 +5784,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       86.96,
@@ -5585,6 +5803,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       70.25,
@@ -5603,6 +5822,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       2.13,
@@ -5621,6 +5841,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       0,
@@ -5639,6 +5860,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -5657,6 +5879,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       12.5,
@@ -5675,6 +5898,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       62.5,
@@ -5693,6 +5917,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       72.62,
@@ -5711,6 +5936,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       80,
@@ -5729,6 +5955,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       73.35,
@@ -5747,6 +5974,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       82.72,
@@ -5765,6 +5993,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       18.26,
@@ -5783,6 +6012,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       50.51,
@@ -5801,6 +6031,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       27.68,
@@ -5819,6 +6050,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       37.04,
@@ -5837,6 +6069,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       0.58,
@@ -5855,6 +6088,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       0.99,
@@ -5873,6 +6107,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       92.85,
@@ -5891,15 +6126,16 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       8.26,
-      7.14,
+      6.96,
       5.88,
-      4.65,
-      3.57,
+      4.62,
+      3.49,
       2.73,
-      1.85,
+      1.83,
       0
     ]
   },
@@ -5909,6 +6145,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       21.21,
@@ -5927,6 +6164,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       8,
@@ -5945,14 +6183,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       2.73,
       6.56,
       22.78,
-      50.38,
-      68.73,
-      84.06,
+      51.52,
+      70,
+      83.78,
       92.48,
       99.17
     ]

--- a/benchmarks/2019.json
+++ b/benchmarks/2019.json
@@ -4730,25 +4730,6 @@
     ]
   },
   {
-    "measureId": "AAD1",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      10.16,
-      18.75,
-      25.13,
-      35.84,
-      43.48,
-      57.08,
-      76.77,
-      100
-    ]
-  },
-  {
     "measureId": "AAD2",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -4765,25 +4746,6 @@
       100,
       100,
       100
-    ]
-  },
-  {
-    "measureId": "AAD3",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      1.58,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
     ]
   },
   {
@@ -4825,44 +4787,6 @@
     ]
   },
   {
-    "measureId": "AAN2",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      42.45,
-      46.27,
-      47.03,
-      49.32,
-      52.31,
-      53.47,
-      55.13,
-      59.19
-    ]
-  },
-  {
-    "measureId": "AAN4",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      27.59,
-      41.35,
-      58.33,
-      74.07,
-      83.91,
-      94.12,
-      98.14,
-      99.74
-    ]
-  },
-  {
     "measureId": "AAN5",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -4901,25 +4825,6 @@
     ]
   },
   {
-    "measureId": "AAO11",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      99.6,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
     "measureId": "AAO8",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -4929,25 +4834,6 @@
     "deciles": [
       0,
       100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ABG1",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      99.98,
       100,
       100,
       100,
@@ -4977,63 +4863,6 @@
     ]
   },
   {
-    "measureId": "ABG21",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      29.34,
-      48.19,
-      62.51,
-      84.87,
-      90.42,
-      95.14,
-      99.77,
-      100
-    ]
-  },
-  {
-    "measureId": "ABG28",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      32.09,
-      44.88,
-      50.16,
-      52.84,
-      58.28,
-      87.26,
-      98.88,
-      100
-    ]
-  },
-  {
-    "measureId": "ABG29",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      44.29,
-      67.23,
-      95.03,
-      99.51,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
     "measureId": "ABG30",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5053,25 +4882,6 @@
     ]
   },
   {
-    "measureId": "ABG31",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      89.72,
-      98.88,
-      99.67,
-      99.98,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
     "measureId": "ABG7",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5084,25 +4894,6 @@
       98.63,
       99.29,
       99.83,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ACCPin3",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
       100,
       100,
       100,
@@ -5224,101 +5015,6 @@
     ]
   },
   {
-    "measureId": "ACRad3",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      0.18,
-      0.24,
-      0.31,
-      0.43,
-      0.49,
-      0.54,
-      0.62,
-      0.8
-    ]
-  },
-  {
-    "measureId": "ACRad31",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ACRad32",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ACRad33",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ACRad6",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      20,
-      21.62,
-      23.08,
-      26.09,
-      29.9,
-      32,
-      35.59,
-      37.16
-    ]
-  },
-  {
     "measureId": "AQI48",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5332,101 +5028,6 @@
       94.52,
       99.09,
       99.99,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "AQI50",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      99.14,
-      99.46,
-      99.83,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "AQI51",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      79.31,
-      92.62,
-      96.4,
-      99.35,
-      99.8,
-      99.95,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "AQUA8",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      100,
-      5.13,
-      4.22,
-      3.21,
-      2.63,
-      1.01,
-      0.69,
-      0,
-      0
-    ]
-  },
-  {
-    "measureId": "ASBS1",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      99.16,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ASBS7",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      98.15,
-      98.47,
-      100,
-      100,
-      100,
       100,
       100,
       100
@@ -5798,44 +5399,6 @@
     ]
   },
   {
-    "measureId": "M2S1",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      70.25,
-      77.55,
-      80.47,
-      81.26,
-      81.62,
-      84.57,
-      89.83,
-      92.82
-    ]
-  },
-  {
-    "measureId": "MBSAQIP7",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      100,
-      2.13,
-      1.84,
-      1.28,
-      0.39,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
     "measureId": "MBSAQIP8",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5852,25 +5415,6 @@
       0,
       0,
       0
-    ]
-  },
-  {
-    "measureId": "MUSIC1",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
     ]
   },
   {
@@ -5928,44 +5472,6 @@
       90.54,
       93.1,
       94.59
-    ]
-  },
-  {
-    "measureId": "PPRNET28",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      80,
-      81.81,
-      82.92,
-      84.84,
-      85.95,
-      86.77,
-      91.41,
-      93.08
-    ]
-  },
-  {
-    "measureId": "PPRNET29",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      73.35,
-      78.89,
-      84.41,
-      86.3,
-      88.1,
-      90.89,
-      93.86,
-      96.3
     ]
   },
   {

--- a/benchmarks/2019/benchmarks-schema.yaml
+++ b/benchmarks/2019/benchmarks-schema.yaml
@@ -16,6 +16,9 @@ definitions:
       isToppedOut:
         description: isToppedOut is a boolean value that describes whether a benchmark's latter deciles repeat a value of 100 or, in the case of inverse measures, a value of 0.
         type: boolean
+        isToppedOutByProgram:
+        description: isToppedOutByProgram is a boolean value that indicates whether or not a Topped Out Measure will receive special scoring. If “true” the measure cannot earn more than 7 points.
+        type: boolean
       benchmarkYear:
         description: The benchmarkYear four digit integer corresponds to the time period of the performance data that was used to generate this benchmark. The submitted performance data will be compared against the benchmarkYear's results.
         type: number

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/scripts/benchmarks/format-benchmark-record.js
+++ b/scripts/benchmarks/format-benchmark-record.js
@@ -13,14 +13,10 @@ const Constants = require('../../constants.js');
  * @enum {string}
  */
 const SUBMISSION_METHOD_MAP = {
-  'claims': 'claims',
-  'registry': 'registry',
-  'registry/qcdr': 'registry',
-  'cmswebinterface': 'cmsWebInterface',
-  'administrativeclaims': 'administrativeClaims',
-  'ehr': 'electronicHealthRecord',
-  'cmsapprovedcahpsvendor': 'certifiedSurveyVendor',
-  'cahpssurveyvendor': 'certifiedSurveyVendor'
+  'ecqm': 'electronicHealthRecord',
+  'medicarepartbclaims': 'claims',
+  'mipscqm': 'registry',
+  'qcdrmeasure': 'registry'
 };
 
 /**
@@ -56,6 +52,15 @@ const formatIsToppedOut = function(isToppedOut) {
   return false;
 };
 
+const formatIsToppedOutByProgram = function(isToppedOutByProgram) {
+  // These come in formatted as 'Yes - see "Scoring Examples" tab of spreadsheet' or 'No'
+  // We want to just look at whether it says yes/no
+  if (isToppedOutByProgram.trim().toLowerCase().split(' ')[0] === 'yes') {
+    return true;
+  }
+  return false;
+};
+
 const floatRegex = /([0-9]*[.]?[0-9]+)/g;
 
 /**
@@ -78,7 +83,8 @@ const floatRegex = /([0-9]*[.]?[0-9]+)/g;
  *  decile8: string?,
  *  decile9: string?,
  *  decile10: string?,
- *  isToppedOut: string}} record
+ *  isToppedOut: string,
+ *  isToppedOutByProgram: string}} record
  *  @returns {function}
  */
 const formatDecileGenerator = function(record) {
@@ -187,7 +193,8 @@ const formatMeasureId = (measureId, performanceYear) => {
  *  decile8: string?,
  *  decile9: string?,
  *  decile10: string?,
- *  isToppedOut: string
+ *  isToppedOut: string,
+ *  isToppedOutByProgram: string
  *  }} record - csv record object
  * @param {{
  *  benchmarkYear: string,
@@ -216,6 +223,7 @@ const formatBenchmarkRecord = function(record, options) {
     performanceYear: parseInt(options.performanceYear),
     submissionMethod: formatSubmissionMethod(record.submissionMethod),
     isToppedOut: formatIsToppedOut(record.isToppedOut),
+    isToppedOutByProgram: formatIsToppedOutByProgram(record.isToppedOutByProgram),
     deciles: [
       record.decile1,
       record.decile2,

--- a/scripts/benchmarks/parse-benchmarks-data.js
+++ b/scripts/benchmarks/parse-benchmarks-data.js
@@ -12,6 +12,8 @@ const BENCHMARK_CSV_COLUMNS = [
   'submissionMethod',
   'measureType',
   'benchmark',
+  'standardDeviation',
+  'average',
   'decile3',
   'decile4',
   'decile5',
@@ -20,7 +22,8 @@ const BENCHMARK_CSV_COLUMNS = [
   'decile8',
   'decile9',
   'decile10',
-  'isToppedOut'
+  'isToppedOut',
+  'isToppedOutByProgram'
 ];
 // Utils
 const { formatBenchmarkRecord } = require('./format-benchmark-record');
@@ -49,7 +52,7 @@ if (benchmarkYear && performanceYear) {
   });
 
   process.stdin.on('end', function() {
-    parse(benchmarksData, {columns: BENCHMARK_CSV_COLUMNS, from: 4}, function(err, records) {
+    parse(benchmarksData, {columns: BENCHMARK_CSV_COLUMNS, from: 3}, function(err, records) {
       if (err) {
         console.log(err);
       } else {

--- a/staging/2019/benchmarks/benchmarks.csv
+++ b/staging/2019/benchmarks/benchmarks.csv
@@ -360,9 +360,7 @@ Asthma: Assessment of Asthma Control – Ambulatory Care Setting,AAAAI2,QCDR mea
 Documentation of Clinical Response to Allergen Immunotherapy within One Year,AAAAI6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Achievement of Projected Effective Dose of Standardized Allergens for Patient Treated With Allergen Immunotherapy for at Least One Year ,AAAAI8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 Assessment of Asthma Symptoms Prior to Administration of Allergen Immunotherapy Injection(s) ,AAAAI9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
-Psoriasis: Assessment of Psoriasis Disease Activity,AAD1,QCDR measure,Process,Y,33,42.5,10.16 - 18.74,18.75 - 25.12,25.13 - 35.83,35.84 - 43.47,43.48 - 57.07,57.08 - 76.76,76.77 - 99.99,100,No,No
 Psoriasis: Screening for Psoriatic Arthritis,AAD2,QCDR measure,Process,Y,23.9,87.6,82.44 - 95.44,95.45 - 99.99,--,--,--,--,--,100,Yes,No
-Basal Cell Carcinoma/Squamous Cell Carcinoma: Mohs Surgery for Superficial Basal Cell Carcinoma of the Trunk for Immune Competent Patients,AAD3,QCDR measure,Process,Y,2.1,1,1.58 - 0.01,--,--,--,--,--,--,0,Yes,No
 Basal Cell Carcinoma/Squamous Cell Carcinoma: Mohs Surgery for Squamous Cell Carcinoma in Situ or Keratoacanthoma Type Squamous Cell Carcinoma 1 cm or Smaller on the Trunk,AAD4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Biopsy: Reporting Time - Clinician to Patient,AAD5,QCDR measure,Process,Y,23,87,73.58 - 90.13,90.14 - 98.61,98.62 - 99.99,--,--,--,--,100,Yes,No
 Diabetes/Pre-Diabetes Screening for Patients with DSP,AAN1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
@@ -374,13 +372,10 @@ Quality of Life Assessment,AAN15,QCDR measure,Process,N,--,--,--,--,--,--,--,--,
 Falls Outcome for Patients with Parkinson's Disease,AAN16,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 First line treatment for infantile spasms (IS),AAN18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Botulinum Toxin Serotype A (BoNT-A) for spasticity or dystonia,AAN19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
-DSP Screening for Unhealthy Alcohol Use ,AAN2,QCDR measure,Process,Y,9.7,48.4,42.45 - 46.26,46.27 - 47.02,47.03 - 49.31,49.32 - 52.30,52.31 - 53.46,53.47 - 55.12,55.13 - 59.18,>= 59.19,No,No
 Querying for co-morbid conditions of tic disorder (TD) and Tourette syndrome (TS),AAN20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
-Screening for Psychiatric or Behavioral Health Disorders,AAN4,QCDR measure,Process,Y,32.3,64.4,27.59 - 41.34,41.35 - 58.32,58.33 - 74.06,74.07 - 83.90,83.91 - 94.11,94.12 - 98.13,98.14 - 99.73,>= 99.74,No,No
 MEDICATION PRESCRIBED FOR ACUTE MIGRAINE ATTACK,AAN5,QCDR measure,Process,Y,16.6,30.1,14.50 - 16.66,16.67 - 22.40,22.41 - 28.43,28.44 - 32.46,32.47 - 40.19,40.20 - 45.50,45.51 - 53.00,>= 53.01,No,No
 Exercise and Appropriate Physical Activity Counseling for Patients with MS,AAN8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Querying About Symptoms of Autonomic Dysfunction for Patients with Parkinson's Disease ,AAN9,QCDR measure,Process,Y,30.2,79.9,61.54 - 82.60,82.61 - 92.85,92.86 - 94.58,94.59 - 97.49,97.50 - 99.99,--,--,100,No,No
-Otitis Media with Effusion: Avoidance of Topical Intranasal Corticosteroids,AAO11,QCDR measure,Process,Y,1.4,99.5,99.60 - 99.99,--,--,--,--,--,--,100,Yes,No
 Topical Ear Drop Monotherapy for Children with Acute Tympanostomy Tube Otorrhea ,AAO12,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Inappropriate Use of Magnetic Resonance Imaging or Computed Tomography Scan for Bell’s Palsy (Inverse Measure),AAO13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Inappropriate Use of Antiviral Monotherapy for Bell’s Palsy (Inverse Measure),AAO14,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
@@ -407,20 +402,14 @@ Palliative Care—Treatment Preferences,ABFM5,QCDR measure,Process,N,--,--,--,--
 Palliative Care Timely Dyspnea Screening & Treatment,ABFM6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Pain Brought Under Control within the first three visits,ABFM7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 Measuring the Value-Functions of Primary Care: Provider Level Continuity Measure,ABFM8,QCDR measure,Structure,N,--,--,--,--,--,--,--,--,--,--,--,No
-Intra-operative anesthesia safety,ABG1,QCDR measure,Outcome,Y,0.2,100,99.98 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
 Planned use of difficult airway equipment,ABG16,QCDR measure,Process,Y,25.7,71.6,56.01 - 61.14,61.15 - 72.26,72.27 - 77.96,77.97 - 82.24,82.25 - 89.40,89.41 - 94.18,94.19 - 99.83,>= 99.84,No,No
-Pre-operative OSA assessment,ABG21,QCDR measure,Process,Y,34.1,67.1,29.34 - 48.18,48.19 - 62.50,62.51 - 84.86,84.87 - 90.41,90.42 - 95.13,95.14 - 99.76,99.77 - 99.99,100,No,No
-Pre-Operative Screening for GERD,ABG28,QCDR measure,Process,Y,32.2,58.2,32.09 - 44.87,44.88 - 50.15,50.16 - 52.83,52.84 - 58.27,58.28 - 87.25,87.26 - 98.87,98.88 - 99.99,100,No,No
-Pre-Operative Screening for Glaucoma,ABG29,QCDR measure,Process,Y,32.3,77.8,44.29 - 67.22,67.23 - 95.02,95.03 - 99.50,99.51 - 99.99,--,--,--,100,Yes,No
 Pre-Operative Screening for PONV Risk,ABG30,QCDR measure,Process,Y,24.9,86,76.64 - 93.46,93.47 - 97.59,97.60 - 99.05,99.06 - 99.66,99.67 - 99.99,--,--,100,Yes,No
-Pre-Operative Screening for Excessive Alcohol and Recreational Drug Use,ABG31,QCDR measure,Process,Y,25.5,87.5,89.72 - 98.87,98.88 - 99.66,99.67 - 99.97,99.98 - 99.99,--,--,--,100,Yes,No
 Pain Related Quality of Life Interference,ABG32,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Lower Body Functional Impairment (LBI),ABG33,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 Mood Assessment Screening and treatment ,ABG34,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 Preoperative Assessment of Frailty,ABG35,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Corneal Abrasion,ABG36,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 Immediate Adult Post-Operative Pain Management,ABG7,QCDR measure,Outcome,Y,3.5,98.4,97.85 - 98.62,98.63 - 99.28,99.29 - 99.82,99.83 - 99.99,--,--,--,100,Yes,No
-ACCPin3 Heart Failure: Patient Self Care Education,ACCPin3,QCDR measure,Process,Y,0,100,--,--,--,--,--,--,--,100,Yes,No
 Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older,ACEP19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,ACEP20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Coagulation Studies in Patients Presenting with Chest Pain with No Coagulopathy or Bleeding,ACEP21,QCDR measure,Process,Y,17.5,15.5,24.61 - 19.33,19.32 - 15.93,15.92 - 9.06,9.05 - 5.75,5.74 - 3.78,3.77 - 0.01,--,0,No,No
@@ -476,12 +465,7 @@ Report Turnaround Time: Mammography,ACRad25,QCDR measure,Outcome,N,--,--,--,--,-
 Appropriate venous access for hemodialysis,ACRad26,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Rate of early peristomal infection following fluoroscopically guided gastrostomy tube placement,ACRad28,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 Rate of percutaneous nephrostomy tube replacement within 30 days secondary to dislodgement,ACRad29,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
-Screening Mammography Cancer Detection Rate (CDR),ACRad3,QCDR measure,Outcome,Y,0.3,0.4,0.18 - 0.23,0.24 - 0.30,0.31 - 0.42,0.43 - 0.48,0.49 - 0.53,0.54 - 0.61,0.62 - 0.79,>= 0.80,No,No
 Rate of Inadequate Percutaneous Image-Guided Biopsy,ACRad30,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
-Percent of CT Abdomen-pelvis exams with contrast (single phase scan) for which Dose Length Product is at or below the size-specific diagnostic reference level.,ACRad31,QCDR measure,Outcome,Y,0,100,--,--,--,--,--,--,--,100,Yes,No
-Percent of CT Chest exams without contrast (single phase scan) for which Dose Length Product is at or below the size-specific diagnostic reference level.,ACRad32,QCDR measure,Outcome,Y,0,100,--,--,--,--,--,--,--,100,Yes,No
-Percent of CT Head/Brain exams without contrast (single phase scan) for which Dose Length Product is at or below the size-specific diagnostic reference level,ACRad33,QCDR measure,Outcome,Y,0,100,--,--,--,--,--,--,--,100,Yes,No
-Screening Mammography Positive Predictive Value 2 (PPV2 - Biopsy Recommended),ACRad6,QCDR measure,Outcome,Y,8.6,27.3,20.00 - 21.61,21.62 - 23.07,23.08 - 26.08,26.09 - 29.89,29.90 - 31.99,32.00 - 35.58,35.59 - 37.15,>= 37.16,No,No
 Screening Mammography Node Negativity Rate,ACRad7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 Screening Mammography Minimal Cancer Rate,ACRad8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 Preoperative Composite,ACS15,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
@@ -516,8 +500,6 @@ Coronary Artery Bypass Graft (CABG): Stroke – Inverse Measure,AQI41,QCDR measu
 Coronary Artery Bypass Graft (CABG): Post-Operative Renal Failure – Inverse Measure,AQI42,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 Patient-Reported Experience with Anesthesia ,AQI48,QCDR measure,Patient Reported Outcome,Y,29.9,78.8,55.23 - 60.02,60.03 - 94.51,94.52 - 99.08,99.09 - 99.98,99.99 - 99.99,--,--,100,Yes,No
 Adherence to Blood Conservation Guidelines for Cardiac Operations using Cardiopulmonary Bypass (CPB) – Composite,AQI49,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
-Application of Lung-Protective Ventilation during General Anesthesia,AQI50,QCDR measure,Intermediate Outcome,Y,5.9,98.4,99.14 - 99.45,99.46 - 99.82,99.83 - 99.99,--,--,--,--,100,Yes,No
-Assessment of Patients for Obstructive Sleep Apnea,AQI51,QCDR measure,Process,Y,31.1,83.5,79.31 - 92.61,92.62 - 96.39,96.40 - 99.34,99.35 - 99.79,99.80 - 99.94,99.95 - 99.99,--,100,Yes,No
 Documentation of Anticoagulant and Antiplatelet Medications when Performing Neuraxial Anesthesia/Analgesia or Interventional Pain Procedures,AQI53,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Use of Pencil-Point Needle for Spinal Anesthesia,AQI54,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Team-Based Implementation of a Care-and-Communication Bundle for ICU Patients,AQI55,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
@@ -546,7 +528,6 @@ Appropriate Testing for Vasectomy Patients,AQUA27,QCDR measure,Process,N,--,--,-
 Prostate Cancer: Patient Report of Urinary function after treatment,AQUA29,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 Cryptorchidism: Inappropriate use of scrotal/groin ultrasound on boys,AQUA3,QCDR measure,Cost/Resource Use,N,--,--,--,--,--,--,--,--,--,--,--,No
 Prostate Cancer: Patient Report of Sexual function after treatment,AQUA30,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
-Hospital admissions/complications within 30 days of TRUS Biopsy,AQUA8,QCDR measure,Outcome,Y,3.5,3.2,5.13 - 4.23,4.22 - 3.22,3.21 - 2.64,2.63 - 1.02,1.01 - 0.70,0.69 - 0.01,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
 Risk Standardized Mortality Rate within 30 days following Trauma Operation,ARCO10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 Head CT or MRI Scan Results for Acute Ischemic Stroke or Hemorrhagic Stroke Patients who Received Head CT or MRI Scan Interpretation within 45 minutes of ED Arrival,ARCO11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 STK-01: Venous Thromboembolism (VTE) Prophylaxis,ARCO12,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
@@ -558,12 +539,10 @@ Heart Failure: Use of Aldosterone Antagonists and Diuretics for Symptom Control,
 Promoting self-care for prevention and management of chronic conditions,ARCO19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 "Percentage of patients using self-monitoring with mobile technology or eHealth solutions to manage their diabetes, hypertension, sodium intake, nutritional status, physical activity, tobacco use, alcohol use, and sedentary behaviors",ARCO20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Antipsychotic Use in Persons with Dementia,ARCO3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
-Surgeon assessment for hereditary cause of breast cancer,ASBS1,QCDR measure,Process,Y,2.2,99.3,99.16 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
 Management of the axilla in breast cancer patients undergoing breast conserving surgery with a positive sentinel node biopsy,ASBS10,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Return to the operating room for re-excision of previous microscopically negative margins in invasive breast cancer patients undergoing breast conserving therapy ,ASBS12,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 Sentinel Node Biopsy for Patients with Ductal Carcinoma in Situ Alone ,ASBS13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Recommendation of Neoadjuvant Chemotherapy for Her2Neu positive invasive breast cancers that are >2.0cm in size and/or have needle biopsy proven axillary metastases. ,ASBS14,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
-Unplanned 30 day re-operation after mastectomy,ASBS7,QCDR measure,Outcome,Y,2.4,98.6,98.15 - 98.46,98.47 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
 Cardiac Stress Nuclear Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low Risk Surgery Patients,ASNC1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Imaging Protocols for SPECT and PET MPI studies - Use of stress only protocol,ASNC19,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 Cardiac Stress Nuclear Imaging Not Meeting Appropriate Use Criteria: Routine Testing After Percutaneous Coronary Intervention (PCI),ASNC2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
@@ -762,7 +741,6 @@ Functional Improvement in low back rehabilitation of non-surgical patients with 
 Functional Improvement in knee rehabilitation of patients with knee injury measured via their validated Knee Outcome Survey (KOS) score.,IROMS2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 "Functional Improvement in arm, shoulder, and hand rehabilitation in surgical patients with musculotendinous injury measured via the validated Disability of Arm Shoulder and Hand (DASH) score.",IROMS8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 Functional Improvement in neck pain/injury patients rehabilitation measured via the validated Neck Disability Index (NDI).,IROMS9,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
-M2S 1: Procedures with statin and antiplatelet agents prescribed at discharge,M2S1,QCDR measure,Process,Y,12.3,79.4,70.25 - 77.54,77.55 - 80.46,80.47 - 81.25,81.26 - 81.61,81.62 - 84.56,84.57 - 89.82,89.83 - 92.81,>= 92.82,No,No
 M2S 10: Survival at least 9 months after elective repair of small thoracic aortic aneurysms ,M2S10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 M2S 11: Imaging-based maximum aortic diameter assessed at least 9 months following Endovascular AAA Repair procedures,M2S11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 "M2S 12: Survival at least 9 months after elective repair Endovascular AAA Repair of small abdominal aortic aneurysms
@@ -791,7 +769,6 @@ Anxiety Response at 6-months,MBHR2,QCDR measure,Patient Reported Outcome,N,--,--
 Risk standardized rate of patients who experienced a postoperative escalation in care event following a primary Laparoscopic Roux-en-Y Gastric Bypass or  Laparoscopic Sleeve Gastrectomy operation,MBSAQIP10,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
 Risk standardized rate of patients who experienced a pulmonary complication following a primary Laparoscopic Roux-en-Y Gastric Bypass or  Laparoscopic Sleeve Gastrectomy,MBSAQIP11,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
 Risk standardized rate of patients who experienced a postoperative complication following a primary Laparoscopic Roux-en-Y Gastric Bypass or  Laparoscopic Sleeve Gastrectomy operation,MBSAQIP12,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
-"Risk standardized rate of patients who experienced postoperative nausea, vomiting or fluid/electrolyte/nutritional depletion following a primary Laparoscopic Roux-en-Y Gastric Bypass or  Laparoscopic Sleeve Gastrectomy operation",MBSAQIP7,QCDR measure,Outcome,Y,1.4,1.2,2.13 - 1.85,1.84 - 1.29,1.28 - 0.40,0.39 - 0.01,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
 Risk standardized rate of patients who experienced an extended length of stay (> 3 days) following a primary Laparoscopic Roux-en-Y Gastric Bypass or  Laparoscopic Sleeve Gastrectomy operation,MBSAQIP8,QCDR measure,Outcome,Y,1.4,0.5,--,--,--,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
 Use of a “PEG Test” to Manage Patients Receiving Opioids,MEDNAX52,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 MEX1: Heel Pain Treatment Outcomes for Adults,MEX1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
@@ -836,7 +813,6 @@ Percent same-day ambulation,MSSIC6,QCDR measure,Process,N,--,--,--,--,--,--,--,-
 Rate of use of Pre-op skin preparation/wash,MSSIC7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Percent of patients achieving MCID for back or neck pain,MSSIC8,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 Percent of patients achieving MCID for leg or arm pain,MSSIC9,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
-Prostate Biopsy Antibiotic Compliance,MUSIC1,QCDR measure,Process,Y,0.4,99.8,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
 Prostate Cancer: Confirmation Testing in low risk AS eligible patients,MUSIC10,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Prostate Cancer: Follow-Up Testing for patients on active surveillance for at least 30 months,MUSIC11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Prostate Cancer: Avoidance of Overuse of CT Scan for Staging Low Risk Prostate Cancer Patients,MUSIC3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
@@ -963,8 +939,6 @@ Use of Multiple Concurrent Antipsychotics in Children and Adolescents (APC),PP7,
 Chronic Kidney Disease (CKD): eGFR Monitoring,PPRNET13,QCDR measure,Process,Y,14.6,71.4,62.50 - 64.85,64.86 - 70.58,70.59 - 73.32,73.33 - 76.04,76.05 - 80.18,80.19 - 84.23,84.24 - 89.05,>= 89.06,No,No
 Chronic Kidney Disease (CKD): Hemoglobin Monitoring,PPRNET14,QCDR measure,Process,Y,12.4,82.7,72.62 - 77.21,77.22 - 82.85,82.86 - 87.29,87.30 - 89.86,89.87 - 90.53,90.54 - 93.09,93.10 - 94.58,>= 94.59,No,No
 Appropriate Treatment for Adults with Upper Respiratory Infection,PPRNET24,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
-"NSAID or Cox 2 Inhibitor Use in Patients with Heart Failure (HF), Hypertension (HTN), or Chronic Kidney Disease (CKD)",PPRNET28,QCDR measure,Process,Y,7.1,84.4,80.00 - 81.80,81.81 - 82.91,82.92 - 84.83,84.84 - 85.94,85.95 - 86.76,86.77 - 91.40,91.41 - 93.07,>= 93.08,No,No
-Monitoring Serum Creatinine,PPRNET29,QCDR measure,Process,Y,22.1,80.3,73.35 - 78.88,78.89 - 84.40,84.41 - 86.29,86.30 - 88.09,88.10 - 90.88,90.89 - 93.85,93.86 - 96.29,>= 96.30,No,No
 Screening for Type 2 Diabetes,PPRNET31,QCDR measure,Process,Y,18.8,83.4,82.72 - 84.17,84.18 - 85.53,85.54 - 87.24,87.25 - 90.70,90.71 - 92.15,92.16 - 93.92,93.93 - 96.19,>= 96.20,No,No
 Screening for albuminuria in patients at risk for CKD (DM and/or HTN),PPRNET32,QCDR measure,Process,Y,26.8,46.9,18.26 - 26.78,26.79 - 47.26,47.27 - 56.41,56.42 - 61.65,61.66 - 66.11,66.12 - 72.25,72.26 - 75.06,>= 75.07,No,No
 Avoiding Use of CNS Depressants in Patients on Long-Term Opioids,PPRNET33,QCDR measure,Process,Y,12,60.7,50.51 - 54.54,54.55 - 55.58,55.59 - 57.79,57.80 - 60.14,60.15 - 65.24,65.25 - 72.38,72.39 - 81.62,>= 81.63,No,No

--- a/staging/2019/benchmarks/benchmarks.csv
+++ b/staging/2019/benchmarks/benchmarks.csv
@@ -1,872 +1,1077 @@
-Table 2: Updated MIPS Benchmark Results Using DY2016 and PY2018 Logic,,,,,,,,,,,,,
-,,,,,,,,,,,,,
-Measure_Name,Measure_ID,Submission_Method,Measure_Type,Benchmark,Decile_3,Decile_4,Decile_5,Decile_6,Decile_7,Decile_8,Decile_9,Decile_10,TOPPED_OUT
-Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,CMS Web Interface,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--
-Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,Claims,Intermediate Outcome,Y,44.44 - 29.04,29.03 - 19.62,19.61 - 14.72,14.71 - 11.12,11.11 - 8.34,8.33 - 5.57,5.56 - 2.79,<= 2.78,No
-Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,EHR,Intermediate Outcome,Y,77.14 - 60.66,60.65 - 48.32,48.31 - 38.73,38.72 - 31.52,31.51 - 25.72,25.71 - 20.46,20.45 - 14.64,<= 14.63,No
-Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,Registry/QCDR,Intermediate Outcome,Y,68.34 - 50.66,50.65 - 37.51,37.50 - 28.70,28.69 - 20.01,20.00 - 13.56,13.55 - 9.01,9.00 - 2.69,<= 2.68,No
-Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy for Left Ventricular Systolic Dysfunction (LVSD),5,EHR,Process,Y,74.10 - 78.56,78.57 - 82.13,82.14 - 85.18,85.19 - 87.89,87.90 - 90.83,90.84 - 93.66,93.67 - 97.52,>= 97.53,No
-Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy for Left Ventricular Systolic Dysfunction (LVSD),5,Registry/QCDR,Process,Y,93.33 - 96.96,96.97 - 98.40,98.41 - 99.99,--,--,--,--,100.00,Yes
-Coronary Artery Disease (CAD): Antiplatelet Therapy,6,Registry/QCDR,Process,Y,84.18 - 88.03,88.04 - 90.69,90.70 - 92.89,92.90 - 95.11,95.12 - 97.10,97.11 - 99.99,--,100.00,No
-Coronary Artery Disease (CAD): Beta-Blocker Therapy-Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF <40%),7,EHR,Process,Y,76.92 - 80.85,80.86 - 83.32,83.33 - 85.60,85.61 - 87.40,87.41 - 89.89,89.90 - 91.99,92.00 - 94.92,>= 94.93,No
-Coronary Artery Disease (CAD): Beta-Blocker Therapy-Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF <40%),7,Registry/QCDR,Process,Y,96.17 - 98.11,98.12 - 99.76,99.77 - 99.99,--,--,--,--,100.00,Yes
-Heart Failure (HF): Beta-Blocker Therapy for Left Ventricular Systolic Dysfunction (LVSD),8,EHR,Process,Y,80.77 - 85.99,86.00 - 89.39,89.40 - 91.29,91.30 - 93.13,93.14 - 94.86,94.87 - 96.42,96.43 - 99.99,100.00,No
-Heart Failure (HF): Beta-Blocker Therapy for Left Ventricular Systolic Dysfunction (LVSD),8,Registry/QCDR,Process,Y,95.45 - 98.05,98.06 - 99.28,99.29 - 99.99,--,--,--,--,100.00,Yes
-Anti-Depressant Medication Management,9,EHR,Process,Y,16.67 - 31.06,31.07 - 42.18,42.19 - 53.15,53.16 - 71.73,71.74 - 82.78,82.79 - 88.88,88.89 - 94.43,>= 94.44,No
-Anti-Depressant Medication Management,9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation,12,Claims,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation,12,EHR,Process,Y,79.84 - 86.72,86.73 - 90.70,90.71 - 93.94,93.95 - 96.37,96.38 - 98.05,98.06 - 99.11,99.12 - 99.99,100.00,No
-Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation,12,Registry/QCDR,Process,Y,96.49 - 99.19,99.20 - 99.99,--,--,--,--,--,100.00,Yes
-Age-Related Macular Degeneration (AMD): Dilated Macular Examination,14,Claims,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Age-Related Macular Degeneration (AMD): Dilated Macular Examination,14,Registry/QCDR,Process,Y,76.54 - 89.80,89.81 - 96.53,96.54 - 99.70,99.71 - 99.99,--,--,--,100.00,Yes
-Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care,19,Claims,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care,19,EHR,Process,Y,33.94 - 47.64,47.65 - 57.94,57.95 - 67.06,67.07 - 75.45,75.46 - 82.48,82.49 - 90.02,90.03 - 96.02,>= 96.03,No
-Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care,19,Registry/QCDR,Process,Y,70.29 - 84.41,84.42 - 92.72,92.73 - 98.56,98.57 - 99.99,--,--,--,100.00,Yes
-Perioperative Care: Selection of Prophylactic Antibiotic - First OR Second Generation Cephalosporin,21,Claims,Process,Y,99.17 - 99.99,--,--,--,--,--,--,100.00,Yes
-Perioperative Care: Selection of Prophylactic Antibiotic - First OR Second Generation Cephalosporin,21,Registry/QCDR,Process,Y,98.72 - 99.99,--,--,--,--,--,--,100.00,Yes
-Perioperative Care: Venous Thromboembolism (VTE) Prophylaxis (When Indicated in ALL Patients),23,Claims,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Perioperative Care: Venous Thromboembolism (VTE) Prophylaxis (When Indicated in ALL Patients),23,Registry/QCDR,Process,Y,98.72 - 99.99,--,--,--,--,--,--,100.00,Yes
-Communication with the Physician or Other Clinician Managing On-going Care Post-Fracture for Men and Women Aged 50 Years and Older,24,Claims,Process,Y,32.35 - 63.63,63.64 - 92.30,92.31 - 96.20,96.21 - 97.61,97.62 - 99.99,--,--,100.00,Yes
-Communication with the Physician or Other Clinician Managing On-going Care Post-Fracture for Men and Women Aged 50 Years and Older,24,Registry/QCDR,Process,Y,26.32 - 47.36,47.37 - 55.31,55.32 - 62.78,62.79 - 74.06,74.07 - 80.55,80.56 - 99.99,--,100.00,No
-Screening for Osteoporosis for Women Aged 65-85 Years of Age,39,Claims,Process,Y,32.81 - 42.40,42.41 - 49.01,49.02 - 55.90,55.91 - 62.54,62.55 - 70.70,70.71 - 82.90,82.91 - 95.49,>= 95.50,No
-Screening for Osteoporosis for Women Aged 65-85 Years of Age,39,Registry/QCDR,Process,Y,11.18 - 22.41,22.42 - 34.61,34.62 - 45.20,45.21 - 58.04,58.05 - 67.97,67.98 - 78.68,78.69 - 88.33,>= 88.34,No
-Coronary Artery Bypass Graft (CABG): Preoperative Beta-Blocker in Patients with Isolated CABG Surgery,44,Registry/QCDR,Process,Y,91.43 - 96.04,96.05 - 97.55,97.56 - 99.99,--,--,--,--,100.00,Yes
-Medication Reconciliation Post-Discharge,46,CMS Web Interface,Process,N,--,--,--,--,--,--,--,--,--
-Medication Reconciliation Post-Discharge,46,Claims,Process,Y,95.74 - 98.40,98.41 - 99.99,--,--,--,--,--,100.00,Yes
-Medication Reconciliation Post-Discharge,46,Registry/QCDR,Process,Y,94.24 - 97.62,97.63 - 99.92,99.93 - 99.99,--,--,--,--,100.00,Yes
-Care Plan,47,Claims,Process,Y,50.33 - 82.63,82.64 - 92.88,92.89 - 97.45,97.46 - 99.29,99.30 - 99.99,--,--,100.00,Yes
-Care Plan,47,Registry/QCDR,Process,Y,24.26 - 44.98,44.99 - 65.68,65.69 - 82.12,82.13 - 91.89,91.90 - 97.29,97.30 - 99.71,99.72 - 99.99,100.00,No
-Urinary Incontinence: Assessment of Presence or Absence of Urinary Incontinence in Women Aged 65 Years and Older,48,Claims,Process,Y,3.88 - 13.85,13.86 - 72.40,72.41 - 96.68,96.69 - 99.99,--,--,--,100.00,Yes
-Urinary Incontinence: Assessment of Presence or Absence of Urinary Incontinence in Women Aged 65 Years and Older,48,Registry/QCDR,Process,Y,12.20 - 31.74,31.75 - 51.71,51.72 - 70.44,70.45 - 84.20,84.21 - 95.10,95.11 - 99.50,99.51 - 99.99,100.00,No
-Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Years and Older,50,Claims,Process,Y,97.30 - 98.87,98.88 - 99.99,--,--,--,--,--,100.00,Yes
-Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Years and Older,50,Registry/QCDR,Process,Y,47.22 - 59.99,60.00 - 68.98,68.99 - 75.63,75.64 - 85.49,85.50 - 92.58,92.59 - 99.65,99.66 - 99.99,100.00,No
-Chronic Obstructive Pulmonary Disease (COPD): Spirometry Evaluation,51,Claims,Process,Y,38.10 - 77.26,77.27 - 92.44,92.45 - 98.75,98.76 - 99.99,--,--,--,100.00,Yes
-Chronic Obstructive Pulmonary Disease (COPD): Spirometry Evaluation,51,Registry/QCDR,Process,Y,25.00 - 45.12,45.13 - 60.42,60.43 - 75.69,75.70 - 86.20,86.21 - 93.89,93.90 - 99.35,99.36 - 99.99,100.00,No
-Chronic Obstructive Pulmonary Disease (COPD): Long-Acting Inhaled Bronchodilator Therapy,52,Claims,Process,Y,90.14 - 98.14,98.15 - 99.99,--,--,--,--,--,100.00,Yes
-Chronic Obstructive Pulmonary Disease (COPD): Long-Acting Inhaled Bronchodilator Therapy,52,Registry/QCDR,Process,Y,90.16 - 95.21,95.22 - 96.48,96.49 - 98.85,98.86 - 99.99,--,--,--,100.00,Yes
-Appropriate Treatment for Children with Upper Respiratory Infection (URI),65,EHR,Process,Y,81.13 - 88.46,88.47 - 91.79,91.80 - 93.87,93.88 - 95.64,95.65 - 96.87,96.88 - 98.21,98.22 - 99.99,100.00,No
-Appropriate Treatment for Children with Upper Respiratory Infection (URI),65,Registry/QCDR,Process,Y,91.49 - 95.01,95.02 - 97.02,97.03 - 97.84,97.85 - 98.69,98.70 - 99.19,99.20 - 99.74,99.75 - 99.99,100.00,Yes
-Appropriate Testing for Children with Pharyngitis,66,EHR,Process,Y,36.35 - 59.83,59.84 - 72.41,72.42 - 78.67,78.68 - 83.48,83.49 - 87.64,87.65 - 91.52,91.53 - 94.58,>= 94.59,No
-Appropriate Testing for Children with Pharyngitis,66,Registry/QCDR,Process,Y,64.57 - 69.60,69.61 - 75.41,75.42 - 81.74,81.75 - 85.50,85.51 - 87.95,87.96 - 91.77,91.78 - 97.54,>= 97.55,No
-Hematology: Myelodysplastic Syndrome (MDS) and Acute Leukemias: Baseline Cytogenetic Testing Performed on Bone Marrow,67,Registry/QCDR,Process,Y,8.00 - 12.49,12.50 - 22.72,22.73 - 28.52,28.53 - 34.61,34.62 - 78.78,78.79 - 99.99,--,100.00,No
-Hematology: Myelodysplastic Syndrome (MDS): Documentation of Iron Stores in Patients Receiving Erythropoietin Therapy,68,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Hematology: Multiple Myeloma: Treatment with Bisphosphonates,69,Registry/QCDR,Process,Y,42.86 - 47.49,47.50 - 64.51,64.52 - 66.66,66.67 - 71.42,71.43 - 71.87,71.88 - 76.91,76.92 - 92.30,>= 92.31,No
-Hematology: Chronic Lymphocytic Leukemia (CLL): Baseline Flow Cytometry,70,Registry/QCDR,Process,Y,16.67 - 23.20,23.21 - 32.25,32.26 - 35.94,35.95 - 67.85,67.86 - 95.44,95.45 - 99.99,--,100.00,No
-Prevention of Central Venous Catheter (CVC) - Related Bloodstream Infections,76,Claims,Process,Y,95.24 - 98.60,98.61 - 99.99,--,--,--,--,--,100.00,Yes
-Prevention of Central Venous Catheter (CVC) - Related Bloodstream Infections,76,Registry/QCDR,Process,Y,95.66 - 99.08,99.09 - 99.99,--,--,--,--,--,100.00,Yes
-Acute Otitis Externa (AOE): Topical Therapy,91,Claims,Process,Y,43.36 - 86.60,86.61 - 93.21,93.22 - 99.65,99.66 - 99.99,--,--,--,100.00,Yes
-Acute Otitis Externa (AOE): Topical Therapy,91,Registry/QCDR,Process,Y,67.34 - 78.78,78.79 - 86.35,86.36 - 91.34,91.35 - 95.23,95.24 - 97.36,97.37 - 99.99,--,100.00,No
-Acute Otitis Externa (AOE): Systemic Antimicrobial Therapy - Avoidance of Inappropriate Use,93,Claims,Process,Y,89.12 - 93.50,93.51 - 96.35,96.36 - 97.82,97.83 - 99.92,99.93 - 99.99,--,--,100.00,Yes
-Acute Otitis Externa (AOE): Systemic Antimicrobial Therapy - Avoidance of Inappropriate Use,93,Registry/QCDR,Process,Y,63.16 - 77.35,77.36 - 83.96,83.97 - 89.65,89.66 - 93.32,93.33 - 96.14,96.15 - 99.99,--,100.00,No
-Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients,102,EHR,Process,Y,59.34 - 75.73,75.74 - 83.90,83.91 - 91.99,92.00 - 98.30,98.31 - 99.99,--,--,100.00,No
-Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients,102,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Prostate Cancer: Adjuvant Hormonal Therapy for High Risk or Very High Risk Prostate Cancer,104,Registry/QCDR,Process,Y,37.38 - 48.16,48.17 - 54.66,54.67 - 73.24,73.25 - 89.73,89.74 - 97.21,97.22 - 99.99,--,100.00,No
-Adult Major Depressive Disorder (MDD): Suicide Risk Assessment,107,EHR,Process,Y,1.51 - 3.56,3.57 - 8.10,8.11 - 17.48,17.49 - 30.28,30.29 - 54.72,54.73 - 77.56,77.57 - 96.66,>= 96.67,No
-Adult Major Depressive Disorder (MDD): Suicide Risk Assessment,107,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Osteoarthritis (OA): Function and Pain Assessment,109,Claims,Process,Y,87.28 - 95.71,95.72 - 98.71,98.72 - 99.88,99.89 - 99.99,--,--,--,100.00,Yes
-Osteoarthritis (OA): Function and Pain Assessment,109,Registry/QCDR,Process,Y,34.62 - 63.00,63.01 - 86.63,86.64 - 94.37,94.38 - 99.99,--,--,--,100.00,No
-Preventive Care and Screening: Influenza Immunization,110,CMS Web Interface,Process,N,--,--,--,--,--,--,--,--,--
-Preventive Care and Screening: Influenza Immunization,110,Claims,Process,Y,29.52 - 41.39,41.40 - 56.25,56.26 - 71.18,71.19 - 82.87,82.88 - 94.15,94.16 - 99.42,99.43 - 99.99,100.00,No
-Preventive Care and Screening: Influenza Immunization,110,EHR,Process,Y,15.60 - 23.82,23.83 - 31.45,31.46 - 38.85,38.86 - 46.95,46.96 - 56.17,56.18 - 67.92,67.93 - 85.19,>= 85.20,No
-Preventive Care and Screening: Influenza Immunization,110,Registry/QCDR,Process,Y,29.77 - 41.42,41.43 - 53.84,53.85 - 66.02,66.03 - 76.93,76.94 - 87.81,87.82 - 96.42,96.43 - 99.99,100.00,No
-Pneumococcal Vaccination Status for Older Adults,111,CMS Web Interface,Process,N,--,--,--,--,--,--,--,--,--
-Pneumococcal Vaccination Status for Older Adults,111,Claims,Process,Y,49.75 - 61.10,61.11 - 70.10,70.11 - 77.30,77.31 - 82.94,82.95 - 89.42,89.43 - 95.68,95.69 - 99.99,100.00,No
-Pneumococcal Vaccination Status for Older Adults,111,EHR,Process,Y,19.01 - 31.16,31.17 - 42.78,42.79 - 53.44,53.45 - 62.88,62.89 - 71.85,71.86 - 80.48,80.49 - 90.47,>= 90.48,No
-Pneumococcal Vaccination Status for Older Adults,111,Registry/QCDR,Process,Y,30.19 - 44.52,44.53 - 55.55,55.56 - 63.63,63.64 - 70.42,70.43 - 76.37,76.38 - 83.76,83.77 - 95.44,>= 95.45,No
-Breast Cancer Screening,112,CMS Web Interface,Process,N,--,--,--,--,--,--,--,--,--
-Breast Cancer Screening,112,Claims,Process,Y,44.44 - 51.99,52.00 - 58.43,58.44 - 64.28,64.29 - 70.96,70.97 - 79.83,79.84 - 90.19,90.20 - 99.99,100.00,No
-Breast Cancer Screening,112,EHR,Process,Y,22.28 - 32.83,32.84 - 42.41,42.42 - 51.17,51.18 - 58.53,58.54 - 65.77,65.78 - 73.58,73.59 - 82.41,>= 82.42,No
-Breast Cancer Screening,112,Registry/QCDR,Process,Y,35.99 - 48.25,48.26 - 57.57,57.58 - 67.38,67.39 - 75.24,75.25 - 85.30,85.31 - 93.44,93.45 - 99.99,100.00,No
-Colorectal Cancer Screening,113,CMS Web Interface,Process,N,--,--,--,--,--,--,--,--,--
-Colorectal Cancer Screening,113,Claims,Process,Y,36.43 - 50.93,50.94 - 62.43,62.44 - 71.18,71.19 - 79.99,80.00 - 88.60,88.61 - 97.72,97.73 - 99.99,100.00,No
-Colorectal Cancer Screening,113,EHR,Process,Y,13.58 - 24.09,24.10 - 34.08,34.09 - 44.52,44.53 - 54.89,54.90 - 64.15,64.16 - 73.47,73.48 - 83.52,>= 83.53,No
-Colorectal Cancer Screening,113,Registry/QCDR,Process,Y,35.81 - 49.70,49.71 - 60.90,60.91 - 70.95,70.96 - 80.76,80.77 - 90.40,90.41 - 97.06,97.07 - 99.99,100.00,No
-Avoidance of Antibiotic Treatment in Adults With Acute Bronchitis,116,Registry/QCDR,Process,Y,44.27 - 57.07,57.08 - 72.02,72.03 - 83.77,83.78 - 90.98,90.99 - 95.56,95.57 - 97.54,97.55 - 99.99,100.00,No
-Diabetes: Eye Exam,117,CMS Web Interface,Process,N,--,--,--,--,--,--,--,--,--
-Diabetes: Eye Exam,117,Claims,Process,Y,72.00 - 96.87,96.88 - 99.99,--,--,--,--,--,100.00,Yes
-Diabetes: Eye Exam,117,EHR,Process,Y,20.50 - 31.81,31.82 - 45.20,45.21 - 65.30,65.31 - 88.90,88.91 - 95.62,95.63 - 98.26,98.27 - 99.73,>= 99.74,No
-Diabetes: Eye Exam,117,Registry/QCDR,Process,Y,77.42 - 89.99,90.00 - 95.81,95.82 - 98.48,98.49 - 99.99,--,--,--,100.00,Yes
-Coronary Artery Disease (CAD): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy - Diabetes or Left Ventricular Systolic Dysfunction (LVEF < 40%),118,Registry/QCDR,Process,Y,76.00 - 78.56,78.57 - 81.07,81.08 - 83.90,83.91 - 86.35,86.36 - 88.72,88.73 - 92.25,92.26 - 98.17,>= 98.18,No
-Diabetes: Medical Attention for Nephropathy,119,EHR,Process,Y,67.90 - 74.99,75.00 - 80.13,80.14 - 84.32,84.33 - 87.85,87.86 - 91.21,91.22 - 94.68,94.69 - 98.41,>= 98.42,No
-Diabetes: Medical Attention for Nephropathy,119,Registry/QCDR,Process,Y,74.38 - 82.85,82.86 - 87.70,87.71 - 91.93,91.94 - 97.23,97.24 - 99.99,--,--,100.00,No
-"Diabetes Mellitus: Diabetic Foot and Ankle Care, Peripheral Neuropathy - Neurological Evaluation",126,Registry/QCDR,Process,Y,66.15 - 85.22,85.23 - 96.42,96.43 - 99.99,--,--,--,--,100.00,Yes
-"Diabetes Mellitus: Diabetic Foot and Ankle Care, Ulcer Prevention - Evaluation of Footwear",127,Registry/QCDR,Process,Y,70.38 - 93.03,93.04 - 99.46,99.47 - 99.99,--,--,--,--,100.00,Yes
-Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,CMS Web Interface,Process,N,--,--,--,--,--,--,--,--,--
-Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,Claims,Process,Y,37.50 - 47.74,47.75 - 74.41,74.42 - 95.17,95.18 - 99.25,99.26 - 99.99,--,--,100.00,Yes
-Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,EHR,Process,Y,21.15 - 24.57,24.58 - 28.48,28.49 - 34.20,34.21 - 43.90,43.91 - 60.50,60.51 - 78.42,78.43 - 93.38,>= 93.39,No
-Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,Registry/QCDR,Process,Y,34.52 - 54.25,54.26 - 74.92,74.93 - 90.60,90.61 - 97.55,97.56 - 99.86,99.87 - 99.99,--,100.00,No
-Documentation of Current Medications in the Medical Record,130,Claims,Process,Y,97.95 - 99.51,99.52 - 99.91,99.92 - 99.99,--,--,--,--,100.00,Yes
-Documentation of Current Medications in the Medical Record,130,EHR,Process,Y,87.63 - 93.54,93.55 - 96.32,96.33 - 98.01,98.02 - 99.00,99.01 - 99.58,99.59 - 99.88,99.89 - 99.99,100.00,Yes
-Documentation of Current Medications in the Medical Record,130,Registry/QCDR,Process,Y,68.02 - 90.27,90.28 - 97.21,97.22 - 99.50,99.51 - 99.99,--,--,--,100.00,Yes
-Pain Assessment and Follow-Up,131,Claims,Process,Y,80.87 - 96.97,96.98 - 99.63,99.64 - 99.99,--,--,--,--,100.00,Yes
-Pain Assessment and Follow-Up,131,Registry/QCDR,Process,Y,15.61 - 39.99,40.00 - 62.80,62.81 - 84.06,84.07 - 95.25,95.26 - 99.54,99.55 - 99.99,--,100.00,No
-Preventive Care and Screening: Screening for Clinical Depression and Follow-Up Plan,134,CMS Web Interface,Process,N,--,--,--,--,--,--,--,--,--
-Preventive Care and Screening: Screening for Clinical Depression and Follow-Up Plan,134,Claims,Process,Y,12.90 - 53.55,53.56 - 80.07,80.08 - 96.83,96.84 - 99.99,--,--,--,100.00,Yes
-Preventive Care and Screening: Screening for Clinical Depression and Follow-Up Plan,134,EHR,Process,Y,4.88 - 10.17,10.18 - 17.94,17.95 - 28.56,28.57 - 42.54,42.55 - 57.06,57.07 - 73.46,73.47 - 87.75,>= 87.76,No
-Preventive Care and Screening: Screening for Clinical Depression and Follow-Up Plan,134,Registry/QCDR,Process,Y,17.11 - 45.64,45.65 - 74.06,74.07 - 90.44,90.45 - 98.49,98.50 - 99.99,--,--,100.00,No
-Melanoma: Continuity of Care - Recall System,137,Registry/QCDR,Structure,Y,83.84 - 94.33,94.34 - 98.79,98.80 - 99.99,--,--,--,--,100.00,No
-Melanoma: Coordination of Care,138,Registry/QCDR,Process,Y,49.44 - 63.63,63.64 - 78.25,78.26 - 92.58,92.59 - 99.99,--,--,--,100.00,No
-Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care,141,Claims,Outcome,Y,--,--,--,--,--,--,--,100.00,Yes
-Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care,141,Registry/QCDR,Outcome,Y,73.85 - 87.49,87.50 - 96.29,96.30 - 99.30,99.31 - 99.99,--,--,--,100.00,No
-Oncology: Medical and Radiation - Pain Intensity Quantified,143,EHR,Process,Y,77.24 - 87.90,87.91 - 94.92,94.93 - 97.29,97.30 - 98.34,98.35 - 99.45,99.46 - 99.99,--,100.00,Yes
-Oncology: Medical and Radiation - Pain Intensity Quantified,143,Registry/QCDR,Process,Y,90.26 - 95.38,95.39 - 97.11,97.12 - 98.54,98.55 - 99.23,99.24 - 99.99,--,--,100.00,Yes
-Radiology: Exposure Dose or Time Reported for Procedures Using Fluoroscopy,145,Claims,Process,Y,66.41 - 82.92,82.93 - 90.90,90.91 - 95.17,95.18 - 97.39,97.40 - 99.06,99.07 - 99.99,--,100.00,Yes
-Radiology: Exposure Dose or Time Reported for Procedures Using Fluoroscopy,145,Registry/QCDR,Process,Y,73.10 - 88.03,88.04 - 94.91,94.92 - 98.15,98.16 - 99.53,99.54 - 99.99,--,--,100.00,Yes
-"Radiology: Inappropriate Use of ""Probably Benign"" Assessment Category in Screening Mammograms",146,Claims,Process,Y,0.23 - 0.01,--,--,--,--,--,--,0.00,Yes
-"Radiology: Inappropriate Use of ""Probably Benign"" Assessment Category in Screening Mammograms",146,Registry/QCDR,Process,Y,0.24 - 0.12,0.11 - 0.05,0.04 - 0.01,--,--,--,--,0.00,Yes
-Nuclear Medicine: Correlation with Existing Imaging Studies for All Patients Undergoing Bone Scintigraphy,147,Claims,Process,Y,76.47 - 87.17,87.18 - 94.05,94.06 - 97.00,97.01 - 99.99,--,--,--,100.00,Yes
-Nuclear Medicine: Correlation with Existing Imaging Studies for All Patients Undergoing Bone Scintigraphy,147,Registry/QCDR,Process,Y,93.04 - 97.96,97.97 - 99.99,--,--,--,--,--,100.00,Yes
-Falls: Risk Assessment,154,Claims,Process,Y,96.94 - 99.99,--,--,--,--,--,--,100.00,Yes
-Falls: Risk Assessment,154,Registry/QCDR,Process,Y,28.84 - 60.81,60.82 - 84.99,85.00 - 96.02,96.03 - 99.89,99.90 - 99.99,--,--,100.00,Yes
-Falls: Plan of Care,155,Claims,Process,Y,55.86 - 84.61,84.62 - 99.20,99.21 - 99.99,--,--,--,--,100.00,Yes
-Falls: Plan of Care,155,Registry/QCDR,Process,Y,67.86 - 86.78,86.79 - 94.99,95.00 - 98.21,98.22 - 99.99,--,--,--,100.00,Yes
-HIV/AIDS: Pneumocystis Jiroveci Pneumonia (PCP) Prophylaxis,160,EHR,Process,N,--,--,--,--,--,--,--,--,--
-HIV/AIDS: Pneumocystis Jiroveci Pneumonia (PCP) Prophylaxis,160,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Coronary Artery Bypass Graft (CABG): Prolonged Intubation,164,Registry/QCDR,Outcome,Y,11.09 - 9.10,9.09 - 7.70,7.69 - 6.83,6.82 - 5.70,5.69 - 4.41,4.40 - 3.04,3.03 - 1.53,<= 1.52,No
-Coronary Artery Bypass Graft (CABG): Deep Sternal Wound Infection Rate,165,Registry/QCDR,Outcome,Y,0.85 - 0.01,--,--,--,--,--,--,0.00,Yes
-Coronary Artery Bypass Graft (CABG): Stroke,166,Registry/QCDR,Outcome,Y,2.38 - 1.80,1.79 - 1.28,1.27 - 0.82,0.81 - 0.01,--,--,--,0.00,Yes
-Coronary Artery Bypass Graft (CABG): Postoperative Renal Failure,167,Registry/QCDR,Outcome,Y,3.45 - 2.71,2.70 - 2.14,2.13 - 1.86,1.85 - 1.31,1.30 - 0.89,0.88 - 0.01,--,0.00,Yes
-Coronary Artery Bypass Graft (CABG): Surgical Re-Exploration,168,Registry/QCDR,Outcome,Y,3.90 - 3.14,3.13 - 2.64,2.63 - 1.80,1.79 - 1.28,1.27 - 0.91,0.90 - 0.01,--,0.00,Yes
-Rheumatoid Arthritis (RA): Tuberculosis Screening,176,Registry/QCDR,Process,Y,32.00 - 48.14,48.15 - 55.99,56.00 - 68.99,69.00 - 80.71,80.72 - 99.99,--,--,100.00,No
-Rheumatoid Arthritis (RA): Periodic Assessment of Disease Activity,177,Registry/QCDR,Process,Y,53.85 - 74.99,75.00 - 88.56,88.57 - 96.59,96.60 - 99.99,--,--,--,100.00,Yes
-Rheumatoid Arthritis (RA): Functional Status Assessment,178,Registry/QCDR,Process,Y,67.71 - 81.43,81.44 - 91.10,91.11 - 96.26,96.27 - 99.99,--,--,--,100.00,Yes
-Rheumatoid Arthritis (RA): Assessment and Classification of Disease Prognosis,179,Registry/QCDR,Process,Y,44.53 - 67.98,67.99 - 87.79,87.80 - 95.44,95.45 - 99.99,--,--,--,100.00,Yes
-Rheumatoid Arthritis (RA): Glucocorticoid Management,180,Registry/QCDR,Process,Y,51.10 - 76.40,76.41 - 88.18,88.19 - 95.14,95.15 - 99.99,--,--,--,100.00,Yes
-Elder Maltreatment Screen and Follow-Up Plan,181,Claims,Process,Y,55.38 - 97.31,97.32 - 99.55,99.56 - 99.99,--,--,--,--,100.00,Yes
-Elder Maltreatment Screen and Follow-Up Plan,181,Registry/QCDR,Process,Y,50.65 - 66.03,66.04 - 77.77,77.78 - 89.28,89.29 - 96.78,96.79 - 99.99,--,--,100.00,No
-Functional Outcome Assessment,182,Claims,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Functional Outcome Assessment,182,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
+Table 2: Historical MIPS Quality Measure Benchmark Results; created using PY2017 data and PY2019 Eligibility Rules,,,,,,,,,,,,,,,,
+Measure_Name,Measure_ID,Collection_Type,Measure_Type,Benchmark,Standard_Deviation,Average,Decile_3,Decile_4,Decile_5,Decile_6,Decile_7,Decile_8,Decile_9,Decile_10,TOPPED_OUT,SevenPointCap
+Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,eCQM,Intermediate Outcome,Y,28.2,46.3,77.14 - 60.79,60.78 - 48.49,48.48 - 38.90,38.89 - 31.60,31.59 - 25.88,25.87 - 20.56,20.55 - 14.72,<= 14.71,No,No
+Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,Medicare Part B Claims,Intermediate Outcome,Y,24.5,24.6,44.44 - 29.04,29.03 - 19.52,19.51 - 14.72,14.71 - 11.12,11.11 - 8.34,8.33 - 5.57,5.56 - 2.79,<= 2.78,No,No
+Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,MIPS CQM,Intermediate Outcome,Y,30.1,36.5,68.31 - 50.63,50.62 - 37.51,37.50 - 28.70,28.69 - 20.01,20.00 - 13.60,13.59 - 9.03,9.02 - 2.71,<= 2.70,No,No
+Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy for Left Ventricular Systolic Dysfunction (LVSD),5,eCQM,Process,Y,13.8,82.8,74.19 - 78.56,78.57 - 82.13,82.14 - 85.18,85.19 - 87.92,87.93 - 90.90,90.91 - 93.74,93.75 - 97.72,>= 97.73,No,No
+Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy for Left Ventricular Systolic Dysfunction (LVSD),5,MIPS CQM,Process,Y,13.5,94.1,93.33 - 96.96,96.97 - 98.40,98.41 - 99.99,--,--,--,--,100,Yes,No
+Coronary Artery Disease (CAD): Antiplatelet Therapy,6,MIPS CQM,Process,Y,13.2,89.6,84.13 - 87.99,88.00 - 90.66,90.67 - 92.85,92.86 - 95.09,95.10 - 97.08,97.09 - 99.99,--,100,No,No
+Coronary Artery Disease (CAD): Beta-Blocker Therapy - Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF < 40%),7,eCQM,Process,Y,13.7,82.9,76.74 - 80.30,80.31 - 83.17,83.18 - 85.28,85.29 - 87.15,87.16 - 89.73,89.74 - 91.91,91.92 - 94.86,>= 94.87,No,No
+Coronary Artery Disease (CAD): Beta-Blocker Therapy - Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF < 40%),7,MIPS CQM,Process,Y,8.8,96.3,96.17 - 98.11,98.12 - 99.76,99.77 - 99.99,--,--,--,--,100,Yes,No
+Heart Failure (HF): Beta-Blocker Therapy for Left Ventricular Systolic Dysfunction (LVSD),8,eCQM,Process,Y,11.1,87.9,80.49 - 85.61,85.62 - 88.97,88.98 - 91.29,91.30 - 93.04,93.05 - 94.73,94.74 - 96.34,96.35 - 99.99,100,No,No
+Heart Failure (HF): Beta-Blocker Therapy for Left Ventricular Systolic Dysfunction (LVSD),8,MIPS CQM,Process,Y,10.3,95.9,95.45 - 98.05,98.06 - 99.28,99.29 - 99.99,--,--,--,--,100,Yes,No
+Anti-Depressant Medication Management,9,eCQM,Process,Y,32.4,53.9,16.67 - 31.06,31.07 - 42.18,42.19 - 53.15,53.16 - 71.73,71.74 - 82.78,82.79 - 88.88,88.89 - 94.43,>= 94.44,No,No
+Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation,12,eCQM,Process,Y,20,86.2,79.11 - 86.57,86.58 - 90.61,90.62 - 93.87,93.88 - 96.31,96.32 - 98.01,98.02 - 99.10,99.11 - 99.99,100,No,No
+Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation,12,Medicare Part B Claims,Process,Y,9.8,97.4,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation,12,MIPS CQM,Process,Y,9.8,96.2,96.47 - 99.16,99.17 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Age-Related Macular Degeneration (AMD): Dilated Macular Examination,14,Medicare Part B Claims,Process,Y,10.2,97.8,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Age-Related Macular Degeneration (AMD): Dilated Macular Examination,14,MIPS CQM,Process,Y,24.3,86.2,76.54 - 89.80,89.81 - 96.53,96.54 - 99.70,99.71 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care,19,eCQM,Process,Y,28.8,61.7,33.90 - 47.61,47.62 - 57.88,57.89 - 67.02,67.03 - 75.36,75.37 - 82.48,82.49 - 90.02,90.03 - 95.99,>= 96.00,No,No
+Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care,19,Medicare Part B Claims,Process,Y,8.6,98.2,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care,19,MIPS CQM,Process,Y,26.6,83.4,70.29 - 84.41,84.42 - 92.72,92.73 - 98.56,98.57 - 99.99,--,--,--,100,Yes,No
+Perioperative Care: Selection of Prophylactic Antibiotic - First OR Second Generation Cephalosporin,21,Medicare Part B Claims,Process,Y,22.6,92,99.17 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Perioperative Care: Selection of Prophylactic Antibiotic - First OR Second Generation Cephalosporin,21,MIPS CQM,Process,Y,17.5,94.6,98.67 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Perioperative Care: Venous Thromboembolism (VTE) Prophylaxis (When Indicated in ALL Patients),23,Medicare Part B Claims,Process,Y,19.9,94.9,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Perioperative Care: Venous Thromboembolism (VTE) Prophylaxis (When Indicated in ALL Patients),23,MIPS CQM,Process,Y,17.4,95,98.68 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Communication with the Physician or Other Clinician Managing On-going Care Post-Fracture for Men and Women Aged 50 Years and Older,24,Medicare Part B Claims,Process,Y,31.9,76.3,32.35 - 63.63,63.64 - 92.30,92.31 - 96.20,96.21 - 97.61,97.62 - 99.99,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Communication with the Physician or Other Clinician Managing On-going Care Post-Fracture for Men and Women Aged 50 Years and Older,24,MIPS CQM,Process,Y,32.4,59.6,26.32 - 45.09,45.10 - 55.31,55.32 - 60.20,60.21 - 69.99,70.00 - 80.55,80.56 - 99.99,--,100,No,No
+Screening for Osteoporosis for Women Aged 65-85 Years of Age,39,Medicare Part B Claims,Process,Y,26.5,56.2,32.79 - 42.36,42.37 - 49.00,49.01 - 55.90,55.91 - 62.54,62.55 - 70.68,70.69 - 82.88,82.89 - 95.49,>= 95.50,No,No
+Screening for Osteoporosis for Women Aged 65-85 Years of Age,39,MIPS CQM,Process,Y,31,46.2,11.38 - 22.43,22.44 - 34.71,34.72 - 45.25,45.26 - 58.10,58.11 - 67.97,67.98 - 78.45,78.46 - 88.23,>= 88.24,No,No
+Coronary Artery Bypass Graft (CABG): Preoperative Beta-Blocker in Patients with Isolated CABG Surgery,44,MIPS CQM,Process,Y,14.7,92.7,90.35 - 95.89,95.90 - 97.38,97.39 - 99.99,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Medication Reconciliation Post-Discharge,46,Medicare Part B Claims,Process,Y,16.3,94.2,95.74 - 98.40,98.41 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Medication Reconciliation Post-Discharge,46,MIPS CQM,Process,Y,17.2,93.3,94.24 - 97.62,97.63 - 99.92,99.93 - 99.99,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Care Plan,47,Medicare Part B Claims,Process,Y,33.1,78.4,50.32 - 82.60,82.61 - 92.88,92.89 - 97.45,97.46 - 99.30,99.31 - 99.99,--,--,100,Yes,No
+Care Plan,47,MIPS CQM,Process,Y,35.9,66.1,24.33 - 45.01,45.02 - 65.74,65.75 - 82.16,82.17 - 91.89,91.90 - 97.31,97.32 - 99.71,99.72 - 99.99,100,No,No
+Urinary Incontinence: Assessment of Presence or Absence of Urinary Incontinence in Women Aged 65 Years and Older,48,Medicare Part B Claims,Process,Y,43.1,65,3.88 - 13.85,13.86 - 72.40,72.41 - 96.68,96.69 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Urinary Incontinence: Assessment of Presence or Absence of Urinary Incontinence in Women Aged 65 Years and Older,48,MIPS CQM,Process,Y,37.5,59.8,12.22 - 31.74,31.75 - 52.36,52.37 - 70.44,70.45 - 84.26,84.27 - 95.10,95.11 - 99.50,99.51 - 99.99,100,No,No
+Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Years and Older,50,Medicare Part B Claims,Process,Y,18.2,94.4,97.30 - 98.87,98.88 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Years and Older,50,MIPS CQM,Process,Y,26.6,71.4,47.22 - 59.99,60.00 - 68.98,68.99 - 75.63,75.64 - 85.49,85.50 - 92.58,92.59 - 99.65,99.66 - 99.99,100,No,No
+Chronic Obstructive Pulmonary Disease (COPD): Spirometry Evaluation,51,Medicare Part B Claims,Process,Y,33.7,77,38.10 - 77.26,77.27 - 92.44,92.45 - 98.75,98.76 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Chronic Obstructive Pulmonary Disease (COPD): Spirometry Evaluation,51,MIPS CQM,Process,Y,33.4,64.9,25.00 - 45.44,45.45 - 60.42,60.43 - 75.75,75.76 - 86.45,86.46 - 93.82,93.83 - 99.35,99.36 - 99.99,100,No,No
+Chronic Obstructive Pulmonary Disease (COPD): Long-Acting Inhaled Bronchodilator Therapy,52,Medicare Part B Claims,Process,Y,21.9,89.9,90.14 - 98.14,98.15 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Chronic Obstructive Pulmonary Disease (COPD): Long-Acting Inhaled Bronchodilator Therapy,52,MIPS CQM,Process,Y,13.4,93.1,90.16 - 95.21,95.22 - 96.48,96.49 - 98.85,98.86 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Appropriate Treatment for Children with Upper Respiratory Infection (URI),65,eCQM,Process,Y,15.8,88.1,80.95 - 88.36,88.37 - 91.76,91.77 - 93.87,93.88 - 95.60,95.61 - 96.87,96.88 - 98.21,98.22 - 99.99,100,No,No
+Appropriate Treatment for Children with Upper Respiratory Infection (URI),65,MIPS CQM,Process,Y,13.9,93.2,91.49 - 95.01,95.02 - 97.02,97.03 - 97.84,97.85 - 98.69,98.70 - 99.19,99.20 - 99.74,99.75 - 99.99,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Appropriate Testing for Children with Pharyngitis,66,eCQM,Process,Y,29.6,66.7,36.71 - 60.04,60.05 - 72.40,72.41 - 78.37,78.38 - 83.32,83.33 - 87.62,87.63 - 91.42,91.43 - 94.58,>= 94.59,No,No
+Appropriate Testing for Children with Pharyngitis,66,MIPS CQM,Process,Y,17.5,77.4,64.57 - 69.60,69.61 - 75.41,75.42 - 81.74,81.75 - 85.50,85.51 - 87.95,87.96 - 91.77,91.78 - 97.54,>= 97.55,No,No
+Hematology: Myelodysplastic Syndrome (MDS) and Acute Leukemias: Baseline Cytogenetic Testing Performed on Bone Marrow,67,MIPS CQM,Process,Y,38.1,42.9,8.00 - 12.49,12.50 - 22.72,22.73 - 28.52,28.53 - 34.61,34.62 - 78.78,78.79 - 99.99,--,100,No,No
+Hematology: Myelodysplastic Syndrome (MDS): Documentation of Iron Stores in Patients Receiving Erythropoietin Therapy,68,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Hematology: Multiple Myeloma: Treatment with Bisphosphonates,69,MIPS CQM,Process,Y,21.1,61.5,42.86 - 47.49,47.50 - 64.51,64.52 - 66.66,66.67 - 71.42,71.43 - 71.87,71.88 - 76.91,76.92 - 92.30,>= 92.31,No,No
+Hematology: Chronic Lymphocytic Leukemia (CLL): Baseline Flow Cytometry,70,MIPS CQM,Process,Y,36.5,53.1,16.67 - 23.20,23.21 - 32.25,32.26 - 35.94,35.95 - 67.85,67.86 - 95.44,95.45 - 99.99,--,100,No,No
+Prevention of Central Venous Catheter (CVC) - Related Bloodstream Infections,76,Medicare Part B Claims,Process,Y,17.3,93.7,95.24 - 98.60,98.61 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Prevention of Central Venous Catheter (CVC) - Related Bloodstream Infections,76,MIPS CQM,Process,Y,15.7,94.2,95.67 - 99.08,99.09 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Acute Otitis Externa (AOE): Topical Therapy,91,Medicare Part B Claims,Process,Y,32.6,78.5,43.36 - 86.60,86.61 - 93.21,93.22 - 99.65,99.66 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Acute Otitis Externa (AOE): Topical Therapy,91,MIPS CQM,Process,Y,20,83.2,67.34 - 78.76,78.77 - 86.33,86.34 - 91.32,91.33 - 95.23,95.24 - 97.36,97.37 - 99.99,--,100,No,No
+Acute Otitis Externa (AOE): Systemic Antimicrobial Therapy - Avoidance of Inappropriate Use,93,Medicare Part B Claims,Process,Y,21.6,88.7,89.12 - 93.50,93.51 - 96.35,96.36 - 97.82,97.83 - 99.92,99.93 - 99.99,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Acute Otitis Externa (AOE): Systemic Antimicrobial Therapy - Avoidance of Inappropriate Use,93,MIPS CQM,Process,Y,23.7,80.1,63.16 - 77.35,77.36 - 83.96,83.97 - 89.65,89.66 - 93.32,93.33 - 96.14,96.15 - 99.99,--,100,No,No
+Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients,102,eCQM,Process,Y,29.8,78.3,59.34 - 75.73,75.74 - 83.90,83.91 - 91.99,92.00 - 98.30,98.31 - 99.99,--,--,100,No,No
+Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients,102,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prostate Cancer: Combination Androgen Deprivation Therapy for High Risk or Very High Risk Prostate Cancer,104,MIPS CQM,Process,Y,30.6,69,39.65 - 48.16,48.17 - 55.05,55.06 - 76.22,76.23 - 93.25,93.26 - 99.59,99.60 - 99.99,--,100,No,No
+Adult Major Depressive Disorder (MDD): Suicide Risk Assessment,107,eCQM,Process,Y,36,33.9,1.51 - 3.56,3.57 - 8.10,8.11 - 17.48,17.49 - 30.28,30.29 - 54.72,54.73 - 77.56,77.57 - 96.66,>= 96.67,No,No
+Osteoarthritis (OA): Function and Pain Assessment,109,Medicare Part B Claims,Process,Y,22.9,89.2,87.28 - 95.71,95.72 - 98.71,98.72 - 99.88,99.89 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Osteoarthritis (OA): Function and Pain Assessment,109,MIPS CQM,Process,Y,35,73.7,34.62 - 63.00,63.01 - 86.63,86.64 - 94.37,94.38 - 99.99,--,--,--,100,No,No
+Preventive Care and Screening: Influenza Immunization,110,eCQM,Process,Y,28.1,42,15.50 - 23.63,23.64 - 31.20,31.21 - 38.65,38.66 - 46.76,46.77 - 56.01,56.02 - 67.49,67.50 - 84.98,>= 84.99,No,No
+Preventive Care and Screening: Influenza Immunization,110,Medicare Part B Claims,Process,Y,32.3,64.2,29.52 - 41.41,41.42 - 56.31,56.32 - 71.18,71.19 - 82.88,82.89 - 94.14,94.15 - 99.41,99.42 - 99.99,100,No,No
+Preventive Care and Screening: Influenza Immunization,110,MIPS CQM,Process,Y,31.4,61.8,29.85 - 41.42,41.43 - 53.84,53.85 - 66.02,66.03 - 76.93,76.94 - 87.80,87.81 - 96.40,96.41 - 99.99,100,No,No
+Pneumococcal Vaccination Status for Older Adults,111,eCQM,Process,Y,30.1,50.8,19.01 - 31.06,31.07 - 42.70,42.71 - 53.43,53.44 - 62.85,62.86 - 71.81,71.82 - 80.42,80.43 - 90.40,>= 90.41,No,No
+Pneumococcal Vaccination Status for Older Adults,111,Medicare Part B Claims,Process,Y,24.8,71.6,49.76 - 61.10,61.11 - 70.10,70.11 - 77.31,77.32 - 82.95,82.96 - 89.43,89.44 - 95.66,95.67 - 99.99,100,No,No
+Pneumococcal Vaccination Status for Older Adults,111,MIPS CQM,Process,Y,28.4,58.4,30.23 - 44.52,44.53 - 55.55,55.56 - 63.63,63.64 - 70.42,70.43 - 76.37,76.38 - 83.76,83.77 - 95.44,>= 95.45,No,No
+Breast Cancer Screening,112,eCQM,Process,Y,26.7,48.4,22.28 - 32.74,32.75 - 42.31,42.32 - 51.05,51.06 - 58.43,58.44 - 65.67,65.68 - 73.43,73.44 - 82.30,>= 82.31,No,No
+Breast Cancer Screening,112,Medicare Part B Claims,Process,Y,24.7,64.6,44.44 - 52.07,52.08 - 58.44,58.45 - 64.28,64.29 - 70.96,70.97 - 79.84,79.85 - 90.23,90.24 - 99.99,100,No,No
+Breast Cancer Screening,112,MIPS CQM,Process,Y,29.3,62.9,35.99 - 48.25,48.26 - 57.57,57.58 - 67.38,67.39 - 75.24,75.25 - 85.30,85.31 - 93.44,93.45 - 99.99,100,No,No
+Colorectal Cancer Screening,113,eCQM,Process,Y,28.9,44.4,13.49 - 24.00,24.01 - 33.96,33.97 - 44.38,44.39 - 54.79,54.80 - 64.00,64.01 - 73.37,73.38 - 83.50,>= 83.51,No,No
+Colorectal Cancer Screening,113,Medicare Part B Claims,Process,Y,28.9,66.3,36.60 - 50.99,51.00 - 62.49,62.50 - 71.22,71.23 - 79.99,80.00 - 88.63,88.64 - 97.72,97.73 - 99.99,100,No,No
+Colorectal Cancer Screening,113,MIPS CQM,Process,Y,30.4,65.3,35.90 - 49.50,49.51 - 60.82,60.83 - 70.87,70.88 - 80.61,80.62 - 90.40,90.41 - 96.97,96.98 - 99.99,100,No,No
+Avoidance of Antibiotic Treatment in Adults With Acute Bronchitis,116,MIPS CQM,Process,Y,27.8,72.6,44.27 - 57.07,57.08 - 72.02,72.03 - 83.77,83.78 - 90.98,90.99 - 95.56,95.57 - 97.54,97.55 - 99.99,100,No,No
+Diabetes: Eye Exam,117,eCQM,Process,Y,35.8,60.7,20.61 - 31.99,32.00 - 45.52,45.53 - 66.01,66.02 - 89.11,89.12 - 95.64,95.65 - 98.25,98.26 - 99.72,>= 99.73,No,No
+Diabetes: Eye Exam,117,Medicare Part B Claims,Process,Y,24.9,86.9,72.00 - 96.87,96.88 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Diabetes: Eye Exam,117,MIPS CQM,Process,Y,24.7,85.8,77.26 - 89.99,90.00 - 95.81,95.82 - 98.48,98.49 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Coronary Artery Disease (CAD): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy - Diabetes or Left Ventricular Systolic Dysfunction (LVEF < 40%),118,MIPS CQM,Process,Y,11.1,83.3,76.00 - 78.56,78.57 - 81.07,81.08 - 83.90,83.91 - 86.35,86.36 - 88.72,88.73 - 92.25,92.26 - 98.17,>= 98.18,No,No
+Diabetes: Medical Attention for Nephropathy,119,eCQM,Process,Y,19.7,79,67.86 - 74.79,74.80 - 79.99,80.00 - 84.13,84.14 - 87.73,87.74 - 91.10,91.11 - 94.62,94.63 - 98.38,>= 98.39,No,No
+Diabetes: Medical Attention for Nephropathy,119,MIPS CQM,Process,Y,20.1,85.1,74.38 - 82.85,82.86 - 87.70,87.71 - 91.93,91.94 - 97.23,97.24 - 99.99,--,--,100,No,No
+"Diabetes Mellitus: Diabetic Foot and Ankle Care, Peripheral Neuropathy - Neurological Evaluation",126,MIPS CQM,Process,Y,29.3,82.5,66.15 - 85.22,85.23 - 96.42,96.43 - 99.99,--,--,--,--,100,Yes,No
+"Diabetes Mellitus: Diabetic Foot and Ankle Care, Ulcer Prevention - Evaluation of Footwear",127,MIPS CQM,Process,Y,27.9,84.8,70.59 - 92.85,92.86 - 99.45,99.46 - 99.99,--,--,--,--,100,Yes,No
+Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,eCQM,Process,Y,28.5,45.4,21.15 - 24.58,24.59 - 28.51,28.52 - 34.20,34.21 - 43.84,43.85 - 60.30,60.31 - 78.24,78.25 - 93.28,>= 93.29,No,No
+Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,Medicare Part B Claims,Process,Y,30.3,74.2,37.52 - 47.77,47.78 - 74.47,74.48 - 95.19,95.20 - 99.26,99.27 - 99.99,--,--,100,Yes,No
+Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,MIPS CQM,Process,Y,31.8,72.6,34.35 - 54.25,54.26 - 74.56,74.57 - 90.59,90.60 - 97.55,97.56 - 99.86,99.87 - 99.99,--,100,No,No
+Documentation of Current Medications in the Medical Record,130,eCQM,Process,Y,18.5,90.3,87.55 - 93.48,93.49 - 96.28,96.29 - 97.98,97.99 - 98.99,99.00 - 99.57,99.58 - 99.88,99.89 - 99.99,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Documentation of Current Medications in the Medical Record,130,Medicare Part B Claims,Process,Y,13.1,96.1,97.95 - 99.51,99.52 - 99.91,99.92 - 99.99,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Documentation of Current Medications in the Medical Record,130,MIPS CQM,Process,Y,30.5,82.6,68.06 - 90.27,90.28 - 97.23,97.24 - 99.50,99.51 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Pain Assessment and Follow-Up,131,Medicare Part B Claims,Process,Y,25,87.9,80.57 - 96.91,96.92 - 99.63,99.64 - 99.99,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Pain Assessment and Follow-Up,131,MIPS CQM,Process,Y,38.2,65.1,15.80 - 39.99,40.00 - 62.78,62.79 - 84.05,84.06 - 95.25,95.26 - 99.54,99.55 - 99.99,--,100,No,No
+Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,eCQM,Process,Y,32.2,37.1,4.88 - 10.17,10.18 - 17.59,17.60 - 28.28,28.29 - 42.29,42.30 - 56.82,56.83 - 73.29,73.30 - 87.49,>= 87.50,No,No
+Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,Medicare Part B Claims,Process,Y,39.6,69.3,12.94 - 53.91,53.92 - 80.22,80.23 - 96.98,96.99 - 99.99,--,--,--,100,Yes,No
+Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,MIPS CQM,Process,Y,38.5,67.7,17.11 - 45.64,45.65 - 73.81,73.82 - 90.05,90.06 - 98.49,98.50 - 99.99,--,--,100,No,No
+Melanoma: Continuity of Care - Recall System,137,MIPS CQM,Structure,Y,23,88.6,83.83 - 94.33,94.34 - 98.79,98.80 - 99.99,--,--,--,--,100,No,No
+Melanoma: Coordination of Care,138,MIPS CQM,Process,Y,30.2,75.8,49.44 - 63.63,63.64 - 78.25,78.26 - 92.58,92.59 - 99.99,--,--,--,100,No,No
+Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care,141,Medicare Part B Claims,Outcome,Y,10.8,97.6,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care,141,MIPS CQM,Outcome,Y,26.4,84.8,73.85 - 87.49,87.50 - 96.29,96.30 - 99.30,99.31 - 99.99,--,--,--,100,No,No
+Oncology: Medical and Radiation - Pain Intensity Quantified,143,eCQM,Process,Y,25.4,84.9,77.21 - 87.78,87.79 - 94.91,94.92 - 97.26,97.27 - 98.34,98.35 - 99.45,99.46 - 99.99,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Oncology: Medical and Radiation - Pain Intensity Quantified,143,MIPS CQM,Process,Y,17.1,91.9,90.31 - 95.39,95.40 - 97.12,97.13 - 98.56,98.57 - 99.25,99.26 - 99.99,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Oncology: Medical and Radiation - Plan of Care for Pain,144,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Radiology: Exposure Dose or Time Reported for Procedures Using Fluoroscopy,145,Medicare Part B Claims,Process,Y,26.5,81.9,66.41 - 82.92,82.93 - 90.90,90.91 - 95.17,95.18 - 97.39,97.40 - 99.06,99.07 - 99.99,--,100,Yes,No
+Radiology: Exposure Dose or Time Reported for Procedures Using Fluoroscopy,145,MIPS CQM,Process,Y,24.9,85.1,73.10 - 88.03,88.04 - 94.91,94.92 - 98.15,98.16 - 99.53,99.54 - 99.99,--,--,100,Yes,No
+"Radiology: Inappropriate Use of ""Probably Benign"" Assessment Category in Screening Mammograms",146,Medicare Part B Claims,Process,Y,1.2,0.3,0.23 - 0.01,--,--,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+"Radiology: Inappropriate Use of ""Probably Benign"" Assessment Category in Screening Mammograms",146,MIPS CQM,Process,Y,3.5,0.5,0.24 - 0.12,0.11 - 0.05,0.04 - 0.01,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Nuclear Medicine: Correlation with Existing Imaging Studies for All Patients Undergoing Bone Scintigraphy,147,Medicare Part B Claims,Process,Y,22.3,86.2,76.47 - 87.17,87.18 - 94.05,94.06 - 97.00,97.01 - 99.99,--,--,--,100,Yes,No
+Nuclear Medicine: Correlation with Existing Imaging Studies for All Patients Undergoing Bone Scintigraphy,147,MIPS CQM,Process,Y,13.7,94.1,93.04 - 97.96,97.97 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Falls: Risk Assessment,154,Medicare Part B Claims,Process,Y,18.3,94,96.95 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Falls: Risk Assessment,154,MIPS CQM,Process,Y,35.4,73.2,28.63 - 60.81,60.82 - 84.99,85.00 - 95.96,95.97 - 99.73,99.74 - 99.99,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Falls: Plan of Care,155,Medicare Part B Claims,Process,Y,30.8,81.4,55.81 - 84.61,84.62 - 99.20,99.21 - 99.99,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Falls: Plan of Care,155,MIPS CQM,Process,Y,28.8,82.7,67.86 - 86.78,86.79 - 94.99,95.00 - 98.21,98.22 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+HIV/AIDS: Pneumocystis Jiroveci Pneumonia (PCP) Prophylaxis,160,eCQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Coronary Artery Bypass Graft (CABG): Prolonged Intubation,164,MIPS CQM,Outcome,Y,5.9,7.6,11.40 - 9.10,9.09 - 7.70,7.69 - 6.81,6.80 - 5.56,5.55 - 4.29,4.28 - 3.09,3.08 - 1.55,<= 1.54,No,No
+Coronary Artery Bypass Graft (CABG): Deep Sternal Wound Infection Rate,165,MIPS CQM,Outcome,Y,1.1,0.5,0.84 - 0.01,--,--,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Coronary Artery Bypass Graft (CABG): Stroke,166,MIPS CQM,Outcome,Y,1.6,1.3,2.38 - 1.80,1.79 - 1.27,1.26 - 0.72,0.71 - 0.01,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Coronary Artery Bypass Graft (CABG): Postoperative Renal Failure,167,MIPS CQM,Outcome,Y,2.6,2.2,3.51 - 2.71,2.70 - 2.16,2.15 - 1.86,1.85 - 1.29,1.28 - 0.89,0.88 - 0.01,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Coronary Artery Bypass Graft (CABG): Surgical Re-Exploration,168,MIPS CQM,Outcome,Y,2.6,2.4,3.95 - 3.14,3.13 - 2.64,2.63 - 1.80,1.79 - 1.28,1.27 - 0.88,0.87 - 0.01,--,0,Yes,No
+Rheumatoid Arthritis (RA): Tuberculosis Screening,176,MIPS CQM,Process,Y,31,65.4,32.00 - 48.14,48.15 - 55.55,55.56 - 68.00,68.01 - 80.42,80.43 - 99.03,99.04 - 99.99,--,100,No,No
+Rheumatoid Arthritis (RA): Periodic Assessment of Disease Activity,177,MIPS CQM,Process,Y,29.4,79,57.23 - 74.99,75.00 - 88.23,88.24 - 96.01,96.02 - 99.99,--,--,--,100,Yes,No
+Rheumatoid Arthritis (RA): Functional Status Assessment,178,MIPS CQM,Process,Y,27.2,82,67.61 - 81.39,81.40 - 90.58,90.59 - 95.94,95.95 - 99.99,--,--,--,100,Yes,No
+Rheumatoid Arthritis (RA): Assessment and Classification of Disease Prognosis,179,MIPS CQM,Process,Y,30.9,76.7,44.53 - 67.88,67.89 - 85.30,85.31 - 95.21,95.22 - 99.99,--,--,--,100,Yes,No
+Rheumatoid Arthritis (RA): Glucocorticoid Management,180,MIPS CQM,Process,Y,28.6,79.3,52.68 - 75.78,75.79 - 87.95,87.96 - 95.05,95.06 - 99.57,99.58 - 99.99,--,--,100,Yes,No
+Elder Maltreatment Screen and Follow-Up Plan,181,Medicare Part B Claims,Process,Y,34.6,80.9,55.38 - 97.31,97.32 - 99.55,99.56 - 99.99,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Elder Maltreatment Screen and Follow-Up Plan,181,MIPS CQM,Process,Y,29.9,75.6,50.65 - 66.03,66.04 - 77.77,77.78 - 89.28,89.29 - 96.78,96.79 - 99.99,--,--,100,No,No
+Functional Outcome Assessment,182,Medicare Part B Claims,Process,Y,14.7,96.7,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Functional Outcome Assessment,182,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 "Colonoscopy Interval for Patients with a History of Adenomatous Polyps
-- Avoidance of Inappropriate Use",185,Claims,Process,Y,98.57 - 99.99,--,--,--,--,--,--,100.00,Yes
+
+- Avoidance of Inappropriate Use",185,Medicare Part B Claims,Process,Y,8.5,97.8,98.57 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
 "Colonoscopy Interval for Patients with a History of Adenomatous Polyps
-- Avoidance of Inappropriate Use",185,Registry/QCDR,Process,Y,61.64 - 84.99,85.00 - 90.53,90.54 - 95.41,95.42 - 98.40,98.41 - 99.99,--,--,100.00,Yes
-Stroke and Stroke Rehabilitation: Thrombolytic Therapy,187,Registry/QCDR,Process,Y,88.89 - 96.48,96.49 - 99.99,--,--,--,--,--,100.00,Yes
-Cataracts: 20/40 or Better Visual Acuity within 90 Days Following Cataract Surgery,191,EHR,Outcome,Y,85.71 - 90.87,90.88 - 93.59,93.60 - 95.63,95.64 - 96.91,96.92 - 97.84,97.85 - 98.79,98.80 - 99.99,100.00,No
-Cataracts: 20/40 or Better Visual Acuity within 90 Days Following Cataract Surgery,191,Registry/QCDR,Outcome,Y,94.37 - 96.87,96.88 - 98.97,98.98 - 99.99,--,--,--,--,100.00,Yes
-Cataracts: Complications within 30 Days Following Cataract Surgery Requiring Additional Surgical Procedures,192,EHR,Outcome,Y,--,--,--,--,--,--,--,0.00,Yes
-Cataracts: Complications within 30 Days Following Cataract Surgery Requiring Additional Surgical Procedures,192,Registry/QCDR,Outcome,Y,--,--,--,--,--,--,--,0.00,Yes
-Radiology: Stenosis Measurement in Carotid Imaging Reports,195,Claims,Process,Y,91.72 - 96.22,96.23 - 98.17,98.18 - 99.99,--,--,--,--,100.00,Yes
-Radiology: Stenosis Measurement in Carotid Imaging Reports,195,Registry/QCDR,Process,Y,97.81 - 99.85,99.86 - 99.99,--,--,--,--,--,100.00,Yes
-"HIV/AIDS: Sexually Transmitted Disease Screening for Chlamydia, Gonorrhea, and Syphilis",205,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Functional Status Change for Patients with Knee Impairments,217,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Functional Status Change for Patients with Hip Impairments,218,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Functional Status Change for Patients with Foot or Ankle Impairments,219,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Functional Status Change for Patients with Lumbar Impairments,220,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Functional Status Change for Patients with Shoulder Impairments,221,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-"Functional Status Change for Patients with Elbow, Wrist or Hand Impairments",222,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Functional Status Change for Patients with General Orthopaedic Impairments,223,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Radiology: Reminder System for Screening Mammograms,225,Claims,Structure,Y,99.36 - 99.99,--,--,--,--,--,--,100.00,Yes
-Radiology: Reminder System for Screening Mammograms,225,Registry/QCDR,Structure,Y,--,--,--,--,--,--,--,100.00,Yes
-Controlling High Blood Pressure,236,CMS Web Interface,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--
-Controlling High Blood Pressure,236,Claims,Intermediate Outcome,Y,58.57 - 63.97,63.98 - 68.82,68.83 - 73.90,73.91 - 78.56,78.57 - 83.32,83.33 - 88.26,88.27 - 94.86,>= 94.87,No
-Controlling High Blood Pressure,236,EHR,Intermediate Outcome,Y,51.46 - 56.83,56.84 - 60.94,60.95 - 64.67,64.68 - 68.20,68.21 - 72.08,72.09 - 76.34,76.35 - 82.27,>= 82.28,No
-Controlling High Blood Pressure,236,Registry/QCDR,Intermediate Outcome,Y,52.48 - 60.14,60.15 - 65.72,65.73 - 70.67,70.68 - 76.82,76.83 - 84.61,84.62 - 93.61,93.62 - 99.99,100.00,No
-Use of High-Risk Medications in the Elderly,238,EHR,Process,Y,8.08 - 4.79,4.78 - 2.71,2.70 - 1.33,1.32 - 0.54,0.53 - 0.06,0.05 - 0.01,--,0.00,Yes
-Use of High-Risk Medications in the Elderly,238,Registry/QCDR,Process,Y,0.67 - 0.29,0.28 - 0.14,0.13 - 0.01,--,--,--,--,0.00,Yes
-Weight Assessment and Counseling for Nutrition and Physical Activity for Children and Adolescents,239,EHR,Process,Y,26.23 - 29.51,29.52 - 31.47,31.48 - 32.82,32.83 - 33.95,33.96 - 38.80,38.81 - 47.92,47.93 - 65.68,>= 65.69,No
-Weight Assessment and Counseling for Nutrition and Physical Activity for Children and Adolescents,239,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Childhood Immunization Status,240,EHR,Process,Y,9.30 - 14.80,14.81 - 20.49,20.50 - 26.67,26.68 - 30.66,30.67 - 37.22,37.23 - 42.41,42.42 - 50.88,>= 50.89,No
-Childhood Immunization Status,240,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Cardiac Rehabilitation Patient Referral from an Outpatient Setting,243,Registry/QCDR,Process,Y,8.11 - 11.87,11.88 - 14.62,14.63 - 17.22,17.23 - 20.77,20.78 - 24.31,24.32 - 30.68,30.69 - 44.43,>= 44.44,No
-Barrett's Esophagus,249,Claims,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Barrett's Esophagus,249,Registry/QCDR,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Radical Prostatectomy Pathology Reporting,250,Claims,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Radical Prostatectomy Pathology Reporting,250,Registry/QCDR,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Ultrasound Determination of Pregnancy Location for Pregnant Patients with Abdominal Pain,254,Claims,Process,N,--,--,--,--,--,--,--,--,--
-Ultrasound Determination of Pregnancy Location for Pregnant Patients with Abdominal Pain,254,Registry/QCDR,Process,Y,74.42 - 80.94,80.95 - 85.36,85.37 - 88.88,88.89 - 91.99,92.00 - 95.23,95.24 - 97.66,97.67 - 99.99,100.00,No
-Rh Immunoglobulin (Rhogam) for Rh-Negative Pregnant Women at Risk of Fetal Blood Exposure,255,Claims,Process,N,--,--,--,--,--,--,--,--,--
-Rh Immunoglobulin (Rhogam) for Rh-Negative Pregnant Women at Risk of Fetal Blood Exposure,255,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Rate of Open Repair of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post-Operative Day #7),258,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post Operative Day #2),259,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-"Rate of Carotid Endarterectomy (CEA) for Asymptomatic Patients, without Major Complications (Discharged to Home by Post-Operative Day #2)",260,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Referral for Otologic Evaluation for Patients with Acute or Chronic Dizziness,261,Claims,Process,N,--,--,--,--,--,--,--,--,--
-Referral for Otologic Evaluation for Patients with Acute or Chronic Dizziness,261,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Image Confirmation of Successful Excision of Image-Localized Breast Lesion,262,Registry/QCDR,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Sentinel Lymph Node Biopsy for Invasive Breast Cancer,264,Registry/QCDR,Process,Y,97.96 - 99.21,99.22 - 99.99,--,--,--,--,--,100.00,Yes
-Biopsy Follow-Up,265,Registry/QCDR,Process,Y,61.20 - 83.69,83.70 - 95.64,95.65 - 99.38,99.39 - 99.99,--,--,--,100.00,Yes
-Epilepsy: Counseling for Women of Childbearing Potential with Epilepsy,268,Claims,Process,N,--,--,--,--,--,--,--,--,--
-Epilepsy: Counseling for Women of Childbearing Potential with Epilepsy,268,Registry/QCDR,Process,Y,32.00 - 45.34,45.35 - 57.13,57.14 - 78.56,78.57 - 95.99,96.00 - 99.06,99.07 - 99.99,--,100.00,No
-Inflammatory Bowel Disease (IBD): Preventive Care: Corticosteroid Related Iatrogenic Injury - Bone Loss Assessment,271,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Inflammatory Bowel Disease (IBD): Assessment of Hepatitis B Virus (HBV) Status Before Initiating Anti-TNF (Tumor Necrosis Factor) Therapy,275,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Sleep Apnea: Severity Assessment at Initial Diagnosis,277,Registry/QCDR,Process,Y,69.01 - 81.02,81.03 - 90.62,90.63 - 99.70,99.71 - 99.99,--,--,--,100.00,Yes
-Sleep Apnea: Assessment of Adherence to Positive Airway Pressure Therapy,279,Registry/QCDR,Process,Y,90.08 - 96.26,96.27 - 99.16,99.17 - 99.99,--,--,--,--,100.00,Yes
-Dementia: Cognitive Assessment,281,EHR,Process,Y,5.88 - 12.89,12.90 - 26.08,26.09 - 44.83,44.84 - 59.25,59.26 - 73.32,73.33 - 88.56,88.57 - 96.76,>= 96.77,No
-Dementia: Cognitive Assessment,281,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Dementia: Functional Status Assessment,282,Registry/QCDR,Process,Y,57.14 - 78.94,78.95 - 95.27,95.28 - 99.12,99.13 - 99.99,--,--,--,100.00,Yes
-Dementia: Neuropsychiatric Symptom Assessment,283,Registry/QCDR,Process,Y,58.14 - 83.07,83.08 - 96.66,96.67 - 99.81,99.82 - 99.99,--,--,--,100.00,Yes
-Dementia: Counseling Regarding Safety Concerns,286,Registry/QCDR,Process,Y,62.86 - 78.68,78.69 - 89.88,89.89 - 98.20,98.21 - 99.99,--,--,--,100.00,Yes
-Dementia: Caregiver Education and Support,288,Registry/QCDR,Process,Y,59.26 - 77.32,77.33 - 89.32,89.33 - 97.53,97.54 - 99.99,--,--,--,100.00,Yes
-Parkinson's Disease: Psychiatric Symptoms Assessment for Patients with Parkinson's Disease,290,Registry/QCDR,Process,Y,85.09 - 92.55,92.56 - 96.91,96.92 - 99.22,99.23 - 99.99,--,--,--,100.00,Yes
-Parkinson's Disease: Cognitive Impairment or Dysfunction Assessment,291,Registry/QCDR,Process,Y,86.49 - 94.99,95.00 - 99.99,--,--,--,--,--,100.00,Yes
-Parkinson's Disease: Rehabilitative Therapy Options,293,Registry/QCDR,Process,Y,67.03 - 82.94,82.95 - 94.28,94.29 - 99.99,--,--,--,--,100.00,Yes
-Cataracts: Improvement in Patient's Visual Function within 90 Days Following Cataract Surgery,303,Registry/QCDR,Outcome,Y,45.11 - 70.87,70.88 - 78.76,78.77 - 84.90,84.91 - 91.77,91.78 - 98.79,98.80 - 99.99,--,100.00,No
-Cataracts: Patient Satisfaction within 90 Days Following Cataract Surgery,304,Registry/QCDR,Outcome,Y,50.00 - 72.21,72.22 - 80.29,80.30 - 87.08,87.09 - 95.41,95.42 - 99.11,99.12 - 99.99,--,100.00,No
-Initiation and Engagement of Alcohol and Other Drug Dependence Treatment,305,EHR,Process,Y,0.31 - 0.41,0.42 - 0.67,0.68 - 1.02,1.03 - 1.34,1.35 - 2.23,2.24 - 3.84,3.85 - 6.90,>= 6.91,No
-Initiation and Engagement of Alcohol and Other Drug Dependence Treatment,305,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Cervical Cancer Screening,309,EHR,Process,Y,9.84 - 16.66,16.67 - 23.61,23.62 - 31.49,31.50 - 39.60,39.61 - 48.20,48.21 - 57.60,57.61 - 72.60,>= 72.61,No
-Cervical Cancer Screening,309,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Chlamydia Screening for Women,310,EHR,Process,Y,16.67 - 22.30,22.31 - 28.04,28.05 - 33.32,33.33 - 39.12,39.13 - 44.77,44.78 - 53.13,53.14 - 63.77,>= 63.78,No
-Chlamydia Screening for Women,310,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,Claims,Process,Y,34.24 - 45.44,45.45 - 58.44,58.45 - 73.18,73.19 - 89.38,89.39 - 98.04,98.05 - 99.99,--,100.00,No
-Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,EHR,Process,Y,19.55 - 24.11,24.12 - 28.14,28.15 - 32.22,32.23 - 36.64,36.65 - 42.19,42.20 - 50.92,50.93 - 74.99,>= 75.00,No
-Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,Registry/QCDR,Process,Y,25.83 - 30.80,30.81 - 35.46,35.47 - 42.52,42.53 - 59.11,59.12 - 83.32,83.33 - 97.29,97.30 - 99.99,100.00,No
-Falls: Screening for Future Fall Risk,318,CMS Web Interface,Process,N,--,--,--,--,--,--,--,--,--
-Falls: Screening for Future Fall Risk,318,EHR,Process,Y,7.25 - 20.22,20.23 - 36.39,36.40 - 52.25,52.26 - 66.76,66.77 - 78.68,78.69 - 88.50,88.51 - 96.54,>= 96.55,No
-Falls: Screening for Future Fall Risk,318,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients,320,Claims,Process,Y,95.24 - 97.72,97.73 - 99.99,--,--,--,--,--,100.00,Yes
-Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients,320,Registry/QCDR,Process,Y,85.29 - 89.73,89.74 - 93.74,93.75 - 95.94,95.95 - 97.72,97.73 - 98.97,98.98 - 99.99,--,100.00,Yes
-Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low Risk Surgery Patients,322,Registry/QCDR,Efficiency,Y,1.90 - 0.01,--,--,--,--,--,--,0.00,Yes
-Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Routine Testing After Percutaneous Coronary Intervention (PCI),323,Registry/QCDR,Efficiency,Y,2.44 - 0.01,--,--,--,--,--,--,0.00,Yes
-"Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Testing in Asymptomatic, Low-Risk Patients",324,Registry/QCDR,Efficiency,Y,6.25 - 2.02,2.01 - 0.01,--,--,--,--,--,0.00,Yes
-Adult Major Depressive Disorder (MDD): Coordination of Care of Patients with Specific Comorbid Conditions,325,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Atrial Fibrillation and Atrial Flutter: Chronic Anticoagulation Therapy,326,Claims,Process,Y,84.13 - 95.28,95.29 - 98.79,98.80 - 99.99,--,--,--,--,100.00,Yes
-Atrial Fibrillation and Atrial Flutter: Chronic Anticoagulation Therapy,326,Registry/QCDR,Process,Y,69.38 - 75.06,75.07 - 78.83,78.84 - 83.04,83.05 - 87.98,87.99 - 94.85,94.86 - 99.99,--,100.00,No
-Pediatric Kidney Disease: ESRD Patients Receiving Dialysis: Hemoglobin Level < 10 g/dL,328,Registry/QCDR,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--
-Adult Kidney Disease: Catheter Use at Initiation of Hemodialysis,329,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Adult Kidney Disease: Catheter Use for Greater Than or Equal to 90 Days,330,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Adult Sinusitis: Antibiotic Prescribed for Acute Sinusitis (Overuse),331,Registry/QCDR,Process,Y,92.15 - 87.51,87.50 - 82.89,82.88 - 75.37,75.36 - 64.36,64.35 - 46.68,46.67 - 20.00,19.99 - 0.01,0.00,No
-Adult Sinusitis: Appropriate Choice of Antibiotic: Amoxicillin With or Without Clavulanate Prescribed for Patients with Acute Bacterial Sinusitis (Appropriate Use),332,Registry/QCDR,Process,Y,93.55 - 96.19,96.20 - 97.58,97.59 - 98.39,98.40 - 99.35,99.36 - 99.99,--,--,100.00,Yes
-Adult Sinusitis: Computerized Tomography (CT) for Acute Sinusitis (Overuse),333,Registry/QCDR,Efficiency,Y,2.50 - 0.91,0.90 - 0.27,0.26 - 0.01,--,--,--,--,0.00,Yes
-Maternity Care: Elective Delivery or Early Induction Without Medical Indication at >= 37 and < 39 Weeks (Overuse),335,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Maternity Care: Post-Partum Follow-Up and Care Coordination,336,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-"Tuberculosis (TB) Prevention for Psoriasis, Psoriatic Arthritis and Rheumatoid Arthritis Patients on a Biological Immune Response Modifier",337,Registry/QCDR,Process,Y,47.06 - 60.60,60.61 - 73.62,73.63 - 82.50,82.51 - 89.99,90.00 - 96.42,96.43 - 99.99,--,100.00,No
-HIV Viral Load Suppression,338,Registry/QCDR,Outcome,Y,74.47 - 78.56,78.57 - 83.99,84.00 - 87.93,87.94 - 93.99,94.00 - 97.23,97.24 - 99.99,--,100.00,No
-HIV Medical Visit Frequency,340,Registry/QCDR,Process,Y,48.97 - 52.85,52.86 - 61.08,61.09 - 82.68,82.69 - 87.99,88.00 - 92.85,92.86 - 95.91,95.92 - 99.99,100.00,No
-Pain Brought Under Control Within 48 Hours,342,Registry/QCDR,Outcome,Y,98.78 - 99.99,--,--,--,--,--,--,100.00,Yes
-"Rate of Carotid Artery Stenting (CAS) for Asymptomatic Patients, Without Major Complications (Discharged to Home by Post-Operative Day #2)",344,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Rate of Postoperative Stroke or Death in Asymptomatic Patients Undergoing Carotid Artery Stenting (CAS),345,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Rate of Postoperative Stroke or Death in Asymptomatic Patients Undergoing Carotid Endarterectomy (CEA),346,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) Who Die While in Hospital,347,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-HRS-3: Implantable Cardioverter-Defibrillator (ICD) Complications Rate,348,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Total Knee Replacement: Shared Decision-Making: Trial of Conservative (Non-surgical) Therapy,350,Registry/QCDR,Process,Y,96.00 - 99.99,--,--,--,--,--,--,100.00,Yes
-Total Knee Replacement: Venous Thromboembolic and Cardiovascular Risk Evaluation,351,Registry/QCDR,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Total Knee Replacement: Preoperative Antibiotic Infusion with Proximal Tourniquet,352,Registry/QCDR,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Total Knee Replacement: Identification of Implanted Prosthesis in Operative Report,353,Registry/QCDR,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Anastomotic Leak Intervention,354,Registry/QCDR,Outcome,Y,3.61 - 3.24,3.23 - 0.74,0.73 - 0.01,--,--,--,--,0.00,Yes
-Unplanned Reoperation within the 30 Day Postoperative Period,355,Registry/QCDR,Outcome,Y,3.15 - 2.28,2.27 - 1.22,1.21 - 0.41,0.40 - 0.01,--,--,--,0.00,Yes
-Unplanned Hospital Readmission within 30 Days of Principal Procedure,356,Registry/QCDR,Outcome,Y,5.00 - 3.31,3.30 - 2.01,2.00 - 0.01,--,--,--,--,0.00,Yes
-Surgical Site Infection (SSI),357,Registry/QCDR,Outcome,Y,3.48 - 2.28,2.27 - 0.96,0.95 - 0.01,--,--,--,--,0.00,Yes
-Patient-Centered Surgical Risk Assessment and Communication,358,Registry/QCDR,Process,Y,17.29 - 61.78,61.79 - 91.42,91.43 - 97.63,97.64 - 99.99,--,--,--,100.00,Yes
-Optimizing Patient Exposure to Ionizing Radiation: Count of Potential High Dose Radiation Imaging Studies: Computed Tomography (CT) and Cardiac Nuclear Medicine Studies,360,Registry/QCDR,Process,Y,31.53 - 61.37,61.38 - 90.54,90.55 - 98.82,98.83 - 99.99,--,--,--,100.00,Yes
-Optimizing Patient Exposure to Ionizing Radiation: Reporting to a Radiation Dose Index Registry,361,Registry/QCDR,Structure,Y,--,--,--,--,--,--,--,100.00,Yes
-Optimizing Patient Exposure to Ionizing Radiation: Computed Tomography (CT) Images Available for Patient Follow-up and Comparison Purposes,362,Registry/QCDR,Structure,Y,--,--,--,--,--,--,--,100.00,Yes
-Optimizing Patient Exposure to Ionizing Radiation: Appropriateness: Follow-up CT Imaging for Incidentally Detected Pulmonary Nodules According to Recommended Guidelines,364,Registry/QCDR,Process,Y,59.02 - 93.24,93.25 - 97.64,97.65 - 99.80,99.81 - 99.99,--,--,--,100.00,Yes
-ADHD: Follow-Up Care for Children Prescribed Attention-Deficit/Hyperactivity Disorder (ADHD) Medication,366,EHR,Process,Y,26.67 - 30.86,30.87 - 33.95,33.96 - 38.09,38.10 - 46.45,46.46 - 48.83,48.84 - 54.54,54.55 - 65.90,>= 65.91,No
-ADHD: Follow-Up Care for Children Prescribed Attention-Deficit/Hyperactivity Disorder (ADHD) Medication,366,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Depression Remission at Twelve Months,370,CMS Web Interface,Outcome,N,--,--,--,--,--,--,--,--,--
-Depression Remission at Twelve Months,370,EHR,Outcome,Y,2.04 - 2.62,2.63 - 3.54,3.55 - 4.23,4.24 - 5.25,5.26 - 7.13,7.14 - 8.81,8.82 - 14.99,>= 15.00,No
-Depression Remission at Twelve Months,370,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Depression Utilization of the PHQ-9 Tool,371,EHR,Process,Y,3.70 - 6.05,6.06 - 8.95,8.96 - 12.49,12.50 - 16.42,16.43 - 21.73,21.74 - 30.09,30.10 - 43.13,>= 43.14,No
-Depression Utilization of the PHQ-9 Tool,371,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Maternal Depression Screening,372,EHR,Process,N,--,--,--,--,--,--,--,--,--
-Maternal Depression Screening,372,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Closing the Referral Loop: Receipt of Specialist Report,374,EHR,Process,Y,7.62 - 14.92,14.93 - 26.32,26.33 - 37.03,37.04 - 48.46,48.47 - 60.31,60.32 - 74.66,74.67 - 90.90,>= 90.91,No
-Functional Status Assessment for Total Knee Replacement,375,EHR,Process,Y,5.00 - 9.67,9.68 - 15.90,15.91 - 20.30,20.31 - 24.55,24.56 - 34.37,34.38 - 53.41,53.42 - 77.26,>= 77.27,No
-Functional Status Assessment for Total Knee Replacement,375,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Functional Status Assessment for Total Hip Replacement,376,EHR,Process,Y,4.82 - 8.50,8.51 - 13.09,13.10 - 19.22,19.23 - 27.58,27.59 - 33.32,33.33 - 40.18,40.19 - 63.48,>= 63.49,No
-Functional Status Assessment for Total Hip Replacement,376,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Functional Status Assessments for Congestive Heart Failure,377,EHR,Process,N,--,--,--,--,--,--,--,--,--
-Functional Status Assessments for Congestive Heart Failure,377,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Children Who Have Dental Decay or Cavities,378,EHR,Outcome,Y,0.48 - 0.11,0.10 - 0.01,--,--,--,--,--,0.00,Yes
-Children Who Have Dental Decay or Cavities,378,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-"Primary Caries Prevention Intervention as Offered by Primary Care Providers, including Dentists",379,EHR,Process,Y,0.32 - 0.54,0.55 - 0.73,0.74 - 1.08,1.09 - 2.07,2.08 - 3.21,3.22 - 4.89,4.90 - 9.04,>= 9.05,No
-"Primary Caries Prevention Intervention as Offered by Primary Care Providers, including Dentists",379,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Child and Adolescent Major Depressive Disorder (MDD): Suicide Risk Assessment,382,EHR,Process,Y,3.43 - 7.00,7.01 - 12.46,12.47 - 14.83,14.84 - 20.25,20.26 - 29.00,29.01 - 36.10,36.11 - 51.71,>= 51.72,No
-Child and Adolescent Major Depressive Disorder (MDD): Suicide Risk Assessment,382,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Adherence to Antipsychotic Medications For Individuals with Schizophrenia,383,Registry/QCDR,Intermediate Outcome,Y,58.00 - 71.42,71.43 - 86.83,86.84 - 90.00,90.01 - 98.32,98.33 - 99.99,--,--,100.00,No
-Adult Primary Rhegmatogenous Retinal Detachment Surgery: No Return to the Operating Room Within 90 Days of Surgery,384,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Adult Primary Rhegmatogenous Retinal Detachment Surgery: Visual Acuity Improvement Within 90 Days of Surgery,385,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Amyotrophic Lateral Sclerosis (ALS) Patient Care Preferences,386,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Annual Hepatitis C Virus (HCV) Screening for Patients who are Active Injection Drug Users,387,Registry/QCDR,Process,Y,0.38 - 0.45,0.46 - 0.58,0.59 - 0.76,0.77 - 1.31,1.32 - 1.40,1.41 - 1.60,1.61 - 2.86,>= 2.87,No
-Cataract Surgery with Intra-Operative Complications (Unplanned Rupture of Posterior Capsule Requiring Unplanned Vitrectomy),388,Registry/QCDR,Outcome,Y,--,--,--,--,--,--,--,0.00,Yes
-Cataract Surgery: Difference Between Planned and Final Refraction,389,Registry/QCDR,Outcome,Y,77.17 - 90.90,90.91 - 96.96,96.97 - 99.21,99.22 - 99.99,--,--,--,100.00,No
-Hepatitis C: Discussion and Shared Decision Making Surrounding Treatment Options,390,Registry/QCDR,Process,Y,63.64 - 80.86,80.87 - 95.44,95.45 - 99.99,--,--,--,--,100.00,Yes
-Follow-Up After Hospitalization for Mental Illness (FUH),391,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-HRS-12: Cardiac Tamponade and/or Pericardiocentesis Following Atrial Fibrillation Ablation,392,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-"HRS-9: Infection within 180 Days of Cardiac Implantable Electronic Device (CIED) Implantation, Replacement, or Revision",393,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Immunizations for Adolescents,394,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Lung Cancer Reporting (Biopsy/Cytology Specimens),395,Claims,Outcome,Y,--,--,--,--,--,--,--,100.00,Yes
-Lung Cancer Reporting (Biopsy/Cytology Specimens),395,Registry/QCDR,Outcome,Y,--,--,--,--,--,--,--,100.00,Yes
-Lung Cancer Reporting (Resection Specimens),396,Claims,Outcome,N,--,--,--,--,--,--,--,--,--
-Lung Cancer Reporting (Resection Specimens),396,Registry/QCDR,Outcome,Y,--,--,--,--,--,--,--,100.00,Yes
-Melanoma Reporting,397,Claims,Outcome,Y,--,--,--,--,--,--,--,100.00,Yes
-Melanoma Reporting,397,Registry/QCDR,Outcome,Y,91.96 - 99.99,--,--,--,--,--,--,100.00,Yes
-Optimal Asthma Control,398,Registry/QCDR,Outcome,Y,33.52 - 59.45,59.46 - 74.99,75.00 - 95.99,96.00 - 98.98,98.99 - 99.99,--,--,100.00,No
-One-Time Screening for Hepatitis C Virus (HCV) for Patients at Risk,400,Registry/QCDR,Process,Y,1.26 - 1.84,1.85 - 3.22,3.23 - 6.30,6.31 - 16.77,16.78 - 24.10,24.11 - 32.00,32.01 - 74.59,>= 74.60,No
-Hepatitis C: Screening for Hepatocellular Carcinoma (HCC) in Patients with Cirrhosis,401,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Tobacco Use and Help with Quitting Among Adolescents,402,Registry/QCDR,Process,Y,86.36 - 91.17,91.18 - 94.11,94.12 - 96.11,96.12 - 97.58,97.59 - 98.83,98.84 - 99.99,--,100.00,Yes
-Adult Kidney Disease: Referral to Hospice,403,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Anesthesiology Smoking Abstinence,404,Registry/QCDR,Intermediate Outcome,Y,40.00 - 50.58,50.59 - 57.34,57.35 - 62.99,63.00 - 69.73,69.74 - 75.24,75.25 - 82.34,82.35 - 93.39,>= 93.40,No
-Appropriate Follow-up Imaging for Incidental Abdominal Lesions,405,Claims,Process,Y,10.26 - 4.45,4.44 - 0.73,0.72 - 0.01,--,--,--,--,0.00,Yes
-Appropriate Follow-up Imaging for Incidental Abdominal Lesions,405,Registry/QCDR,Process,Y,12.24 - 6.68,6.67 - 2.64,2.63 - 0.47,0.46 - 0.01,--,--,--,0.00,Yes
-Appropriate Follow-up Imaging for Incidental Thyroid Nodules in Patients,406,Claims,Process,Y,61.90 - 48.01,48.00 - 37.51,37.50 - 15.57,15.56 - 2.57,2.56 - 0.01,--,--,0.00,No
-Appropriate Follow-up Imaging for Incidental Thyroid Nodules in Patients,406,Registry/QCDR,Process,Y,14.23 - 5.81,5.80 - 3.48,3.47 - 0.04,0.03 - 0.01,--,--,--,0.00,Yes
-Appropriate Treatment of Methicillin-Sensitive Staphylococcus Aureus (MSSA) Bacteremia,407,Claims,Process,N,--,--,--,--,--,--,--,--,--
-Appropriate Treatment of Methicillin-Sensitive Staphylococcus Aureus (MSSA) Bacteremia,407,Registry/QCDR,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Opioid Therapy Follow-up Evaluation,408,Registry/QCDR,Process,Y,68.35 - 91.35,91.36 - 98.48,98.49 - 99.99,--,--,--,--,100.00,Yes
-Clinical Outcome Post Endovascular Stroke Treatment,409,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Psoriasis: Clinical Response to Oral Systemic or Biologic Medications,410,Claims,Outcome,N,--,--,--,--,--,--,--,--,--
-Psoriasis: Clinical Response to Oral Systemic or Biologic Medications,410,Registry/QCDR,Outcome,Y,23.08 - 36.35,36.36 - 49.99,50.00 - 61.53,61.54 - 72.21,72.22 - 87.49,87.50 - 97.21,97.22 - 99.99,100.00,No
-Depression Remission at Six Months,411,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Documentation of Signed Opioid Treatment Agreement,412,Registry/QCDR,Process,Y,61.17 - 88.34,88.35 - 97.43,97.44 - 99.62,99.63 - 99.99,--,--,--,100.00,Yes
-Door to Puncture Time for Endovascular Stroke Treatment,413,Registry/QCDR,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--
-Evaluation or Interview for Risk of Opioid Misuse,414,Registry/QCDR,Process,Y,88.55 - 98.59,98.60 - 99.99,--,--,--,--,--,100.00,Yes
-Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older,415,Claims,Efficiency,Y,96.00 - 99.99,--,--,--,--,--,--,100.00,Yes
-Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older,415,Registry/QCDR,Efficiency,Y,63.41 - 69.99,70.00 - 76.18,76.19 - 80.36,80.37 - 83.45,83.46 - 86.48,86.49 - 89.60,89.61 - 98.20,>= 98.21,No
-Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,416,Claims,Efficiency,N,--,--,--,--,--,--,--,--,--
-Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,416,Registry/QCDR,Efficiency,Y,46.67 - 40.01,40.00 - 35.01,35.00 - 28.38,28.37 - 22.82,22.81 - 18.76,18.75 - 14.82,14.81 - 9.53,<= 9.52,No
-Rate of Open Repair of Small or Moderate Abdominal Aortic Aneurysms (AAA) Where Patients Are Discharged Alive,417,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Osteoporosis Management in Women Who Had a Fracture,418,Claims,Process,N,--,--,--,--,--,--,--,--,--
-Osteoporosis Management in Women Who Had a Fracture,418,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Overuse Of Neuroimaging For Patients With Primary Headache And A Normal Neurological Examination,419,Claims,Efficiency,N,--,--,--,--,--,--,--,--,--
-Varicose Vein Treatment with Saphenous Ablation: Outcome Survey,420,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Appropriate Assessment of Retrievable Inferior Vena Cava (IVC) Filters for Removal,421,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Performing Cystoscopy at the Time of Hysterectomy for Pelvic Organ Prolapse to Detect Lower Urinary Tract Injury,422,Claims,Process,N,--,--,--,--,--,--,--,--,--
-Performing Cystoscopy at the Time of Hysterectomy for Pelvic Organ Prolapse to Detect Lower Urinary Tract Injury,422,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Perioperative Temperature Management,424,Registry/QCDR,Outcome,Y,98.46 - 99.51,99.52 - 99.74,99.75 - 99.87,99.88 - 99.98,99.99 - 99.99,--,--,100.00,Yes
-Photodocumentation of Cecal Intubation,425,Claims,Process,Y,97.44 - 98.48,98.49 - 99.15,99.16 - 99.99,--,--,--,--,100.00,Yes
-Pelvic Organ Prolapse: Preoperative Assessment of Occult Stress Urinary Incontinence,428,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Pelvic Organ Prolapse: Preoperative Screening for Uterine Malignancy,429,Claims,Process,N,--,--,--,--,--,--,--,--,--
-Pelvic Organ Prolapse: Preoperative Screening for Uterine Malignancy,429,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Prevention of Post-Operative Nausea and Vomiting (PONV) - Combination Therapy,430,Registry/QCDR,Process,Y,93.66 - 97.17,97.18 - 98.50,98.51 - 99.21,99.22 - 99.63,99.64 - 99.91,99.92 - 99.99,--,100.00,Yes
-Preventive Care and Screening: Unhealthy Alcohol Use: Screening & Brief Counseling,431,Registry/QCDR,Process,Y,33.43 - 49.34,49.35 - 66.11,66.12 - 78.14,78.15 - 86.99,87.00 - 93.51,93.52 - 97.95,97.96 - 99.99,100.00,No
-Proportion of Patients Sustaining a Bladder Injury at the Time of any Pelvic Organ Prolapse Repair,432,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Proportion of Patients Sustaining a Bowel Injury at the time of any Pelvic Organ Prolapse Repair,433,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Proportion of Patients Sustaining a Ureter Injury at the Time of any Pelvic Organ Prolapse Repair,434,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Quality of Life Assessment For Patients With Primary Headache Disorders,435,Claims,Outcome,N,--,--,--,--,--,--,--,--,--
-Quality of Life Assessment For Patients With Primary Headache Disorders,435,Registry/QCDR,Outcome,Y,2.05 - 3.02,3.03 - 5.49,5.50 - 12.43,12.44 - 25.81,25.82 - 75.85,75.86 - 99.99,--,100.00,No
-Radiation Consideration for Adult CT: Utilization of Dose Lowering Techniques,436,Claims,Process,Y,85.73 - 94.12,94.13 - 97.45,97.46 - 98.95,98.96 - 99.65,99.66 - 99.99,--,--,100.00,Yes
-Radiation Consideration for Adult CT: Utilization of Dose Lowering Techniques,436,Registry/QCDR,Process,Y,93.28 - 96.95,96.96 - 99.04,99.05 - 99.66,99.67 - 99.91,99.92 - 99.99,--,--,100.00,Yes
-Rate of Surgical Conversion from Lower Extremity Endovascular Revascularization Procedure,437,Claims,Outcome,Y,1.32 - 0.56,0.55 - 0.01,--,--,--,--,--,0.00,Yes
-Rate of Surgical Conversion from Lower Extremity Endovascular Revascularization Procedure,437,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Statin Therapy for the Prevention and Treatment of Cardiovascular Disease,438,CMS Web Interface,Process,N,--,--,--,--,--,--,--,--,--
-Statin Therapy for the Prevention and Treatment of Cardiovascular Disease,438,Registry/QCDR,Process,Y,69.86 - 77.17,77.18 - 88.87,88.88 - 96.53,96.54 - 99.99,--,--,--,100.00,Yes
-Age Appropriate Screening Colonoscopy,439,Registry/QCDR,Efficiency,N,--,--,--,--,--,--,--,--,--
-Basal Cell Carcinoma (BCC)/Squamous Cell Carcinoma: Biopsy Reporting Time - Pathologist to Clinician,440,Registry/QCDR,Process,Y,96.91 - 98.95,98.96 - 99.87,99.88 - 99.99,--,--,--,--,100.00,Yes
-Ischemic Vascular Disease (IVD) All or None Outcome Measure (Optimal Control),441,Registry/QCDR,Intermediate Outcome,Y,32.40 - 37.13,37.14 - 40.16,40.17 - 44.03,44.04 - 47.77,47.78 - 50.61,50.62 - 54.35,54.36 - 58.25,>= 58.26,No
-Persistence of Beta-Blocker Treatment After a Heart Attack,442,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Non-Recommended Cervical Cancer Screening in Adolescent Females,443,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Medication Management for People with Asthma,444,Registry/QCDR,Process,Y,91.67 - 95.99,96.00 - 97.77,97.78 - 98.43,98.44 - 99.99,--,--,--,100.00,Yes
-Risk-Adjusted Operative Mortality for Coronary Artery Bypass Graft (CABG),445,Registry/QCDR,Outcome,Y,3.90 - 3.40,3.39 - 2.69,2.68 - 2.26,2.25 - 1.75,1.74 - 1.16,1.15 - 0.01,--,0.00,No
-Operative Mortality Stratified by the Five STS-EACTS Mortality Categories,446,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Appropriate Workup Prior to Endometrial Ablation,448,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-HER2 Negative or Undocumented Breast Cancer Patients Spared Treatment with HER2-Targeted Therapies,449,Registry/QCDR,Process,Y,94.80 - 98.14,98.15 - 99.99,--,--,--,--,--,100.00,Yes
-Trastuzumab Received By Patients With AJCC Stage I (T1c) -  III And HER2 Positive Breast Cancer Receiving Adjuvant Chemotherapy,450,Registry/QCDR,Process,Y,87.59 - 90.44,90.45 - 93.19,93.20 - 97.85,97.86 - 99.99,--,--,--,100.00,Yes
-KRAS Gene Mutation Testing Performed for Patients with Metastatic Colorectal Cancer who receive Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibody Therapy,451,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Patients with Metastatic Colorectal Cancer and KRAS Gene Mutation Spared Treatment with Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibodies,452,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Proportion Receiving Chemotherapy in the Last 14 Days of Life,453,Registry/QCDR,Process,Y,15.00 - 10.43,10.42 - 9.19,9.18 - 8.19,8.18 - 7.64,7.63 - 7.31,7.30 - 6.48,6.47 - 0.01,0.00,No
-Proportion of Patients who Died from Cancer with more than One Emergency Department Visit in the Last 30 Days of Life,454,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Proportion Admitted to the Intensive Care Unit (ICU) in the Last 30 Days of Life,455,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Proportion Not Admitted To Hospice,456,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Proportion Admitted to Hospice for less than 3 days,457,Registry/QCDR,Outcome,Y,15.38 - 15.10,15.09 - 13.52,13.51 - 12.21,12.20 - 9.71,9.70 - 6.46,6.45 - 4.33,4.32 - 0.01,0.00,No
-Asthma Assessment and Classification,AAAAI11,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Lung Function/Spirometry Evaluation,AAAAI12,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Asthma Control: Minimal Important Difference Improvement,AAAAI17,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Penicillin Allergy: Appropriate Removal or Confirmation,AAAAI18,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Asthma: Pharmacologic Therapy for Persistent Asthma – Ambulatory Care Setting,AAAAI19,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Asthma: Assessment of Asthma Control – Ambulatory Care Setting,AAAAI2,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Allergen Immunotherapy Treatment: Allergen Specific Immunoglobulin E (IgE) Sensitivity Assessed and Documented Prior to Treatment,AAAAI5,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Documentation of Clinical Response to Allergen Immunotherapy within One Year,AAAAI6,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Achievement of Projected Effective Dose of Standardized Allergens for Patient Treated With Allergen Immunotherapy for at Least One Year,AAAAI8,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Assessment of Asthma Symptoms Prior to Administration of Allergen Immunotherapy Injection(s),AAAAI9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Psoriasis: Assessment of Psoriasis Disease Activity,AAD1,Registry/QCDR,Process,Y,10.16 - 18.74,18.75 - 25.12,25.13 - 35.83,35.84 - 43.47,43.48 - 57.07,57.08 - 76.76,76.77 - 99.99,100.00,No
-Psoriasis: Screening for Psoriatic Arthritis,AAD2,Registry/QCDR,Process,Y,82.44 - 95.44,95.45 - 99.99,--,--,--,--,--,100.00,Yes
-Basal Cell Carcinoma/Squamous Cell Carcinoma: Mohs Surgery for Superficial Basal Cell Carcinoma of the Trunk for Immune Competent Patients,AAD3,Registry/QCDR,Process,Y,1.58 - 0.01,--,--,--,--,--,--,0.00,Yes
-Basal Cell Carcinoma/Squamous Cell Carcinoma: Mohs Surgery for Squamous Cell Carcinoma in Situ or Keratoacanthoma Type Squamous Cell Carcinoma 1 cm or Smaller on the Trunk,AAD4,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Biopsy Reporting Time - Clinician to Patient,AAD5,Registry/QCDR,Process,Y,73.58 - 90.13,90.14 - 98.61,98.62 - 99.99,--,--,--,--,100.00,Yes
-Diabetes/Pre-Diabetes Screening for Patients with DSP,AAN1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Falls screening,AAN10,Registry/QCDR,Process,Y,3.92 - 11.89,11.90 - 21.87,21.88 - 29.88,29.89 - 55.30,55.31 - 66.67,66.68 - 82.12,82.13 - 90.60,>= 90.61,No
-Overuse of Opioid and Barbiturate Containing Medications for Primary Headache Disorders.,AAN11,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Screening for Unhealthy Alcohol Use,AAN2,Registry/QCDR,Process,Y,42.45 - 46.26,46.27 - 47.02,47.03 - 49.31,49.32 - 52.30,52.31 - 53.46,53.47 - 55.12,55.13 - 59.18,>= 59.19,No
-Screening for Psychiatric or Behavioral Health Disorders,AAN4,Registry/QCDR,Process,Y,27.59 - 41.34,41.35 - 55.95,55.96 - 73.61,73.62 - 83.99,84.00 - 94.11,94.12 - 98.13,98.14 - 99.73,>= 99.74,No
-MEDICATION PRESCRIBED FOR ACUTE MIGRAINE ATTACK,AAN5,Registry/QCDR,Process,Y,14.39 - 17.85,17.86 - 22.94,22.95 - 28.56,28.57 - 33.93,33.94 - 40.19,40.20 - 45.55,45.56 - 53.00,>= 53.01,No
-Exercise and Appropriate Physical Activity Counseling for Patients with MS,AAN8,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Querying about Symptoms of Autonomic Dysfunction,AAN9,Registry/QCDR,Process,Y,61.54 - 82.60,82.61 - 92.85,92.86 - 94.58,94.59 - 97.49,97.50 - 99.99,--,--,100.00,No
-Otitis Media with Effusion: Avoidance of Topical Intranasal Corticosteroids,AAO11,Registry/QCDR,Process,Y,99.60 - 99.99,--,--,--,--,--,--,100.00,Yes
-Otitis Media with Effusion: Antihistamines or Decongestants – Avoidance of Inappropriate Use,AAO8,Registry/QCDR,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Intra-operative anesthesia safety,ABG1,Registry/QCDR,Outcome,Y,99.98 - 99.99,--,--,--,--,--,--,100.00,Yes
-Patient Experience Survey,ABG12,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Planned use of difficult airway equipment,ABG16,Registry/QCDR,Process,Y,56.01 - 61.14,61.15 - 72.26,72.27 - 77.96,77.97 - 82.24,82.25 - 89.40,89.41 - 94.18,94.19 - 99.83,>= 99.84,No
-Pre-operative OSA assessment,ABG21,Registry/QCDR,Process,Y,29.34 - 48.18,48.19 - 62.50,62.51 - 84.86,84.87 - 90.41,90.42 - 95.13,95.14 - 99.76,99.77 - 99.99,100.00,No
-Pre-Operative Screening for GERD,ABG28,Registry/QCDR,Process,Y,32.09 - 44.87,44.88 - 50.15,50.16 - 52.83,52.84 - 58.27,58.28 - 87.25,87.26 - 98.87,98.88 - 99.99,100.00,No
-Pre-Operative Screening for Glaucoma,ABG29,Registry/QCDR,Process,Y,44.29 - 67.22,67.23 - 95.02,95.03 - 99.50,99.51 - 99.99,--,--,--,100.00,Yes
-Pre-Operative Screening for PONV Risk,ABG30,Registry/QCDR,Process,Y,76.64 - 93.46,93.47 - 97.59,97.60 - 99.05,99.06 - 99.66,99.67 - 99.99,--,--,100.00,Yes
-Pre-Operative Screening for Excessive Alcohol and Recreational Drug Use,ABG31,Registry/QCDR,Process,Y,89.72 - 98.87,98.88 - 99.66,99.67 - 99.97,99.98 - 99.99,--,--,--,100.00,Yes
-Pain Related Quality of Life Interference,ABG32,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Lower Body Functional Impairment (LBI),ABG33,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Mood Assessment Screening and treatment,ABG34,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Immediate Adult Post-Operative Pain Management,ABG7,Registry/QCDR,Outcome,Y,97.85 - 98.62,98.63 - 99.28,99.29 - 99.82,99.83 - 99.99,--,--,--,100.00,Yes
-Stroke intra or post PCI procedure in patients without CABG or other major surgeries during admission.,ACCCATH1,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Cardiac Rehabilitation Patient Referral From an Inpatient Setting,ACCCATH13,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-New requirement for dialysis post PCI in patients without CABG or other major surgeries during admission.,ACCCATH2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Vascular access site injury requiring treatment or major bleeding post PCI in patients without CABG or other major surgeries during admission.,ACCCATH3,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Cardiac tamponade post PCI in patients without CABG or other major surgery during admission.,ACCCATH4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-STEMI patients receiving immediate PCI within 90 minutes.,ACCCATH5,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-ACE-I or ARB prescribed at discharge for patients with an ejection fraction < 40% who had a PCI during the episode of care.,ACCCATH6,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Percutaneous Coronary Intervention (PCI): Post-procedural Optimal Medical Therapy,ACCCATH8,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-PCI procedures that were inappropriate for patients with Acute Coronary Syndrome (ACS).,ACCCATH9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-HF: Patient Self Care Education,ACCPIN3,Registry/QCDR,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Coagulation Studies in Patients Presenting with Chest Pain with No Coagulopathy or Bleeding,ACEP21,Registry/QCDR,Process,Y,24.61 - 19.33,19.32 - 15.93,15.92 - 9.06,9.05 - 5.75,5.74 - 3.78,3.77 - 0.01,--,0.00,No
-Appropriate Emergency Department Utilization of CT for Pulmonary Embolism,ACEP22,Registry/QCDR,Process,Y,8.00 - 14.99,15.00 - 18.95,18.96 - 22.72,22.73 - 26.55,26.56 - 29.46,29.47 - 36.66,36.67 - 50.58,>= 50.59,No
-Pregnancy Test for Female Abdominal Pain Patients,ACEP24,Registry/QCDR,Process,Y,55.27 - 60.22,60.23 - 64.28,64.29 - 68.37,68.38 - 73.24,73.25 - 77.93,77.94 - 80.55,80.56 - 84.76,>= 84.77,No
-Tobacco Use: Screening and Cessation Intervention,ACEP25,Registry/QCDR,Process,Y,63.89 - 67.52,67.53 - 71.87,71.88 - 74.99,75.00 - 78.78,78.79 - 81.81,81.82 - 85.70,85.71 - 89.99,>= 90.00,No
-Sepsis Management: Septic Shock: Repeat Lactate Level Measurement,ACEP29,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Sepsis Management: Septic Shock: Lactate Clearance Rate ≥ 10%,ACEP30,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Emergency Medicine: Appropriate Foley Catheter Use in the Emergency Department,ACEP31,Registry/QCDR,Process,Y,43.04 - 51.99,52.00 - 59.08,59.09 - 63.36,63.37 - 69.04,69.05 - 73.07,73.08 - 88.09,88.10 - 91.66,>= 91.67,No
-Sepsis Management: Septic Shock: Blood Cultures Ordered,ACEP48,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Emergency Medicine: Appropriate Use of Imaging for Recurrent Renal Colic,ACEP49,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-High Risk Pneumococcal Vaccination,ACPGR1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-"Tdap (Tetanus, Diphtheria, Acellular Pertussis) Vaccination",ACPGR2,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Fixed-dose Combination of Hydralazine and Isosorbide Dinitrate Therapy for Self-identified Black or African American Patients with Heart Failure and LVEF <40% on ACEI or ARB and Beta-blocker Therapy,ACPGR3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Gout: Serum Urate Target,ACR7,Registry/QCDR,Intermediate Outcome,Y,20.83 - 24.55,24.56 - 31.81,31.82 - 38.09,38.10 - 41.45,41.46 - 44.61,44.62 - 47.82,47.83 - 65.24,>= 65.25,No
-CT Colonography True Positive Rate,ACRAD1,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-CT Colonography Clinically Significant Extracolonic Findings (Inverse Measure),ACRAD2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Lung Cancer Screening Cancer Detection Rate (CDR),ACRAD21,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Lung Cancer Screening Positive Predictive Value (PPV),ACRAD22,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Appropriate venous access for hemodialysis,ACRAD26,Registry/QCDR,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--
-Uterine artery embolization technique: Documentation of angiographic endpoints and interrogation of ovarian arteries,ACRAD27,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Rate of early peristomal infection following fluoroscopically guided gastrostomy tube placement,ACRAD28,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Rate of percutaneous nephrostomy tube replacement within 30 days secondary to dislodgement,ACRAD29,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Screening Mammography Cancer Detection Rate (CDR),ACRAD3,Registry/QCDR,Outcome,Y,0.18 - 0.23,0.24 - 0.30,0.31 - 0.42,0.43 - 0.48,0.49 - 0.53,0.54 - 0.61,0.62 - 0.79,>= 0.80,No
-Rate of Inadequate Percutaneous Image-Guided Biopsy,ACRAD30,Registry/QCDR,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--
-Percent of CT Abdomen-pelvis exams with contrast (single phase scan) for which Dose Length Product is at or below the size-specific diagnostic reference level.,ACRAD31,Registry/QCDR,Outcome,Y,--,--,--,--,--,--,--,100.00,Yes
-Percent of CT Chest exams without contrast (single phase scan) for which Dose Length Product is at or below the size-specific diagnostic reference level.,ACRAD32,Registry/QCDR,Outcome,Y,--,--,--,--,--,--,--,100.00,Yes
-Percent of CT Head/Brain exams without contrast (single phase scan) for which Dose Length Product is at or below the size-specific diagnostic reference level,ACRAD33,Registry/QCDR,Outcome,Y,--,--,--,--,--,--,--,100.00,Yes
-"Screening Mammography Positive Predictive Value 2 (PPV2 - Biopsy
-Recommended)",ACRAD6,Registry/QCDR,Outcome,Y,20.00 - 21.61,21.62 - 23.07,23.08 - 26.08,26.09 - 29.89,29.90 - 31.99,32.00 - 35.58,35.59 - 37.15,>= 37.16,No
-Screening Mammography Node Negativity Rate,ACRAD7,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Screening Mammography Minimal Cancer Rate,ACRAD8,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Preoperative Composite,ACS15,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Preventative Care and Screening: Tobacco Screening and Cessation Intervention,ACS16,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Preoperative Key Medications Review for Anticoagulation Medication,ACS17,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Patient Frailty Evaluation,ACS18,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Intraoperative Composite,ACS19,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Optimal Postoperative Communication Plan and Patient Care Coordination Composite,ACS20,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Post-Acute Recovery Composite,ACS21,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Unplanned Reoperation within the 30 Day Postoperative Period,ACS22,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Unplanned Hospital Readmission within 30 Days of Principal Procedure,ACS23,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Ventral Hernia Repair: Surgical Site Occurrence Requiring Procedural Intervention within the 30 Day Postoperative Period,AHSQC1,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Unplanned Hospital Readmission or Observation Visit within the 30 Day Postoperative Period,AHSQC2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Abdominal Wall Reconstruction Surgical Site Occurrence Requiring Procedural Intervention within the 30 Day Postoperative Period,AHSQC6,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Abdominal Wall Reconstruction Preoperative Diabetes Assessment,AHSQC7,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Ventral Hernia Repair: Biologic Mesh Prosthesis Use in Low Risk Patients,AHSQC8,Registry/QCDR,Efficiency,N,--,--,--,--,--,--,--,--,--
-Ventral Hernia Repair: Pain and Functional Status Assessment,AHSQC9,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Hip Arthroplasty: Postoperative Complications within 90 Days Following the Procedure,AJRR1,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Hip Arthroplasty: Health and Functional Improvement,AJRR2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Hip Arthroplasty: Shared Decision-Making: Trial of Conservative (Non-surgical) Therapy,AJRR3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Hip Arthroplasty: Venous Thromboembolic and Cardiovascular Risk Evaluation,AJRR4,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Comprehensive Diabetic Foot Examination,APMA1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Coronary Artery Bypass Graft (CABG): Prolonged Intubation - INVERSE MEASURE,AQI18,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Anesthesia Safety,AQI30,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Coronary Artery Bypass Graft (CABG): Stroke - INVERSE MEASURE,AQI41,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Coronary Artery Bypass Graft (CABG): Post-Operative Renal Failure - INVERSE MEASURE,AQI42,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Anesthesia: Patient Experience Survey,AQI48,Registry/QCDR,Process,Y,55.23 - 60.02,60.03 - 94.51,94.52 - 99.08,99.09 - 99.98,99.99 - 99.99,--,--,100.00,Yes
-Adherence to Blood Conservation Guidelines for Cardiac Operations using Cardiopulmonary Bypass (CPB) – Composite,AQI49,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Application of Lung-Protective Ventilation during General Anesthesia,AQI50,Registry/QCDR,Intermediate Outcome,Y,99.14 - 99.45,99.46 - 99.82,99.83 - 99.99,--,--,--,--,100.00,Yes
-Assessment of Patients for Obstructive Sleep Apnea,AQI51,Registry/QCDR,Process,Y,79.31 - 92.61,92.62 - 96.39,96.40 - 99.34,99.35 - 99.79,99.80 - 99.94,99.95 - 99.99,--,100.00,Yes
-Treatment of Hyperglycemia with Insulin,AQI52,Registry/QCDR,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--
-Prostate Cancer: Patient Report of Urinary function after treatment,AQUA10,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Prostate Cancer: Patient Report of Sexual function after treatment,AQUA11,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Benign Prostate Hyperplasia: IPSS improvement after diagnosis,AQUA12,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Stress Urinary Incontinence (SUI): Revision surgery within 12 months of incontinence procedure,AQUA13,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Stones: Repeat Shock Wave Lithotripsy (SWL) within 6 months of treatment,AQUA14,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Stones: Urinalysis documented 30 days before surgical stone procedures,AQUA15,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Non-Muscle Invasive Bladder Cancer: Repeat Transurethal Resection of Bladder Tumor (TURBT) for T1 disease,AQUA16,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Non-Muscle Invasive Bladder Cancer: Initiation of BCG 3 months of diagnosis of high-grade T1 bladder cancer and/or CIS,AQUA17,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Non-Muscle Invasive Bladder Cancer: Early surveillance cystoscopy within 4 months of initial diagnosis,AQUA18,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Cryptorchidism: Inappropriate use of scrotal/groin ultrasound on boys,AQUA3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Hypogonadism: Testosterone lab ordered/reported within 6 months of starting testosterone replacement,AQUA4,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Hospital re-admissions/complications within 30 days of TRUS Biopsy,AQUA8,Registry/QCDR,Outcome,Y,5.13 - 4.23,4.22 - 3.22,3.21 - 2.64,2.63 - 1.02,1.01 - 0.70,0.69 - 0.01,--,0.00,Yes
-Risk Standardized Mortality Rate within 30 days following Trauma Operation,ARCO10,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Head CT or MRI Scan Results for Acute Ischemic Stroke or Hemorrhagic Stroke Patients who Received Head CT or MRI Scan Interpretation within 45 minutes of ED Arrival,ARCO11,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Venous Thromboembolism (VTE) Prophylaxis,ARCO12,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Ischemic stroke patients management -,ARCO13,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Gout: ULT Therapy,ARCO14,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Antipsychotic Use in Persons with Dementia,ARCO3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Laboratory Investigation for Secondary Causes of Fracture,ARCO7,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Surgeon assessment for hereditary cause of breast cancer,ASBS1,Registry/QCDR,Process,Y,99.16 - 99.99,--,--,--,--,--,--,100.00,Yes
-Management of the axilla in breast cancer patients undergoing breast conserving surgery with a positive sentinel node biopsy,ASBS10,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Unplanned 30 day re-operation after mastectomy,ASBS7,Registry/QCDR,Outcome,Y,98.15 - 98.46,98.47 - 99.99,--,--,--,--,--,100.00,Yes
-Cardiac Stress Nuclear Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low Risk Surgery Patients,ASNC1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-SPECT-MPI studies meeting appropriate use criteria,ASNC13,Registry/QCDR,Efficiency,N,--,--,--,--,--,--,--,--,--
-PET-MPI studies meeting appropriate use criteria,ASNC14,Registry/QCDR,Efficiency,N,--,--,--,--,--,--,--,--,--
-SPECT-MPI studies not Equivocal,ASNC17,Registry/QCDR,Efficiency,N,--,--,--,--,--,--,--,--,--
-PET-MPI studies not Equivocal,ASNC18,Registry/QCDR,Efficiency,N,--,--,--,--,--,--,--,--,--
-Imaging Protocols for SPECT and PET MPI studies - Use of stress only protocol,ASNC19,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Cardiac Stress Nuclear Imaging Not Meeting Appropriate Use Criteria: Routine Testing After Percutaneous Coronary Intervention (PCI),ASNC2,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-SPECT-MPI studies performed without the use of thallium,ASNC20,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-SPECT-MPI study appropriate imaging protocol selection for morbidly obese patients,ASNC21,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-SPECT and PET MPI studies reporting Left Ventricular Ejection Fraction,ASNC22,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-SPECT-MPI study clinical utilization of Attenuation Correction image acquisition,ASNC23,Registry/QCDR,Efficiency,N,--,--,--,--,--,--,--,--,--
-SPECT-MPI study utilization of exercise as a stressor,ASNC24,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-SPECT-MPI study adequate exercise testing performed,ASNC25,Registry/QCDR,Efficiency,N,--,--,--,--,--,--,--,--,--
-"Cardiac Stress Nuclear Imaging Not Meeting Appropriate Use Criteria: Testing in Asymptomatic, Low-Risk Patients",ASNC3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Utilization of standardized nomenclature and reporting for nuclear cardiology imaging studies,ASNC4,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Transfusion goal of hematocrit less than 30 or hemoglobin less than 10.,ASPIRE13,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Avoiding intraoperative hypotension,ASPIRE16,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Avoiding myocardial Injury,ASPIRE18,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Avoiding acute kidney injury,ASPIRE19,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Train of Four Monitor Documented After Last Dose of Non-depolarizing Neuromuscular Blocker,ASPIRE2,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Avoiding medication overdose,ASPIRE22,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Administration of Neostigmine before Extubation for Cases with Nondepolarizing Neuromuscular Blockade,ASPIRE3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Administration of insulin or glucose recheck for patients with hyperglycemia,ASPIRE4,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Avoiding excessively high tidal volumes during positive pressure ventilation,ASPIRE6,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Core temperature measurement for all general anesthetics,ASPIRE8,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Breast Reconstruction: Return to OR,ASPS5,Registry/QCDR,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--
-Breast Reconstruction: Flap Loss,ASPS6,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Complete assessment and evaluation of patient’s pelvic organ prolapse prior to surgical repair,AUGS1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Preoperative utilization of pessary prior to Pelvic Organ Prolapse surgery,AUGS2,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Preoperative assessment of sexual function prior to pelvic organ prolapse repair,AUGS3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Performing an intraoperative rectal examination at the time of prolapse repair,AUGS4,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Performing vaginal apical suspension at the time of hysterectomy to address pelvic organ prolapse,AUGS5,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Route of Hysterectomy,AUGS6,Registry/QCDR,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--
-Documentation that conservative management was offered prior to fecal incontinence surgery or procedures.,AUGS7,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Documentation of weight loss counseling prior to surgery for stress urinary incontinence procedures for obese women,AUGS8,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Over-utilization of synthetic mesh in the posterior compartment,AUGS9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Patient Reported Comprehensive Assessment of Safety,BIVARUS27,Registry/QCDR,Patient Engagement Experience,N,--,--,--,--,--,--,--,--,--
-Patient Reported Experience and Care Coordination,BIVARUS28,Registry/QCDR,Patient Engagement Experience,N,--,--,--,--,--,--,--,--,--
-Patient Reported Pain Treatment Effectiveness,BIVARUS30,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Patient Reported Communication and Care Coordination,BIVARUS31,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Patient Reported Care Team Communication,BIVARUS32,Registry/QCDR,Patient Engagement Experience,N,--,--,--,--,--,--,--,--,--
-Preoperative notification of risk of developing ischemic optic neuropathy (ION) during prone spine procedures,BNS1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Topic: Turnaround time (TAT) for standard biopsies,CAP1,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Cancer Protocol Elements for Carcinoma of the Endometrium Completed,CAP2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Cancer Protocol Elements for Invasive Carcinoma of Renal Tubular Origin Completed,CAP3,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Cancer Protocol Elements for Carcinoma of the Intrahepatic Bile Ducts Completed,CAP4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Cancer Protocol Elements for Hepatocellular Carcinoma Completed,CAP5,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Cancer Protocol Elements for Carcinoma of the Pancreas Completed,CAP6,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-1-Year Patient-Reported Pain and Function Improvement after Total Knee Arthroplasty,CCOME1,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-1-Year Patient-Reported Pain and Function Improvement after Total Hip Arthroplasty,CCOME2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-1-Year Patient-Reported Pain and Function Improvement after Total Shoulder Arthroplasty,CCOME3,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-1-Year Patient-Reported Pain and Function Improvement after ACLR Surgery,CCOME4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Extent of Osteoarthritis Observed in Arthroscopic Partial Meniscectomy,CCOME5,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Adequate Off-loading of Diabetic Foot Ulcer at each treatment visit,CDR1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Vascular Assessment of patients with chronic leg ulcers,CDR10,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Diabetic Foot Ulcer (DFU) Healing or Closure,CDR2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Plan of Care Creation for Diabetic Foot Ulcers (DFU) not Achieving 30% Closure at 4 Weeks,CDR3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Adequate Compression of Venous Leg Ulcers at each treatment visit,CDR5,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Venous Leg Ulcer outcome measure: Healing or Closure,CDR6,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Plan of Care for Venous Leg Ulcers not Achieving 30% Closure at 4 Weeks,CDR7,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Appropriate use of hyperbaric oxygen therapy for patients with diabetic foot ulcers,CDR8,Registry/QCDR,Efficiency,N,--,--,--,--,--,--,--,--,--
-Appropriate use of Cellular and/or Tissue Based Product (CTP) in diabetic foot ulcers (DFUs) or venous leg ulcers (VLUs),CDR9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Post operative hypocalcemia after thyroidectomy surgery,CESQIP1,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Related readmission for thyroid or parathyroid related problems,CESQIP2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Pre operative ultrasound exam of patients with thyroid cancer,CESQIP3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Persistent hypercalcemia,CESQIP4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Related readmission for adrenal related problems,CESQIP5,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Evaluation and Integration of anti-coagulant medication prior to surgery,CESQIP6,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Improved Global Physical Health Outcome Assessment for Shoulder Replacement,CODE1,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Improved Global Physical Health Outcome Assessment for Shoulder Arthroscopy,CODE10,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Improved Functional Outcome Assessment for Knee Arthroscopy,CODE11,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Improved Functional Outcome Assessment for Hip Arthroscopy,CODE12,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Improved Functional Outcome Assessment for ACL Repair,CODE2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Improved Functional Outcome Assessment for Foot/Ankle Repair,CODE3,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Improved Global Physical Health Outcome Assessment for Spine Surgery,CODE5,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Improved Functional Outcome Assessment for Hip Replacement,CODE6,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Improved Functional Outcome Assessment for Knee Replacement,CODE7,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Improved Global Physical Health Outcome Assessment for Cervical Surgery,CODE8,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Improved Global Physical Health Outcome Assessment for Hand/Wrist/Elbow Repair,CODE9,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-"CAHPS Clinician/Group Surveys - (Adult Primary Care, Pediatric Care, and Specialist Care Surveys)",CUHSM3,Registry/QCDR,Patient Engagement Experience,N,--,--,--,--,--,--,--,--,--
-CAHPS Health Plan Survey v 4.0 - Adult questionnaire,CUHSM4,Registry/QCDR,Patient Engagement Experience,N,--,--,--,--,--,--,--,--,--
-Adherence to Mood Stabilizers for Individuals with Bipolar I Disorder,CUHSM6,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Cardiovascular Health Screening for People With Schizophrenia or Bipolar Disorder Who Are Prescribed Antipsychotic Medications,CUHSM8,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Avoid Head CT for Patients with Uncomplicated Syncope,ECPR39,Registry/QCDR,Process,Y,83.33 - 84.77,84.78 - 87.17,87.18 - 88.44,88.45 - 90.90,90.91 - 92.67,92.68 - 94.43,94.44 - 96.98,>= 96.99,No
-Initiation of the Initial Sepsis Bundle,ECPR40,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Rh Status Evaluation and Treatment of Pregnant Women at Risk of Fetal Blood Exposure,ECPR41,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Restrictive Use of Blood Transfusions,ECPR42,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Ultrasound Guidance for Central Venous Catheter Placement,EPREOP26,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Short-term Pain Management/Maximum Pain Score,EPREOP4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Appropriate management of anticoagulation in the peri-procedural period rate – EGD,GIQIC10,Registry/QCDR,Process,Y,31.25 - 52.34,52.35 - 61.53,61.54 - 66.77,66.78 - 81.35,81.36 - 90.90,90.91 - 98.90,98.91 - 99.99,100.00,No
-Appropriate indication for colonoscopy,GIQIC12,Registry/QCDR,Process,Y,83.72 - 87.91,87.92 - 90.19,90.20 - 91.85,91.86 - 93.51,93.52 - 95.05,95.06 - 96.57,96.58 - 98.14,>= 98.15,No
-Appropriate follow-up interval of 3 years recommended based on pathology findings from screening colonoscopy in average-risk patients,GIQIC15,Registry/QCDR,Process,Y,61.11 - 71.42,71.43 - 76.09,76.10 - 79.19,79.20 - 83.66,83.67 - 87.12,87.13 - 90.23,90.24 - 93.74,>= 93.75,No
-Use of high risk sleep medications in the elderly,HADV1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Atrial fibrillation (afib) prevention and treatment: Patients with afib who are assessed for lifestyle and disease factors that contribute to uncontrolled afib,HADV2,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Stroke Venous Thromboembolism (VTE) Prophylaxis,HCPR13,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Venous Thromboembolism (VTE) Prophylaxis,HCPR14,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Physician’s Orders for Life-Sustaining Treatment (POLST) Form,HCPR16,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Pressure Ulcers – Risk Assessment and Plan of Care,HCPR17,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Unintentional Weight Loss – Risk Assessment and Plan of Care,HCPR18,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Excess Days Rate and Degree of Excess (Including Physician Response),ICLOPS15,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Rate of Follow Up Visits Within 7 Days of Discharge (Including Physician Response),ICLOPS17,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Corneal Graft Surgery - Post-operative improvement in visual acuity of 20/40 or greater,IRIS1,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Exudative Age-Related Macular Degeneration - Loss of Visual Acuity,IRIS10,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Nonexudative Age-Related Macular Degeneration - Loss of Visual Acuity,IRIS11,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Diabetic Macular Edema - Loss of Visual Acuity,IRIS13,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Acute Anterior Uveitis - Post-treatment visual acuity,IRIS16,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Acute Anterior Uveitis - Post-treatment Grade 0 anterior chamber cells,IRIS17,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Chronic Anterior Uveitis -  Post-treatment visual acuity,IRIS18,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Chronic Anterior Uveitis -  Post-treatment Grade 0 anterior chamber cells,IRIS19,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Glaucoma -  Intraocular Pressure (IOP)Reduction,IRIS2,Registry/QCDR,Outcome,Y,86.96 - 97.36,97.37 - 98.99,99.00 - 99.99,--,--,--,--,100.00,Yes
-Idiopathic Intracranial Hypertension:  No worsening or improvement of mean deviation,IRIS20,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Ocular Myasthenia Gravis:  Improvement of ocular deviation or absence of diplopia or functional improvement,IRIS21,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Giant Cell Arteritis:  Absence of fellow eye involvement after corticosteroid treatment,IRIS22,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Refractive Surgery: Postoperative Improvement in Uncorrected Visual Acuity of 20/20 or better,IRIS23,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Refractive Surgery:  Postoperative correction within + 0.5 Diopter of the Intended Correction,IRIS24,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Adenoviral Conjunctivitis:  Avoidance of Antibiotics,IRIS25,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Intravitreal Injections:  Avoidance of Routine Antibiotic Use,IRIS26,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Glaucoma - Visual Field Progression,IRIS3,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Glaucoma - Intraocular Pressure Reduction Following Laser Trabeculoplasty,IRIS4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Surgery for Acquired Involutional Ptosis - Patients with an Improvement of Marginal Reflex Distance,IRIS5,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Acquired Involutional Entropion -  Normalized Lid Position After Surgical Repair,IRIS6,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Amblyopia - Interocular Visual Acuity,IRIS7,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Surgical Esotropia - Postoperative Alignment,IRIS8,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Diabetic Retinopathy - Documentation of the Presence or Absence of Macular Edema and the Level of Severity of Retinopathy,IRIS9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Procedures with statin and antiplatelet agents prescribed at discharge,M2S1,Registry/QCDR,Process,Y,70.25 - 77.54,77.55 - 80.46,80.47 - 81.25,81.26 - 81.61,81.62 - 84.56,84.57 - 89.82,89.83 - 92.81,>= 92.82,No
-Survival at least 9 months after elective repair of small thoracic aortic aneurysms,M2S10,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Imaging-based maximum aortic diameter assessed at least 9 months following Endovascular AAA Repair procedures,M2S11,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Survival at least 9 months after elective repair Endovascular AAA Repair of small abdominal aortic aneurysms,M2S12,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Survival at least 9 months after elective Open AAA repair of small abdominal aortic aneurysms,M2S13,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Absence of unplanned reoperation after major lower extremity amputation,M2S16,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Absence of serious technical complications during peripheral arterial intervention,M2S17,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Venous clinical severity score (VCSS) assessment before varicose vein treatment,M2S18,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Proper patient selection for perforator vein ablation,M2S19,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Amputation-free survival assessed at least 9 months following Infra-Inguinal Bypass for intermittent claudication,M2S2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Infra-inguinal bypass for claudication patency assessed at least 9 months following surgery,M2S3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Amputation-free survival assessed at least 9 months following Supra-Inguinal Bypassfor claudication,M2S4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Amputation-free survival at assessed at least 9 months following Peripheral Vascular Interventionfor intermittent claudication,M2S5,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Peripheral Vascular Intervention patency assessed at least 9 months following infrainguinal PVI for claudication,M2S6,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Ipsilateral stroke-free survival at assessed at least 9 months following Carotid Artery Stenting for asymptomatic procedures,M2S7,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Ipsilateral stroke-free survival assessed at least 9 months following isolated Carotid Endarterectomy for asymptomatic procedures,M2S8,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Imaging-based maximum aortic diameter assessed at least 9 months following Thoracic and Complex EVAR procedures,M2S9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Case Delay,MA1,Registry/QCDR,Efficiency,N,--,--,--,--,--,--,--,--,--
-Corneal Abrasion,MA2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-"Risk standardized rate of patients who experienced postoperative nausea, vomiting or fluid/electrolyte/nutritional depletion within 30 days",MBSAQIP7,Registry/QCDR,Outcome,Y,2.13 - 1.85,1.84 - 1.29,1.28 - 0.40,0.39 - 0.01,--,--,--,0.00,Yes
-Risk standardized rate of patients who experienced extended length of stay (> 7 days),MBSAQIP8,Registry/QCDR,Outcome,Y,--,--,--,--,--,--,--,0.00,Yes
-Hemoglobin A1c Test for Pediatric Patients,MEHC1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Heel Pain Treatment Outcomes for Adults,MEX1,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Heel Pain Treatment Outcomes for Pediatric Patients,MEX2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Identification of Flat Foot in Pediatric Patients,MEX3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Plan All Cause Readmissions,MHAN3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-General Health Postoperative Improvement,MICS1,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Surgery Specific Postoperative Improvement in Pain Levels,MICS2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Surgery Specific Postoperative Improvement in Function Levels,MICS3,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Screening and patient education for patients meeting guidelines for Colorectal Cancer screening,MIRAMED11,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Screening and patient education for high risk patients meeting guidelines for Lung Cancer Screening with CT,MIRAMED12,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Screening and patient education for high risk patients meeting guidelines for Abdominal Aortic Ultrasound Screening,MIRAMED13,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Screening and patient education for high risk patients meeting guidelines for Breast Cancer screening with MRI,MIRAMED14,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Screening and patient education for high risk patients meeting guidelines for osteoporosis screening,MIRAMED15,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Perioperative Pain Plan,MIRAMED16,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Optimal Diabetes Care,MNCM1,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Optimal Vascular Care,MNCM2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Optimal Asthma Control,MNCM3,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Diabetes Hemoglobin A1c Poor Control (>9.0%),MNCM4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Ischemic (IVD): Use of Aspirin or Another Antiplatelet,MNCM5,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Objectifying pain and/or functionality to determine manipulative medicine efficacy with correlative treatment adjustment.,MOA1,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Treatment of spinal stenosis with manipulative medicine and alternative medicine modalities.,MOA12,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Urine Drug Screen Utilization in Pain Management and Substance Use Disorders; no less than quarterly for pain and no less than monthly for substance use disorders.,MOA13,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Addressing anxiety in pain patients with SNRI and SSRIs and reducing/eliminating benzodiazepines for chronic anxiety.,MOA14,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Weight loss in pain patients with BMI >30 with opiate utilization for weight related pain conditions rather than opiate dose escalation for improved pain control.,MOA15,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Appropriate use of advanced imaging by ordering provider with glucocorticoid management to spare motor neuron loss when physical findings suggest neuropathic etiology.,MOA2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Appropriate controlled substance prescribing (definitive diagnosis(es)) via adherence to Controlled Substance Agreements (CSA) or (OA's) with corrective action taken for pain and/or substance use disorder patients when violations occur.,MOA7,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Pre-surgical screening for depression,MSSIC1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Percent of patients achieving MCID for pain-related disability (ODI/NDI),MSSIC10,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Percent Satisfied with Result,MSSIC11,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Risk-adjusted rate of hospital readmission,MSSIC12,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Risk-adjusted rate of surgical site infection,MSSIC13,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Risk-adjusted rate of urinary retention,MSSIC14,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Unplanned Return to OR Rate,MSSIC15,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Assessment of back or neck pain,MSSIC2,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Assessment of leg or arm pain,MSSIC3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Assessment of pain-related disability (ODI/NDI),MSSIC4,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Follow-up (90 day) assessment of myelopathy (cervical only),MSSIC5,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Percent same-day ambulation,MSSIC6,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Rate of use of Pre-op skin preparation/wash,MSSIC7,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Percent of patients achieving MCID for back or neck pain,MSSIC8,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Percent of patients achieving MCID for leg or arm pain,MSSIC9,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Prostate Biopsy Antibiotic Compliance,MUSIC1,Registry/QCDR,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Prostate Cancer: Confirmation Testing in low risk AS eligible patients,MUSIC10,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Prostate Cancer: Follow-Up Testing for patients on active surveillance for at least 30 months,MUSIC11,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Prostate Cancer: Avoidance of Overuse of CT Scan for Staging Low Risk Prostate Cancer Patients,MUSIC3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Prostate Cancer: Active Surveillance/Watchful Waiting for Low Risk Prostate Cancer Patients,MUSIC4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Prostate Cancer: Radical Prostatectomy Cases LOS,MUSIC5,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Prostate Cancer: Unplanned Hospital Readmission After Radical Prostatectomy,MUSIC6,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Prostate Biopsy: Repeat Biopsy for Patients with Atypical Small Acinar Proliferation (ASAP),MUSIC9,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-"Telephone Contact, Virtual, or In-person Visit Within 48 Hours of Hospital Discharge of Home-Based Primary Care and Palliative Care Patients",NHBPC10,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Medication Reconciliation Within 2 Weeks of Hospital Discharge of Home-Based Primary Care and Palliative Care Patients,NHBPC11,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Interdisciplinary Team Assessment for Home-Based Primary care and Palliative Care Patients,NHBPC13,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Cognitive Assessment for Home-Based Primary Care and Palliative Care Patients,NHBPC14,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-A Functional Assessment (Basic and Instrumental Activities of Daily Living [ADL]) for Home-Based Primary Care and Palliative Care Patients (Multiperformance Measure),NHBPC15,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Patient Reported Outcome for Home-Based Primary Care and Palliative Care Practices,NHBPC16,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Alcohol Problem Use Assessment for Home-Based Primary Care and Palliative Care Patients,NHBPC2,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Depression Symptom Assessment for Home-Based Primary Care and Palliative Care Patients,NHBPC3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Pain Screen for Home-Based Primary Care and Palliative Care Patients,NHBPC4,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Depression Treatment Plan for Home-Based Primary Care and Palliative Care Patients Who Screen Positive for Depression,NHBPC5,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Screen for Risk of Future Fall for Home-Based Primary Care and Palliative Care Patients,NHBPC6,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Delirium Assessment in Home-Based Primary Care and Palliative Care Patients: Medication List Reviewed & Offending Medications Discontinued (Multiperformance-Rate Measure),NHBPC7,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Referral to Hospice for Appropriate Home-Based Primary Care and Palliative Care Patients,NHBPC9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Repeat screening or surveillance colonoscopy recommended within one year due to inadequate/poor bowel preparation,NHCR4,Registry/QCDR,Outcome,Y,12.50 - 19.37,19.38 - 23.66,23.67 - 33.98,33.99 - 40.33,40.34 - 49.38,49.39 - 68.20,68.21 - 80.29,>= 80.30,No
-Colonoscopy: Repeat colonoscopy recommended due to piecemeal resection,NHCR5,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-RATE OF CAUDAL AND INTERLAMINAR EPIDURAL INJECTIONS WITHOUT DURAL PUNCTURE,NIPM2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-AVOIDING EXCESSIVE USE OF THERAPEUTIC FACET JOINT INTERVENTIONS IN MANAGING CHRONIC LUMBAR SPINAL PAIN,NIPM3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-APPROPRIATE PATIENT SELECTION FOR DIAGNOSTIC FACET JOINT PROCEDURES,NIPM4,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-APPROPRIATE PATIENT SELECTION FOR TRIAL SPINAL CORD STIMULATION,NIPM5,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-"APPROPRIATE PATIENT SELECTION FOR USE OF EPIDURAL INJECTIONS IN MANAGING PAIN ORIGINATING IN THE SACRAL, LUMBAR, THORACIC OR CERVICAL SPINE",NIPM6,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-SHARED DECISION MAKING REGARDING ANTICOAGULANT AND ANTITHROMBOTIC USE IN THE SETTING OF CAUDAL OR INTERLAMINAR EPIDURAL INJECTIONS,NIPM7,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-"AVOIDING EXCESSIVE USE OF EPIDURAL INJECTIONS IN MANAGING CHRONIC PAIN ORIGINATING IN THE CERVICAL AND THORACIC SPINE
 
-(Measure 18)",NIPM8,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-"AVOIDING EXCESSIVE USE OF THERAPEUTIC FACET JOINT INTERVENTIONS IN MANAGING CHRONIC CERVICAL AND THORACIC SPINAL PAIN
+- Avoidance of Inappropriate Use",185,MIPS CQM,Process,Y,25.8,82,61.64 - 84.99,85.00 - 90.53,90.54 - 95.41,95.42 - 98.40,98.41 - 99.99,--,--,100,Yes,No
+Stroke and Stroke Rehabilitation: Thrombolytic Therapy,187,MIPS CQM,Process,Y,20.5,90.1,88.89 - 96.48,96.49 - 99.99,--,--,--,--,--,100,Yes,No
+Cataracts: 20/40 or Better Visual Acuity within 90 Days Following Cataract Surgery,191,eCQM,Outcome,Y,18.4,88.5,85.25 - 90.62,90.63 - 93.40,93.41 - 95.58,95.59 - 96.87,96.88 - 97.82,97.83 - 98.77,98.78 - 99.99,100,No,No
+Cataracts: 20/40 or Better Visual Acuity within 90 Days Following Cataract Surgery,191,MIPS CQM,Outcome,Y,9.3,96.1,94.37 - 96.87,96.88 - 98.97,98.98 - 99.99,--,--,--,--,100,Yes,No
+Cataracts: Complications within 30 Days Following Cataract Surgery Requiring Additional Surgical Procedures,192,eCQM,Outcome,Y,0.9,0.2,--,--,--,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Cataracts: Complications within 30 Days Following Cataract Surgery Requiring Additional Surgical Procedures,192,MIPS CQM,Outcome,Y,6.5,0.9,--,--,--,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Radiology: Stenosis Measurement in Carotid Imaging Reports,195,Medicare Part B Claims,Process,Y,16.1,92.7,91.72 - 96.22,96.23 - 98.17,98.18 - 99.99,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Radiology: Stenosis Measurement in Carotid Imaging Reports,195,MIPS CQM,Process,Y,10.7,96.6,97.81 - 99.84,99.85 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+"HIV/AIDS: Sexually Transmitted Disease Screening for Chlamydia, Gonorrhea, and Syphilis",205,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Status Change for Patients with Knee Impairments,217,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Status Change for Patients with Hip Impairments,218,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Status Change for Patients with Foot or Ankle Impairments,219,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Status Change for Patients with Lumbar Impairments,220,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Status Change for Patients with Shoulder Impairments,221,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Functional Status Change for Patients with Elbow, Wrist or Hand Impairments",222,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Status Change for Patients with Other General Orthopaedic Impairments,223,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Radiology: Reminder System for Screening Mammograms,225,Medicare Part B Claims,Structure,Y,19.3,94.3,99.36 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Radiology: Reminder System for Screening Mammograms,225,MIPS CQM,Structure,Y,13.8,97.4,--,--,--,--,--,--,--,100,Yes,No
+Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,eCQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Controlling High Blood Pressure,236,eCQM,Intermediate Outcome,Y,16.6,63,51.46 - 56.82,56.83 - 60.94,60.95 - 64.67,64.68 - 68.17,68.18 - 72.00,72.01 - 76.25,76.26 - 82.20,>= 82.21,No,No
+Controlling High Blood Pressure,236,Medicare Part B Claims,Intermediate Outcome,Y,18.6,72.2,58.57 - 63.97,63.98 - 68.82,68.83 - 73.90,73.91 - 78.56,78.57 - 83.32,83.33 - 88.31,88.32 - 94.88,>= 94.89,No,No
+Controlling High Blood Pressure,236,MIPS CQM,Intermediate Outcome,Y,24.1,69.3,52.41 - 60.04,60.05 - 65.67,65.68 - 70.61,70.62 - 76.82,76.83 - 84.61,84.62 - 93.39,93.40 - 99.99,100,No,No
+Use of High-Risk Medications in the Elderly,238,eCQM,Process,Y,9,4.7,8.04 - 4.75,4.74 - 2.68,2.67 - 1.32,1.31 - 0.54,0.53 - 0.05,0.04 - 0.01,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Use of High-Risk Medications in the Elderly,238,MIPS CQM,Process,Y,6.6,1.7,0.68 - 0.29,0.28 - 0.14,0.13 - 0.01,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Weight Assessment and Counseling for Nutrition and Physical Activity for Children and Adolescents,239,eCQM,Process,Y,19.9,37.6,26.23 - 29.51,29.52 - 31.47,31.48 - 32.79,32.80 - 33.85,33.86 - 38.72,38.73 - 47.76,47.77 - 65.52,>= 65.53,No,No
+Childhood Immunization Status,240,eCQM,Process,Y,17.3,26.9,9.30 - 14.80,14.81 - 20.49,20.50 - 26.67,26.68 - 30.66,30.67 - 37.22,37.23 - 42.41,42.42 - 50.88,>= 50.89,No,No
+Cardiac Rehabilitation Patient Referral from an Outpatient Setting,243,MIPS CQM,Process,Y,20.1,22.2,8.11 - 11.87,11.88 - 14.62,14.63 - 17.22,17.23 - 20.77,20.78 - 24.31,24.32 - 30.68,30.69 - 44.43,>= 44.44,No,No
+Barrett's Esophagus,249,Medicare Part B Claims,Process,Y,0.2,100,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Barrett's Esophagus,249,MIPS CQM,Process,Y,4.1,99.5,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Radical Prostatectomy Pathology Reporting,250,Medicare Part B Claims,Process,Y,0.7,99.9,--,--,--,--,--,--,--,100,Yes,No
+Radical Prostatectomy Pathology Reporting,250,MIPS CQM,Process,Y,1.5,99.7,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Ultrasound Determination of Pregnancy Location for Pregnant Patients with Abdominal Pain,254,MIPS CQM,Process,Y,15.3,85.1,74.42 - 80.94,80.95 - 85.36,85.37 - 88.88,88.89 - 91.99,92.00 - 95.23,95.24 - 97.66,97.67 - 99.99,100,No,No
+Ultrasound Determination of Pregnancy Location for Pregnant Patients with Abdominal Pain,254,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rh Immunoglobulin (Rhogam) for Rh-Negative Pregnant Women at Risk of Fetal Blood Exposure,255,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rh Immunoglobulin (Rhogam) for Rh-Negative Pregnant Women at Risk of Fetal Blood Exposure,255,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of Open Repair of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post-Operative Day #7),258,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post Operative Day #2),259,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Rate of Carotid Endarterectomy (CEA) for Asymptomatic Patients, without Major Complications (Discharged to Home by Post-Operative Day #2)",260,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Referral for Otologic Evaluation for Patients with Acute or Chronic Dizziness,261,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Referral for Otologic Evaluation for Patients with Acute or Chronic Dizziness,261,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Image Confirmation of Successful Excision of Image-Localized Breast Lesion,262,MIPS CQM,Process,Y,0.2,100,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Sentinel Lymph Node Biopsy for Invasive Breast Cancer,264,MIPS CQM,Process,Y,6.1,98,97.96 - 99.21,99.22 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Biopsy Follow-Up,265,MIPS CQM,Process,Y,29.5,81.8,61.23 - 83.62,83.63 - 95.64,95.65 - 99.37,99.38 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Epilepsy: Counseling for Women of Childbearing Potential with Epilepsy,268,MIPS CQM,Process,Y,35.9,65,32.00 - 45.34,45.35 - 57.13,57.14 - 78.56,78.57 - 95.99,96.00 - 99.06,99.07 - 99.99,--,100,No,No
+Epilepsy: Counseling for Women of Childbearing Potential with Epilepsy,268,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Inflammatory Bowel Disease (IBD): Preventive Care: Corticosteroid Related Iatrogenic Injury - Bone Loss Assessment,271,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Inflammatory Bowel Disease (IBD): Assessment of Hepatitis B Virus (HBV) Status Before Initiating Anti-TNF (Tumor Necrosis Factor) Therapy,275,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Sleep Apnea: Severity Assessment at Initial Diagnosis,277,MIPS CQM,Process,Y,26.9,82.1,69.01 - 81.02,81.03 - 90.62,90.63 - 99.70,99.71 - 99.99,--,--,--,100,Yes,No
+Sleep Apnea: Assessment of Adherence to Positive Airway Pressure Therapy,279,MIPS CQM,Process,Y,17.8,92,90.08 - 96.26,96.27 - 99.16,99.17 - 99.99,--,--,--,--,100,Yes,No
+Dementia: Cognitive Assessment,281,eCQM,Process,Y,35.7,46.1,5.88 - 12.89,12.90 - 26.08,26.09 - 44.99,45.00 - 59.25,59.26 - 73.32,73.33 - 88.56,88.57 - 96.76,>= 96.77,No,No
+Dementia: Functional Status Assessment,282,MIPS CQM,Process,Y,32.2,79.2,57.14 - 78.94,78.95 - 95.27,95.28 - 99.12,99.13 - 99.99,--,--,--,100,Yes,No
+Dementia Associated Behavioral and Psychiatric Symptoms Screening and Management,283,MIPS CQM,Process,Y,29.9,81.3,58.14 - 83.07,83.08 - 96.66,96.67 - 99.81,99.82 - 99.99,--,--,--,100,Yes,No
+Dementia: Safety Concerns Screening and Mitigation Recommendations or Referral for Patients with Dementia,286,MIPS CQM,Process,Y,27.3,82,62.86 - 78.68,78.69 - 89.88,89.89 - 98.20,98.21 - 99.99,--,--,--,100,Yes,No
+Dementia: Caregiver Education and Support,288,MIPS CQM,Process,Y,27.9,80.9,59.26 - 77.32,77.33 - 89.32,89.33 - 97.53,97.54 - 99.99,--,--,--,100,Yes,No
+Parkinson's Disease: Psychiatric Symptoms Assessment for Patients with Parkinson's Disease,290,MIPS CQM,Process,Y,19.2,89.7,85.09 - 92.55,92.56 - 96.91,96.92 - 99.22,99.23 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Parkinson's Disease: Cognitive Impairment or Dysfunction Assessment,291,MIPS CQM,Process,Y,13.1,93.3,86.49 - 94.99,95.00 - 99.99,--,--,--,--,--,100,Yes,No
+Parkinson's Disease: Rehabilitative Therapy Options,293,MIPS CQM,Process,Y,19.8,86.6,67.03 - 82.94,82.95 - 94.28,94.29 - 99.99,--,--,--,--,100,Yes,No
+Cataracts: Improvement in Patient's Visual Function within 90 Days Following Cataract Surgery,303,MIPS CQM,Patient Reported Outcome,Y,30.5,74,45.11 - 70.87,70.88 - 78.76,78.77 - 84.90,84.91 - 91.77,91.78 - 98.79,98.80 - 99.99,--,100,No,No
+Cataracts: Patient Satisfaction within 90 Days Following Cataract Surgery,304,MIPS CQM,Patient Engagement Experience,Y,28.4,76.6,50.00 - 72.21,72.22 - 80.29,80.30 - 87.08,87.09 - 95.41,95.42 - 99.11,99.12 - 99.99,--,100,No,No
+Initiation and Engagement of Alcohol and Other Drug Dependence Treatment,305,eCQM,Process,Y,6.2,3.3,0.31 - 0.41,0.42 - 0.67,0.68 - 1.02,1.03 - 1.34,1.35 - 2.23,2.24 - 3.84,3.85 - 6.90,>= 6.91,No,No
+Cervical Cancer Screening,309,eCQM,Process,Y,25.6,35.1,9.83 - 16.79,16.80 - 23.65,23.66 - 31.53,31.54 - 39.71,39.72 - 48.30,48.31 - 57.62,57.63 - 72.60,>= 72.61,No,No
+Chlamydia Screening for Women,310,eCQM,Process,Y,20.2,35.2,16.67 - 22.30,22.31 - 28.04,28.05 - 33.32,33.33 - 39.12,39.13 - 44.77,44.78 - 53.13,53.14 - 63.77,>= 63.78,No,No
+Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,eCQM,Process,Y,23.6,37.3,19.56 - 24.13,24.14 - 28.18,28.19 - 32.30,32.31 - 36.66,36.67 - 42.11,42.12 - 50.69,50.70 - 74.54,>= 74.55,No,No
+Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,Medicare Part B Claims,Process,Y,30.1,68,34.25 - 45.47,45.48 - 58.48,58.49 - 73.28,73.29 - 89.40,89.41 - 98.06,98.07 - 99.99,--,100,No,No
+Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,MIPS CQM,Process,Y,32.7,54.1,25.75 - 30.80,30.81 - 35.46,35.47 - 42.56,42.57 - 59.14,59.15 - 83.48,83.49 - 97.31,97.32 - 99.99,100,No,No
+Falls: Screening for Future Fall Risk,318,eCQM,Process,Y,35.4,49.8,7.24 - 20.26,20.27 - 36.40,36.41 - 52.24,52.25 - 66.72,66.73 - 78.59,78.60 - 88.50,88.51 - 96.55,>= 96.56,No,No
+Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients,320,Medicare Part B Claims,Process,Y,21.1,91.8,95.24 - 97.72,97.73 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients,320,MIPS CQM,Process,Y,19.5,88.9,85.00 - 89.73,89.74 - 93.60,93.61 - 95.94,95.95 - 97.72,97.73 - 98.95,98.96 - 99.99,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low Risk Surgery Patients,322,MIPS CQM,Efficiency,Y,16.9,4.1,1.90 - 0.01,--,--,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Routine Testing After Percutaneous Coronary Intervention (PCI),323,MIPS CQM,Efficiency,Y,16.9,4.4,2.44 - 0.01,--,--,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+"Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Testing in Asymptomatic, Low-Risk Patients",324,MIPS CQM,Efficiency,Y,13.4,5.1,6.25 - 2.02,2.01 - 0.01,--,--,--,--,--,0,Yes,No
+Adult Major Depressive Disorder (MDD): Coordination of Care of Patients with Specific Comorbid Conditions,325,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Atrial Fibrillation and Atrial Flutter: Chronic Anticoagulation Therapy,326,Medicare Part B Claims,Process,Y,20.6,89.5,84.13 - 95.28,95.29 - 98.79,98.80 - 99.99,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Atrial Fibrillation and Atrial Flutter: Chronic Anticoagulation Therapy,326,MIPS CQM,Process,Y,18,81.2,69.54 - 75.10,75.11 - 78.89,78.90 - 83.08,83.09 - 88.16,88.17 - 94.93,94.94 - 99.99,--,100,No,No
+Pediatric Kidney Disease: ESRD Patients Receiving Dialysis: Hemoglobin Level < 10g/dL,328,MIPS CQM,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Adult Kidney Disease: Catheter Use at Initiation of Hemodialysis,329,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Adult Kidney Disease: Catheter Use for Greater Than or Equal to 90 Days,330,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Adult Sinusitis: Antibiotic Prescribed for Acute Viral Sinusitis (Overuse),331,MIPS CQM,Process,Y,34.5,61.5,92.15 - 87.51,87.50 - 82.89,82.88 - 75.37,75.36 - 64.36,64.35 - 46.68,46.67 - 20.00,19.99 - 0.01,0,No,No
+Adult Sinusitis: Appropriate Choice of Antibiotic: Amoxicillin With or Without Clavulanate Prescribed for Patients with Acute Bacterial Sinusitis (Appropriate Use),332,MIPS CQM,Process,Y,15.4,93.2,93.55 - 96.19,96.20 - 97.58,97.59 - 98.39,98.40 - 99.35,99.36 - 99.99,--,--,100,Yes,No
+Adult Sinusitis: Computerized Tomography (CT) for Acute Sinusitis (Overuse),333,MIPS CQM,Efficiency,Y,6.7,2.2,2.50 - 0.91,0.90 - 0.27,0.26 - 0.01,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Maternity Care: Elective Delivery or Early Induction Without Medical Indication at >= 37 and < 39 Weeks (Overuse),335,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Maternity Care: Post-Partum Follow-Up and Care Coordination,336,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Psoriasis: Tuberculosis (TB) Prevention for Patients with Psoriasis, Psoriatic Arthritis and Rheumatoid Arthritis Patients on a Biological Immune Response Modifier",337,MIPS CQM,Process,Y,30,72.1,47.06 - 60.60,60.61 - 73.62,73.63 - 82.50,82.51 - 89.99,90.00 - 96.42,96.43 - 99.99,--,100,No,No
+HIV Viral Load Suppression,338,MIPS CQM,Outcome,Y,24.2,80.9,74.47 - 78.56,78.57 - 83.99,84.00 - 87.93,87.94 - 93.99,94.00 - 97.23,97.24 - 99.99,--,100,No,No
+HIV Medical Visit Frequency,340,MIPS CQM,Process,Y,25.8,71.5,48.97 - 52.85,52.86 - 61.08,61.09 - 82.68,82.69 - 87.99,88.00 - 92.85,92.86 - 95.91,95.92 - 99.99,100,No,No
+Pain Brought Under Control Within 48 Hours,342,MIPS CQM,Outcome,Y,9.2,96.6,98.78 - 99.99,--,--,--,--,--,--,100,Yes,No
+Screening Colonoscopy Adenoma Detection Rate,343,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Rate of Carotid Artery Stenting (CAS) for Asymptomatic Patients, Without Major Complications (Discharged to Home by Post-Operative Day #2)",344,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of Asymptomatic Patients Undergoing Carotid Artery Stenting (CAS) Who Are Stroke Free or Discharged Alive,345,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of Asymptomatic Patients Undergoing Carotid Endarterectomy (CEA) Who Are Stroke Free or Discharged Alive,346,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) Who Are Discharged Alive,347,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+HRS-3: Implantable Cardioverter-Defibrillator (ICD) Complications Rate,348,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Total Knee Replacement: Shared Decision-Making: Trial of Conservative (Non-surgical) Therapy,350,MIPS CQM,Process,Y,14.8,94.4,96.00 - 99.99,--,--,--,--,--,--,100,Yes,No
+Total Knee Replacement: Venous Thromboembolic and Cardiovascular Risk Evaluation,351,MIPS CQM,Process,Y,16.7,95.3,--,--,--,--,--,--,--,100,Yes,No
+Total Knee Replacement: Preoperative Antibiotic Infusion with Proximal Tourniquet,352,MIPS CQM,Process,Y,4.8,98.8,--,--,--,--,--,--,--,100,Yes,No
+Total Knee Replacement: Identification of Implanted Prosthesis in Operative Report,353,MIPS CQM,Process,Y,6.3,98.6,--,--,--,--,--,--,--,100,Yes,No
+Anastomotic Leak Intervention,354,MIPS CQM,Outcome,Y,4.1,2.2,3.61 - 3.24,3.23 - 0.74,0.73 - 0.01,--,--,--,--,0,Yes,No
+Unplanned Reoperation within the 30 Day Postoperative Period,355,MIPS CQM,Outcome,Y,11.9,3.5,3.15 - 2.28,2.27 - 1.22,1.21 - 0.41,0.40 - 0.01,--,--,--,0,Yes,No
+Unplanned Hospital Readmission within 30 Days of Principal Procedure,356,MIPS CQM,Outcome,Y,14.5,5,5.00 - 3.31,3.30 - 2.01,2.00 - 0.01,--,--,--,--,0,Yes,No
+Surgical Site Infection (SSI),357,MIPS CQM,Outcome,Y,16.1,4.8,3.48 - 2.28,2.27 - 0.94,0.93 - 0.01,--,--,--,--,0,Yes,No
+Patient-Centered Surgical Risk Assessment and Communication,358,MIPS CQM,Process,Y,38.6,72.2,17.29 - 61.78,61.79 - 91.42,91.43 - 97.63,97.64 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Optimizing Patient Exposure to Ionizing Radiation: Count of Potential High Dose Radiation Imaging Studies: Computed Tomography (CT) and Cardiac Nuclear Medicine Studies,360,MIPS CQM,Process,Y,34.1,75.9,31.53 - 61.37,61.38 - 90.54,90.55 - 98.82,98.83 - 99.99,--,--,--,100,Yes,No
+Optimizing Patient Exposure to Ionizing Radiation: Reporting to a Radiation Dose Index Registry,361,MIPS CQM,Structure,Y,14.3,96.5,--,--,--,--,--,--,--,100,Yes,No
+Optimizing Patient Exposure to Ionizing Radiation: Computed Tomography (CT) Images Available for Patient Follow-up and Comparison,362,MIPS CQM,Structure,Y,21.9,94.4,--,--,--,--,--,--,--,100,Yes,No
+Optimizing Patient Exposure to Ionizing Radiation: Appropriateness: Follow-up CT Imaging for Incidentally Detected Pulmonary Nodules According to Recommended Guidelines,364,MIPS CQM,Process,Y,25.3,84.6,59.02 - 93.24,93.25 - 97.64,97.65 - 99.80,99.81 - 99.99,--,--,--,100,Yes,No
+Follow-Up Care for Children Prescribed ADHD Medication (ADD),366,eCQM,Process,Y,16.4,40.2,26.67 - 30.86,30.87 - 33.95,33.96 - 38.09,38.10 - 46.45,46.46 - 48.83,48.84 - 54.54,54.55 - 65.90,>= 65.91,No,No
+Depression Remission at Twelve Months,370,eCQM,Outcome,Y,9.7,7.1,2.08 - 2.69,2.70 - 3.69,3.70 - 4.34,4.35 - 5.31,5.32 - 7.13,7.14 - 8.76,8.77 - 14.99,>= 15.00,No,No
+Depression Remission at Twelve Months,370,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Depression Utilization of the PHQ-9 Tool,371,eCQM,Process,Y,19.1,18.6,3.82 - 6.11,6.12 - 9.08,9.09 - 12.68,12.69 - 16.66,16.67 - 22.08,22.09 - 30.29,30.30 - 43.13,>= 43.14,No,No
+Maternal Depression Screening,372,eCQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Closing the Referral Loop: Receipt of Specialist Report,374,eCQM,Process,Y,31.7,41.2,7.63 - 14.97,14.98 - 26.32,26.33 - 36.73,36.74 - 48.14,48.15 - 60.24,60.25 - 74.43,74.44 - 90.74,>= 90.75,No,No
+Closing the Referral Loop: Receipt of Specialist Report,374,MIPS CQM,Process,Y,40,53.1,6.77 - 8.50,8.51 - 37.83,37.84 - 62.85,62.86 - 82.42,82.43 - 88.88,88.89 - 92.73,92.74 - 99.01,>= 99.02,No,No
+Functional Status Assessment for Total Knee Replacement,375,eCQM,Process,Y,27.7,29,5.00 - 9.67,9.68 - 15.90,15.91 - 20.30,20.31 - 24.55,24.56 - 34.37,34.38 - 53.41,53.42 - 77.26,>= 77.27,No,No
+Functional Status Assessment for Total Hip Replacement,376,eCQM,Process,Y,24.5,26.5,4.82 - 8.50,8.51 - 13.09,13.10 - 19.22,19.23 - 27.58,27.59 - 33.32,33.33 - 40.18,40.19 - 63.48,>= 63.49,No,No
+Functional Status Assessments for Congestive Heart Failure,377,eCQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Children Who Have Dental Decay or Cavities,378,eCQM,Outcome,Y,1.6,0.4,0.47 - 0.10,0.09 - 0.01,--,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+"Primary Caries Prevention Intervention as Offered by Primary Care Providers, including Dentists",379,eCQM,Process,Y,7.4,3.6,0.32 - 0.54,0.55 - 0.73,0.74 - 1.08,1.09 - 2.07,2.08 - 3.21,3.22 - 4.89,4.90 - 9.04,>= 9.05,No,No
+Child and Adolescent Major Depressive Disorder (MDD): Suicide Risk Assessment,382,eCQM,Process,Y,23.8,22.8,3.43 - 7.00,7.01 - 12.46,12.47 - 14.83,14.84 - 20.25,20.26 - 29.00,29.01 - 36.10,36.11 - 51.71,>= 51.72,No,No
+Adherence to Antipsychotic Medications For Individuals with Schizophrenia,383,MIPS CQM,Intermediate Outcome,Y,21.1,82.1,58.00 - 71.42,71.43 - 86.83,86.84 - 90.00,90.01 - 98.32,98.33 - 99.99,--,--,100,No,No
+Adult Primary Rhegmatogenous Retinal Detachment Surgery: No Return to the Operating Room Within 90 Days of Surgery,384,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Adult Primary Rhegmatogenous Retinal Detachment Surgery: Visual Acuity Improvement Within 90 Days of Surgery,385,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Amyotrophic Lateral Sclerosis (ALS) Patient Care Preferences,386,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Annual Hepatitis C Virus (HCV) Screening for Patients who are Active Injection Drug Users,387,MIPS CQM,Process,Y,20.5,7.1,0.38 - 0.45,0.46 - 0.58,0.59 - 0.76,0.77 - 1.31,1.32 - 1.40,1.41 - 1.60,1.61 - 2.86,>= 2.87,No,No
+Cataract Surgery with Intra-Operative Complications (Unplanned Rupture of Posterior Capsule Requiring Unplanned Vitrectomy),388,MIPS CQM,Outcome,Y,4.8,0.4,--,--,--,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Cataract Surgery: Difference Between Planned and Final Refraction,389,MIPS CQM,Outcome,Y,22.4,87.6,77.17 - 90.90,90.91 - 96.96,96.97 - 99.21,99.22 - 99.99,--,--,--,100,No,No
+Hepatitis C: Discussion and Shared Decision Making Surrounding Treatment Options,390,MIPS CQM,Process,Y,24.1,84.2,63.64 - 80.86,80.87 - 95.44,95.45 - 99.99,--,--,--,--,100,Yes,No
+Follow-Up After Hospitalization for Mental Illness (FUH),391,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+HRS-12: Cardiac Tamponade and/or Pericardiocentesis Following Atrial Fibrillation Ablation,392,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"HRS-9: Infection within 180 Days of Cardiac Implantable Electronic Device (CIED) Implantation, Replacement, or Revision",393,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Immunizations for Adolescents,394,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Lung Cancer Reporting (Biopsy/Cytology Specimens),395,Medicare Part B Claims,Process,Y,3.7,98.9,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Lung Cancer Reporting (Biopsy/Cytology Specimens),395,MIPS CQM,Process,Y,9.7,98,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Lung Cancer Reporting (Resection Specimens),396,MIPS CQM,Process,Y,0.5,99.9,--,--,--,--,--,--,--,100,Yes,No
+Lung Cancer Reporting (Resection Specimens),396,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Melanoma Reporting,397,Medicare Part B Claims,Process,Y,2.6,99.2,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Melanoma Reporting,397,MIPS CQM,Process,Y,25.6,89.5,91.96 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Optimal Asthma Control,398,MIPS CQM,Outcome,Y,33.8,71.9,33.52 - 59.45,59.46 - 74.99,75.00 - 95.99,96.00 - 98.98,98.99 - 99.99,--,--,100,No,No
+One-Time Screening for Hepatitis C Virus (HCV) for Patients at Risk,400,MIPS CQM,Process,Y,28.6,20.9,1.26 - 1.84,1.85 - 3.22,3.23 - 6.30,6.31 - 16.77,16.78 - 24.10,24.11 - 32.00,32.01 - 74.59,>= 74.60,No,No
+Hepatitis C: Screening for Hepatocellular Carcinoma (HCC) in Patients with Cirrhosis,401,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Tobacco Use and Help with Quitting Among Adolescents,402,MIPS CQM,Process,Y,13.8,91.2,86.36 - 91.17,91.18 - 94.11,94.12 - 96.11,96.12 - 97.58,97.59 - 98.83,98.84 - 99.99,--,100,Yes,No
+Adult Kidney Disease: Referral to Hospice,403,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Anesthesiology Smoking Abstinence,404,MIPS CQM,Intermediate Outcome,Y,24.2,61.2,39.88 - 50.58,50.59 - 57.24,57.25 - 62.99,63.00 - 69.74,69.75 - 75.26,75.27 - 82.40,82.41 - 93.37,>= 93.38,No,No
+Appropriate Follow-up Imaging for Incidental Abdominal Lesions,405,Medicare Part B Claims,Process,Y,16.7,7.8,10.26 - 4.45,4.44 - 0.73,0.72 - 0.01,--,--,--,--,0,Yes,No
+Appropriate Follow-up Imaging for Incidental Abdominal Lesions,405,MIPS CQM,Process,Y,9.8,5.8,12.11 - 6.68,6.67 - 2.64,2.63 - 0.54,0.53 - 0.01,--,--,--,0,Yes,No
+Appropriate Follow-up Imaging for Incidental Thyroid Nodules in Patients,406,Medicare Part B Claims,Process,Y,34.7,31.2,61.90 - 48.01,48.00 - 37.51,37.50 - 15.57,15.56 - 2.57,2.56 - 0.01,--,--,0,No,No
+Appropriate Follow-up Imaging for Incidental Thyroid Nodules in Patients,406,MIPS CQM,Process,Y,18.2,9.4,14.94 - 5.98,5.97 - 3.65,3.64 - 0.10,0.09 - 0.01,--,--,--,0,Yes,No
+Appropriate Treatment of Methicillin-Sensitive Staphylococcus Aureus (MSSA) Bacteremia,407,MIPS CQM,Process,Y,4.8,98.7,--,--,--,--,--,--,--,100,Yes,No
+Appropriate Treatment of Methicillin-Sensitive Staphylococcus Aureus (MSSA) Bacteremia,407,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Opioid Therapy Follow-up Evaluation,408,MIPS CQM,Process,Y,29.8,83.1,68.35 - 91.35,91.36 - 98.48,98.49 - 99.99,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Clinical Outcome Post Endovascular Stroke Treatment,409,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Psoriasis: Clinical Response to Oral Systemic or Biologic Medications,410,MIPS CQM,Outcome,Y,32.8,59.2,23.08 - 36.35,36.36 - 49.99,50.00 - 61.53,61.54 - 72.21,72.22 - 87.49,87.50 - 97.21,97.22 - 99.99,100,No,No
+Depression Remission at Six Months,411,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Documentation of Signed Opioid Treatment Agreement,412,MIPS CQM,Process,Y,32.2,81.1,61.17 - 88.34,88.35 - 97.43,97.44 - 99.66,99.67 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Door to Puncture Time for Endovascular Stroke Treatment,413,MIPS CQM,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Evaluation or Interview for Risk of Opioid Misuse,414,MIPS CQM,Process,Y,21.3,91.1,88.55 - 98.59,98.60 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older,415,Medicare Part B Claims,Efficiency,Y,3.6,98.2,96.00 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older,415,MIPS CQM,Efficiency,Y,14.9,77.7,63.41 - 69.99,70.00 - 76.18,76.19 - 80.36,80.37 - 83.45,83.46 - 86.48,86.49 - 89.60,89.61 - 98.20,>= 98.21,No,No
+Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,416,MIPS CQM,Efficiency,Y,17.8,30.5,46.67 - 40.01,40.00 - 35.01,35.00 - 28.38,28.37 - 22.82,22.81 - 18.76,18.75 - 14.82,14.81 - 9.53,<= 9.52,No,No
+Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,416,Medicare Part B Claims,Efficiency,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of Open Repair of Small or Moderate Abdominal Aortic Aneurysms (AAA) Where Patients Are Discharged Alive,417,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Osteoporosis Management in Women Who Had a Fracture,418,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Osteoporosis Management in Women Who Had a Fracture,418,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Overuse of Imaging for the Evaluation of Primary Headache,419,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Overuse of Imaging for the Evaluation of Primary Headache,419,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Varicose Vein Treatment with Saphenous Ablation: Outcome Survey,420,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate Assessment of Retrievable Inferior Vena Cava (IVC) Filters for Removal,421,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Performing Cystoscopy at the Time of Hysterectomy for Pelvic Organ Prolapse to Detect Lower Urinary Tract Injury,422,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Performing Cystoscopy at the Time of Hysterectomy for Pelvic Organ Prolapse to Detect Lower Urinary Tract Injury,422,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Perioperative Temperature Management,424,MIPS CQM,Outcome,Y,8.9,97.2,98.46 - 99.51,99.52 - 99.74,99.75 - 99.87,99.88 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Photodocumentation of Cecal Intubation,425,Medicare Part B Claims,Process,Y,15.6,94.7,97.44 - 98.48,98.49 - 99.15,99.16 - 99.99,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Photodocumentation of Cecal Intubation,425,MIPS CQM,Process,Y,4.4,98.1,97.59 - 98.31,98.32 - 98.73,98.74 - 99.04,99.05 - 99.29,99.30 - 99.50,99.51 - 99.76,99.77 - 99.99,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Pelvic Organ Prolapse: Preoperative Assessment of Occult Stress Urinary Incontinence,428,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Pelvic Organ Prolapse: Preoperative Screening for Uterine Malignancy,429,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Pelvic Organ Prolapse: Preoperative Screening for Uterine Malignancy,429,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prevention of Post-Operative Nausea and Vomiting (PONV) - Combination Therapy,430,MIPS CQM,Process,Y,13.2,94.3,93.66 - 97.17,97.18 - 98.53,98.54 - 99.21,99.22 - 99.63,99.64 - 99.91,99.92 - 99.99,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Preventive Care and Screening: Unhealthy Alcohol Use: Screening & Brief Counseling,431,MIPS CQM,Process,Y,33,66.4,33.43 - 49.34,49.35 - 66.11,66.12 - 78.12,78.13 - 86.99,87.00 - 93.51,93.52 - 97.95,97.96 - 99.99,100,No,No
+Proportion of Patients Sustaining a Bladder Injury at the Time of any Pelvic Organ Prolapse Repair,432,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Proportion of Patients Sustaining a Bowel Injury at the time of any Pelvic Organ Prolapse Repair,433,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Proportion of Patients Sustaining a Ureter Injury at the Time of any Pelvic Organ Prolapse Repair,434,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Quality of Life Assessment For Patients With Primary Headache Disorders,435,MIPS CQM,Patient Reported Outcome,Y,42.3,38.3,2.05 - 3.02,3.03 - 5.49,5.50 - 12.43,12.44 - 25.81,25.82 - 75.85,75.86 - 99.99,--,100,No,No
+Quality of Life Assessment For Patients With Primary Headache Disorders,435,Medicare Part B Claims,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Radiation Consideration for Adult CT: Utilization of Dose Lowering Techniques,436,Medicare Part B Claims,Process,Y,23.3,88.4,85.73 - 94.12,94.13 - 97.45,97.46 - 98.95,98.96 - 99.65,99.66 - 99.99,--,--,100,Yes,No
+Radiation Consideration for Adult CT: Utilization of Dose Lowering Techniques,436,MIPS CQM,Process,Y,20.2,92,93.28 - 96.96,96.97 - 99.05,99.06 - 99.66,99.67 - 99.91,99.92 - 99.99,--,--,100,Yes,No
+Rate of Surgical Conversion from Lower Extremity Endovascular Revascularization Procedure,437,Medicare Part B Claims,Outcome,Y,6.6,2,1.32 - 0.56,0.55 - 0.01,--,--,--,--,--,0,Yes,No
+Rate of Surgical Conversion from Lower Extremity Endovascular Revascularization Procedure,437,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Statin Therapy for the Prevention and Treatment of Cardiovascular Disease,438,eCQM,Process,Y,19.1,82.2,63.75 - 71.06,71.07 - 77.11,77.12 - 84.26,84.27 - 99.99,--,--,--,100,No,No
+Statin Therapy for the Prevention and Treatment of Cardiovascular Disease,438,MIPS CQM,Process,Y,16.9,89.8,78.72 - 91.66,91.67 - 95.64,95.65 - 97.37,97.38 - 99.99,--,--,--,100,Yes,No
+Age Appropriate Screening Colonoscopy,439,MIPS CQM,Efficiency,N,--,--,--,--,--,--,--,--,--,--,--,No
+Basal Cell Carcinoma (BCC)/Squamous Cell Carcinoma (SCC): Biopsy Reporting Time - Pathologist to Clinician,440,MIPS CQM,Process,Y,21.1,92.2,96.91 - 98.95,98.96 - 99.87,99.88 - 99.99,--,--,--,--,100,Yes,No
+Ischemic Vascular Disease (IVD) All or None Outcome Measure (Optimal Control),441,MIPS CQM,Intermediate Outcome,Y,13.4,42.9,32.40 - 37.13,37.14 - 40.16,40.17 - 44.03,44.04 - 47.77,47.78 - 50.61,50.62 - 54.35,54.36 - 58.25,>= 58.26,No,No
+Persistence of Beta-Blocker Treatment After a Heart Attack,442,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Non-Recommended Cervical Cancer Screening in Adolescent Females,443,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Medication Management for People with Asthma,444,MIPS CQM,Process,Y,12.6,94.3,91.67 - 95.99,96.00 - 97.77,97.78 - 98.43,98.44 - 99.99,--,--,--,100,Yes,No
+Risk-Adjusted Operative Mortality for Coronary Artery Bypass Graft (CABG),445,MIPS CQM,Outcome,Y,2.2,2.5,3.90 - 3.17,3.16 - 2.69,2.68 - 2.25,2.24 - 1.73,1.72 - 1.23,1.22 - 0.01,--,0,No,No
+Operative Mortality Stratified by the Five STS-EACTS Mortality Categories,446,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate Work Up Prior to Endometrial Ablation,448,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+HER2 Negative or Undocumented Breast Cancer Patients Spared Treatment with HER2-Targeted Therapies,449,MIPS CQM,Process,Y,5.4,97.4,95.71 - 98.52,98.53 - 99.99,--,--,--,--,--,100,Yes,No
+Trastuzumab Received By Patients With AJCC Stage I (T1c) -  III And HER2 Positive Breast Cancer Receiving Adjuvant Chemotherapy,450,MIPS CQM,Process,Y,23.7,87.4,90.00 - 90.90,90.91 - 93.54,93.55 - 99.99,--,--,--,--,100,Yes,No
+RAS (KRAS and NRAS) Gene Mutation Testing Performed for Patients with Metastatic Colorectal Cancer who receive Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibody Therapy,451,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patients with Metastatic Colorectal Cancer and RAS (KRAS or NRAS) 4 with Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibodies,452,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Proportion Receiving Chemotherapy in the Last 14 Days of Life,453,MIPS CQM,Process,Y,6.3,8.9,15.00 - 10.43,10.42 - 9.19,9.18 - 8.00,7.99 - 7.36,7.35 - 7.04,7.03 - 2.39,2.38 - 0.01,0,No,No
+Proportion of Patients who Died from Cancer with more than One Emergency Department Visit in the Last 30 Days of Life,454,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Proportion Admitted to the Intensive Care Unit (ICU) in the Last 30 Days of Life,455,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Proportion Not Admitted To Hospice,456,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Proportion Admitted to Hospice for less than 3 days,457,MIPS CQM,Outcome,Y,7.6,10.7,15.38 - 15.01,15.00 - 13.52,13.51 - 11.11,11.10 - 9.65,9.64 - 6.46,6.45 - 0.01,--,0,No,No
+Average Change in Back Pain following Lumbar Discectomy / Laminotomy,459,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Average Change in Back Pain following Lumbar Fusion,460,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Average Change in Leg Pain following Lumbar Discectomy and/or Laminotomy,461,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Bone Density Evaluation for Patients with Prostate Cancer and Receiving Androgen Deprivation Therapy,462,eCQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prevention of Post-Operative Vomiting (POV) - Combination Therapy (Pediatrics),463,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Otitis Media with Effusion (OME): Systemic Antimicrobials- Avoidance of Inappropriate Use,464,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Uterine Artery Embolization Technique: Documentation of Angiographic Endpoints and.Interrogation of Ovarian Arteries,465,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Developmental Screening in the First Three Years of Life,467,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Continuity of Pharmacotherapy for Opioid Use Disorder (OUD),468,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Average Change in Functional Status Following Lumbar Fusion Surgery,469,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Average Change In Functional Status Following Total Knee Replacement Surgery,470,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Average Change in Functional Status Following Lumbar Discectomy/Laminotomy Surgery,471,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate Use of DXA Scans in Women Under 65 Years Who Do Not Meet the Risk Factor Profile for Osteoporotic Fracture,472,eCQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Average Change in Leg Pain Following Lumbar Fusion Surgery,473,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Zoster (Shingles) Vaccination,474,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+HIV Screening,475,eCQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Asthma Assessment and Classification,AAAAI11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Lung Function/Spirometry Evaluation,AAAAI12,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Asthma Control: Minimal Important Difference Improvement,AAAAI17,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Penicillin Allergy: Appropriate Removal or Confirmation,AAAAI18,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Asthma: Assessment of Asthma Control – Ambulatory Care Setting,AAAAI2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Documentation of Clinical Response to Allergen Immunotherapy within One Year,AAAAI6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Achievement of Projected Effective Dose of Standardized Allergens for Patient Treated With Allergen Immunotherapy for at Least One Year ,AAAAI8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Assessment of Asthma Symptoms Prior to Administration of Allergen Immunotherapy Injection(s) ,AAAAI9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Psoriasis: Assessment of Psoriasis Disease Activity,AAD1,QCDR measure,Process,Y,33,42.5,10.16 - 18.74,18.75 - 25.12,25.13 - 35.83,35.84 - 43.47,43.48 - 57.07,57.08 - 76.76,76.77 - 99.99,100,No,No
+Psoriasis: Screening for Psoriatic Arthritis,AAD2,QCDR measure,Process,Y,23.9,87.6,82.44 - 95.44,95.45 - 99.99,--,--,--,--,--,100,Yes,No
+Basal Cell Carcinoma/Squamous Cell Carcinoma: Mohs Surgery for Superficial Basal Cell Carcinoma of the Trunk for Immune Competent Patients,AAD3,QCDR measure,Process,Y,2.1,1,1.58 - 0.01,--,--,--,--,--,--,0,Yes,No
+Basal Cell Carcinoma/Squamous Cell Carcinoma: Mohs Surgery for Squamous Cell Carcinoma in Situ or Keratoacanthoma Type Squamous Cell Carcinoma 1 cm or Smaller on the Trunk,AAD4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Biopsy: Reporting Time - Clinician to Patient,AAD5,QCDR measure,Process,Y,23,87,73.58 - 90.13,90.14 - 98.61,98.62 - 99.99,--,--,--,--,100,Yes,No
+Diabetes/Pre-Diabetes Screening for Patients with DSP,AAN1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Falls screening (aggregation of AAN disease specific falls measures),AAN10,QCDR measure,Process,Y,34.3,42.1,4.09 - 11.95,11.96 - 22.21,22.22 - 30.42,30.43 - 53.84,53.85 - 65.26,65.27 - 81.94,81.95 - 90.33,>= 90.34,No,No
+Overuse of barbiturate and opioid containing medications for primary headache disorders ,AAN11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Quality of Life Assessment for Patients with Epilepsy,AAN12,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Current MS Disability Scale Score,AAN14,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Quality of Life Assessment,AAN15,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Falls Outcome for Patients with Parkinson's Disease,AAN16,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+First line treatment for infantile spasms (IS),AAN18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Botulinum Toxin Serotype A (BoNT-A) for spasticity or dystonia,AAN19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+DSP Screening for Unhealthy Alcohol Use ,AAN2,QCDR measure,Process,Y,9.7,48.4,42.45 - 46.26,46.27 - 47.02,47.03 - 49.31,49.32 - 52.30,52.31 - 53.46,53.47 - 55.12,55.13 - 59.18,>= 59.19,No,No
+Querying for co-morbid conditions of tic disorder (TD) and Tourette syndrome (TS),AAN20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Screening for Psychiatric or Behavioral Health Disorders,AAN4,QCDR measure,Process,Y,32.3,64.4,27.59 - 41.34,41.35 - 58.32,58.33 - 74.06,74.07 - 83.90,83.91 - 94.11,94.12 - 98.13,98.14 - 99.73,>= 99.74,No,No
+MEDICATION PRESCRIBED FOR ACUTE MIGRAINE ATTACK,AAN5,QCDR measure,Process,Y,16.6,30.1,14.50 - 16.66,16.67 - 22.40,22.41 - 28.43,28.44 - 32.46,32.47 - 40.19,40.20 - 45.50,45.51 - 53.00,>= 53.01,No,No
+Exercise and Appropriate Physical Activity Counseling for Patients with MS,AAN8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Querying About Symptoms of Autonomic Dysfunction for Patients with Parkinson's Disease ,AAN9,QCDR measure,Process,Y,30.2,79.9,61.54 - 82.60,82.61 - 92.85,92.86 - 94.58,94.59 - 97.49,97.50 - 99.99,--,--,100,No,No
+Otitis Media with Effusion: Avoidance of Topical Intranasal Corticosteroids,AAO11,QCDR measure,Process,Y,1.4,99.5,99.60 - 99.99,--,--,--,--,--,--,100,Yes,No
+Topical Ear Drop Monotherapy for Children with Acute Tympanostomy Tube Otorrhea ,AAO12,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Inappropriate Use of Magnetic Resonance Imaging or Computed Tomography Scan for Bell’s Palsy (Inverse Measure),AAO13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Inappropriate Use of Antiviral Monotherapy for Bell’s Palsy (Inverse Measure),AAO14,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percentage of patients with cerumen impaction and a suggestive history of a non-intact tympanic membrane who receive just manual removal.,AAO15,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Audiometric Evaluation for Older Adults with Hearing Loss ,AAO16,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Advanced Diagnostic Imaging of Bilateral Presbycusis or Symmetric Sensorineural Hearing Loss-Avoidance of Inappropriate Use ,AAO17,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percentage of visits with patients with hearing aids where otoscopy is routinely performed,AAO18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Shared Decision Making for Treatment Options for Bilateral Presbycusis or Symmetric Sensorineural Hearing Loss,AAO19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Otitis Media with Effusion: Hearing Testing,AAO20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Audiometry for Chronic Otitis Media with Effusion in Children,AAO21,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percentage of patients with allergic rhinitis who do not receive sinonasal imaging for allergic rhinitis ,AAO22,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percentage of patients with allergic rhinitis who are offered intranasal corticosteroids or oral antihistamines,AAO23,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percentage of patients with allergic rhinitis who do not receive leukotriene inhibitors,AAO24,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percentage of patients with allergic rhinitis who do not receive IgG-based immunoglobulin testing,AAO25,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Otitis Media with Effusion: Diagnostic Evaluation - Assessment of Tympanic Membrane Mobility,AAO26,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Otitis Media with Effusion: Resolution of Otitis Media with Effusion in Children,AAO27,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Otitis Media with Effusion: Resolution of Otitis Media with Effusion in Adults,AAO28,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Otitis Media with Effusion: Antihistamines or Decongestants – Avoidance of Inappropriate Use,AAO8,QCDR measure,Process,Y,0.8,99.8,--,--,--,--,--,--,--,100,Yes,No
+All Patients Who Die an Expected Death with an ICD that Has Been Deactivated,ABFM1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patients Admitted to ICU who Have Care Preferences Documented,ABFM2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patients Treated with an Opioid Who Are Given a Bowel Regimen,ABFM3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Palliative Care – Spiritual Assessment,ABFM4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Palliative Care—Treatment Preferences,ABFM5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Palliative Care Timely Dyspnea Screening & Treatment,ABFM6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Pain Brought Under Control within the first three visits,ABFM7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Measuring the Value-Functions of Primary Care: Provider Level Continuity Measure,ABFM8,QCDR measure,Structure,N,--,--,--,--,--,--,--,--,--,--,--,No
+Intra-operative anesthesia safety,ABG1,QCDR measure,Outcome,Y,0.2,100,99.98 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Planned use of difficult airway equipment,ABG16,QCDR measure,Process,Y,25.7,71.6,56.01 - 61.14,61.15 - 72.26,72.27 - 77.96,77.97 - 82.24,82.25 - 89.40,89.41 - 94.18,94.19 - 99.83,>= 99.84,No,No
+Pre-operative OSA assessment,ABG21,QCDR measure,Process,Y,34.1,67.1,29.34 - 48.18,48.19 - 62.50,62.51 - 84.86,84.87 - 90.41,90.42 - 95.13,95.14 - 99.76,99.77 - 99.99,100,No,No
+Pre-Operative Screening for GERD,ABG28,QCDR measure,Process,Y,32.2,58.2,32.09 - 44.87,44.88 - 50.15,50.16 - 52.83,52.84 - 58.27,58.28 - 87.25,87.26 - 98.87,98.88 - 99.99,100,No,No
+Pre-Operative Screening for Glaucoma,ABG29,QCDR measure,Process,Y,32.3,77.8,44.29 - 67.22,67.23 - 95.02,95.03 - 99.50,99.51 - 99.99,--,--,--,100,Yes,No
+Pre-Operative Screening for PONV Risk,ABG30,QCDR measure,Process,Y,24.9,86,76.64 - 93.46,93.47 - 97.59,97.60 - 99.05,99.06 - 99.66,99.67 - 99.99,--,--,100,Yes,No
+Pre-Operative Screening for Excessive Alcohol and Recreational Drug Use,ABG31,QCDR measure,Process,Y,25.5,87.5,89.72 - 98.87,98.88 - 99.66,99.67 - 99.97,99.98 - 99.99,--,--,--,100,Yes,No
+Pain Related Quality of Life Interference,ABG32,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Lower Body Functional Impairment (LBI),ABG33,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Mood Assessment Screening and treatment ,ABG34,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Preoperative Assessment of Frailty,ABG35,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Corneal Abrasion,ABG36,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Immediate Adult Post-Operative Pain Management,ABG7,QCDR measure,Outcome,Y,3.5,98.4,97.85 - 98.62,98.63 - 99.28,99.29 - 99.82,99.83 - 99.99,--,--,--,100,Yes,No
+ACCPin3 Heart Failure: Patient Self Care Education,ACCPin3,QCDR measure,Process,Y,0,100,--,--,--,--,--,--,--,100,Yes,No
+Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older,ACEP19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,ACEP20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Coagulation Studies in Patients Presenting with Chest Pain with No Coagulopathy or Bleeding,ACEP21,QCDR measure,Process,Y,17.5,15.5,24.61 - 19.33,19.32 - 15.93,15.92 - 9.06,9.05 - 5.75,5.74 - 3.78,3.77 - 0.01,--,0,No,No
+Appropriate Emergency Department Utilization of CT for Pulmonary Embolism,ACEP22,QCDR measure,Process,Y,18.8,25.3,8.00 - 14.99,15.00 - 18.95,18.96 - 22.72,22.73 - 26.55,26.56 - 29.46,29.47 - 36.66,36.67 - 50.58,>= 50.59,No,No
+Pregnancy Test for Female Abdominal Pain Patients,ACEP24,QCDR measure,Process,Y,18.5,65.6,55.27 - 60.22,60.23 - 64.28,64.29 - 68.37,68.38 - 73.24,73.25 - 77.93,77.94 - 80.55,80.56 - 84.76,>= 84.77,No,No
+Tobacco Use: Screening and Cessation Intervention for Patients with Asthma and COPD,ACEP25,QCDR measure,Process,Y,14.5,73.6,63.89 - 67.52,67.53 - 71.87,71.88 - 74.99,75.00 - 78.78,78.79 - 81.81,81.82 - 85.70,85.71 - 89.99,>= 90.00,No,No
+Sepsis Management: Septic Shock: Repeat Lactate Level Measurement,ACEP29,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Sepsis Management: Septic Shock: Lactate Clearance Rate of >=10%,ACEP30,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate Foley Catheter Use in the Emergency Department,ACEP31,QCDR measure,Process,Y,21.9,63,43.04 - 51.99,52.00 - 59.08,59.09 - 63.36,63.37 - 69.04,69.05 - 73.07,73.08 - 88.09,88.10 - 91.66,>= 91.67,No,No
+ED Median Time from ED arrival to ED departure for discharged ED patients for Adult Patients,ACEP32,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"ED Median Time from ED arrival to ED departure for discharged ED patients for Adult Patients in Supercenter EDs
+(80k +)",ACEP33,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"ED Median Time from ED arrival to ED departure for discharged ED patients for Adult Patients in High Volume EDs (60k-79,999)",ACEP35,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"ED Median Time from ED arrival to ED departure for discharged ED patients for Adult Patients in Average Volume EDs (40k-59,999)",ACEP36,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"ED Median Time from ED arrival to ED departure for discharged ED patients for Adult Patients in Moderate Volume EDs (20k-39,999)",ACEP37,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"ED Median Time from ED arrival to ED departure for discharged ED patients for Adult Patients in Low Volume EDs (19,999 and less)",ACEP38,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+ED Median Time from ED arrival to ED departure for discharged ED patients for Adult Patients in Freestanding Ends,ACEP39,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+ED Median Time from ED arrival to ED departure for discharged ED patients for Pediatric Patients,ACEP40,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+ED Median Time from ED arrival to ED departure for discharged ED patients for Pediatric Patients in Supercenter EDs (80k +),ACEP41,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"ED Median Time from ED arrival to ED departure for discharged ED patients for Pediatric Patients in High Volume EDs (60k-79,999)",ACEP43,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"ED Median Time from ED arrival to ED departure for discharged ED patients for Pediatric Patients in Average Volume EDs (40k-59,999)",ACEP44,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"ED Median Time from ED arrival to ED departure for discharged ED patients for Pediatric Patients in Moderate Volume EDs (20k-39,999)",ACEP45,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"ED Median Time from ED arrival to ED departure for discharged ED patients for Pediatric Patients in Low Volume EDs (19,999 and less)",ACEP46,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+ED Median Time from ED arrival to ED departure for discharged ED patients for Pediatric Patients in Freestanding EDs,ACEP47,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Sepsis Management: Septic Shock: Lactate Level Management, Antibiotics Ordered, and Fluid Resuscitation",ACEP48,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Screening for risk of opioid misuse/overuse,ACMT1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Pregnancy test in women who receive a toxicologic consult,ACMT2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+EKG assessment in acute overdoses,ACMT3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate treatment for acetaminophen ingestions,ACMT4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Assessment of suspected ethylene glycol or methanol exposures,ACMT5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Repeat assessment of salicylate concentrations in overdose patients,ACMT6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+High Risk Pneumococcal Vaccination,ACPGR1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Tdap (Tetanus, Diphtheria, Acellular Pertussis) Vaccination",ACPGR2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Fixed-dose Combination of Hydralazine and Isosorbide Dinitrate Therapy for Self-identified Black or African American Patients with Heart Failure and LVEF <40% on ACEI or ARB and Beta-blocker Therapy,ACPGR3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+COPD Exacerbation Requiring Hospital Admission: Palliative Care Evaluation,ACQR1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+COPD Exacerbation: % of patients discharged from inpatient status on Long Acting Beta Agonist (LABA) bronchodilator,ACQR2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+COPD: Steroids for no more than 5 days in COPD Exacerbation,ACQR3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CHF Exacerbation Requiring Hospital Admission: Palliative Care Evaluation,ACQR4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CHF: Document AHA/ACC staging of CHF (A-D),ACQR5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"POLST Utilization: POLST form reviewed or completed for any patients with limited code status (i.e. any status other than, ""Attempt Resuscitation"" if unresponsive, pulseless and not breathing;  and ""Full Treatment"" if patient is pulseless and breathing)",ACQR6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Sepsis Management: Septic Shock: Repeat Lactate Level Measurement within 6 hours,ACQR7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Stroke/TIA: % of patients discharged on antithrombotic therapy,ACQR8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Gout: Serum Urate Target ,ACR7,QCDR measure,Intermediate Outcome,Y,20.2,39.2,21.19 - 28.09,28.10 - 34.77,34.78 - 38.16,38.17 - 41.88,41.89 - 46.53,46.54 - 58.87,58.88 - 67.14,>= 67.15,No,No
+CT Colonography True Positive Rate,ACRad1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Report Turnaround Time: Radiography (modified),ACRad15,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Report Turnaround Time: Ultrasound (Excluding Breast US),ACRad16,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Report Turnaround Time: MRI,ACRad17,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Report Turnaround Time: CT,ACRad18,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Report Turnaround Time: PET,ACRad19,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Lung Cancer Screening Cancer Detection Rate (CDR),ACRad21,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Lung Cancer Screening Positive Predictive Value (PPV),ACRad22,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Report Turnaround Time: Mammography,ACRad25,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate venous access for hemodialysis,ACRad26,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of early peristomal infection following fluoroscopically guided gastrostomy tube placement,ACRad28,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of percutaneous nephrostomy tube replacement within 30 days secondary to dislodgement,ACRad29,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Screening Mammography Cancer Detection Rate (CDR),ACRad3,QCDR measure,Outcome,Y,0.3,0.4,0.18 - 0.23,0.24 - 0.30,0.31 - 0.42,0.43 - 0.48,0.49 - 0.53,0.54 - 0.61,0.62 - 0.79,>= 0.80,No,No
+Rate of Inadequate Percutaneous Image-Guided Biopsy,ACRad30,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent of CT Abdomen-pelvis exams with contrast (single phase scan) for which Dose Length Product is at or below the size-specific diagnostic reference level.,ACRad31,QCDR measure,Outcome,Y,0,100,--,--,--,--,--,--,--,100,Yes,No
+Percent of CT Chest exams without contrast (single phase scan) for which Dose Length Product is at or below the size-specific diagnostic reference level.,ACRad32,QCDR measure,Outcome,Y,0,100,--,--,--,--,--,--,--,100,Yes,No
+Percent of CT Head/Brain exams without contrast (single phase scan) for which Dose Length Product is at or below the size-specific diagnostic reference level,ACRad33,QCDR measure,Outcome,Y,0,100,--,--,--,--,--,--,--,100,Yes,No
+Screening Mammography Positive Predictive Value 2 (PPV2 - Biopsy Recommended),ACRad6,QCDR measure,Outcome,Y,8.6,27.3,20.00 - 21.61,21.62 - 23.07,23.08 - 26.08,26.09 - 29.89,29.90 - 31.99,32.00 - 35.58,35.59 - 37.15,>= 37.16,No,No
+Screening Mammography Node Negativity Rate,ACRad7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Screening Mammography Minimal Cancer Rate,ACRad8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Preoperative Composite,ACS15,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
+Preventative Care and Screening: Tobacco Screening and Cessation Intervention,ACS16,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Preoperative Key Medications Review for Anticoagulation Medication,ACS17,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Frailty Evaluation,ACS18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Intraoperative Composite ,ACS19,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
+Optimal Postoperative Communication Plan and Patient Care Coordination Composite,ACS20,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
+Post-Acute Recovery Composite,ACS21,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
+Unplanned Reoperation within the 30 Day Postoperative Period,ACS22,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Unplanned Hospital Readmission within 30 Days of Principal Procedure,ACS23,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Surgical Phases of Care Patient-Reported Outcome Composite Measure,ACS24,QCDR measure,Patient Engagement Experience,N,--,--,--,--,--,--,--,--,--,--,--,No
+Surgical Site Infection (SSI),ACS25,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Trauma Initial Assessment Composite,ACSTrauma1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Mortality Rate Following Blunt Traumatic Injury to the Chest and/or Abdomen,ACSTrauma2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Mortality Rate Following Penetrating Traumatic Injury to the Chest and/or Abdomen,ACSTrauma3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Splenic Salvage Rate,ACSTrauma4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Optimal Timing of Surgical or Procedural Intervention for Hemorrhage in Trauma,ACSTrauma5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Optimal Ratio of Blood Product Transfusion,ACSTrauma6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Timely Initiation of VTE Prophylaxis in Trauma Patients,ACSTrauma7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Ventral Hernia Repair: Surgical Site Occurrence Requiring Procedural Intervention within the 30 Day Postoperative Period,AHSQC1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Unplanned Hospital Readmission or Observation Visit within the 30 Day Postoperative Period,AHSQC2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Abdominal Wall Reconstruction Surgical Site Occurrence Requiring Procedural Intervention within the 30 Day Postoperative Period,AHSQC6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Ventral Hernia Repair: Biologic Mesh Prosthesis Use in Low Risk Patients,AHSQC8,QCDR measure,Cost/Resource Use,N,--,--,--,--,--,--,--,--,--,--,--,No
+Ventral Hernia Repair: Pain and Functional Status Assessment,AHSQC9,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Hip Arthroplasty: Postoperative Complications within 90 Days Following the Procedure,AJRR1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Hip Arthroplasty: Shared Decision-Making: Trial of Conservative (Non-surgical) Therapy,AJRR3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Hip Arthroplasty: Venous Thromboembolic and Cardiovascular Risk Evaluation,AJRR4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Comprehensive Diabetic Foot Examination,APMA1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Coronary Artery Bypass Graft (CABG): Prolonged Intubation – Inverse Measure,AQI18,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Coronary Artery Bypass Graft (CABG): Stroke – Inverse Measure,AQI41,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Coronary Artery Bypass Graft (CABG): Post-Operative Renal Failure – Inverse Measure,AQI42,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient-Reported Experience with Anesthesia ,AQI48,QCDR measure,Patient Reported Outcome,Y,29.9,78.8,55.23 - 60.02,60.03 - 94.51,94.52 - 99.08,99.09 - 99.98,99.99 - 99.99,--,--,100,Yes,No
+Adherence to Blood Conservation Guidelines for Cardiac Operations using Cardiopulmonary Bypass (CPB) – Composite,AQI49,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
+Application of Lung-Protective Ventilation during General Anesthesia,AQI50,QCDR measure,Intermediate Outcome,Y,5.9,98.4,99.14 - 99.45,99.46 - 99.82,99.83 - 99.99,--,--,--,--,100,Yes,No
+Assessment of Patients for Obstructive Sleep Apnea,AQI51,QCDR measure,Process,Y,31.1,83.5,79.31 - 92.61,92.62 - 96.39,96.40 - 99.34,99.35 - 99.79,99.80 - 99.94,99.95 - 99.99,--,100,Yes,No
+Documentation of Anticoagulant and Antiplatelet Medications when Performing Neuraxial Anesthesia/Analgesia or Interventional Pain Procedures,AQI53,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Use of Pencil-Point Needle for Spinal Anesthesia,AQI54,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Team-Based Implementation of a Care-and-Communication Bundle for ICU Patients,AQI55,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Use of Neuraxial Techniques and/or Peripheral Nerve Blocks for Total Knee Arthroplasty (TKA),AQI56,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Safe Opioid Prescribing Practices,AQI57,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
+Infection Control Practices for Open Interventional Pain Procedures,AQI58,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
+Multimodal Pain Management,AQI59,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+New Corneal Injury Not Diagnosed Prior to Discharge ,AQI60,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Benign Prostate Hyperplasia: IPSS improvement after diagnosis,AQUA12,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Stress Urinary Incontinence (SUI): Revision surgery within 12 months of incontinence procedure,AQUA13,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Stones: Repeat Shock Wave Lithotripsy (SWL) within 6 months of treatment,AQUA14,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Stones: Urinalysis documented 30 days before surgical stone procedures,AQUA15,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Non-Muscle Invasive Bladder Cancer: Repeat Transurethral Resection of Bladder Tumor (TURBT) for T1 disease,AQUA16,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Non-Muscle Invasive Bladder Cancer: Initiation of BCG 3 months of diagnosis of high-grade T1 bladder cancer and/or CIS,AQUA17,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Non-Muscle Invasive Bladder Cancer: Early surveillance cystoscopy within 4 months of initial diagnosis,AQUA18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Diagnosis of Type of Azoospermia and Diagnostic Testing for Obstructive Azoospermia,AQUA19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Genetic Testing  of the Azoospermic Male,AQUA20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate Management of Obstructive Azoospermia,AQUA21,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Bone imaging and soft tissue imaging at the time of diagnosis of metastatic CRPC,AQUA22,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Blood work for patients receiving abiraterone,AQUA23,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Testosterone and PSA levels checked for CRPC patients,AQUA24,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Use of Prednisone for CRPC patients on abiraterone,AQUA25,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+ Benign Prostate Hyperplasia Care: Benign Prostate Hyperplasia,AQUA26,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate Testing for Vasectomy Patients,AQUA27,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+ Hypogonadism: Testosterone and hematocrit within 6 months of starting testosterone replacement,AQUA28,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prostate Cancer: Patient Report of Urinary function after treatment,AQUA29,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cryptorchidism: Inappropriate use of scrotal/groin ultrasound on boys,AQUA3,QCDR measure,Cost/Resource Use,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prostate Cancer: Patient Report of Sexual function after treatment,AQUA30,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Hospital admissions/complications within 30 days of TRUS Biopsy,AQUA8,QCDR measure,Outcome,Y,3.5,3.2,5.13 - 4.23,4.22 - 3.22,3.21 - 2.64,2.63 - 1.02,1.01 - 0.70,0.69 - 0.01,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Risk Standardized Mortality Rate within 30 days following Trauma Operation,ARCO10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Head CT or MRI Scan Results for Acute Ischemic Stroke or Hemorrhagic Stroke Patients who Received Head CT or MRI Scan Interpretation within 45 minutes of ED Arrival,ARCO11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+STK-01: Venous Thromboembolism (VTE) Prophylaxis,ARCO12,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+STK 02: Ischemic stroke patients management - ,ARCO13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Diabetes: Nutritional, Weight Loss Counseling, Reduction of Sedentary Behavior",ARCO15,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Dyspnea or Heart Failure: Use of BNP or NT- pro BNP screening,ARCO16,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Heart Failure: Use of Aldosterone Antagonists and Diuretics for Symptom Control,ARCO17,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Heart Failure: Counseling on Self-care, Including Monitoring Blood Pressure, Weight, Sodium Intake, and Physical Activity",ARCO18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Promoting self-care for prevention and management of chronic conditions,ARCO19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Percentage of patients using self-monitoring with mobile technology or eHealth solutions to manage their diabetes, hypertension, sodium intake, nutritional status, physical activity, tobacco use, alcohol use, and sedentary behaviors",ARCO20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Antipsychotic Use in Persons with Dementia,ARCO3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Surgeon assessment for hereditary cause of breast cancer,ASBS1,QCDR measure,Process,Y,2.2,99.3,99.16 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Management of the axilla in breast cancer patients undergoing breast conserving surgery with a positive sentinel node biopsy,ASBS10,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Return to the operating room for re-excision of previous microscopically negative margins in invasive breast cancer patients undergoing breast conserving therapy ,ASBS12,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Sentinel Node Biopsy for Patients with Ductal Carcinoma in Situ Alone ,ASBS13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Recommendation of Neoadjuvant Chemotherapy for Her2Neu positive invasive breast cancers that are >2.0cm in size and/or have needle biopsy proven axillary metastases. ,ASBS14,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Unplanned 30 day re-operation after mastectomy,ASBS7,QCDR measure,Outcome,Y,2.4,98.6,98.15 - 98.46,98.47 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Cardiac Stress Nuclear Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low Risk Surgery Patients,ASNC1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Imaging Protocols for SPECT and PET MPI studies - Use of stress only protocol,ASNC19,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cardiac Stress Nuclear Imaging Not Meeting Appropriate Use Criteria: Routine Testing After Percutaneous Coronary Intervention (PCI),ASNC2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+SPECT-MPI studies performed without the use of thallium,ASNC20,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+SPECT-MPI study appropriate imaging protocol selection for morbidly obese patients,ASNC21,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+SPECT and PET MPI studies reporting Left Ventricular Ejection Fraction,ASNC22,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+SPECT-MPI study clinical utilization of Attenuation Correction image acquisition,ASNC23,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+SPECT-MPI study utilization of exercise as a stressor,ASNC24,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+SPECT-MPI study adequate exercise testing performed,ASNC25,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+SPECT and PET MPI studies meeting appropriate use criteria,ASNC26,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+SPECT and PET MPI studies not Equivocal,ASNC27,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Effective dose less than or equal to 9 millisieverts as per ASNC guideline recommendations,ASNC28,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+SPECT and PET MPI study documentation of stress perfusion defects,ASNC29,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Cardiac Stress Nuclear Imaging Not Meeting Appropriate Use Criteria: Testing in Asymptomatic, Low-Risk Patients",ASNC3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+" Transthoracic Echo (TTE) studies meeting appropriate use criteria
+",ASNC30,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Transthoracic Echo (TTE) studies reporting pulmonary artery pressures, 100% views, contrast use  
+",ASNC31,QCDR measure,Efficiency,N,--,--,--,--,--,--,--,--,--,--,--,No
+Avoiding myocardial Injury ,ASPIRE18,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Avoiding acute kidney injury,ASPIRE19,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Train of Four Monitor Documented After Last Dose of Non-depolarizing Neuromuscular Blocker,ASPIRE2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Application of Lung-Protective Ventilation during General Anesthesia,ASPIRE6,QCDR measure,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Satisfaction with Information Provided during Breast Reconstruction,ASPS10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Operative Time for Autologous Breast Reconstruction,ASPS11,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Unplanned hospital admission after panniculectomy,ASPS12,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Wound disruption rate after primary panniculectomy in patients with BMI > or = to 35,ASPS13,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Wound disruption rate after primary panniculectomy in patients with BMI < 35,ASPS14,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Seroma rate after primary panniculectomy,ASPS15,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Breast Reconstruction: Return to OR,ASPS5,QCDR measure,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Breast Reconstruction: Flap Loss,ASPS6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of Blood Transfusion for Patients Undergoing Autologous Breast Reconstruction,ASPS7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Coordination of Care for Patients Undergoing Breast Reconstruction,ASPS8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Length of Stay Following Autologous Breast Reconstruction,ASPS9,QCDR measure,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Complete assessment and evaluation of patient’s pelvic organ prolapse prior to surgical repair,AUGS1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Documentation of offering a preoperative pessary for Pelvic Organ Prolapse,AUGS10,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Documentation that a trial of conservative management was offered prior to use of procedure based therapy for urgency urinary incontinence,AUGS11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Preoperative assessment of sexual function prior to pelvic organ prolapse repair,AUGS3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Performing an intraoperative rectal examination at the time of prolapse repair,AUGS4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Performing vaginal apical suspension at the time of hysterectomy to address pelvic organ prolapse,AUGS5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Route of Hysterectomy,AUGS6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Documentation that conservative management was offered prior to fecal incontinence surgery or procedures,AUGS7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Documentation of weight loss counseling prior to surgery for stress urinary incontinence procedures for obese women,AUGS8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Over-utilization of synthetic mesh in the posterior compartment,AUGS9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Reported Comprehensive Assessment of Safety,BIVARUS27,QCDR measure,Patient Engagement Experience,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Reported Experience and Care Coordination,BIVARUS28,QCDR measure,Patient Engagement Experience,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Reported Care Team Communication,BIVARUS32,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Reported Procedure Readiness and Care ,BIVARUS33,QCDR measure,Patient Engagement Experience,N,--,--,--,--,--,--,--,--,--,--,--,No
+Turn-Around Time (TAT) - Standard biopsies,CAP1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cancer Protocol Elements for Carcinoma and Carcinosarcoma of the Endometrium,CAP2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cancer Protocol Elements for Invasive Carcinoma of Renal Tubular Origin,CAP3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cancer Protocol Elements for Carcinoma of the Intrahepatic Bile Ducts Completed,CAP4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cancer Protocol Elements for Hepatocellular Carcinoma Completed,CAP5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cancer Protocol Elements for Carcinoma of the Pancreas Completed,CAP6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Helicobacter pylori documentation rate,CAP7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Turn-Around Time (TAT) - Lactate,CAP8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Turn-Around Time (TAT) - Troponin,CAP9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+1-Year Patient-Reported Pain and Function Improvement after Total Knee Arthroplasty,CCOME1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+1-Year Patient-Reported Pain and Function Improvement after Total Hip Arthroplasty,CCOME2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+1-Year Patient-Reported Pain and Function Improvement after Total Shoulder Arthroplasty,CCOME3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+1-Year Patient-Reported Pain and Function Improvement after ACLR Surgery,CCOME4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Extent of Osteoarthritis Observed in Arthroscopic Partial Meniscectomy,CCOME5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+1-Year Patient-Reported Pain and Function Improvement after APM Surgery,CCOME6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Adequate Off-loading of Diabetic Foot Ulcer at each visit,CDR1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Diabetic Foot Ulcer (DFU) Healing or Closure ,CDR2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Plan of Care Creation for Diabetic Foot Ulcer (DFU) Patients not Achieving 30% Closure at 4 Weeks AND Plan of Care Creation for Venous Leg Ulcer (VLU) Patients not Achieving 30% Closure at 4 Weeks,CDR3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Adequate Compression at each visit for Patients with VLUs ,CDR5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Venous Leg Ulcer (VLU) outcome measure: Healing or Closure,CDR6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate Use of hyperbaric oxygen therapy for patients with diabetic foot ulcers,CDR8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate Use of Cellular and/or Tissue Based Product (CTP) in diabetic foot ulcers (DFUs) or venous leg ulcer (VLUs) among patients 18 years or older,CDR9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Post operative hypocalcemia after thyroidectomy surgery,CESQIP1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Related readmission for thyroid or parathyroid related problems,CESQIP2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Pre operative ultrasound exam of patients with thyroid cancer,CESQIP3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Persistent hypercalcemia,CESQIP4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Related readmission for adrenal related problems,CESQIP5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Vocal cord dysfunction following thyroidectomy,CESQIP7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Hematoma requiring evacuation following thyroidectomy,CESQIP8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Back Pain: Use of EMG & CNS,CLLC1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Morton's Neuroma - Avoidance of Alcohol Injections,CLLC2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cancer Patients - Survivorship Care Plan,CLLC3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Foot Bone Infection Diagnosis Without MRI,CLLC4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Global Physical Health Outcome Assessment for Shoulder Replacement,CODE1,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Global Physical Health Outcome Assessment for Shoulder Arthroscopy,CODE10,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Functional Outcome Assessment for Knee Arthroscopy,CODE11,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Functional Outcome Assessment for Hip Arthroscopy,CODE12,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Functional Outcome Assessment for ACL Repair,CODE2,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Functional Outcome Assessment for Foot/Ankle Repair,CODE3,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Global Physical Health Outcome Assessment for Spine Surgery,CODE5,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Functional Outcome Assessment for Hip Replacement,CODE6,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Functional Outcome Assessment for Knee Replacement,CODE7,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Global Physical Health Outcome Assessment for Cervical Surgery,CODE8,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Global Physical Health Outcome Assessment for Hand/Wrist/Elbow Repair,CODE9,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"CAHPS Clinician/Group Surveys - (Adult Primary Care, Pediatric Care, and Specialist Care Surveys)",CUHSM3,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+CAHPS Health Plan Survey v 4.0 - Adult questionnaire,CUHSM4,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Adherence to Mood Stabilizers for Individuals with Bipolar I Disorder,CUHSM6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cardiovascular Health Screening for People With Schizophrenia or Bipolar Disorder Who Are Prescribed Antipsychotic Medications,CUHSM8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOneEGFR,CURE1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOneNSCLCBRAFTTP,CURE10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOneMelBRAFTTP,CURE11,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOneALK,CURE2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOneROS1,CURE3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOneNSCLCBRAF,CURE4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOnePDL1,CURE5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOneMelBRAF,CURE6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOneEGFRTTP,CURE7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOneALKTTP,CURE8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOneROS1TTP,CURE9,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Three Day All Cause Return ED Visit Rate,ECPR11,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Door to Diagnostic Evaluation by a Provider – Emergency Department (ED) Patients,ECPR2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Mean Time from Emergency Department (ED) Arrival to ED Departure for Discharged Lower Acuity ED Patients,ECPR5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Mean Time from Emergency Department (ED) Arrival to ED Departure for Discharged Higher Acuity ED Patients,ECPR6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Avoid Head CT for Patients with Uncomplicated Syncope,ECPR39,QCDR measure,Process,Y,8.9,87.6,83.33 - 84.77,84.78 - 87.17,87.18 - 88.44,88.45 - 90.90,90.91 - 92.67,92.68 - 94.43,94.44 - 96.98,>= 96.99,No,No
+Initiation of the Initial Sepsis Bundle,ECPR40,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rh Status Evaluation and Treatment of Pregnant Women at Risk of Fetal Blood Exposure ,ECPR41,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Restrictive Use of Blood Transfusions,ECPR42,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Avoidance of Creatine Kinase-MB (CK-MB) Testing for Non-traumatic Chest Pain ,ECPR45,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Avoidance of Opiate Prescriptions for Low Back Pain or Migraines,ECPR46,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Avoidance of Opiate Prescriptions for Greater Than 3 Days Duration for Acute Pain ,ECPR47,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Avoidance of Long-Acting (LA) or Extended-Release (ER) Opiate Prescriptions ,ECPR48,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Avoidance of Tramadol or Codeine for Children,ECPR49,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Door to Diagnostic Evaluation by a Provider Within 30 Minutes – Urgent Care Patients,ECPR50,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Preoperative Frailty Assessment,EPREOP28,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Preoperative Assessment for Opioid Dependence Risk ,EPREOP29,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Short-term Pain Management/Maximum Pain Score,EPREOP4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Review of Functional Status Assessment for Patients with Osteoarthritis,FORCE20,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Review of Pain Status Assessment for Patients with Osteoarthritis,FORCE21,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improvement in Pain after Knee Replacement,FORCE22,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improvement in Pain after Hip Replacement,FORCE23,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate management of anticoagulation in the peri-procedural period rate – EGD,GIQIC10,QCDR measure,Process,Y,31,65.2,31.25 - 52.34,52.35 - 61.53,61.54 - 66.77,66.78 - 81.35,81.36 - 90.90,90.91 - 98.90,98.91 - 99.99,100,No,No
+Appropriate indication for colonoscopy,GIQIC12,QCDR measure,Process,Y,10.5,89,83.71 - 87.91,87.92 - 90.17,90.18 - 91.82,91.83 - 93.51,93.52 - 95.00,95.01 - 96.57,96.58 - 98.14,>= 98.15,No,No
+Appropriate follow-up interval of 3 years recommended based on pathology findings from screening colonoscopy in average-risk patients,GIQIC15,QCDR measure,Process,Y,17.4,75.7,61.11 - 71.42,71.43 - 76.09,76.10 - 79.19,79.20 - 83.66,83.67 - 87.12,87.13 - 90.23,90.24 - 93.74,>= 93.75,No,No
+Appropriate follow-up interval of 5 years for colonoscopies with findings of sessile serrated polyps < 10 mm without dysplasia,GIQIC17,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate follow-up interval of not less than 5 years for colonoscopies with findings of 1-2 tubular adenomas < 10 mm,GIQIC18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate indication for esophagogastroduodenoscopy (EGD),GIQIC19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate follow-up interval of 10 years for colonoscopies with only hyperplastic polyp findings,GIQIC20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+HAdv1 - Use of high risk sleep medications in the elderly,HAdv1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+HAdv2 - Atrial Fibrillation Prevention and Treatment – Lifestyle and Disease Factor Assessment,HAdv2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Mean Length of Stay for Inpatients – Pneumonia,HCPR3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Mean Length of Stay for Inpatients – CHF,HCPR4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Mean Length of Stay for Inpatients – COPD,HCPR5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Stroke Venous Thromboembolism (VTE) Prophylaxis,HCPR13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Venous Thromboembolism (VTE) Prophylaxis,HCPR14,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Physician’s Orders for Life-Sustaining Treatment (POLST) Form,HCPR16,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Pressure Ulcers - Risk Assessment and Plan of Care,HCPR17,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Unintentional Weight Loss - Risk Assessment and Plan of Care,HCPR18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+30 Day All-Cause Readmission Rate for Discharged Inpatients,HCPR19,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Clostridium Difficile - Risk Assessment and Plan of Care,HCPR20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate Use of Telemetry for Admission or Observation Placement ,HCPR21,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Care Transfer of Care - Use of Verbal Checklist or Protocol,HCPR22,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Exclusive Breast Milk Feeding,HEF1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Surgical Reconstruction for Anterior Cruciate Ligament (ACL) Injury,HF2,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Shoulder Instability - Labral Reconstruction: Change in Validated Shoulder Patient Reported Outcome Measure Following Labral Reconstruction for Shoulder,HF3,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Shoulder Arthroscopy: Measure of Change in a Validated Shoulder Patient Reported Outcome Following Shoulder Arthroscopy,HF4,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Shoulder Arthroplasty: Change in a Validated Shoulder Patient Reported Outcome Measure Following Shoulder Arthroplasty,HF5,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Knee Arthroscopy for Meniscal Repair: Change in a Validated Knee Patient Reported Outcome Measure Following Knee Arthroscopy for Meniscal Repair,HF6,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Surgical Repair for Rotator Cuff Tear: Change in a Validated Shoulder Patient Reported Outcome Measure Following Surgical Rotator Cuff Repair,HF7,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+ACE/ARB use,HM1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+A1C treatment ,HM2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+A1C in good control,HM3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Hypogonadism: Serum T, CBC, PSA, IPSS within 6  months of Rx",IQSS1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Prostate Cancer: Newly diagnosed with document T, PSA, Gleason and Prostate Cancer: Initial Eval. Document T, PSA, Gleason",IQSS2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prostate Cancer: Treatment Options Counseling,IQSS3,QCDR measure,Patient Engagement Experience,N,--,--,--,--,--,--,--,--,--,--,--,No
+BPH: Anticholinergics,IQSS4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Counseling SUI,IQSS5,QCDR measure,Patient Engagement Experience,N,--,--,--,--,--,--,--,--,--,--,--,No
+Endothelial Keratoplasty: Post-operative improvement in best corrected visual acuity to 20/40 or greater,IRIS1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Exudative Age-Related Macular Degeneration - Loss of Visual Acuity,IRIS10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Nonexudative Age-Related Macular Degeneration - Loss of Visual Acuity ,IRIS11,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Diabetic Macular Edema - Loss of Visual Acuity,IRIS13,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Acute Anterior Uveitis - Post-treatment visual acuity,IRIS16,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Acute Anterior Uveitis - Post-treatment Grade 0 anterior chamber cells,IRIS17,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Chronic Anterior Uveitis -  Post-treatment visual acuity,IRIS18,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Glaucoma -  Intraocular Pressure (IOP) Reduction,IRIS2,QCDR measure,Outcome,Y,9.6,94.5,86.96 - 97.36,97.37 - 98.99,99.00 - 99.99,--,--,--,--,100,Yes,No
+Idiopathic Intracranial Hypertension:  No worsening or improvement of mean deviation,IRIS20,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Ocular Myasthenia Gravis:  Improvement of ocular deviation or absence of diplopia or functional improvement,IRIS21,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Giant Cell Arteritis:  Absence of fellow eye involvement after treatment ,IRIS22,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Refractive Surgery: Postoperative Improvement in Uncorrected Visual Acuity of 20/20 or better ,IRIS23,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Refractive Surgery:  Postoperative correction within + 0.5 Diopter of the Intended Correction,IRIS24,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Adenoviral Conjunctivitis:  Avoidance of Antibiotics,IRIS25,QCDR measure,Cost/Resource Use,N,--,--,--,--,--,--,--,--,--,--,--,No
+Intravitreal Injections: Avoidance of Routine Antibiotic Use,IRIS26,QCDR measure,Cost/Resource Use,N,--,--,--,--,--,--,--,--,--,--,--,No
+Adverse Events After Cataract Surgery,IRIS27,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Regaining Vision After Cataract Surgery,IRIS28,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved visual acuity after epiretinal membrane treatment within 90 days,IRIS29,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Glaucoma - Visual Field Progression,IRIS3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Return to OR within 90 days after epiretinal membrane surgical treatment,IRIS30,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Avoidance of Genetic Testing for Age-related Macular Degeneration,IRIS31,QCDR measure,Cost/Resource Use,N,--,--,--,--,--,--,--,--,--,--,--,No
+Evidence of anatomic closure of macular hole within 90 days after surgery as documented by OCT.,IRIS32,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Return to OR within 90 days after macular hole surgery,IRIS33,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Age-Related Macular Degeneration: Disease Progression,IRIS34,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Glaucoma - Intraocular Pressure Reduction Following Laser Trabeculoplasty,IRIS4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Surgery for Acquired Involutional Ptosis - Patients with an Improvement of Marginal Reflex Distance,IRIS5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Acquired Involutional Entropion -  Normalized Lid Position After Surgical Repair,IRIS6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Amblyopia - Interocular Visual Acuity,IRIS7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Surgical Esotropia - Postoperative Alignment,IRIS8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Diabetic Retinopathy - Documentation of the Presence or Absence of Macular Edema and the Level of Severity of Retinopathy,IRIS9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Functional Improvement in hip, leg or ankle rehabilitation in patients with lower extremity injury measured via the validated Lower Extremity Function Scale (LEFS) score. ",IROMS1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Improvement in low back rehabilitation of non-surgical patients with low pack pain measured via the validated Modified Low Back Pain Disability Questionnaire (MDQ).,IROMS10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Improvement in knee rehabilitation of patients with knee injury measured via their validated Knee Outcome Survey (KOS) score.,IROMS2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Functional Improvement in arm, shoulder, and hand rehabilitation in surgical patients with musculotendinous injury measured via the validated Disability of Arm Shoulder and Hand (DASH) score.",IROMS8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Improvement in neck pain/injury patients rehabilitation measured via the validated Neck Disability Index (NDI).,IROMS9,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+M2S 1: Procedures with statin and antiplatelet agents prescribed at discharge,M2S1,QCDR measure,Process,Y,12.3,79.4,70.25 - 77.54,77.55 - 80.46,80.47 - 81.25,81.26 - 81.61,81.62 - 84.56,84.57 - 89.82,89.83 - 92.81,>= 92.82,No,No
+M2S 10: Survival at least 9 months after elective repair of small thoracic aortic aneurysms ,M2S10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+M2S 11: Imaging-based maximum aortic diameter assessed at least 9 months following Endovascular AAA Repair procedures,M2S11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"M2S 12: Survival at least 9 months after elective repair Endovascular AAA Repair of small abdominal aortic aneurysms
+",M2S12,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"M2S 13: Survival at least 9 months after elective Open AAA repair of small abdominal aortic aneurysms
 
-(Measure 19)",NIPM9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Critical Result: Pulmonary Embolism,NJIISMD1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Critical Result: Ruptured Ectopic Pregnancy,NJIISMD10,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Critical Result: New Deep Venous Thrombosis (DVT),NJIISMD11,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Critical Result: Ectopic Pregnancy,NJIISMD12,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Critical Test Protocol,NJIISMD13,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Critical Result Protocol,NJIISMD14,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Urgent Result Protocol,NJIISMD15,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Unexpected Result Protocol,NJIISMD16,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Result Requiring Follow Up Protocol,NJIISMD17,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Critical Finding: Cord Compression,NJIISMD19,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Critical Result: ICH,NJIISMD2,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Critical Finding: CTA of GI bleed,NJIISMD20,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Critical Finding: Positive bleeding scan,NJIISMD21,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Critical Finding: Acute Ocular injury,NJIISMD22,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Critical Result: Aortic Dissection,NJIISMD3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Critical test: OR Foreign Body,NJIISMD4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Critical test: Stroke,NJIISMD5,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Critical test: Intracranial Hemorrhage,NJIISMD6,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Critical test: Aortic Dissection,NJIISMD7,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Critical Result: Occlusive Intracranial Stroke,NJIISMD8,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Critical Result: Placental abruption,NJIISMD9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Substance Use Screening,NNEPTN1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Transforming Clinical Practice Initiative Common Measure Name: Substance Use Screening and Intervention Composite,NNEPTN2,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Transforming Clinical Practice Initiative Common Measure Name: TCPI 01: Documentation of a Comprehensive Health and Life Plan Developed Collaboratively by the Patient and the Health Professional Team,NNEPTN3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Transforming Clinical Practice Initiative Common Measure Name: TCPI 02: Referral of At-Risk Patients to Community Based Prevention and Support Resources,NNEPTN4,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-"Osteoporosis: Management Following Fracture of Hip, Spine or Distal Radius for Men and Women Aged 50 Years and Older",NOF13,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Hip Fracture Mortality Rate (IQI 19),NOF6,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-"Osteoporosis: percentage of patients, any age, with a diagnosis of osteoporosis who are either receiving both calcium & vitamin D intake, & exercise at least once within 12 months.",NOF7,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Unplanned Readmission Following Spine Procedure within the 30-day Postoperative Period,NPA11,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Selection of Prophylactic Antibiotic Prior to Spine Procedure,NPA12,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Medicine Reconciliation Following Spine Related Procedure,NPA14,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Risk Assessment for Elective Spine Procedure,NPA15,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Depression and Anxiety Assessment Prior to Spine-Related Therapies,NPA16,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Narcotic Pain Medicine Management Following Elective Spine Procedure,NPA17,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Smoking Assessment and Cessation Coincident with Spine-Related Therapies,NPA18,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Body Mass Assessment and Follow-up Coincident with Spine-Related Therapies,NPA19,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Unhealthy Alcohol Use Assessment Coincident with Spine Care,NPA20,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Spine/Extremity Pain Assessment,NPA22,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Functional Outcome Assessment for Spine Intervention,NPA3,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Quality-of-Life Assessment for Spine Intervention,NPA4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Patient Satisfaction with Spine Care,NPA5,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Spine-Related Procedure Site Infection,NPA6,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Referral for Post-Acute Care Rehabilitation Following Spine Procedure,NPA9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Spine/Extremity Pain Assessment,NPAGSC10,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Functional Outcome Assessment for Spine Intervention,NPAGSC3,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Quality-of-Life Assessment for Spine Intervention,NPAGSC4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Patient Satisfaction with Spine Care,NPAGSC5,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Depression and Anxiety Assessment Prior to Spine-Related Therapies,NPAGSC6,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Complication Following Percutaneous Spine-Related Procedure,NPAGSC8,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Unplanned Admission to Hospital Following Percutaneous Spine Procedure within the 30-Day Post-procedure Period,NPAGSC9,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Patient Satisfaction: CG-CAHPS Composite Tracking v,OBERD12,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Post-Stroke Outcome and Follow-up,OBERD22,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Health Related Quality of Life: Patient Defined Outcomes,OBERD23,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Inflamatory Bowel Disease: Follow-up and Outcomes,OBERD24,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Patient Satisfaction: Tracking Satisfaction Improvement with CG-CAHPS,OBERD25,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Optimal vascular care,OEIS1,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-"Emergent transfer from an outpatient, ambulatory surgical center, or office setting",OEIS2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Antiplatelet Therapy,OEIS3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Lipid-Lowering Medications for Patients with PAD,OEIS4,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Appropriate non-invasive arterial testing for patients with critical limb ischemia who are undergoing a LE peripheral vascular intervention,OEIS5,Registry/QCDR,Structure,N,--,--,--,--,--,--,--,--,--
-Appropriate non-invasive arterial testing for patients with intermittent claudication who are undergoing a LE peripheral vascular intervention,OEIS6,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Assessment and Intervention for Psychosocial Distress in Adults Receiving Cancer Treatment,ONSQIR15,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Recommendation for Exercise to Adult Cancer Survivors,ONSQIR16,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Assessment and Intervention for Sleep-Wake Disturbance During Cancer Treatment,ONSQIR17,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Goal Setting and Attainment for Cancer Survivors,ONSQIR18,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Post-Treatment Education,ONSQIR19,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Fatigue Improvement,ONSQIR20,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Education on Neutropenia Precautions,ONSQIR6,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Surgical Site Infection (SSI),PINC51,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Postoperative Sepsis Rate,PINC53,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Iatrogenic Pneumothorax,PINC54,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Annual Monitoring for Patients on Persistent Medications (MPM),PP1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Follow-Up After Hospitalization for Schizophrenia (7- and 30-day),PP2,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Chronic Kidney Disease (CKD): eGFR Monitoring,PPRNET13,Registry/QCDR,Process,Y,62.50 - 64.85,64.86 - 70.58,70.59 - 73.32,73.33 - 76.04,76.05 - 80.18,80.19 - 84.23,84.24 - 89.05,>= 89.06,No
-Chronic Kidney Disease (CKD): Hemoglobin Monitoring,PPRNET14,Registry/QCDR,Process,Y,72.62 - 77.21,77.22 - 82.85,82.86 - 87.29,87.30 - 89.86,89.87 - 90.53,90.54 - 93.09,93.10 - 94.58,>= 94.59,No
-Appropriate Treatment for Adults with Upper Respiratory Infection,PPRNET24,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-NSAID or Cox 2 Inhibitor Use in Patients with Heart Failure (HF) or Chronic Kidney Disease (CKD),PPRNET28,Registry/QCDR,Process,Y,80.00 - 81.80,81.81 - 82.91,82.92 - 84.83,84.84 - 85.94,85.95 - 86.76,86.77 - 91.40,91.41 - 93.07,>= 93.08,No
-Monitoring Serum Creatinine,PPRNET29,Registry/QCDR,Process,Y,73.35 - 78.88,78.89 - 84.40,84.41 - 86.29,86.30 - 88.09,88.10 - 90.88,90.89 - 93.85,93.86 - 96.29,>= 96.30,No
-Screening for Type 2 Diabetes,PPRNET31,Registry/QCDR,Process,Y,82.72 - 84.17,84.18 - 85.53,85.54 - 87.24,87.25 - 90.70,90.71 - 92.15,92.16 - 93.92,93.93 - 96.19,>= 96.20,No
-Screening for albuminuria in patients at risk for CKD (DM and/or HTN),PPRNET32,Registry/QCDR,Process,Y,18.26 - 26.78,26.79 - 47.26,47.27 - 56.41,56.42 - 61.65,61.66 - 66.11,66.12 - 72.25,72.26 - 75.06,>= 75.07,No
-Avoiding Use of CNS Depressants in Patients on Long-Term Opioids,PPRNET33,Registry/QCDR,Process,Y,50.51 - 54.54,54.55 - 55.58,55.59 - 57.79,57.80 - 60.14,60.15 - 65.24,65.25 - 72.38,72.39 - 81.62,>= 81.63,No
-Antiplatelet Medication for High Risk Patients,PPRNET8,Registry/QCDR,Process,Y,27.68 - 36.18,36.19 - 41.59,41.60 - 47.90,47.91 - 50.61,50.62 - 59.08,59.09 - 67.67,67.68 - 74.60,>= 74.61,No
-Opioid Therapy Follow-up Evaluation (Q408),Q408,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Evaluation or Interview for Risk of Opioid Misuse (Q414),Q414,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older,Q415,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,Q416,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Combination chemotherapy received within 4 months of diagnosis by women under 70 with AJCC stage IA (T1c) to III ER/PR negative breast cancer,QOPI11,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-GCSF administered to patients who received chemotherapy for metastatic cancer (Lower score-better),QOPI15,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-"Chemotherapy administered to patients with metastatic solid tumors and performance status of 3,4, or undocumented (lower score-better)",QOPI5,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Central Line Ultrasound Guidance,QUANTUM31,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Gastric Aspiration,QUANTUM37,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Case Cancellation on Day of Surgery,QUANTUM41,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Unplanned Hospital Admission After An Intended Outpatient Procedure,QUANTUM42,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Unplanned ICU Admission,QUANTUM51,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-CKD 3-5 Patients Seen at the Recommended Frequency Levels,RCOIR1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Upper Extremity Edema Improvement,RCOIR10,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Patients with a Visit to a Nephrologists Prior to 6 Months of Dialysis Onset,RCOIR2,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-CKD 3-5 Patients with a Urine ACR or Urine PCR Lab Test,RCOIR3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-CKD 4-5 Patients with Transplant Referral,RCOIR4,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-End Stage Renal Disease (ESRD) Initiation of Home Dialysis or Self-Care,RCOIR5,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-End Stage Renal Disease (ESRD) Missed Dialysis Treatments,RCOIR6,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Improved Access Site Bleeding,RCOIR7,Registry/QCDR,Outcome,Y,37.04 - 40.21,40.22 - 44.52,44.53 - 59.99,60.00 - 63.63,63.64 - 66.66,66.67 - 69.22,69.23 - 74.99,>= 75.00,No
-Post Procedure Bleeding,RCOIR8,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Diabetic patients with significant change in HgbA1C level or overall change in HgbA1C,RHI1,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Hypertensive patients with significant change in systolic blood pressure or overall change in systolic pressure,RHI2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Patients who have a change in tobacco use status (Improvement),RHI3,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Patients with Change in BMI,RHI4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Low back pain patients who undergo an operative procedure on the spine within 12 weeks after a referral from a primary care physician,RHI5,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Breast Mass Follow Up: Percent of patients with a breast mass who do not have follow-up physician contact,RHI6,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Uncontrolled chronic disease patients without a follow-up office visit,RHI7,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Angiotensin Converting Enzyme (ACE) Inhibitor or AngiotensinReceptor Blocker (ARB) Therapy,RPAQIR1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Hospitalization Rate Following Procedures Performed under Procedure Sedation Analgesia,RPAQIR11,Registry/QCDR,Outcome,Y,0.58 - 0.27,0.26 - 0.08,0.07 - 0.01,--,--,--,--,0.00,Yes
-Arterial Complication Rate Following Arteriovenous Access Intervention,RPAQIR12,Registry/QCDR,Outcome,Y,0.99 - 0.74,0.73 - 0.55,0.54 - 0.40,0.39 - 0.01,--,--,--,0.00,Yes
-Rate of Timely Documentation Transmission to Dialysis Unit/Referring Physician,RPAQIR13,Registry/QCDR,Process,Y,92.85 - 94.06,94.07 - 94.94,94.95 - 95.86,95.87 - 97.27,97.28 - 97.88,97.89 - 99.20,99.21 - 99.76,>= 99.77,Yes
-Arteriovenious Graft Thrombectomy Success Rate,RPAQIR14,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Arteriovenous Fistulae Thrombectomy Success Rate,RPAQIR15,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Peritoneal Dialysis Catheter Success Rate,RPAQIR16,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Peritoneal Dialysis Catheter Exit Site Infection Rate,RPAQIR17,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Advance Directives Completed,RPAQIR18,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Adequacy of Volume Management,RPAQIR2,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Arteriovenous Fistula Rate,RPAQIR4,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Transplant Referral,RPAQIR5,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Advance Care Planning (Pediatric Kidney Disease),RPAQIR9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-"Improvement in Quality of Life from Partial Foot, Prosthetics",SCG05,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Evaluation of High Risk Pain Medications for Morphine Milligram Equivalents (MME),SCG1,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Outcome Assessment for Patients Prescribed Ankle Orthosis for Ambulation and Functional Improvement,SCG2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Outcome Assessment for Patients Prescribed Foot Orthosis for Ambulation and Functional Improvement,SCG3,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Prevention of Antibiotic or Natural Herbal Supplement Impairment of Anesthesia,SCG4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Education of patients with inflammatory diseases regarding increased cardiovascular risk and the need for PCP evaluation,SDPAD1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-HCV testing in Lichen Planus,SDPAD2,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Avoiding antibiotic use in ruptured epidermal inclusion cyst,SDPAD3,Registry/QCDR,Efficiency,N,--,--,--,--,--,--,--,--,--
-Appropriate Testing and Treatment of Nail tinea infection,SDPAD4,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Cardiovascular Monitoring for People with Cardiovascular Disease and Schizophrenia,SMX1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Diabetes Screening for People With Schizophrenia or Bipolar Disorder Who Are Using Antipsychotic Medications,SMX2,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Use of Multiple Concurrent Antipsychotics in Children and Adolescents,SMX3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Metabolic Monitoring for Children and Adolescents on Antipsychotics,SMX4,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Repeated X-ray Imaging,SPINEIQ3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Prolonged Length of Stay Following Coronary Artery Bypass Grafting,STS1,Registry/QCDR,Outcome,Y,8.26 - 7.15,7.14 - 5.89,5.88 - 4.66,4.65 - 3.58,3.57 - 2.74,2.73 - 1.86,1.85 - 0.01,0.00,No
-Prolonged Length of Stay for Coronary Artery Bypass Grafting (CABG) + Valve Replacement,STS3,Registry/QCDR,Outcome,Y,21.21 - 14.30,14.29 - 9.10,9.09 - 7.46,7.45 - 5.01,5.00 - 4.77,4.76 - 2.71,2.70 - 0.01,0.00,Yes
-Prolonged Length of Stay following Valve Surgery,STS5,Registry/QCDR,Outcome,Y,8.00 - 5.89,5.88 - 5.27,5.26 - 4.09,4.08 - 3.46,3.45 - 3.04,3.03 - 1.62,1.61 - 0.01,0.00,No
-Patient Centered Surgical Risk Assessment and Communication for Cardiac Surgery,STS7,Registry/QCDR,Patient Engagement Experience,Y,2.73 - 6.55,6.56 - 22.77,22.78 - 50.37,50.38 - 68.72,68.73 - 84.05,84.06 - 92.47,92.48 - 99.16,>= 99.17,No
-"Patient Vital Sign Assessment and Blood Glucose Check Prior to Hyperbaric Oxygen
-Therapy (HBOT) Treatment",USWR13,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-"Healing or Closure of Wagner Grade 3, 4 or 5 Diabetic Foot Ulcers (DFUs) Treated with HBOT",USWR15,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-"Major Amputation in Wagner Grade 3, 4 or 5 Diabetic Foot Ulcers (DFUs) Treated with HBOT",USWR16,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Nutritional Screening and Intervention Plan in Patients with Chronic Wounds and Ulcers,USWR20,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Wound Outcome,USWR21,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Patient Reported Nutritional Assessment in Patients with Wounds and Ulcers,USWR22,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Diabetes Care All or None Outcome Measure: Optimal Control,WCHQ10,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Ischemic Vascular Disease Care Blood Pressure Control,WCHQ13,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Screening For Osteoporosis,WCHQ15,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Controlling High Blood Pressure: eGFR Test Annually,WCHQ32,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Diabetes Care All or None Process Measure: Optimal Testing,WCHQ9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Nutritional Screening and Intervention Plan in Patients with Chronic Wounds and Ulcers,WCQIC16,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,cmsWebInterface,Intermediate Outcome,Y,100 - 70,70 - 60,60 - 50,50 - 40,40 - 30,30 - 20,20 - 10,<= 10,No
-Preventive Care and Screening: Influenza Immunization,110,cmsWebInterface,Process,Y,0 - 30,30 - 40,40 - 50,50 - 60,60 - 70,70 - 80,80 - 90,>= 90,No
-Breast Cancer Screening,112,cmsWebInterface,Process,Y,0 - 30,30 - 40,40 - 50,50 - 60,60 - 70,70 - 80,80 - 90,>= 90,No
-Colorectal Cancer Screening,113,cmsWebInterface,Process,Y,0 - 30,30 - 40,40 - 50,50 - 60,60 - 70,70 - 80,80 - 90,>= 90,No
-Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,cmsWebInterface,Process,Y,0 - 30,30 - 40,40 - 50,50 - 60,60 - 70,70 - 80,80 - 90,>= 90,No
-Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,cmsWebInterface,Process,N,--,--,--,--,--,--,--,--,--
-Controlling High Blood Pressure,236,cmsWebInterface,Intermediate Outcome,Y,0 - 30,30 - 40,40 - 50,50 - 60,60 - 70,70 - 80,80 - 90,>= 90,No
-Falls: Screening for Future Fall Risk,318,cmsWebInterface,Process,Y,0 - 43.42,43.42 - 50.42,50.42 - 58.45,58.45 - 66,66 - 73.39,73.39 - 81.79,81.79 - 90.73,>= 90.73,No
+",M2S13,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Absence of unplanned reoperation after closed lower extremity major amputation,M2S16,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+M2S 17: Absence of serious technical complications during peripheral arterial intervention,M2S17,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+M2S 19: Proper patient selection for perforator vein ablation,M2S19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"M2S 2: Amputation-free survival assessed at least 9 months following Infra-Inguinal Bypass for intermittent claudication
+
+",M2S2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+M2S 5: Amputation-free survival at assessed at least 9 months following Peripheral Vascular Intervention for intermittent claudication,M2S5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"M2S 7: Ipsilateral stroke-free survival at assessed at least 9 months following Carotid Artery Stenting for asymptomatic procedures 
+
+",M2S7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+" M2S 8: Ipsilateral stroke-free survival assessed at least 9 months following isolated Carotid Endarterectomy for asymptomatic procedures 
+
+",M2S8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+M2S 9: Imaging-based maximum aortic diameter assessed at least 9 months following Thoracic and Complex EVAR procedures,M2S9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Case Delay,MA1,QCDR measure,Efficiency,N,--,--,--,--,--,--,--,--,--,--,--,No
+Corneal Abrasion,MA3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Anxiety Utilization of the GAD-7 Tool,MBHR1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Anxiety Response at 6-months,MBHR2,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk standardized rate of patients who experienced a postoperative escalation in care event following a primary Laparoscopic Roux-en-Y Gastric Bypass or  Laparoscopic Sleeve Gastrectomy operation,MBSAQIP10,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk standardized rate of patients who experienced a pulmonary complication following a primary Laparoscopic Roux-en-Y Gastric Bypass or  Laparoscopic Sleeve Gastrectomy,MBSAQIP11,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk standardized rate of patients who experienced a postoperative complication following a primary Laparoscopic Roux-en-Y Gastric Bypass or  Laparoscopic Sleeve Gastrectomy operation,MBSAQIP12,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Risk standardized rate of patients who experienced postoperative nausea, vomiting or fluid/electrolyte/nutritional depletion following a primary Laparoscopic Roux-en-Y Gastric Bypass or  Laparoscopic Sleeve Gastrectomy operation",MBSAQIP7,QCDR measure,Outcome,Y,1.4,1.2,2.13 - 1.85,1.84 - 1.29,1.28 - 0.40,0.39 - 0.01,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Risk standardized rate of patients who experienced an extended length of stay (> 3 days) following a primary Laparoscopic Roux-en-Y Gastric Bypass or  Laparoscopic Sleeve Gastrectomy operation,MBSAQIP8,QCDR measure,Outcome,Y,1.4,0.5,--,--,--,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Use of a “PEG Test” to Manage Patients Receiving Opioids,MEDNAX52,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX1: Heel Pain Treatment Outcomes for Adults,MEX1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Vascular Testing Outcome Measure Supervised Programs,MEX10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX2018-19: Non-Invasive Vascular Testing in Patients with Abnormal CVI Screening That Completed Hyperbaric Oxygen Therapy ,MEX11,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Peripheral Vascular Assessment % of Diabetic Patients 50+ ,MEX12,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX2018-22: Patients with Lower Limb Ulceration with a Previously Abnormal Vascular Study Receiving Negative Pressure Wound Therapy ,MEX13,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX2: Heel Pain Treatment Outcomes for Pediatric Patients,MEX2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX3: Identification of Flat Foot in Pediatric Patients,MEX3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX2018-2: Bunion Outcome - Adult and Adolescent,MEX4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX2018-3: Hammer Toe Outcome,MEX5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX2018-11: Peripheral Vascular Assessment - Patients 70+,MEX6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX2018-6: Foot Wound Outcome,MEX7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX2018-20: Non-Invasive Vascular Testing Follow-up in Patients After Revascularization,MEX8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX2018-16: Non-Invasive Vascular Testing in Patients Diagnosed with Intermittent Claudication Who Use Cilostazol or Pentoxifylline,MEX9,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Plan All Cause Readmissions,MHAN3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+General Health Postoperative Improvement,MICS1,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Surgery Specific Postoperative Improvement in Pain Levels,MICS2,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Surgery Specific Postoperative Improvement in Function Levels,MICS3,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Perioperative Pain Plan,MIRAMED16,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of witnessed gastric aspiration,MIRAMED17,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Unplanned Conversion to General Anesthesia from Regional or MAC for all scheduled cases,MIRAMED18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Onset atrial fibrillation or dysrthymia requiring unanticipated therapy,MIRAMED19,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Perioperative cognitive function test in elderly,MIRAMED20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Ischemic Vascular Disease Use of Aspirin or Anti-platelet Medication,MNCM5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Diabetes A1c Control (<8.0),MNCM6,QCDR measure,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Objectifying pain and/or functionality to determine manipulative medicine efficacy with correlative treatment adjustment,MOA1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Treatment of spinal stenosis with manipulative medicine and alternative medicine modalities,MOA12,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Urine Drug Screen Utilization in Pain Management and Substance Use Disorders; no less than quarterly for pain and no less than monthly for substance use disorders,MOA13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Addressing anxiety in pain patients with SNRI and SSRIs and reducing/eliminating benzodiazepines for chronic anxiety,MOA14,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Weight loss in pain patients with BMI > = 30 with opiate utilization for weight related pain conditions rather than opiate dose escalation for improved pain control,MOA15,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate use of advanced imaging by ordering provider with glucocorticoid management to spare motor neuron loss when physical findings suggest neuropathic etiology,MOA2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate controlled substance prescribing (definitive diagnosis(es)) via adherence to Controlled Substance Agreements (CSA) or (OA's) with corrective action taken for pain and/or substance use disorder patients when violations occur,MOA7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Pre-surgical screening for depression,MSSIC1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent of patients achieving MCID for pain-related disability (ODI/NDI),MSSIC10,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent Satisfied with Result,MSSIC11,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-adjusted rate of hospital readmission,MSSIC12,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-adjusted rate of surgical site infection,MSSIC13,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-adjusted rate of urinary retention,MSSIC14,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent of patients achieving MCID for myelopathy,MSSIC16,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent same-day ambulation,MSSIC6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of use of Pre-op skin preparation/wash,MSSIC7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent of patients achieving MCID for back or neck pain,MSSIC8,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent of patients achieving MCID for leg or arm pain,MSSIC9,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prostate Biopsy Antibiotic Compliance,MUSIC1,QCDR measure,Process,Y,0.4,99.8,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Prostate Cancer: Confirmation Testing in low risk AS eligible patients,MUSIC10,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prostate Cancer: Follow-Up Testing for patients on active surveillance for at least 30 months,MUSIC11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prostate Cancer: Avoidance of Overuse of CT Scan for Staging Low Risk Prostate Cancer Patients,MUSIC3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prostate Cancer: Active Surveillance/Watchful Waiting for Low Risk Prostate Cancer Patients,MUSIC4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prostate Cancer:  Radical Prostatectomy Cases LOS,MUSIC5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prostate Biopsy: Repeat Biopsy for Patients with Atypical Small Acinar Proliferation (ASAP),MUSIC9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Telephone Contact, Virtual, or In-person Visit Within 48 Hours of Hospital Discharge of Home-Based Primary Care and Palliative Care Patients",NHBPC10,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Interdisciplinary Team Assessment for Home-Based Primary care and Palliative Care Patients,NHBPC13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cognitive Assessment for Home-Based Primary Care and Palliative Care Patients,NHBPC14,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+A Functional Assessment (Basic and Instrumental Activities of Daily Living [ADL]) for Home-Based Primary Care and Palliative Care Patients (Multiperformance Measure),NHBPC15,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Reported Outcome for Home-Based Primary Care and Palliative Care Practices   ,NHBPC16,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Screening for Depression and Follow-up Plan in Home-Based Primary Care and Palliative Care Patients,NHBPC17,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Alcohol Problem Use Assessment for Home-Based Primary Care and Palliative Care Patients,NHBPC2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Screen for Risk of Future Fall for Home-Based Primary Care and Palliative Care Patients,NHBPC6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Delirium Assessment in Home-Based Primary Care and Palliative Care Patients: Medication List Reviewed & Offending Medications Discontinued (Multiperformance-Rate Measure),NHBPC7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Referral to Hospice for Appropriate Home-Based Primary Care and Palliative Care Patients,NHBPC9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+NHCR4: Repeat screening or surveillance colonoscopy recommended within one year due to inadequate/poor bowel preparation ,NHCR4,QCDR measure,Process,Y,27.4,38.5,12.50 - 19.37,19.38 - 23.66,23.67 - 33.98,33.99 - 40.33,40.34 - 49.38,49.39 - 68.20,68.21 - 80.29,>= 80.30,No,No
+NHCR5: Repeat colonoscopy recommended due to piecemeal resection,NHCR5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate indication for colonoscopy,NHCR9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+COMMUNICATING CONCURRENT OPIOID AND BENZODIAZEPINE PRESCRIBING TO OTHER PRESCRIBERS,NIPM10,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+PATIENT COUNSELING REGARDING RISKS OF CO-PRESCRIBED OPIOIDS AND BENZODIAZEPINES,NIPM11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+FUNCTIONAL STATUS ASSESSMENT FOR SPINAL CORD STIMULATOR IMPLANTATION,NIPM12,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+FUNCTIONAL STATUS ASSESSMENT FOR LUMBAR MEDIAL BRANCH RADIOFREQUENCY ABLATION,NIPM13,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+FUNCTIONAL STATUS ASSESSMENT FOR CERVICAL MEDIAL BRANCH RADIOFREQUENCY ABLATION,NIPM14,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+REDUCTION IN PATIENT REPORTED PAIN FOLLOWING SPINAL CORD STIMULATOR IMPLANTATION FOR FAILED BACK SURGERY SYNDROME,NIPM15,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+REDUCTION IN PATIENT REPORTED PAIN FOLLOWING LUMBAR MEDIAL BRANCH RADIOFREQUENCY ABLATION,NIPM16,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+REDUCTION IN PATIENT REPORTED PAIN FOLLOWING CERVICAL/THORACIC MEDIAL BRANCH RADIOFREQUENCY ABLATION,NIPM17,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+APPROPRIATE PATIENT SELECTION FOR DIAGNOSTIC FACET JOINT PROCEDURES,NIPM4,QCDR measure,Cost/Resource Use,N,--,--,--,--,--,--,--,--,--,--,--,No
+AVOIDING EXCESSIVE USE OF EPIDURAL INJECTIONS IN MANAGING CHRONIC PAIN ORIGINATING IN THE CERVICAL AND THORACIC SPINE,NIPM8,QCDR measure,Cost/Resource Use,N,--,--,--,--,--,--,--,--,--,--,--,No
+AVOIDING EXCESSIVE USE OF THERAPEUTIC FACET JOINT INTERVENTIONS IN MANAGING CHRONIC CERVICAL AND THORACIC SPINAL PAIN ,NIPM9,QCDR measure,Cost/Resource Use,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: Pulmonary Embolism,NJIISMD1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: Ruptured Ectopic Pregnancy,NJIISMD10,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: New Deep Venous Thrombosis (DVT),NJIISMD11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: Ectopic Pregnancy,NJIISMD12,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Result Requiring Follow Up Protocol,NJIISMD17,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: Cord Compression,NJIISMD19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: ICH,NJIISMD2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: CTA of GI bleed,NJIISMD20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: Positive bleeding scan,NJIISMD21,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: Acute Ocular injury,NJIISMD22,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: Aortic Dissection,NJIISMD3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: Occlusive Intracranial Stroke,NJIISMD8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: Placental abruption,NJIISMD9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Substance Use Screening,NNEPTN1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Transforming Clinical Practice Initiative Common Measure Name: Substance Use Screening and Intervention Composite,NNEPTN2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Transforming Clinical Practice Initiative Common Measure Name: TCP01: Documentation of a Comprehensive Health and Life Plan Developed Collaboratively by the Patient and the Health Professional Team,NNEPTN3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Median Time to Pain Management for Long Bone Fracture,NOF12,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Osteoporosis: Management Following Fracture of Hip, Spine or Distal Radius for Men and Women Aged 50 Years and Older",NOF13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Hip Fracture Mortality Rate (IQI 19),NOF6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Osteoporosis: percentage of patients, any age, with a diagnosis of osteoporosis who are either receiving both calcium & vitamin D intake, & exercise at least once within 12 months.",NOF7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Unplanned Readmission Following Spine Procedure within the 30-Day Postoperative Period,NPA11,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Selection of Prophylactic Antibiotic Prior to Spine Procedure,NPA12,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Medicine Reconciliation Following Spine Related Procedure,NPA14,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk Assessment for Elective Spine Procedure,NPA15,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Depression and Anxiety Assessment Prior to Spine-Related Therapies,NPA16,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Narcotic Pain Medicine Management Following Elective Spine Procedure,NPA17,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Smoking Assessment and Cessation Coincident With Spine-Related Therapies,NPA18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Body Mass Assessment and Follow-up Coincident With Spine-Related Therapies,NPA19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Unhealthy Alcohol Use Assessment Coincident With Spine Care,NPA20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Spine/Extremity Pain Assessment,NPA23,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Outcome Assessment for Spine Intervention,NPA3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Quality-of-Life Assessment for Spine Intervention,NPA4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Satisfaction With Spine Care,NPA5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Spine-Related Procedure Site Infection,NPA6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Spine/Extremity Pain Assessment ,NPAGSC10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Outcome Assessment for Spine Intervention ,NPAGSC3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Quality-of-Life Assessment for Spine Intervention ,NPAGSC4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Satisfaction with Spine Care ,NPAGSC5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Depression and Anxiety Assessment Prior to Spine-Related Therapies,NPAGSC6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Narcotic Pain Medicine Management Prior to and Following Spine Therapy ,NPAGSC7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Complication Following Percutaneous Spine-Related Procedure ,NPAGSC8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Unplanned Admission to Hospital Following Percutaneous Spine Procedure within the 30-Day Post-procedure Period ,NPAGSC9,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Notification to the ordering provider requesting myoglobin or CK-MB in the diagnosis of suspected acute myocardial infarction (AMI). ,NPQR1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of amended pathology reports with a major discrepancy,NPQR10,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of communicating results of an amended report with a major discrepancy to the responsible provider ,NPQR11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of cytopathology case review,NPQR12,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of notification to clinical provider of a new diagnosis of malignancy ,NPQR13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Frozen section diagnosis within 20 minutes of receipt in lab (single block frozen section),NPQR14,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Notification to the ordering provider requesting thyroid screening tests other than only a Thyroid Stimulating Hormone (TSH) test in the initial screening of a patient with a suspected thyroid disorder,NPQR2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Notification to the ordering provider requesting amylase testing in the diagnosis of suspected acute pancreatitis,NPQR3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Time interval: critical value reporting for chemistry,NPQR4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Time interval: critical value reporting for cerebrospinal fluid - white blood cell (CSF - WBC),NPQR5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Time interval: critical value reporting for toxicology,NPQR6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Time interval: critical value reporting for troponin,NPQR7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of review of slides with high-grade squamous intraepithelial lesion (HSIL) with negative cervical biopsies,NPQR8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of follow up letter after high-grade squamous intraepithelial lesion (HSIL) pap test,NPQR9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Post Stroke Outcome and Follow-Up,OBERD22,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Health Related Quality of Life: Patient Defined Outcomes,OBERD23,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Tracking Satisfaction Improvement with CG-CAHPS,OBERD25,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cervical Spine Functional Outcomes,OBERD26,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Foot/Ankle Functional Outcomes,OBERD27,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Hip Functional Outcomes,OBERD28,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Knee Functional Outcomes,OBERD29,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Lumbar Spine Functional Outcomes,OBERD30,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Quality of Life-Mental Health Outcomes,OBERD31,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Quality of Life - Physical Health Outcomes,OBERD32,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Acceptable Symptom State Outcomes,OBERD33,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Upper Extremity Functional Outcomes,OBERD34,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Emergent transfer from an outpatient, ambulatory surgical center, or office setting",OEIS2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Antiplatelet Therapy,OEIS3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+ Lipid-Lowering Medications for Patients with PAD,OEIS4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+ Appropriate non-invasive arterial testing for patients with intermittent claudication who are undergoing a LE peripheral vascular intervention,OEIS6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Goal Setting and Attainment for Cancer Survivors,ONSQIR18,QCDR measure,Patient Engagement Experience,N,--,--,--,--,--,--,--,--,--,--,--,No
+Fatigue Improvement,ONSQIR20,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Advance Care Planning in Stage 4 Disease,PIMSH1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Utilization of GCSF in Metastatic Colon Cancer,PIMSH2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Combination chemotherapy is recommended or administered within 4 months (120 days) of diagnosis for women under 70 with AJCC T1cN0M0 or Stage IB-III hormone receptor negative breast cancer,PIMSH3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-adjusted 30 day Readmission for Acute Myocardial Infarction,Pinc1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-adjusted 30 day Readmission for Heart Failure,Pinc2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-adjusted 30 day Readmission for Pneumonia,Pinc3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-Adjusted Average Length of Inpatient Hospital Stay for Acute Myocardial Infarction,Pinc33,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-Adjusted Average Length of Inpatient Hospital Stay for Heart Failure,Pinc34,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-Adjusted Average Length of Inpatient Hospital Stay for Pneumonia,Pinc35,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-adjusted 30 day Inpatient Mortality for Acute Myocardial Infarction,Pinc4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-adjusted 30 day Inpatient Mortality for Heart Failure ,Pinc5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-adjusted 30 day Inpatient Mortality for Pneumonia,Pinc6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Annual Monitoring for Patients on Persistent Medications (MPM),PP1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Follow-Up After Hospitalization for Schizophrenia (7- and 30-day),PP2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+ADHD: Symptom Reduction in Follow up Period,PP3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risky Behavior Assessment or Counseling by Age 18 Years,PP4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Bipolar disorder: the percentage of patients diagnosed and treated for bipolar disorder who are monitored for change in their symptom complex within 12 weeks of initiating treatment; AND if there is no change or deterioration in symptoms, a revised care plan is documented following the 12 week monitoring phase",PP5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Pharmacological Treatment of Dementia,PP6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Use of Multiple Concurrent Antipsychotics in Children and Adolescents (APC),PP7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Chronic Kidney Disease (CKD): eGFR Monitoring,PPRNET13,QCDR measure,Process,Y,14.6,71.4,62.50 - 64.85,64.86 - 70.58,70.59 - 73.32,73.33 - 76.04,76.05 - 80.18,80.19 - 84.23,84.24 - 89.05,>= 89.06,No,No
+Chronic Kidney Disease (CKD): Hemoglobin Monitoring,PPRNET14,QCDR measure,Process,Y,12.4,82.7,72.62 - 77.21,77.22 - 82.85,82.86 - 87.29,87.30 - 89.86,89.87 - 90.53,90.54 - 93.09,93.10 - 94.58,>= 94.59,No,No
+Appropriate Treatment for Adults with Upper Respiratory Infection,PPRNET24,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"NSAID or Cox 2 Inhibitor Use in Patients with Heart Failure (HF), Hypertension (HTN), or Chronic Kidney Disease (CKD)",PPRNET28,QCDR measure,Process,Y,7.1,84.4,80.00 - 81.80,81.81 - 82.91,82.92 - 84.83,84.84 - 85.94,85.95 - 86.76,86.77 - 91.40,91.41 - 93.07,>= 93.08,No,No
+Monitoring Serum Creatinine,PPRNET29,QCDR measure,Process,Y,22.1,80.3,73.35 - 78.88,78.89 - 84.40,84.41 - 86.29,86.30 - 88.09,88.10 - 90.88,90.89 - 93.85,93.86 - 96.29,>= 96.30,No,No
+Screening for Type 2 Diabetes,PPRNET31,QCDR measure,Process,Y,18.8,83.4,82.72 - 84.17,84.18 - 85.53,85.54 - 87.24,87.25 - 90.70,90.71 - 92.15,92.16 - 93.92,93.93 - 96.19,>= 96.20,No,No
+Screening for albuminuria in patients at risk for CKD (DM and/or HTN),PPRNET32,QCDR measure,Process,Y,26.8,46.9,18.26 - 26.78,26.79 - 47.26,47.27 - 56.41,56.42 - 61.65,61.66 - 66.11,66.12 - 72.25,72.26 - 75.06,>= 75.07,No,No
+Avoiding Use of CNS Depressants in Patients on Long-Term Opioids,PPRNET33,QCDR measure,Process,Y,12,60.7,50.51 - 54.54,54.55 - 55.58,55.59 - 57.79,57.80 - 60.14,60.15 - 65.24,65.25 - 72.38,72.39 - 81.62,>= 81.63,No,No
+Zoster (Shingles) Vaccination,PPRNET34,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Antiplatelet Medication for High Risk Patients,PPRNET8,QCDR measure,Process,Y,18.2,47.4,27.68 - 36.18,36.19 - 41.59,41.60 - 47.90,47.91 - 50.61,50.62 - 59.08,59.09 - 67.67,67.68 - 74.60,>= 74.61,No,No
+Combination chemotherapy received within 4 months of diagnosis by women under 70 with AJCC stage IA (T1c) to III ER/PR negative breast cancer,QOPI11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+GCSF administered to patients who received chemotherapy for metastatic cancer (Lower Score -Better),QOPI15,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Oncology: Treatment Summary Communication – Radiation Oncology,QOPI21,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+External Beam Radiotherapy for Bone Metastases,QOPI22,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Chemotherapy administered to patients with metastatic solid tumor with performance status of 3, 4, or undocumented  (Lower Score - Better)",QOPI5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Central Line Ultrasound Guidance,Quantum31,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Case Cancellation on Day of Surgery,Quantum41,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+CKD 3-5 Patients Seen at the Recommended Frequency Levels,RCOIR1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Upper Extremity Edema Improvement,RCOIR10,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Optimal End Stage Renal Disease (ESRD) Starts,RCOIR11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CKD 3-5 Patients with a Urine ACR or Urine PCR Lab Test,RCOIR3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CKD 4-5 Patients with Transplant Referral,RCOIR4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+ESRD Prevalence of Home Dialysis or Self-Care,RCOIR5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Access Site Bleeding,RCOIR7,QCDR measure,Outcome,Y,21.2,54.1,37.04 - 40.21,40.22 - 44.52,44.53 - 59.99,60.00 - 63.63,63.64 - 66.66,66.67 - 69.22,69.23 - 74.99,>= 75.00,No,No
+Post Procedure Bleeding,RCOIR8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Angiotensin Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy,RPAQIR1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Hospitalization Rate Following Procedures Performed under Procedure Sedation Analgesia,RPAQIR11,QCDR measure,Outcome,Y,0.6,0.3,0.58 - 0.27,0.26 - 0.08,0.07 - 0.01,--,--,--,--,0,Yes,No
+Arterial Complication Rate Following Arteriovenous Access Intervention,RPAQIR12,QCDR measure,Outcome,Y,0.7,0.6,0.99 - 0.74,0.73 - 0.55,0.54 - 0.40,0.39 - 0.01,--,--,--,0,Yes,No
+Rate of Timely Documentation Transmission to Dialysis Unit/Referring Physician,RPAQIR13,QCDR measure,Process,Y,7,94.2,92.85 - 94.06,94.07 - 94.94,94.95 - 95.86,95.87 - 97.27,97.28 - 97.88,97.89 - 99.20,99.21 - 99.76,>= 99.77,Yes,No
+Arteriovenous Graft Thrombectomy Success Rate,RPAQIR14,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Arteriovenous Fistulae Thrombectomy Success Rate,RPAQIR15,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Peritoneal Dialysis Catheter Success Rate,RPAQIR16,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Peritoneal Dialysis Catheter Exit Site Infection Rate,RPAQIR17,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Advance Directives Completed,RPAQIR18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Adequacy of Volume Management,RPAQIR2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Arteriovenous Fistula Rate,RPAQIR4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Transplant Referral,RPAQIR5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Advance Care Planning (Pediatric Kidney Disease),RPAQIR9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Improvement in Quality of Life from Partial Foot, Prosthetics ",SCG05,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+SCG1 Evaluation of High Risk Pain Medications for MME,SCG1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+SCG2 Outcome Assessment for Patients Prescribed Ankle Orthosis for Ambulation and Functional Improvement,SCG2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Outcome Assessment for Patients Prescribed Foot Orthosis for Ambulation and Functional Improvement ,SCG3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prevention of Antibiotic or Herbal Supplement Impairment of Anesthesia ,SCG4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Outcome of High Risk Pain Medications Prescribed in Last 6 Months,SCG6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Education of patients with inflammatory diseases regarding increased cardiovascular risk and the need for PCP evaluation,SDPAD1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+HCV testing in Lichen Planus,SDPAD2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Avoiding antibiotic use in rupture epidermal inclusion cyst,SDPAD3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate Testing and Treatment of Nail tinea infection,SDPAD4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Urgent Result:  Breast Specimen Radiography,SMD23,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result:  Testicular Torsion,SMD24,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result:  Subdural hematoma,SMD25,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"GI Radiography Result Notification
+•Critical Result:  Bowel Obstruction
+•Critical Result:  Sigmoid Volvulus",SMD26,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Chest Imaging Result Notification:
+•Critical Result:  Pneumothorax
+•Critical Result:  Tension Pneumothorax
+•Follow Up Result:  Suspicious Lung Nodule",SMD27,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Musculoskeletal Radiology Result Notification:
+•Critical Result:  Fracture C-Spine
+•Urgent Result: Osteomyelitis
+•Urgent Result:  Meniscal Tear
+",SMD28,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cardiovascular Monitoring for People with Cardiovascular Disease and Schizophrenia,SMX1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Diabetes Screening for People With Schizophrenia or Bipolar Disorder Who Are Using Antipsychotic Medications,SMX2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+SMX1004: Use of Multiple Concurrent Antipsychotics in Children and Adolescents,SMX3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Medication Adherence for Diabetes Medication,SMX5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Screening for Psychiatric or Behavioral Health Disorders,SMX6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Medication Adherence for Hypertension,SMX7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Assessment and Intervention for Psychosocial Distress in Adults Receiving Cancer Treatment ,SMX8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Mental Health Assessment for Patients with orthopedic conditions,SMX9,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Repeated X-ray Imaging,SPINEIQ3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Change in Functional Outcomes,SPINEIQ5,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Change in Pain Intensity,SPINEIQ6,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+MRI  of the lumbar spine without prior conservative care,SPINEIQ7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Assessment and Management of Muscle Spasticity--Inpatient,SQOD1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Management of Muscle Spasticity--Outpatient,SQOD2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Post-Acute Brain Injury: Depression Screening and Follow-Up Plan of Care,SQOD3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Family Training—Inpatient Rehabilitation/Skilled Nursing Facility-Discharged to Home,SQOD4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Assessment to Determine Rehabilitation Needs,SQOD5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prolonged Length of Stay Following Coronary Artery Bypass Grafting,STS1,QCDR measure,Outcome,Y,4.8,5.4,8.26 - 6.97,6.96 - 5.89,5.88 - 4.63,4.62 - 3.50,3.49 - 2.74,2.73 - 1.84,1.83 - 0.01,0,No,No
+Operative Mortality for Lobectomy,STS10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Lobectomy – Air Leak Greater than 5 Days,STS11,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Lobectomy – Unplanned Return to OR,STS12,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Recording Performance Status Prior to Lung Cancer Resection,STS13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prolonged Length of Stay for Coronary Artery Bypass Grafting (CABG) + Valve Replacement,STS3,QCDR measure,Outcome,Y,9,10.3,21.21 - 14.30,14.29 - 9.10,9.09 - 7.46,7.45 - 5.01,5.00 - 4.77,4.76 - 2.71,2.70 - 0.01,0,Yes,No
+Prolonged Length of Stay following Valve Surgery,STS5,QCDR measure,Outcome,Y,4.6,5.2,8.00 - 5.89,5.88 - 5.27,5.26 - 4.09,4.08 - 3.46,3.45 - 3.04,3.03 - 1.62,1.61 - 0.01,0,No,No
+Patient Centered Surgical Risk Assessment and Communication for Cardiac Surgery ,STS7,QCDR measure,Patient Engagement Experience,Y,39.5,47.2,2.73 - 6.55,6.56 - 22.77,22.78 - 51.51,51.52 - 69.99,70.00 - 83.77,83.78 - 92.47,92.48 - 99.16,>= 99.17,No,No
+Operative Mortality for Esophageal Resection,STS8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Recording Performance Status prior to Esophageal Cancer Resection,STS9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent of patients meeting MCID thresholds for back or neck pain,SpineTRACK1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent of patients meeting MCID thresholds for leg or arm pain,SpineTRACK2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Percent of patients meeting MCID thresholds for pain-related disability (ODI/NDI)
+",SpineTRACK3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Percent of patients meeting SCB thresholds for back or neck pain
+",SpineTRACK4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent of patients meeting SCB thresholds for leg or arm pain,SpineTRACK5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent of patients meeting SCB thresholds for pain-related disability (ODI/NDI),SpineTRACK6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+UR002 - Ankylosing Spondylitis: Controlled Disease,UREQA1,QCDR measure,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+UR003 - Ankylosing Spondylitis: Appropriate Pharmacologic Therapy,UREQA2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+UR008 - Controlled Gout for Patients on Urate-Lowering Pharmacologic Therapy ,UREQA3,QCDR measure,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+UR007 - Folic or Folinic Acid Therapy for Patients Treated with Methotrexate,UREQA4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+UR006 - Regular Evaluation of Psoriatic Arthritis (PsA),UREQA5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Vital Sign Assessment and Blood Glucose Check Prior to HBOT Treatment,USWR13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Major Amputation in Wagner 3, 4, or 5 Diabetic Foot Ulcers (DFUs) Treated with HBOT
+",USWR16,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Nutritional Screening and Intervention Plan in Patients with Chronic Wounds and Ulcers,USWR20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Reported Nutritional Assessment in Patients with Wounds and Ulcers,USWR22,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Non Invasive Arterial Assessment of patients with lower extremity wounds or ulcers for determination of healing potential ,USWR23,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Reported Experience of Care: Wound Outcome,USWR24,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Advance Care planning: Electronic submission of new POLST/MOLST/POST/MOST (""orders for life-sustaining treatment"" or ""orders for scope of treatment"") into an eRegistry powered by Medcordance",VCMAHEMR1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Diabetes Care All or None Outcome Measure: Optimal Control ,WCHQ10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Screening For Osteoporosis ,WCHQ15,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Controlling High Blood Pressure: eGFR Test Annually,WCHQ32,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Diabetes Care All or None Process Measure: Optimal Testing,WCHQ9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No

--- a/staging/2019/benchmarks/json/benchmarks.json
+++ b/staging/2019/benchmarks/json/benchmarks.json
@@ -5,11 +5,12 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       44.44,
       29.03,
-      19.61,
+      19.51,
       14.71,
       11.11,
       8.33,
@@ -21,36 +22,19 @@
     "measureId": "001",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
-    "submissionMethod": "cmsWebInterface",
-    "isToppedOut": false,
-    "deciles": [
-      100,
-      100,
-      70,
-      60,
-      50,
-      40,
-      30,
-      20,
-      10
-    ]
-  },
-  {
-    "measureId": "001",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       77.14,
-      60.65,
-      48.31,
-      38.72,
-      31.51,
-      25.71,
-      20.45,
-      14.63
+      60.78,
+      48.48,
+      38.89,
+      31.59,
+      25.87,
+      20.55,
+      14.71
     ]
   },
   {
@@ -59,16 +43,17 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
-      68.34,
-      50.65,
+      68.31,
+      50.62,
       37.5,
       28.69,
       20,
-      13.55,
-      9,
-      2.68
+      13.59,
+      9.02,
+      2.7
     ]
   },
   {
@@ -77,16 +62,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      74.1,
+      74.19,
       78.57,
       82.14,
       85.19,
-      87.9,
-      90.84,
-      93.67,
-      97.53
+      87.93,
+      90.91,
+      93.75,
+      97.73
     ]
   },
   {
@@ -95,6 +81,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       93.33,
@@ -113,14 +100,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      84.18,
-      88.04,
-      90.7,
-      92.9,
-      95.12,
-      97.11,
+      84.13,
+      88,
+      90.67,
+      92.86,
+      95.1,
+      97.09,
       100,
       100
     ]
@@ -131,16 +119,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      76.92,
-      80.86,
-      83.33,
-      85.61,
-      87.41,
-      89.9,
-      92,
-      94.93
+      76.74,
+      80.31,
+      83.18,
+      85.29,
+      87.16,
+      89.74,
+      91.92,
+      94.87
     ]
   },
   {
@@ -149,6 +138,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       96.17,
@@ -167,15 +157,16 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      80.77,
-      86,
-      89.4,
+      80.49,
+      85.62,
+      88.98,
       91.3,
-      93.14,
-      94.87,
-      96.43,
+      93.05,
+      94.74,
+      96.35,
       100
     ]
   },
@@ -185,6 +176,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       95.45,
@@ -203,6 +195,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       16.67,
@@ -221,6 +214,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -239,15 +233,16 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      79.84,
-      86.73,
-      90.71,
-      93.95,
-      96.38,
-      98.06,
-      99.12,
+      79.11,
+      86.58,
+      90.62,
+      93.88,
+      96.32,
+      98.02,
+      99.11,
       100
     ]
   },
@@ -257,10 +252,11 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      96.49,
-      99.2,
+      96.47,
+      99.17,
       100,
       100,
       100,
@@ -275,6 +271,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -293,6 +290,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       76.54,
@@ -311,6 +309,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -329,16 +328,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      33.94,
-      47.65,
-      57.95,
-      67.07,
-      75.46,
+      33.9,
+      47.62,
+      57.89,
+      67.03,
+      75.37,
       82.49,
       90.03,
-      96.03
+      96
     ]
   },
   {
@@ -347,6 +347,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       70.29,
@@ -365,6 +366,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       99.17,
@@ -383,9 +385,10 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      98.72,
+      98.67,
       100,
       100,
       100,
@@ -401,6 +404,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -419,9 +423,10 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      98.72,
+      98.68,
       100,
       100,
       100,
@@ -437,6 +442,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       32.35,
@@ -455,13 +461,14 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       26.32,
-      47.37,
+      45.1,
       55.32,
-      62.79,
-      74.07,
+      60.21,
+      70,
       80.56,
       100,
       100
@@ -473,15 +480,16 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      32.81,
-      42.41,
-      49.02,
+      32.79,
+      42.37,
+      49.01,
       55.91,
       62.55,
-      70.71,
-      82.91,
+      70.69,
+      82.89,
       95.5
     ]
   },
@@ -491,16 +499,17 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      11.18,
-      22.42,
-      34.62,
-      45.21,
-      58.05,
+      11.38,
+      22.44,
+      34.72,
+      45.26,
+      58.11,
       67.98,
-      78.69,
-      88.34
+      78.46,
+      88.24
     ]
   },
   {
@@ -509,11 +518,12 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      91.43,
-      96.05,
-      97.56,
+      90.35,
+      95.9,
+      97.39,
       100,
       100,
       100,
@@ -527,6 +537,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       95.74,
@@ -545,6 +556,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       94.24,
@@ -563,13 +575,14 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      50.33,
-      82.64,
+      50.32,
+      82.61,
       92.89,
       97.46,
-      99.3,
+      99.31,
       100,
       100,
       100
@@ -581,14 +594,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      24.26,
-      44.99,
-      65.69,
-      82.13,
+      24.33,
+      45.02,
+      65.75,
+      82.17,
       91.9,
-      97.3,
+      97.32,
       99.72,
       100
     ]
@@ -599,6 +613,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       3.88,
@@ -617,13 +632,14 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      12.2,
+      12.22,
       31.75,
-      51.72,
+      52.37,
       70.45,
-      84.21,
+      84.27,
       95.11,
       99.51,
       100
@@ -635,6 +651,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       97.3,
@@ -653,6 +670,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       47.22,
@@ -671,6 +689,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       38.1,
@@ -689,14 +708,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       25,
-      45.13,
+      45.45,
       60.43,
-      75.7,
-      86.21,
-      93.9,
+      75.76,
+      86.46,
+      93.83,
       99.36,
       100
     ]
@@ -707,6 +727,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       90.14,
@@ -725,6 +746,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       90.16,
@@ -743,13 +765,14 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      81.13,
-      88.47,
-      91.8,
+      80.95,
+      88.37,
+      91.77,
       93.88,
-      95.65,
+      95.61,
       96.88,
       98.22,
       100
@@ -761,6 +784,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       91.49,
@@ -779,15 +803,16 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      36.35,
-      59.84,
-      72.42,
-      78.68,
-      83.49,
-      87.65,
-      91.53,
+      36.71,
+      60.05,
+      72.41,
+      78.38,
+      83.33,
+      87.63,
+      91.43,
       94.59
     ]
   },
@@ -797,6 +822,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       64.57,
@@ -815,6 +841,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       8,
@@ -833,6 +860,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       42.86,
@@ -851,6 +879,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       16.67,
@@ -869,6 +898,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       95.24,
@@ -887,9 +917,10 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      95.66,
+      95.67,
       99.09,
       100,
       100,
@@ -905,6 +936,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       43.36,
@@ -923,12 +955,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       67.34,
-      78.79,
-      86.36,
-      91.35,
+      78.77,
+      86.34,
+      91.33,
       95.24,
       97.37,
       100,
@@ -941,6 +974,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       89.12,
@@ -959,6 +993,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       63.16,
@@ -977,6 +1012,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       59.34,
@@ -995,14 +1031,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      37.38,
+      39.65,
       48.17,
-      54.67,
-      73.25,
-      89.74,
-      97.22,
+      55.06,
+      76.23,
+      93.26,
+      99.6,
       100,
       100
     ]
@@ -1013,6 +1050,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       1.51,
@@ -1031,6 +1069,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       87.28,
@@ -1049,6 +1088,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       34.62,
@@ -1067,34 +1107,17 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       29.52,
-      41.4,
-      56.26,
+      41.42,
+      56.32,
       71.19,
-      82.88,
-      94.16,
-      99.43,
+      82.89,
+      94.15,
+      99.42,
       100
-    ]
-  },
-  {
-    "measureId": "110",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "cmsWebInterface",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      0,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
     ]
   },
   {
@@ -1103,16 +1126,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      15.6,
-      23.83,
-      31.46,
-      38.86,
-      46.96,
-      56.18,
-      67.93,
-      85.2
+      15.5,
+      23.64,
+      31.21,
+      38.66,
+      46.77,
+      56.02,
+      67.5,
+      84.99
     ]
   },
   {
@@ -1121,15 +1145,16 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      29.77,
+      29.85,
       41.43,
       53.85,
       66.03,
       76.94,
-      87.82,
-      96.43,
+      87.81,
+      96.41,
       100
     ]
   },
@@ -1139,15 +1164,16 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      49.75,
+      49.76,
       61.11,
       70.11,
-      77.31,
-      82.95,
-      89.43,
-      95.69,
+      77.32,
+      82.96,
+      89.44,
+      95.67,
       100
     ]
   },
@@ -1157,16 +1183,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       19.01,
-      31.17,
-      42.79,
-      53.45,
-      62.89,
-      71.86,
-      80.49,
-      90.48
+      31.07,
+      42.71,
+      53.44,
+      62.86,
+      71.82,
+      80.43,
+      90.41
     ]
   },
   {
@@ -1175,9 +1202,10 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      30.19,
+      30.23,
       44.53,
       55.56,
       63.64,
@@ -1193,34 +1221,17 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       44.44,
-      52,
-      58.44,
+      52.08,
+      58.45,
       64.29,
       70.97,
-      79.84,
-      90.2,
+      79.85,
+      90.24,
       100
-    ]
-  },
-  {
-    "measureId": "112",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "cmsWebInterface",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      0,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
     ]
   },
   {
@@ -1229,16 +1240,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       22.28,
-      32.84,
-      42.42,
-      51.18,
-      58.54,
-      65.78,
-      73.59,
-      82.42
+      32.75,
+      42.32,
+      51.06,
+      58.44,
+      65.68,
+      73.44,
+      82.31
     ]
   },
   {
@@ -1247,6 +1259,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       35.99,
@@ -1265,14 +1278,15 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      36.43,
-      50.94,
-      62.44,
-      71.19,
+      36.6,
+      51,
+      62.5,
+      71.23,
       80,
-      88.61,
+      88.64,
       97.73,
       100
     ]
@@ -1281,36 +1295,19 @@
     "measureId": "113",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
-    "submissionMethod": "cmsWebInterface",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      0,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
-    ]
-  },
-  {
-    "measureId": "113",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      13.58,
-      24.1,
-      34.09,
-      44.53,
-      54.9,
-      64.16,
-      73.48,
-      83.53
+      13.49,
+      24.01,
+      33.97,
+      44.39,
+      54.8,
+      64.01,
+      73.38,
+      83.51
     ]
   },
   {
@@ -1319,15 +1316,16 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      35.81,
-      49.71,
-      60.91,
-      70.96,
-      80.77,
+      35.9,
+      49.51,
+      60.83,
+      70.88,
+      80.62,
       90.41,
-      97.07,
+      96.98,
       100
     ]
   },
@@ -1337,6 +1335,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       44.27,
@@ -1355,6 +1354,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       72,
@@ -1373,16 +1373,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      20.5,
-      31.82,
-      45.21,
-      65.31,
-      88.91,
-      95.63,
-      98.27,
-      99.74
+      20.61,
+      32,
+      45.53,
+      66.02,
+      89.12,
+      95.65,
+      98.26,
+      99.73
     ]
   },
   {
@@ -1391,9 +1392,10 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      77.42,
+      77.26,
       90,
       95.82,
       98.49,
@@ -1409,6 +1411,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       76,
@@ -1427,16 +1430,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      67.9,
-      75,
-      80.14,
-      84.33,
-      87.86,
-      91.22,
-      94.69,
-      98.42
+      67.86,
+      74.8,
+      80,
+      84.14,
+      87.74,
+      91.11,
+      94.63,
+      98.39
     ]
   },
   {
@@ -1445,6 +1449,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       74.38,
@@ -1463,6 +1468,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       66.15,
@@ -1481,11 +1487,12 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      70.38,
-      93.04,
-      99.47,
+      70.59,
+      92.86,
+      99.46,
       100,
       100,
       100,
@@ -1499,13 +1506,14 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      37.5,
-      47.75,
-      74.42,
-      95.18,
-      99.26,
+      37.52,
+      47.78,
+      74.48,
+      95.2,
+      99.27,
       100,
       100,
       100
@@ -1517,16 +1525,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       21.15,
-      24.58,
-      28.49,
+      24.59,
+      28.52,
       34.21,
-      43.91,
-      60.51,
-      78.43,
-      93.39
+      43.85,
+      60.31,
+      78.25,
+      93.29
     ]
   },
   {
@@ -1535,12 +1544,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      34.52,
+      34.35,
       54.26,
-      74.93,
-      90.61,
+      74.57,
+      90.6,
       97.56,
       99.87,
       100,
@@ -1553,6 +1563,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       97.95,
@@ -1571,14 +1582,15 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      87.63,
-      93.55,
-      96.33,
-      98.02,
-      99.01,
-      99.59,
+      87.55,
+      93.49,
+      96.29,
+      97.99,
+      99,
+      99.58,
       99.89,
       100
     ]
@@ -1589,11 +1601,12 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      68.02,
+      68.06,
       90.28,
-      97.22,
+      97.24,
       99.51,
       100,
       100,
@@ -1607,10 +1620,11 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      80.87,
-      96.98,
+      80.57,
+      96.92,
       99.64,
       100,
       100,
@@ -1625,12 +1639,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      15.61,
+      15.8,
       40,
-      62.81,
-      84.07,
+      62.79,
+      84.06,
       95.26,
       99.55,
       100,
@@ -1643,12 +1658,13 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      12.9,
-      53.56,
-      80.08,
-      96.84,
+      12.94,
+      53.92,
+      80.23,
+      96.99,
       100,
       100,
       100,
@@ -1659,36 +1675,19 @@
     "measureId": "134",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
-    "submissionMethod": "cmsWebInterface",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      0,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
-    ]
-  },
-  {
-    "measureId": "134",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       4.88,
       10.18,
-      17.95,
-      28.57,
-      42.55,
-      57.07,
-      73.47,
-      87.76
+      17.6,
+      28.29,
+      42.3,
+      56.83,
+      73.3,
+      87.5
     ]
   },
   {
@@ -1697,12 +1696,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       17.11,
       45.65,
-      74.07,
-      90.45,
+      73.82,
+      90.06,
       98.5,
       100,
       100,
@@ -1715,9 +1715,10 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      83.84,
+      83.83,
       94.34,
       98.8,
       100,
@@ -1733,6 +1734,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       49.44,
@@ -1751,6 +1753,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -1769,6 +1772,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       73.85,
@@ -1787,12 +1791,13 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      77.24,
-      87.91,
-      94.93,
-      97.3,
+      77.21,
+      87.79,
+      94.92,
+      97.27,
       98.35,
       99.46,
       100,
@@ -1805,13 +1810,14 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      90.26,
-      95.39,
-      97.12,
-      98.55,
-      99.24,
+      90.31,
+      95.4,
+      97.13,
+      98.57,
+      99.26,
       100,
       100,
       100
@@ -1823,6 +1829,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       66.41,
@@ -1841,6 +1848,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       73.1,
@@ -1859,6 +1867,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       0.23,
@@ -1877,6 +1886,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       0.24,
@@ -1895,6 +1905,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       76.47,
@@ -1913,6 +1924,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       93.04,
@@ -1931,9 +1943,10 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      96.94,
+      96.95,
       100,
       100,
       100,
@@ -1949,13 +1962,14 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      28.84,
+      28.63,
       60.82,
       85,
-      96.03,
-      99.9,
+      95.97,
+      99.74,
       100,
       100,
       100
@@ -1967,9 +1981,10 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      55.86,
+      55.81,
       84.62,
       99.21,
       100,
@@ -1985,6 +2000,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       67.86,
@@ -2003,16 +2019,17 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
-      11.09,
+      11.4,
       9.09,
       7.69,
-      6.82,
-      5.69,
-      4.4,
-      3.03,
-      1.52
+      6.8,
+      5.55,
+      4.28,
+      3.08,
+      1.54
     ]
   },
   {
@@ -2021,9 +2038,10 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
-      0.85,
+      0.84,
       0,
       0,
       0,
@@ -2039,12 +2057,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       2.38,
       1.79,
-      1.27,
-      0.81,
+      1.26,
+      0.71,
       0,
       0,
       0,
@@ -2057,13 +2076,14 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
-      3.45,
+      3.51,
       2.7,
-      2.13,
+      2.15,
       1.85,
-      1.3,
+      1.28,
       0.88,
       0,
       0
@@ -2075,14 +2095,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
-      3.9,
+      3.95,
       3.13,
       2.63,
       1.79,
       1.27,
-      0.9,
+      0.87,
       0,
       0
     ]
@@ -2093,14 +2114,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       32,
       48.15,
-      56,
-      69,
-      80.72,
-      100,
+      55.56,
+      68.01,
+      80.43,
+      99.04,
       100,
       100
     ]
@@ -2111,12 +2133,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      53.85,
+      57.23,
       75,
-      88.57,
-      96.6,
+      88.24,
+      96.02,
       100,
       100,
       100,
@@ -2129,12 +2152,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      67.71,
-      81.44,
-      91.11,
-      96.27,
+      67.61,
+      81.4,
+      90.59,
+      95.95,
       100,
       100,
       100,
@@ -2147,12 +2171,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       44.53,
-      67.99,
-      87.8,
-      95.45,
+      67.89,
+      85.31,
+      95.22,
       100,
       100,
       100,
@@ -2165,13 +2190,14 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      51.1,
-      76.41,
-      88.19,
-      95.15,
-      100,
+      52.68,
+      75.79,
+      87.96,
+      95.06,
+      99.58,
       100,
       100,
       100
@@ -2183,6 +2209,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       55.38,
@@ -2201,6 +2228,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       50.65,
@@ -2219,6 +2247,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -2237,6 +2266,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       98.57,
@@ -2255,6 +2285,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       61.64,
@@ -2273,6 +2304,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       88.89,
@@ -2291,15 +2323,16 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      85.71,
-      90.88,
-      93.6,
-      95.64,
-      96.92,
-      97.85,
-      98.8,
+      85.25,
+      90.63,
+      93.41,
+      95.59,
+      96.88,
+      97.83,
+      98.78,
       100
     ]
   },
@@ -2309,6 +2342,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       94.37,
@@ -2327,6 +2361,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       0,
@@ -2345,6 +2380,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       0,
@@ -2363,6 +2399,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       91.72,
@@ -2381,10 +2418,11 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       97.81,
-      99.86,
+      99.85,
       100,
       100,
       100,
@@ -2399,6 +2437,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       99.36,
@@ -2417,6 +2456,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -2435,6 +2475,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       58.57,
@@ -2443,26 +2484,8 @@
       73.91,
       78.57,
       83.33,
-      88.27,
-      94.87
-    ]
-  },
-  {
-    "measureId": "236",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "cmsWebInterface",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      0,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
+      88.32,
+      94.89
     ]
   },
   {
@@ -2471,16 +2494,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       51.46,
-      56.84,
+      56.83,
       60.95,
       64.68,
-      68.21,
-      72.09,
-      76.35,
-      82.28
+      68.18,
+      72.01,
+      76.26,
+      82.21
     ]
   },
   {
@@ -2489,15 +2513,16 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      52.48,
-      60.15,
-      65.73,
-      70.68,
+      52.41,
+      60.05,
+      65.68,
+      70.62,
       76.83,
       84.62,
-      93.62,
+      93.4,
       100
     ]
   },
@@ -2507,14 +2532,15 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
-      8.08,
-      4.78,
-      2.7,
-      1.32,
+      8.04,
+      4.74,
+      2.67,
+      1.31,
       0.53,
-      0.05,
+      0.04,
       0,
       0
     ]
@@ -2525,9 +2551,10 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
-      0.67,
+      0.68,
       0.28,
       0.13,
       0,
@@ -2543,16 +2570,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       26.23,
       29.52,
       31.48,
-      32.83,
-      33.96,
-      38.81,
-      47.93,
-      65.69
+      32.8,
+      33.86,
+      38.73,
+      47.77,
+      65.53
     ]
   },
   {
@@ -2561,6 +2589,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       9.3,
@@ -2579,6 +2608,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       8.11,
@@ -2597,6 +2627,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -2615,6 +2646,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -2633,6 +2665,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -2651,6 +2684,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -2669,6 +2703,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       74.42,
@@ -2687,6 +2722,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -2705,6 +2741,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       97.96,
@@ -2723,12 +2760,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      61.2,
-      83.7,
+      61.23,
+      83.63,
       95.65,
-      99.39,
+      99.38,
       100,
       100,
       100,
@@ -2741,6 +2779,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       32,
@@ -2759,6 +2798,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       69.01,
@@ -2777,6 +2817,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       90.08,
@@ -2795,12 +2836,13 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       5.88,
       12.9,
       26.09,
-      44.84,
+      45,
       59.26,
       73.33,
       88.57,
@@ -2813,6 +2855,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       57.14,
@@ -2831,6 +2874,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       58.14,
@@ -2849,6 +2893,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       62.86,
@@ -2867,6 +2912,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       59.26,
@@ -2885,6 +2931,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       85.09,
@@ -2903,6 +2950,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       86.49,
@@ -2921,6 +2969,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       67.03,
@@ -2939,6 +2988,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       45.11,
@@ -2957,6 +3007,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       50,
@@ -2975,6 +3026,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       0.31,
@@ -2993,15 +3045,16 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      9.84,
-      16.67,
-      23.62,
-      31.5,
-      39.61,
-      48.21,
-      57.61,
+      9.83,
+      16.8,
+      23.66,
+      31.54,
+      39.72,
+      48.31,
+      57.63,
       72.61
     ]
   },
@@ -3011,6 +3064,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       16.67,
@@ -3029,14 +3083,15 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      34.24,
-      45.45,
-      58.45,
-      73.19,
-      89.39,
-      98.05,
+      34.25,
+      45.48,
+      58.49,
+      73.29,
+      89.41,
+      98.07,
       100,
       100
     ]
@@ -3047,16 +3102,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      19.55,
-      24.12,
-      28.15,
-      32.23,
-      36.65,
-      42.2,
-      50.93,
-      75
+      19.56,
+      24.14,
+      28.19,
+      32.31,
+      36.67,
+      42.12,
+      50.7,
+      74.55
     ]
   },
   {
@@ -3065,34 +3121,17 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      25.83,
+      25.75,
       30.81,
       35.47,
-      42.53,
-      59.12,
-      83.33,
-      97.3,
+      42.57,
+      59.15,
+      83.49,
+      97.32,
       100
-    ]
-  },
-  {
-    "measureId": "318",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "cmsWebInterface",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      0,
-      43.42,
-      50.42,
-      58.45,
-      66,
-      73.39,
-      81.79,
-      90.73
     ]
   },
   {
@@ -3101,16 +3140,17 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      7.25,
-      20.23,
-      36.4,
-      52.26,
-      66.77,
-      78.69,
+      7.24,
+      20.27,
+      36.41,
+      52.25,
+      66.73,
+      78.6,
       88.51,
-      96.55
+      96.56
     ]
   },
   {
@@ -3119,6 +3159,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       95.24,
@@ -3137,14 +3178,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      85.29,
+      85,
       89.74,
-      93.75,
+      93.61,
       95.95,
       97.73,
-      98.98,
+      98.96,
       100,
       100
     ]
@@ -3155,6 +3197,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       1.9,
@@ -3173,6 +3216,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       2.44,
@@ -3191,6 +3235,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       6.25,
@@ -3209,6 +3254,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       84.13,
@@ -3227,14 +3273,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      69.38,
-      75.07,
-      78.84,
-      83.05,
-      87.99,
-      94.86,
+      69.54,
+      75.11,
+      78.9,
+      83.09,
+      88.17,
+      94.94,
       100,
       100
     ]
@@ -3245,6 +3292,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       92.15,
@@ -3263,6 +3311,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       93.55,
@@ -3281,6 +3330,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       2.5,
@@ -3299,6 +3349,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       47.06,
@@ -3317,6 +3368,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       74.47,
@@ -3335,6 +3387,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       48.97,
@@ -3353,6 +3406,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       98.78,
@@ -3371,6 +3425,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       96,
@@ -3389,6 +3444,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -3407,6 +3463,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -3425,6 +3482,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -3443,6 +3501,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       3.61,
@@ -3461,6 +3520,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       3.15,
@@ -3479,6 +3539,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       5,
@@ -3497,11 +3558,12 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       3.48,
       2.27,
-      0.95,
+      0.93,
       0,
       0,
       0,
@@ -3515,6 +3577,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       17.29,
@@ -3533,6 +3596,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       31.53,
@@ -3551,6 +3615,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -3569,6 +3634,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -3587,6 +3653,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       59.02,
@@ -3605,6 +3672,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       26.67,
@@ -3623,15 +3691,16 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      2.04,
-      2.63,
-      3.55,
-      4.24,
-      5.26,
+      2.08,
+      2.7,
+      3.7,
+      4.35,
+      5.32,
       7.14,
-      8.82,
+      8.77,
       15
     ]
   },
@@ -3641,15 +3710,16 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      3.7,
-      6.06,
-      8.96,
-      12.5,
-      16.43,
-      21.74,
-      30.1,
+      3.82,
+      6.12,
+      9.09,
+      12.69,
+      16.67,
+      22.09,
+      30.3,
       43.14
     ]
   },
@@ -3659,16 +3729,36 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      7.62,
-      14.93,
+      7.63,
+      14.98,
       26.33,
-      37.04,
-      48.47,
-      60.32,
-      74.67,
-      90.91
+      36.74,
+      48.15,
+      60.25,
+      74.44,
+      90.75
+    ]
+  },
+  {
+    "measureId": "374",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      6.77,
+      8.51,
+      37.84,
+      62.86,
+      82.43,
+      88.89,
+      92.74,
+      99.02
     ]
   },
   {
@@ -3677,6 +3767,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       5,
@@ -3695,6 +3786,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       4.82,
@@ -3713,10 +3805,11 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
-      0.48,
-      0.1,
+      0.47,
+      0.09,
       0,
       0,
       0,
@@ -3731,6 +3824,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       0.32,
@@ -3749,6 +3843,7 @@
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       3.43,
@@ -3767,6 +3862,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       58,
@@ -3785,6 +3881,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       0.38,
@@ -3803,6 +3900,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       0,
@@ -3821,6 +3919,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       77.17,
@@ -3839,6 +3938,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       63.64,
@@ -3857,6 +3957,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -3875,6 +3976,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -3893,6 +3995,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -3911,6 +4014,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -3929,6 +4033,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       91.96,
@@ -3947,6 +4052,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       33.52,
@@ -3965,6 +4071,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       1.26,
@@ -3983,6 +4090,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       86.36,
@@ -4001,16 +4109,17 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      40,
+      39.88,
       50.59,
-      57.35,
+      57.25,
       63,
-      69.74,
-      75.25,
-      82.35,
-      93.4
+      69.75,
+      75.27,
+      82.41,
+      93.38
     ]
   },
   {
@@ -4019,6 +4128,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       10.26,
@@ -4037,12 +4147,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
-      12.24,
+      12.11,
       6.67,
       2.63,
-      0.46,
+      0.53,
       0,
       0,
       0,
@@ -4055,6 +4166,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       61.9,
@@ -4073,12 +4185,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
-      14.23,
-      5.8,
-      3.47,
-      0.03,
+      14.94,
+      5.97,
+      3.64,
+      0.09,
       0,
       0,
       0,
@@ -4091,6 +4204,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -4109,6 +4223,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       68.35,
@@ -4127,6 +4242,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       23.08,
@@ -4145,12 +4261,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       61.17,
       88.35,
       97.44,
-      99.63,
+      99.67,
       100,
       100,
       100,
@@ -4163,6 +4280,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       88.55,
@@ -4181,6 +4299,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       96,
@@ -4199,6 +4318,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       63.41,
@@ -4217,6 +4337,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       46.67,
@@ -4235,13 +4356,14 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       98.46,
       99.52,
       99.75,
       99.88,
-      99.99,
+      100,
       100,
       100,
       100
@@ -4253,6 +4375,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       97.44,
@@ -4266,16 +4389,36 @@
     ]
   },
   {
+    "measureId": "425",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      97.59,
+      98.32,
+      98.74,
+      99.05,
+      99.3,
+      99.51,
+      99.77,
+      100
+    ]
+  },
+  {
     "measureId": "430",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       93.66,
       97.18,
-      98.51,
+      98.54,
       99.22,
       99.64,
       99.92,
@@ -4289,12 +4432,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       33.43,
       49.35,
       66.12,
-      78.15,
+      78.13,
       87,
       93.52,
       97.96,
@@ -4307,6 +4451,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       2.05,
@@ -4325,6 +4470,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       85.73,
@@ -4343,11 +4489,12 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       93.28,
-      96.96,
-      99.05,
+      96.97,
+      99.06,
       99.67,
       99.92,
       100,
@@ -4361,6 +4508,7 @@
     "performanceYear": 2019,
     "submissionMethod": "claims",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       1.32,
@@ -4377,14 +4525,34 @@
     "measureId": "438",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      69.86,
-      77.18,
-      88.88,
-      96.54,
+      63.75,
+      71.07,
+      77.12,
+      84.27,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "438",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      78.72,
+      91.67,
+      95.65,
+      97.38,
       100,
       100,
       100,
@@ -4397,6 +4565,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       96.91,
@@ -4415,6 +4584,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       32.4,
@@ -4433,6 +4603,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       91.67,
@@ -4451,14 +4622,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       3.9,
-      3.39,
+      3.16,
       2.68,
-      2.25,
-      1.74,
-      1.15,
+      2.24,
+      1.72,
+      1.22,
       0,
       0
     ]
@@ -4469,10 +4641,11 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      94.8,
-      98.15,
+      95.71,
+      98.53,
       100,
       100,
       100,
@@ -4487,12 +4660,13 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      87.59,
-      90.45,
-      93.2,
-      97.86,
+      90,
+      90.91,
+      93.55,
+      100,
       100,
       100,
       100,
@@ -4505,15 +4679,16 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       15,
       10.42,
       9.18,
-      8.18,
-      7.63,
-      7.3,
-      6.47,
+      7.99,
+      7.35,
+      7.03,
+      2.38,
       0
     ]
   },
@@ -4523,15 +4698,16 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       15.38,
-      15.09,
+      15,
       13.51,
-      12.2,
-      9.7,
+      11.1,
+      9.64,
       6.45,
-      4.32,
+      0,
       0
     ]
   },
@@ -4541,6 +4717,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       10.16,
@@ -4559,6 +4736,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       82.44,
@@ -4577,6 +4755,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       1.58,
@@ -4595,6 +4774,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       73.58,
@@ -4613,16 +4793,17 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      3.92,
-      11.9,
-      21.88,
-      29.89,
-      55.31,
-      66.68,
-      82.13,
-      90.61
+      4.09,
+      11.96,
+      22.22,
+      30.43,
+      53.85,
+      65.27,
+      81.95,
+      90.34
     ]
   },
   {
@@ -4631,6 +4812,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       42.45,
@@ -4649,13 +4831,14 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       27.59,
       41.35,
-      55.96,
-      73.62,
-      84,
+      58.33,
+      74.07,
+      83.91,
       94.12,
       98.14,
       99.74
@@ -4667,15 +4850,16 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      14.39,
-      17.86,
-      22.95,
-      28.57,
-      33.94,
+      14.5,
+      16.67,
+      22.41,
+      28.44,
+      32.47,
       40.2,
-      45.56,
+      45.51,
       53.01
     ]
   },
@@ -4685,6 +4869,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       61.54,
@@ -4703,6 +4888,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       99.6,
@@ -4721,6 +4907,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -4739,6 +4926,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       99.98,
@@ -4757,6 +4945,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       56.01,
@@ -4775,6 +4964,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       29.34,
@@ -4793,6 +4983,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       32.09,
@@ -4811,6 +5002,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       44.29,
@@ -4829,6 +5021,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       76.64,
@@ -4847,6 +5040,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       89.72,
@@ -4865,6 +5059,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       97.85,
@@ -4878,11 +5073,12 @@
     ]
   },
   {
-    "measureId": "ACCPIN3",
+    "measureId": "ACCPin3",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -4901,6 +5097,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       24.61,
@@ -4919,6 +5116,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       8,
@@ -4937,6 +5135,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       55.27,
@@ -4955,6 +5154,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       63.89,
@@ -4973,6 +5173,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       43.04,
@@ -4991,24 +5192,26 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      20.83,
-      24.56,
-      31.82,
-      38.1,
-      41.46,
-      44.62,
-      47.83,
-      65.25
+      21.19,
+      28.1,
+      34.78,
+      38.17,
+      41.89,
+      46.54,
+      58.88,
+      67.15
     ]
   },
   {
-    "measureId": "ACRAD3",
+    "measureId": "ACRad3",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       0.18,
@@ -5022,11 +5225,12 @@
     ]
   },
   {
-    "measureId": "ACRAD31",
+    "measureId": "ACRad31",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -5040,11 +5244,12 @@
     ]
   },
   {
-    "measureId": "ACRAD32",
+    "measureId": "ACRad32",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -5058,11 +5263,12 @@
     ]
   },
   {
-    "measureId": "ACRAD33",
+    "measureId": "ACRad33",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,
@@ -5076,11 +5282,12 @@
     ]
   },
   {
-    "measureId": "ACRAD6",
+    "measureId": "ACRad6",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       20,
@@ -5099,6 +5306,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       55.23,
@@ -5117,6 +5325,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       99.14,
@@ -5135,6 +5344,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       79.31,
@@ -5153,6 +5363,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       5.13,
@@ -5171,6 +5382,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       99.16,
@@ -5189,6 +5401,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       98.15,
@@ -5207,6 +5420,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       83.33,
@@ -5225,6 +5439,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       31.25,
@@ -5243,14 +5458,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      83.72,
+      83.71,
       87.92,
-      90.2,
-      91.86,
+      90.18,
+      91.83,
       93.52,
-      95.06,
+      95.01,
       96.58,
       98.15
     ]
@@ -5261,6 +5477,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       61.11,
@@ -5279,6 +5496,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       86.96,
@@ -5297,6 +5515,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       70.25,
@@ -5315,6 +5534,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       2.13,
@@ -5333,6 +5553,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       0,
@@ -5351,6 +5572,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
       100,
@@ -5369,6 +5591,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       12.5,
@@ -5387,6 +5610,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       62.5,
@@ -5405,6 +5629,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       72.62,
@@ -5423,6 +5648,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       80,
@@ -5441,6 +5667,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       73.35,
@@ -5459,6 +5686,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       82.72,
@@ -5477,6 +5705,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       18.26,
@@ -5495,6 +5724,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       50.51,
@@ -5513,6 +5743,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       27.68,
@@ -5531,6 +5762,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       37.04,
@@ -5549,6 +5781,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       0.58,
@@ -5567,6 +5800,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       0.99,
@@ -5585,6 +5819,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       92.85,
@@ -5603,15 +5838,16 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       8.26,
-      7.14,
+      6.96,
       5.88,
-      4.65,
-      3.57,
+      4.62,
+      3.49,
       2.73,
-      1.85,
+      1.83,
       0
     ]
   },
@@ -5621,6 +5857,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       21.21,
@@ -5639,6 +5876,7 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       100,
       8,
@@ -5657,14 +5895,15 @@
     "performanceYear": 2019,
     "submissionMethod": "registry",
     "isToppedOut": false,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       2.73,
       6.56,
       22.78,
-      50.38,
-      68.73,
-      84.06,
+      51.52,
+      70,
+      83.78,
       92.48,
       99.17
     ]

--- a/staging/2019/benchmarks/json/benchmarks.json
+++ b/staging/2019/benchmarks/json/benchmarks.json
@@ -4712,25 +4712,6 @@
     ]
   },
   {
-    "measureId": "AAD1",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      10.16,
-      18.75,
-      25.13,
-      35.84,
-      43.48,
-      57.08,
-      76.77,
-      100
-    ]
-  },
-  {
     "measureId": "AAD2",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -4747,25 +4728,6 @@
       100,
       100,
       100
-    ]
-  },
-  {
-    "measureId": "AAD3",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      1.58,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
     ]
   },
   {
@@ -4807,44 +4769,6 @@
     ]
   },
   {
-    "measureId": "AAN2",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      42.45,
-      46.27,
-      47.03,
-      49.32,
-      52.31,
-      53.47,
-      55.13,
-      59.19
-    ]
-  },
-  {
-    "measureId": "AAN4",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      27.59,
-      41.35,
-      58.33,
-      74.07,
-      83.91,
-      94.12,
-      98.14,
-      99.74
-    ]
-  },
-  {
     "measureId": "AAN5",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -4883,25 +4807,6 @@
     ]
   },
   {
-    "measureId": "AAO11",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      99.6,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
     "measureId": "AAO8",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -4911,25 +4816,6 @@
     "deciles": [
       0,
       100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ABG1",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      99.98,
       100,
       100,
       100,
@@ -4959,63 +4845,6 @@
     ]
   },
   {
-    "measureId": "ABG21",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      29.34,
-      48.19,
-      62.51,
-      84.87,
-      90.42,
-      95.14,
-      99.77,
-      100
-    ]
-  },
-  {
-    "measureId": "ABG28",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      32.09,
-      44.88,
-      50.16,
-      52.84,
-      58.28,
-      87.26,
-      98.88,
-      100
-    ]
-  },
-  {
-    "measureId": "ABG29",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      44.29,
-      67.23,
-      95.03,
-      99.51,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
     "measureId": "ABG30",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5035,25 +4864,6 @@
     ]
   },
   {
-    "measureId": "ABG31",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      89.72,
-      98.88,
-      99.67,
-      99.98,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
     "measureId": "ABG7",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5066,25 +4876,6 @@
       98.63,
       99.29,
       99.83,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ACCPin3",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
       100,
       100,
       100,
@@ -5206,101 +4997,6 @@
     ]
   },
   {
-    "measureId": "ACRad3",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      0.18,
-      0.24,
-      0.31,
-      0.43,
-      0.49,
-      0.54,
-      0.62,
-      0.8
-    ]
-  },
-  {
-    "measureId": "ACRad31",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ACRad32",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ACRad33",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ACRad6",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      20,
-      21.62,
-      23.08,
-      26.09,
-      29.9,
-      32,
-      35.59,
-      37.16
-    ]
-  },
-  {
     "measureId": "AQI48",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5314,101 +5010,6 @@
       94.52,
       99.09,
       99.99,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "AQI50",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      99.14,
-      99.46,
-      99.83,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "AQI51",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      79.31,
-      92.62,
-      96.4,
-      99.35,
-      99.8,
-      99.95,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "AQUA8",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      100,
-      5.13,
-      4.22,
-      3.21,
-      2.63,
-      1.01,
-      0.69,
-      0,
-      0
-    ]
-  },
-  {
-    "measureId": "ASBS1",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      99.16,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "ASBS7",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      98.15,
-      98.47,
-      100,
-      100,
-      100,
       100,
       100,
       100
@@ -5510,44 +5111,6 @@
     ]
   },
   {
-    "measureId": "M2S1",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      70.25,
-      77.55,
-      80.47,
-      81.26,
-      81.62,
-      84.57,
-      89.83,
-      92.82
-    ]
-  },
-  {
-    "measureId": "MBSAQIP7",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      100,
-      2.13,
-      1.84,
-      1.28,
-      0.39,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
     "measureId": "MBSAQIP8",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5564,25 +5127,6 @@
       0,
       0,
       0
-    ]
-  },
-  {
-    "measureId": "MUSIC1",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
     ]
   },
   {
@@ -5640,44 +5184,6 @@
       90.54,
       93.1,
       94.59
-    ]
-  },
-  {
-    "measureId": "PPRNET28",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      80,
-      81.81,
-      82.92,
-      84.84,
-      85.95,
-      86.77,
-      91.41,
-      93.08
-    ]
-  },
-  {
-    "measureId": "PPRNET29",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      73.35,
-      78.89,
-      84.41,
-      86.3,
-      88.1,
-      90.89,
-      93.86,
-      96.3
     ]
   },
   {

--- a/test/scripts/benchmarks/fixtures/test-benchmarks.csv
+++ b/test/scripts/benchmarks/fixtures/test-benchmarks.csv
@@ -1,445 +1,1077 @@
-Table 2: MIPS Benchmark Results ,,,,,,,,,,,,,
-,,,,,,,,,,,,,
-Measure_Name,Measure_ID,Submission_Method,Measure_Type,Benchmark,Decile 3,Decile 4,Decile 5,Decile 6,Decile 7,Decile 8,Decile 9,Decile 10,Topped Out
-Diabetes: Hemoglobin A1c Poor Control,1,Claims,Outcome,Y, 35.00 - 25.72, 25.71 - 20.32, 20.31 - 16.23, 16.22 - 13.05, 13.04 - 10.01, 10.00 -  7.42,  7.41 -  4.01,<=  4.00,No
-Diabetes: Hemoglobin A1c Poor Control,1,EHR,Outcome,Y, 54.67 - 35.91, 35.90 - 25.63, 25.62 - 19.34, 19.33 - 14.15, 14.14 -  9.10,  9.09 -  3.34,  3.33 -  0.01,  0.00,No
-Diabetes: Hemoglobin A1c Poor Control,1,Registry/QCDR,Outcome,Y, 83.10 - 68.19, 68.18 - 53.14, 53.13 - 40.66, 40.65 - 30.20, 30.19 - 22.74, 22.73 - 16.82, 16.81 - 10.33,<= 10.32,No
-Colorectal Cancer Resection Pathology Reporting: pT Category (Primary Tumor) and pN Category (Regional Lymph Nodes) with Histologic Grade,100,Claims,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Colorectal Cancer Resection Pathology Reporting: pT Category (Primary Tumor) and pN Category (Regional Lymph Nodes) with Histologic Grade,100,Registry/QCDR,Process,Y, 83.96 - 96.96, 96.97 - 99.99,--,--,--,--,--,100.00,Yes
-Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients,102,Registry/QCDR,Process,Y, 42.12 - 54.99, 55.00 - 71.72, 71.73 - 82.13, 82.14 - 99.46, 99.47 - 99.99,--,--,100.00,No
-Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients,102,EHR,Process,N,--,--,--,--,--,--,--,--,--
-Prostate Cancer: Adjuvant Hormonal Therapy for High Risk Prostate Cancer Patients,104,Registry/QCDR,Process,Y, 77.31 - 80.64, 80.65 - 91.19, 91.20 - 96.66, 96.67 - 98.82, 98.83 - 99.99,--,--,100.00,Yes
-Adult Major Depressive Disorder (MDD): Suicide Risk Assessment,107,EHR,Process,Y, 53.85 - 64.74, 64.75 - 70.90, 70.91 - 86.68, 86.69 - 89.31, 89.32 - 92.90, 92.91 - 96.54, 96.55 - 98.67,>= 98.68,No
-Osteoarthritis (OA): Function and Pain Assessment,109,Claims,Process,Y, 80.92 - 94.14, 94.15 - 98.67, 98.68 - 99.99,--,--,--,--,100.00,Yes
-Osteoarthritis (OA): Function and Pain Assessment,109,Registry/QCDR,Process,Y,  5.16 - 14.84, 14.85 - 37.78, 37.79 - 65.33, 65.34 - 88.04, 88.05 - 97.81, 97.82 - 99.99,--,100.00,No
-Preventive Care and Screening: Influenza Immunization,110,Claims,Process,Y, 22.64 - 31.75, 31.76 - 43.13, 43.14 - 54.68, 54.69 - 66.38, 66.39 - 77.47, 77.48 - 92.03, 92.04 - 99.99,100.00,No
-Preventive Care and Screening: Influenza Immunization,110,EHR,Process,Y, 11.22 - 18.57, 18.58 - 24.99, 25.00 - 31.84, 31.85 - 38.92, 38.93 - 47.86, 47.87 - 59.99, 60.00 - 79.01,>= 79.02,No
-Preventive Care and Screening: Influenza Immunization,110,Registry/QCDR,Process,Y, 11.57 - 21.39, 21.40 - 31.39, 31.40 - 41.31, 41.32 - 51.13, 51.14 - 62.04, 62.05 - 74.27, 74.28 - 91.83,>= 91.84,No
-Pneumonia Vaccination Status for Older Adults,111,Claims,Process,Y, 39.78 - 51.32, 51.33 - 61.67, 61.68 - 70.47, 70.48 - 77.77, 77.78 - 84.49, 84.50 - 91.99, 92.00 - 99.06,>= 99.07,No
-Pneumonia Vaccination Status for Older Adults,111,EHR,Process,Y, 14.13 - 23.25, 23.26 - 33.02, 33.03 - 43.58, 43.59 - 53.96, 53.97 - 63.60, 63.61 - 74.54, 74.55 - 85.52,>= 85.53,No
-Pneumonia Vaccination Status for Older Adults,111,Registry/QCDR,Process,Y, 12.24 - 24.02, 24.03 - 36.34, 36.35 - 48.51, 48.52 - 58.95, 58.96 - 68.05, 68.06 - 77.77, 77.78 - 90.19,>= 90.20,No
-Breast Cancer Screening,112,Claims,Process,Y, 38.46 - 48.01, 48.02 - 55.67, 55.68 - 62.78, 62.79 - 69.41, 69.42 - 77.18, 77.19 - 87.87, 87.88 - 98.52,>= 98.53,No
-Breast Cancer Screening,112,EHR,Process,Y, 12.41 - 22.21, 22.22 - 32.30, 32.31 - 40.86, 40.87 - 47.91, 47.92 - 55.25, 55.26 - 63.06, 63.07 - 73.22,>= 73.23,No
-Breast Cancer Screening,112,Registry/QCDR,Process,Y, 14.49 - 24.52, 24.53 - 35.70, 35.71 - 46.01, 46.02 - 55.06, 55.07 - 63.67, 63.68 - 74.06, 74.07 - 87.92,>= 87.93,No
-Colorectal Cancer Screening,113,Claims,Process,Y, 29.50 - 42.36, 42.37 - 53.84, 53.85 - 64.40, 64.41 - 75.40, 75.41 - 84.67, 84.68 - 93.13, 93.14 - 99.99,100.00,No
-Colorectal Cancer Screening,113,EHR,Process,Y,  7.35 - 15.97, 15.98 - 24.66, 24.67 - 33.45, 33.46 - 44.39, 44.40 - 56.19, 56.20 - 67.91, 67.92 - 82.28,>= 82.29,No
-Colorectal Cancer Screening,113,Registry/QCDR,Process,Y, 10.08 - 20.68, 20.69 - 32.73, 32.74 - 45.20, 45.21 - 55.95, 55.96 - 66.31, 66.32 - 77.01, 77.02 - 88.14,>= 88.15,No
-Avoidance of Antibiotic Treatment in Adults With Acute Bronchitis,116,Registry/QCDR,Process,Y, 23.19 - 31.47, 31.48 - 63.74, 63.75 - 99.99,--,--,--,--,100.00,Yes
-Diabetes: Eye Exam,117,Claims,Process,Y, 86.36 - 97.77, 97.78 - 99.99,--,--,--,--,--,100.00,Yes
-Diabetes: Eye Exam,117,EHR,Process,Y, 50.57 - 80.68, 80.69 - 90.05, 90.06 - 94.11, 94.12 - 96.66, 96.67 - 98.57, 98.58 - 99.99,--,100.00,No
-Diabetes: Eye Exam,117,Registry/QCDR,Process,Y, 69.39 - 89.68, 89.69 - 95.95, 95.96 - 98.72, 98.73 - 99.99,--,--,--,100.00,Yes
-Coronary Artery Disease (CAD): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy - Diabetes or Left Ventricular Systolic Dysfunction (LVEF < 40%),118,Registry/QCDR,Process,Y, 71.03 - 74.18, 74.19 - 76.51, 76.52 - 78.94, 78.95 - 81.10, 81.11 - 83.99, 84.00 - 87.79, 87.80 - 95.99,>= 96.00,No
-Diabetes: Medical Attention for Nephropathy,119,Claims,Process,Y, 61.76 - 73.84, 73.85 - 82.49, 82.50 - 88.88, 88.89 - 93.64, 93.65 - 97.21, 97.22 - 99.99,--,100.00,No
-Diabetes: Medical Attention for Nephropathy,119,EHR,Process,Y, 66.67 - 72.91, 72.92 - 78.12, 78.13 - 82.26, 82.27 - 86.12, 86.13 - 89.95, 89.96 - 93.32, 93.33 - 96.63,>= 96.64,No
-Diabetes: Medical Attention for Nephropathy,119,Registry/QCDR,Process,Y, 66.24 - 73.41, 73.42 - 79.16, 79.17 - 83.01, 83.02 - 86.95, 86.96 - 90.47, 90.48 - 94.51, 94.52 - 99.70,>= 99.71,No
-Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation,12,Claims,Process,Y, 99.01 - 99.99,--,--,--,--,--,--,100.00,Yes
-Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation,12,EHR,Process,Y, 73.33 - 82.41, 82.42 - 87.39, 87.40 - 90.90, 90.91 - 94.16, 94.17 - 96.57, 96.58 - 98.25, 98.26 - 99.57,>= 99.58,No
-Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation,12,Registry/QCDR,Process,Y, 95.07 - 98.10, 98.11 - 99.35, 99.36 - 99.99,--,--,--,--,100.00,Yes
-Adult Kidney Disease: Laboratory Testing (Lipid Profile),121,Registry/QCDR,Process,Y, 20.00 - 34.26, 34.27 - 45.70, 45.71 - 58.96, 58.97 - 69.48, 69.49 - 78.60, 78.61 - 90.15, 90.16 - 99.99,100.00,No
-"Diabetes Mellitus: Diabetic Foot and Ankle Care, Peripheral Neuropathy - Neurological Evaluation",126,Registry/QCDR,Process,Y, 10.34 - 18.46, 18.47 - 28.94, 28.95 - 41.66, 41.67 - 60.23, 60.24 - 75.20, 75.21 - 89.89, 89.90 - 99.99,100.00,No
-"Diabetes Mellitus: Diabetic Foot and Ankle Care, Ulcer Prevention - Evaluation of Footwear",127,Registry/QCDR,Process,Y,  4.26 - 11.10, 11.11 - 22.80, 22.81 - 39.99, 40.00 - 61.69, 61.70 - 79.56, 79.57 - 93.74, 93.75 - 99.99,100.00,No
-Documentation of Current Medications in the Medical Record,130,Claims,Process,Y, 96.11 - 98.73, 98.74 - 99.64, 99.65 - 99.99,--,--,--,--,100.00,Yes
-Documentation of Current Medications in the Medical Record,130,EHR,Process,Y, 76.59 - 87.88, 87.89 - 92.73, 92.74 - 95.35, 95.36 - 97.08, 97.09 - 98.27, 98.28 - 99.12, 99.13 - 99.75,>= 99.76,Yes
-Documentation of Current Medications in the Medical Record,130,Registry/QCDR,Process,Y, 61.27 - 82.11, 82.12 - 91.71, 91.72 - 96.86, 96.87 - 99.30, 99.31 - 99.99,--,--,100.00,Yes
-Pain Assessment and Follow-Up,131,Claims,Process,Y, 75.66 - 95.78, 95.79 - 99.33, 99.34 - 99.99,--,--,--,--,100.00,Yes
-Pain Assessment and Follow-Up,131,Registry/QCDR,Process,Y,  8.91 - 26.13, 26.14 - 50.11, 50.12 - 72.57, 72.58 - 91.42, 91.43 - 99.02, 99.03 - 99.99,--,100.00,No
-Preventive Care and Screening: Screening for Clinical Depression and Follow-Up Plan,134,Claims,Process,Y, 11.54 - 30.67, 30.68 - 62.08, 62.09 - 94.03, 94.04 - 99.45, 99.46 - 99.99,--,--,100.00,No
-Preventive Care and Screening: Screening for Clinical Depression and Follow-Up Plan,134,EHR,Process,Y,  1.22 -  2.93,  2.94 -  5.93,  5.94 - 11.09, 11.10 - 17.87, 17.88 - 30.29, 30.30 - 51.32, 51.33 - 72.63,>= 72.64,No
-Preventive Care and Screening: Screening for Clinical Depression and Follow-Up Plan,134,Registry/QCDR,Process,Y,  2.01 -  5.26,  5.27 - 14.88, 14.89 - 32.90, 32.91 - 50.42, 50.43 - 64.99, 65.00 - 85.25, 85.26 - 99.99,100.00,No
-Melanoma: Continuity of Care - Recall System,137,Registry/QCDR,Structure,Y, 53.73 - 75.75, 75.76 - 88.45, 88.46 - 98.07, 98.08 - 99.99,--,--,--,100.00,No
-Melanoma: Coordination of Care,138,Registry/QCDR,Process,Y, 35.19 - 66.66, 66.67 - 88.88, 88.89 - 96.54, 96.55 - 99.99,--,--,--,100.00,Yes
-Age-Related Macular Degeneration (AMD): Dilated Macular Examination,14,Claims,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Age-Related Macular Degeneration (AMD): Dilated Macular Examination,14,Registry/QCDR,Process,Y, 31.01 - 55.12, 55.13 - 77.24, 77.25 - 91.17, 91.18 - 98.18, 98.19 - 99.99,--,--,100.00,No
-Age-Related Macular Degeneration (AMD): Counseling on Antioxidant Supplement,140,Claims,Process,Y, 97.50 - 99.99,--,--,--,--,--,--,100.00,Yes
-Age-Related Macular Degeneration (AMD): Counseling on Antioxidant Supplement,140,Registry/QCDR,Process,Y, 32.26 - 48.38, 48.39 - 65.54, 65.55 - 78.94, 78.95 - 89.99, 90.00 - 97.43, 97.44 - 99.99,--,100.00,No
-Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care,141,Claims,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care,141,Registry/QCDR,Process,Y, 78.95 - 93.68, 93.69 - 98.03, 98.04 - 99.75, 99.76 - 99.99,--,--,--,100.00,Yes
-Oncology: Medical and Radiation - Pain Intensity Quantified,143,EHR,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Oncology: Medical and Radiation - Pain Intensity Quantified,143,Registry/QCDR,Process,Y, 35.53 - 76.18, 76.19 - 82.13, 82.14 - 90.20, 90.21 - 96.76, 96.77 - 99.99,--,--,100.00,No
-Oncology: Medical and Radiation - Plan of Care for Pain,144,Registry/QCDR,Process,Y, 33.64 - 48.19, 48.20 - 66.91, 66.92 - 78.41, 78.42 - 85.83, 85.84 - 99.11, 99.12 - 99.99,--,100.00,No
-Radiology: Exposure Time Reported for Procedures Using Fluoroscopy,145,Claims,Process,Y, 69.33 - 83.10, 83.11 - 89.99, 90.00 - 93.80, 93.81 - 96.13, 96.14 - 97.82, 97.83 - 99.77, 99.78 - 99.99,100.00,No
-Radiology: Exposure Time Reported for Procedures Using Fluoroscopy,145,Registry/QCDR,Process,Y, 67.86 - 77.99, 78.00 - 84.61, 84.62 - 89.77, 89.78 - 93.41, 93.42 - 96.66, 96.67 - 99.59, 99.60 - 99.99,100.00,No
-"Radiology: Inappropriate Use of ""Probably Benign"" Assessment Category in Mammography Screening",146,Claims,Process,Y,  0.31 -  0.01,--,--,--,--,--,--,  0.00,Yes
-"Radiology: Inappropriate Use of ""Probably Benign"" Assessment Category in Mammography Screening",146,Registry/QCDR,Process,Y,  4.77 -  2.75,  2.74 -  1.25,  1.24 -  0.52,  0.51 -  0.15,  0.14 -  0.01,--,--,  0.00,Yes
-Nuclear Medicine: Correlation with Existing Imaging Studies for All Patients Undergoing Bone Scintigraphy,147,Claims,Structure,Y, 50.00 - 65.37, 65.38 - 77.77, 77.78 - 86.95, 86.96 - 93.74, 93.75 - 96.96, 96.97 - 99.99,--,100.00,No
-Nuclear Medicine: Correlation with Existing Imaging Studies for All Patients Undergoing Bone Scintigraphy,147,Registry/QCDR,Structure,Y, 59.52 - 71.10, 71.11 - 83.09, 83.10 - 91.66, 91.67 - 96.54, 96.55 - 99.33, 99.34 - 99.99,--,100.00,No
-Falls: Risk Assessment,154,Claims,Process,Y, 88.89 - 98.75, 98.76 - 99.99,--,--,--,--,--,100.00,Yes
-Falls: Risk Assessment,154,Registry/QCDR,Process,Y,  7.81 - 19.99, 20.00 - 38.12, 38.13 - 57.62, 57.63 - 84.16, 84.17 - 99.82, 99.83 - 99.99,--,100.00,No
-Falls: Plan of Care,155,Claims,Process,Y, 34.78 - 55.55, 55.56 - 86.26, 86.27 - 99.11, 99.12 - 99.99,--,--,--,100.00,Yes
-Falls: Plan of Care,155,Registry/QCDR,Process,Y, 20.00 - 41.43, 41.44 - 62.11, 62.12 - 75.44, 75.45 - 85.99, 86.00 - 93.32, 93.33 - 98.07, 98.08 - 99.99,100.00,No
-Oncology: Radiation Dose Limits to Normal Tissues,156,Registry/QCDR,Process,Y, 93.10 - 96.76, 96.77 - 97.72, 97.73 - 99.99,--,--,--,--,100.00,Yes
-Oncology: Radiation Dose Limits to Normal Tissues,156,Claims,Process,N,--,--,--,--,--,--,--,--,--
-Diabetes: Foot Exam,163,Claims,Process,Y, 37.84 - 54.28, 54.29 - 71.87, 71.88 - 86.51, 86.52 - 96.66, 96.67 - 99.99,--,--,100.00,No
-Diabetes: Foot Exam,163,EHR,Process,Y,  5.31 - 10.90, 10.91 - 19.99, 20.00 - 29.26, 29.27 - 38.77, 38.78 - 50.09, 50.10 - 62.60, 62.61 - 76.16,>= 76.17,No
-Diabetes: Foot Exam,163,Registry/QCDR,Process,Y,  6.14 - 14.70, 14.71 - 25.57, 25.58 - 39.80, 39.81 - 55.87, 55.88 - 72.21, 72.22 - 86.43, 86.44 - 98.03,>= 98.04,No
-Coronary Artery Bypass Graft (CABG): Prolonged Intubation,164,Registry/QCDR,Outcome,Y, 12.16 - 10.65, 10.64 -  9.29,  9.28 -  7.56,  7.55 -  6.30,  6.29 -  4.97,  4.96 -  3.59,  3.58 -  1.83,<=  1.82,No
-Coronary Artery Bypass Graft (CABG): Deep Sternal Wound Infection Rate,165,Registry/QCDR,Outcome,Y,--,--,--,--,--,--,--,  0.00,Yes
-Coronary Artery Bypass Graft (CABG): Stroke,166,Registry/QCDR,Outcome,Y,  2.41 -  1.96,  1.95 -  1.39,  1.38 -  0.88,  0.87 -  0.01,--,--,--,  0.00,Yes
-Coronary Artery Bypass Graft (CABG): Postoperative Renal Failure,167,Registry/QCDR,Outcome,Y,  3.70 -  3.04,  3.03 -  2.48,  2.47 -  1.91,  1.90 -  1.38,  1.37 -  0.30,  0.29 -  0.01,--,  0.00,Yes
-Coronary Artery Bypass Graft (CABG): Surgical Re-Exploration,168,Registry/QCDR,Outcome,Y,  3.60 -  2.79,  2.78 -  2.09,  2.08 -  1.63,  1.62 -  1.25,  1.24 -  0.90,  0.89 -  0.01,--,  0.00,Yes
-Hemodialysis Vascular Access Decision-Making by Surgeon to Maximize Placement of Autogenous Arterial Venous (AV) Fistula,172,Claims,Process,Y, 88.54 - 95.44, 95.45 - 99.99,--,--,--,--,--,100.00,Yes
-Hemodialysis Vascular Access Decision-Making by Surgeon to Maximize Placement of Autogenous Arterial Venous (AV) Fistula,172,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Preventive Care and Screening: Unhealthy Alcohol Use - Screening,173,Registry/QCDR,Process,Y, 48.93 - 62.39, 62.40 - 71.86, 71.87 - 80.71, 80.72 - 88.21, 88.22 - 94.43, 94.44 - 98.48, 98.49 - 99.99,100.00,No
-Rheumatoid Arthritis (RA): Functional Status Assessment,178,Registry/QCDR,Process,Y, 27.99 - 45.95, 45.96 - 64.17, 64.18 - 74.46, 74.47 - 81.36, 81.37 - 87.82, 87.83 - 92.34, 92.35 - 99.71,>= 99.72,No
-Diabetic Retinopathy: Documentation of Presence or Absence of Macular Edema and Level of Severity of Retinopathy,18,EHR,Process,Y, 31.69 - 41.32, 41.33 - 49.99, 50.00 - 56.97, 56.98 - 64.17, 64.18 - 70.58, 70.59 - 76.97, 76.98 - 85.15,>= 85.16,No
-Elder Maltreatment Screen and Follow-Up Plan,181,Claims,Process,Y,  7.69 - 91.72, 91.73 - 99.27, 99.28 - 99.99,--,--,--,--,100.00,Yes
-Elder Maltreatment Screen and Follow-Up Plan,181,Registry/QCDR,Process,Y, 28.80 - 42.30, 42.31 - 51.95, 51.96 - 67.46, 67.47 - 85.94, 85.95 - 97.24, 97.25 - 99.65, 99.66 - 99.99,100.00,No
-Functional Outcome Assessment,182,Claims,Process,Y, 98.46 - 99.90, 99.91 - 99.99,--,--,--,--,--,100.00,Yes
-Functional Outcome Assessment,182,Registry/QCDR,Process,Y, 94.35 - 97.47, 97.48 - 99.20, 99.21 - 99.99,--,--,--,--,100.00,Yes
-Colonoscopy Interval for Patients with a History of Adenomatous Polyps ? Avoidance of Inappropriate Use ? National Quality Strategy Domain: Communication and Care Coordination,185,Claims,Process,Y, 98.82 - 99.99,--,--,--,--,--,--,100.00,Yes
-Colonoscopy Interval for Patients with a History of Adenomatous Polyps ? Avoidance of Inappropriate Use ? National Quality Strategy Domain: Communication and Care Coordination,185,Registry/QCDR,Process,Y, 81.08 - 88.67, 88.68 - 93.23, 93.24 - 96.19, 96.20 - 98.27, 98.28 - 99.99,--,--,100.00,Yes
-Stroke and Stroke Rehabilitation: Thrombolytic Therapy,187,Registry/QCDR,Outcome,Y, 14.55 - 34.99, 35.00 - 43.74, 43.75 - 52.37, 52.38 - 66.66, 66.67 - 76.24, 76.25 - 96.66, 96.67 - 99.99,100.00,No
-Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care,19,Claims,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care,19,EHR,Process,Y, 20.00 - 29.78, 29.79 - 38.35, 38.36 - 45.70, 45.71 - 52.53, 52.54 - 60.79, 60.80 - 68.80, 68.81 - 79.30,>= 79.31,No
-Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care,19,Registry/QCDR,Process,Y, 36.21 - 59.99, 60.00 - 78.56, 78.57 - 89.80, 89.81 - 96.22, 96.23 - 99.99,--,--,100.00,No
-Cataracts: 20/40 or Better Visual Acuity within 90 Days Following Cataract Surgery,191,EHR,Outcome,Y, 86.61 - 91.42, 91.43 - 94.43, 94.44 - 96.07, 96.08 - 97.35, 97.36 - 98.30, 98.31 - 99.24, 99.25 - 99.99,100.00,No
-Cataracts: 20/40 or Better Visual Acuity within 90 Days Following Cataract Surgery,191,Registry/QCDR,Outcome,Y, 42.89 - 59.56, 59.57 - 83.17, 83.18 - 91.52, 91.53 - 94.84, 94.85 - 96.79, 96.80 - 99.25, 99.26 - 99.99,100.00,No
-Cataracts: Complications within 30 Days Following Cataract Surgery Requiring Additional Surgical Procedures,192,EHR,Outcome,Y,  0.92 -  0.43,  0.42 -  0.01,--,--,--,--,--,  0.00,Yes
-Cataracts: Complications within 30 Days Following Cataract Surgery Requiring Additional Surgical Procedures,192,Registry/QCDR,Outcome,Y,  1.60 -  0.75,  0.74 -  0.24,  0.23 -  0.01,--,--,--,--,  0.00,Yes
-Perioperative Temperature Management,193,Claims,Outcome,Y, 92.50 - 95.82, 95.83 - 97.64, 97.65 - 98.71, 98.72 - 99.45, 99.46 - 99.99,--,--,100.00,Yes
-Perioperative Temperature Management,193,Registry/QCDR,Outcome,Y, 98.18 - 99.99,--,--,--,--,--,--,100.00,Yes
-Oncology: Cancer Stage Documented,194,Registry/QCDR,Process,Y,  5.00 -  9.81,  9.82 - 23.88, 23.89 - 62.49, 62.50 - 83.01, 83.02 - 94.86, 94.87 - 99.82, 99.83 - 99.99,100.00,No
-Radiology: Stenosis Measurement in Carotid Imaging Reports,195,Claims,Process,Y, 78.57 - 87.49, 87.50 - 92.49, 92.50 - 95.78, 95.79 - 97.66, 97.67 - 99.62, 99.63 - 99.99,--,100.00,Yes
-Radiology: Stenosis Measurement in Carotid Imaging Reports,195,Registry/QCDR,Process,Y, 82.98 - 90.90, 90.91 - 94.49, 94.50 - 96.76, 96.77 - 98.40, 98.41 - 99.99,--,--,100.00,Yes
-Diabetes: Low Density Lipoprotein (LDL-C) Control (<100 mg/dL),2,Registry/QCDR,Outcome,Y,  0.83 -  1.06,  1.07 -  1.35,  1.36 -  1.82,  1.83 -  2.51,  2.52 -  3.53,  3.54 -  6.45,  6.46 - 25.57,>= 25.58,No
-Ischemic Vascular Disease (IVD): Use of Aspirin or Another Antithrombotic,204,Claims,Process,Y, 84.09 - 87.17, 87.18 - 89.46, 89.47 - 91.29, 91.30 - 93.05, 93.06 - 94.99, 95.00 - 96.76, 96.77 - 99.99,100.00,No
-Ischemic Vascular Disease (IVD): Use of Aspirin or Another Antithrombotic,204,EHR,Process,Y, 55.21 - 63.76, 63.77 - 69.99, 70.00 - 74.99, 75.00 - 78.78, 78.79 - 81.99, 82.00 - 85.03, 85.04 - 88.69,>= 88.70,No
-Ischemic Vascular Disease (IVD): Use of Aspirin or Another Antithrombotic,204,Registry/QCDR,Process,Y, 68.03 - 75.75, 75.76 - 80.76, 80.77 - 84.61, 84.62 - 87.92, 87.93 - 90.94, 90.95 - 94.73, 94.74 - 99.99,100.00,No
-"HIV/AIDS: Sexually Transmitted Disease Screening for Chlamydia, Gonorrhea, and Syphilis",205,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Perioperative Care: Selection of Prophylactic Antibiotic - First OR Second Generation Cephalosporin,21,Claims,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Perioperative Care: Selection of Prophylactic Antibiotic - First OR Second Generation Cephalosporin,21,Registry/QCDR,Process,Y, 91.17 - 99.10, 99.11 - 99.99,--,--,--,--,--,100.00,Yes
-Functional Deficit: Change in Risk-Adjusted Functional Status for Patients with Knee Impairments,217,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Functional Deficit: Change in Risk-Adjusted Functional Status for Patients with Hip Impairments,218,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-"Functional Deficit: Change in Risk-Adjusted Functional Status for Patients with Lower Leg, Foot or Ankle Impairments",219,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Perioperative Care: Discontinuation of Prophylactic Parenteral Antibiotics (Non-Cardiac Procedures),22,Claims,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Perioperative Care: Discontinuation of Prophylactic Parenteral Antibiotics (Non-Cardiac Procedures),22,Registry/QCDR,Process,Y, 45.69 - 77.37, 77.38 - 97.77, 97.78 - 99.99,--,--,--,--,100.00,Yes
-Functional Deficit: Change in Risk-Adjusted Functional Status for Patients with Lumbar Spine Impairments,220,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Functional Deficit: Change in Risk-Adjusted Functional Status for Patients with Shoulder Impairments,221,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-"Functional Deficit: Change in Risk-Adjusted Functional Status for Patients with Elbow, Wrist or Hand Impairments",222,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-"Functional Deficit: Change in Risk-Adjusted Functional Status for Patients with Neck, Cranium, Mandible, Thoracic Spine, Ribs, or Other General Orthopedic Impairments",223,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Melanoma: Overutilization of Imaging Studies in Melanoma,224,Registry/QCDR,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Radiology: Reminder System for Screening Mammograms,225,Claims,Structure,Y, 89.85 - 98.64, 98.65 - 99.99,--,--,--,--,--,100.00,No
-Radiology: Reminder System for Screening Mammograms,225,Registry/QCDR,Structure,Y, 99.89 - 99.99,--,--,--,--,--,--,100.00,Yes
-Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,Claims,Process,Y, 95.60 - 97.85, 97.86 - 99.25, 99.26 - 99.99,--,--,--,--,100.00,Yes
-Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,EHR,Process,Y, 72.59 - 81.59, 81.60 - 86.68, 86.69 - 90.15, 90.16 - 92.64, 92.65 - 94.67, 94.68 - 96.58, 96.59 - 98.51,>= 98.52,No
-Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,Registry/QCDR,Process,Y, 76.67 - 85.53, 85.54 - 89.87, 89.88 - 92.85, 92.86 - 95.14, 95.15 - 97.21, 97.22 - 99.10, 99.11 - 99.99,100.00,No
-Perioperative Care: Venous Thromboembolism (VTE) Prophylaxis (When Indicated in ALL Patients),23,Claims,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Perioperative Care: Venous Thromboembolism (VTE) Prophylaxis (When Indicated in ALL Patients),23,Registry/QCDR,Process,Y, 89.74 - 96.66, 96.67 - 99.99,--,--,--,--,--,100.00,Yes
-Controlling High Blood Pressure,236,Claims,Process,Y, 57.69 - 63.44, 63.45 - 68.28, 68.29 - 72.78, 72.79 - 77.06, 77.07 - 81.47, 81.48 - 86.75, 86.76 - 93.42,>= 93.43,No
-Controlling High Blood Pressure,236,EHR,Process,Y, 50.00 - 55.39, 55.40 - 59.72, 59.73 - 63.59, 63.60 - 67.38, 67.39 - 71.00, 71.01 - 75.33, 75.34 - 80.89,>= 80.90,No
-Controlling High Blood Pressure,236,Registry/QCDR,Process,Y, 51.00 - 58.20, 58.21 - 63.56, 63.57 - 68.27, 68.28 - 72.40, 72.41 - 76.69, 76.70 - 82.75, 82.76 - 91.06,>= 91.07,No
-"Osteoporosis: Communication with the Physician Managing On-going Care Post-Fracture of Hip, Spine or Distal Radius for Men and Women Aged 50 Years and Older",24,Claims,Process,Y, 75.00 - 91.29, 91.30 - 96.42, 96.43 - 99.99,--,--,--,--,100.00,Yes
-"Osteoporosis: Communication with the Physician Managing On-going Care Post-Fracture of Hip, Spine or Distal Radius for Men and Women Aged 50 Years and Older",24,Registry/QCDR,Process,Y,  8.00 - 10.33, 10.34 - 12.49, 12.50 - 17.06, 17.07 - 21.87, 21.88 - 49.99, 50.00 - 82.49, 82.50 - 99.99,100.00,No
-Childhood Immunization Status,240,EHR,Process,Y,  4.76 -  6.51,  6.52 -  9.08,  9.09 - 13.00, 13.01 - 18.17, 18.18 - 23.80, 23.81 - 29.32, 29.33 - 41.66,>= 41.67,No
-Cardiac Rehabilitation Patient Referral from an Outpatient Setting,243,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Barrett's Esophagus,249,Claims,Structure,Y,--,--,--,--,--,--,--,100.00,Yes
-Barrett's Esophagus,249,Registry/QCDR,Structure,Y,--,--,--,--,--,--,--,100.00,Yes
-Radical Prostatectomy Pathology Reporting,250,Claims,Structure,Y,--,--,--,--,--,--,--,100.00,Yes
-Radical Prostatectomy Pathology Reporting,250,Registry/QCDR,Structure,N,--,--,--,--,--,--,--,--,--
-Quantitative Immunohistochemical (IHC) Evaluation of Human Epidermal Growth Factor Receptor 2 Testing (HER2) for Breast Cancer Patients,251,Claims,Structure,Y,--,--,--,--,--,--,--,100.00,Yes
-Quantitative Immunohistochemical (IHC) Evaluation of Human Epidermal Growth Factor Receptor 2 Testing (HER2) for Breast Cancer Patients,251,Registry/QCDR,Structure,Y,--,--,--,--,--,--,--,100.00,Yes
-Ultrasound Determination of Pregnancy Location for Pregnant Patients with Abdominal Pain,254,Claims,Process,N,--,--,--,--,--,--,--,--,--
-Ultrasound Determination of Pregnancy Location for Pregnant Patients with Abdominal Pain,254,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Rh Immunoglobulin (Rhogam) for Rh-Negative Pregnant Women at Risk of Fetal Blood Exposure,255,Claims,Process,N,--,--,--,--,--,--,--,--,--
-Rh Immunoglobulin (Rhogam) for Rh-Negative Pregnant Women at Risk of Fetal Blood Exposure,255,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Statin Therapy at Discharge after Lower Extremity Bypass (LEB),257,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Rate of Open Repair of Small or Moderate Non-Ruptured Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post-Operative Day #7),258,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post-Operative Day #2),259,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-"Rate of Carotid Endarterectomy (CEA) for Asymptomatic Patients, without Major Complications (Discharged to Home by Post-Operative Day #2)",260,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Referral for Otologic Evaluation for Patients with Acute or Chronic Dizziness,261,Claims,Process,N,--,--,--,--,--,--,--,--,--
-Referral for Otologic Evaluation for Patients with Acute or Chronic Dizziness,261,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Image Confirmation of Successful Excision of Image-Localized Breast Lesion,262,Registry/QCDR,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Image Confirmation of Successful Excision of Image-Localized Breast Lesion,262,Claims,Process,N,--,--,--,--,--,--,--,--,--
-Preoperative Diagnosis of Breast Cancer,263,Registry/QCDR,Process,Y, 97.95 - 98.91, 98.92 - 99.99,--,--,--,--,--,100.00,Yes
-Preoperative Diagnosis of Breast Cancer,263,Claims,Process,N,--,--,--,--,--,--,--,--,--
-Sentinel Lymph Node Biopsy for Invasive Breast Cancer,264,Registry/QCDR,Process,Y, 97.01 - 97.99, 98.00 - 98.89, 98.90 - 99.99,--,--,--,--,100.00,Yes
-Biopsy Follow-Up,265,Registry/QCDR,Process,Y, 24.44 - 53.53, 53.54 - 78.78, 78.79 - 94.99, 95.00 - 99.99,--,--,--,100.00,Yes
-Epilepsy: Counseling for Women of Childbearing Potential with Epilepsy,268,Claims,Outcome,N,--,--,--,--,--,--,--,--,--
-Epilepsy: Counseling for Women of Childbearing Potential with Epilepsy,268,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Inflammatory Bowel Disease (IBD): Preventive Care: Corticosteroid Sparing Therapy,270,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Inflammatory Bowel Disease (IBD): Preventive Care: Corticosteroid Related Iatrogenic Injury - Bone Loss Assessment,271,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Inflammatory Bowel Disease (IBD): Testing for Latent Tuberculosis (TB) Before Initiating Anti-TNF (Tumor Necrosis Factor) Therapy,274,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Inflammatory Bowel Disease (IBD): Assessment of Hepatitis B Virus (HBV) Status Before Initiating Anti-TNF (Tumor Necrosis Factor) Therapy,275,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Dementia: Cognitive Assessment,281,EHR,Process,Y,  5.66 - 17.56, 17.57 - 30.76, 30.77 - 56.25, 56.26 - 78.05, 78.06 - 88.13, 88.14 - 95.55, 95.56 - 99.99,100.00,No
-Dementia: Cognitive Assessment,281,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Cataracts: Improvement in Patient's Visual Function within 90 Days Following Cataract Surgery,303,Registry/QCDR,Outcome,Y,  5.76 -  9.37,  9.38 - 23.80, 23.81 - 29.87, 29.88 - 43.60, 43.61 - 56.69, 56.70 - 94.33, 94.34 - 99.99,100.00,No
-Cataracts: Patient Satisfaction within 90 Days Following Cataract Surgery,304,Registry/QCDR,Outcome,Y,  5.32 -  7.68,  7.69 - 21.69, 21.70 - 26.67, 26.68 - 39.60, 39.61 - 46.60, 46.61 - 83.07, 83.08 - 99.99,100.00,No
-Cervical Cancer Screening,309,EHR,Process,Y,  8.89 - 15.08, 15.09 - 21.79, 21.80 - 28.83, 28.84 - 36.66, 36.67 - 44.99, 45.00 - 54.77, 54.78 - 68.99,>= 69.00,No
-Cervical Cancer Screening,309,Registry/QCDR,Process,Y, 28.95 - 35.91, 35.92 - 43.02, 43.03 - 45.56, 45.57 - 49.25, 49.26 - 51.40, 51.41 - 53.78, 53.79 - 59.23,>= 59.24,No
-Chlamydia Screening for Women,310,EHR,Process,Y,  8.33 - 12.86, 12.87 - 18.17, 18.18 - 24.99, 25.00 - 33.32, 33.33 - 39.99, 40.00 - 49.99, 50.00 - 61.53,>= 61.54,No
-Chlamydia Screening for Women,310,Registry/QCDR,Process,Y,  6.06 -  7.18,  7.19 -  9.08,  9.09 - 10.23, 10.24 - 11.53, 11.54 - 13.78, 13.79 - 18.17, 18.18 - 20.86,>= 20.87,No
-Use of Appropriate Medications for Asthma,311,EHR,Process,Y, 16.67 - 41.02, 41.03 - 58.05, 58.06 - 69.05, 69.06 - 75.48, 75.49 - 81.81, 81.82 - 87.49, 87.50 - 92.97,>= 92.98,No
-Use of Appropriate Medications for Asthma,311,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Use of Imaging Studies for Low Back Pain,312,EHR,Process,Y, 83.12 - 90.47, 90.48 - 96.14, 96.15 - 99.99,--,--,--,--,100.00,Yes
-Use of Imaging Studies for Low Back Pain,312,Registry/QCDR,Process,Y, 55.00 - 91.99, 92.00 - 99.99,--,--,--,--,--,100.00,Yes
-Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,Claims,Process,Y, 42.13 - 50.44, 50.45 - 59.06, 59.07 - 68.11, 68.12 - 78.63, 78.64 - 92.67, 92.68 - 99.53, 99.54 - 99.99,100.00,No
-Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,EHR,Process,Y, 17.90 - 22.55, 22.56 - 25.80, 25.81 - 28.83, 28.84 - 31.69, 31.70 - 34.67, 34.68 - 38.96, 38.97 - 46.26,>= 46.27,No
-Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,Registry/QCDR,Process,Y, 24.74 - 35.47, 35.48 - 47.87, 47.88 - 62.14, 62.15 - 71.64, 71.65 - 79.36, 79.37 - 88.85, 88.86 - 98.87,>= 98.88,No
-Falls: Screening for Future Fall Risk,318,EHR,Process,Y,  6.33 - 17.92, 17.93 - 31.98, 31.99 - 47.86, 47.87 - 63.81, 63.82 - 81.04, 81.05 - 90.20, 90.21 - 98.49,>= 98.50,No
-Falls: Screening for Future Fall Risk,318,Registry/QCDR,Process,Y,  0.11 -  0.11,  0.12 -  0.14,  0.15 -  0.20,  0.21 -  0.28,  0.29 -  0.50,  0.51 - 55.23, 55.24 - 92.20,>= 92.21,No
-Stroke and Stroke Rehabilitation: Discharged on Antithrombotic Therapy,32,Claims,Process,Y, 51.16 - 63.63, 63.64 - 87.99, 88.00 - 96.42, 96.43 - 99.99,--,--,--,100.00,Yes
-Stroke and Stroke Rehabilitation: Discharged on Antithrombotic Therapy,32,Registry/QCDR,Process,Y, 27.17 - 46.29, 46.30 - 67.85, 67.86 - 80.85, 80.86 - 90.90, 90.91 - 96.42, 96.43 - 99.99,--,100.00,No
-Endoscopy/Polyp Surveillance: Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients,320,Claims,Process,Y, 90.00 - 95.44, 95.45 - 99.99,--,--,--,--,--,100.00,Yes
-Endoscopy/Polyp Surveillance: Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients,320,Registry/QCDR,Process,Y, 81.82 - 90.69, 90.70 - 95.44, 95.45 - 98.11, 98.12 - 99.99,--,--,--,100.00,Yes
-Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low Risk Surgery Patients,322,Registry/QCDR,Efficiency,Y,  2.67 -  0.54,  0.53 -  0.01,--,--,--,--,--,  0.00,Yes
-Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Routine Testing After Percutaneous Coronary Intervention (PCI),323,Registry/QCDR,Efficiency,Y,  1.00 -  0.01,--,--,--,--,--,--,  0.00,Yes
-"Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Testing in Asymptomatic, Low-Risk Patients",324,Registry/QCDR,Efficiency,Y,  3.38 -  0.79,  0.78 -  0.01,--,--,--,--,--,  0.00,Yes
-Adult Major Depressive Disorder (MDD): Coordination of Care of Patients with Specific Comorbid Conditions,325,Registry/QCDR,Process,Y, 91.30 - 98.50, 98.51 - 99.99,--,--,--,--,--,100.00,Yes
-Atrial Fibrillation and Atrial Flutter: Chronic Anticoagulation Therapy,326,Claims,Process,Y, 94.09 - 96.85, 96.86 - 99.37, 99.38 - 99.99,--,--,--,--,100.00,Yes
-Atrial Fibrillation and Atrial Flutter: Chronic Anticoagulation Therapy,326,Registry/QCDR,Process,Y, 20.00 - 39.18, 39.19 - 52.33, 52.34 - 69.56, 69.57 - 76.18, 76.19 - 82.49, 82.50 - 94.33, 94.34 - 99.99,100.00,No
-Pediatric Kidney Disease: Adequacy of Volume Management,327,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Adult Kidney Disease: Catheter Use at Initiation of Hemodialysis,329,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Stroke and Stroke Rehabilitation: Anticoagulant Therapy Prescribed for Atrial Fibrillation (AF) at Discharge,33,Registry/QCDR,Process,Y, 29.55 - 43.18, 43.19 - 55.77, 55.78 - 73.75, 73.76 - 87.79, 87.80 - 95.22, 95.23 - 99.99,--,100.00,No
-Adult Kidney Disease: Catheter Use for Greater Than or Equal to 90 Days,330,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Adult Sinusitis: Antibiotic Prescribed for Acute Sinusitis (Appropriate Use),331,Registry/QCDR,Process,Y, 89.07 - 82.41, 82.40 - 71.44, 71.43 - 46.46, 46.45 - 16.91, 16.90 -  0.60,  0.59 -  0.01,--,  0.00,No
-Adult Sinusitis: Appropriate Choice of Antibiotic: Amoxicillin Prescribed for Patients with Acute Bacterial Sinusitis,332,Registry/QCDR,Process,Y, 44.39 - 47.99, 48.00 - 51.88, 51.89 - 57.57, 57.58 - 64.99, 65.00 - 72.72, 72.73 - 95.99, 96.00 - 99.99,100.00,No
-Adult Sinusitis: Computerized Tomography (CT) for Acute Sinusitis (Overuse),333,Registry/QCDR,Outcome,Y,  2.13 -  0.66,  0.65 -  0.01,--,--,--,--,--,  0.00,Yes
-Adult Sinusitis: More than One Computerized Tomography (CT) Scan Within 90 Days for Chronic Sinusitis (Overuse),334,Registry/QCDR,Outcome,Y,  2.25 -  1.73,  1.72 -  1.12,  1.11 -  0.01,--,--,--,--,  0.00,Yes
-Maternity Care: Elective Delivery or Early Induction Without Medical Indication at >= 37 and < 39 Weeks,335,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Maternity Care: Post-Partum Follow-Up and Care Coordination,336,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Tuberculosis Prevention for Psoriasis and Psoriatic Arthritis Patients on a Biological Immune Response Modifier,337,Registry/QCDR,Process,Y,  6.82 - 16.12, 16.13 - 24.13, 24.14 - 47.59, 47.60 - 90.90, 90.91 - 99.99,--,--,100.00,No
-Pain Brought Under Control within 48 Hours,342,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Screening Colonoscopy Adenoma Detection Rate,343,Registry/QCDR,Outcome,Y, 29.63 - 38.09, 38.10 - 41.85, 41.86 - 45.70, 45.71 - 48.69, 48.70 - 56.51, 56.52 - 63.40, 63.41 - 80.32,>= 80.33,No
-"Rate of Carotid Artery Stenting (CAS) for Asymptomatic Patients, Without Major Complications (Discharged to Home by Post-Operative Day #2)",344,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Rate of Postoperative Stroke or Death in Asymptomatic Patients Undergoing Carotid Artery Stenting (CAS),345,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Rate of Postoperative Stroke or Death in Asymptomatic Patients Undergoing Carotid Endarterectomy (CEA),346,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Abdominal Aortic Aneurysms (AAA) Who Die While in Hospital,347,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-HRS-3: Implantable Cardioverter-Defibrillator (ICD) Complications Rate,348,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Patient-Centered Surgical Risk Assessment and Communication,358,Registry/QCDR,Process,Y,  8.47 - 27.02, 27.03 - 78.25, 78.26 - 95.23, 95.24 - 99.99,--,--,--,100.00,Yes
-Optimizing Patient Exposure to Ionizing Radiation: Utilization of a Standardized Nomenclature for Computerized Tomography (CT) Imaging Description,359,Registry/QCDR,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Optimizing Patient Exposure to Ionizing Radiation: Computed Tomography (CT) Images Available for Patient Follow-up and Comparison Purposes,362,Registry/QCDR,Structure,Y,--,--,--,--,--,--,--,100.00,Yes
-"Optimizing Patient Exposure to Ionizing Radiation: Search for Prior Computed Tomography (CT) Imaging Studies Through a Secure, Authorized, Media-Free, Shared Archive",363,Registry/QCDR,Structure,Y,--,--,--,--,--,--,--,100.00,Yes
-Optimizing Patient Exposure to Ionizing Radiation: Appropriateness: Follow-up CT Imaging for Incidentally Detected Pulmonary Nodules According to Recommended Guidelines,364,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Hemoglobin A1c Test for Pediatric Patients,365,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Bipolar Disorder and Major Depression: Appraisal for Alcohol or Chemical Substance Use,367,EHR,Process,N,--,--,--,--,--,--,--,--,--
-HIV/AIDS: Medical Visit,368,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Pregnant Women that had HBsAg Testing,369,EHR,Process,N,--,--,--,--,--,--,--,--,--
-Pregnant Women that had HBsAg Testing,369,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Depression Remission at Twelve Months,370,EHR,Outcome,N,--,--,--,--,--,--,--,--,--
-Maternal Depression Screening,372,EHR,Process,N,--,--,--,--,--,--,--,--,--
-Hypertension: Improvement in Blood Pressure,373,EHR,Outcome,Y,  6.82 -  9.31,  9.32 - 11.70, 11.71 - 14.40, 14.41 - 17.39, 17.40 - 21.44, 21.45 - 27.61, 27.62 - 39.04,>= 39.05,No
-Hypertension: Improvement in Blood Pressure,373,Registry/QCDR,Outcome,Y,  2.39 -  2.93,  2.94 -  3.46,  3.47 -  3.92,  3.93 -  4.71,  4.72 -  5.53,  5.54 -  6.74,  6.75 -  9.99,>= 10.00,No
-Closing the Referral Loop: Receipt of Specialist Report,374,EHR,Process,Y,  2.70 -  6.24,  6.25 - 11.46, 11.47 - 18.15, 18.16 - 25.57, 25.58 - 36.95, 36.96 - 51.17, 51.18 - 71.87,>= 71.88,No
-Functional Status Assessment for Knee Replacement,375,EHR,Process,Y,  5.36 -  9.51,  9.52 -  9.99, 10.00 - 43.95, 43.96 - 47.82, 47.83 - 54.54, 54.55 - 66.04, 66.05 - 85.18,>= 85.19,No
-Functional Status Assessment for Hip Replacement,376,EHR,Process,N,--,--,--,--,--,--,--,--,--
-Functional Status Assessment for Complex Chronic Conditions,377,EHR,Process,N,--,--,--,--,--,--,--,--,--
-Children Who Have Dental Decay or Cavities,378,EHR,Outcome,Y,  0.36 -  0.01,--,--,--,--,--,--,  0.00,Yes
-Children Who Have Dental Decay or Cavities,378,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-"Primary Caries Prevention Intervention as Offered by Primary Care Providers, including Dentists",379,EHR,Process,Y,  0.79 -  0.96,  0.97 -  1.62,  1.63 -  2.03,  2.04 -  4.26,  4.27 -  6.59,  6.60 -  7.88,  7.89 - 14.28,>= 14.29,No
-ADE Prevention and Monitoring: Warfarin Time in Therapeutic Range,380,EHR,Outcome,N,--,--,--,--,--,--,--,--,--
-HIV/AIDS: RNA Control for Patients with HIV,381,EHR,Outcome,Y, 19.47 - 27.84, 27.85 - 33.42, 33.43 - 42.85, 42.86 - 76.26, 76.27 - 84.99, 85.00 - 90.31, 90.32 - 92.49,>= 92.50,No
-HIV/AIDS: RNA Control for Patients with HIV,381,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Child and Adolescent Major Depressive Disorder (MDD): Suicide Risk Assessment,382,EHR,Process,Y,  4.84 - 10.64, 10.65 - 16.29, 16.30 - 28.56, 28.57 - 92.97, 92.98 - 98.50, 98.51 - 99.33, 99.34 - 99.99,100.00,No
-Adherence to Antipsychotic Medications for Individuals with Schizophrenia,383,Registry/QCDR,Outcome,Y, 34.78 - 60.50, 60.51 - 72.36, 72.37 - 80.54, 80.55 - 91.99, 92.00 - 99.99,--,--,100.00,No
-Adult Primary Rhegmatogenous Retinal Detachment Repair Success Rate,384,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Adult Primary Rhegmatogenous Retinal Detachment Surgery Success Rate,385,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Amyotrophic Lateral Sclerosis (ALS) Patient Care Preferences,386,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Annual Hepatitis C Virus (HCV) Screening for Patients who are Active Injection Drug Users,387,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Cataract Surgery with Intra-Operative Complications (Unplanned Rupture of Posterior Capsule Requiring Unplanned Vsitrectomy),388,Registry/QCDR,Outcome,Y,  0.26 -  0.01,--,--,--,--,--,--,  0.00,Yes
-Cataract Surgery: Difference Between Planned and Final Refraction,389,Registry/QCDR,Outcome,Y, 66.67 - 88.45, 88.46 - 94.11, 94.12 - 98.09, 98.10 - 99.99,--,--,--,100.00,No
-Screening or Therapy for Osteoporosis for Women Aged 65 Years and Older,39,Claims,Process,Y, 30.77 - 39.54, 39.55 - 46.74, 46.75 - 53.96, 53.97 - 61.89, 61.90 - 70.86, 70.87 - 82.53, 82.54 - 95.87,>= 95.88,No
-Screening or Therapy for Osteoporosis for Women Aged 65 Years and Older,39,Registry/QCDR,Process,Y, 13.39 - 16.66, 16.67 - 20.39, 20.40 - 25.31, 25.32 - 33.99, 34.00 - 47.94, 47.95 - 64.65, 64.66 - 82.53,>= 82.54,No
-Discussion and Shared Decision Making Surrounding Treatment Options,390,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-"HRS-9: Infection within 180 Days of Cardiac Implantable Electronic Device (CIED) Implantation, Replacement, or Revision",393,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Lung Cancer Reporting (Biopsy/Cytology Specimens),395,Claims,Process,Y, 91.30 - 97.49, 97.50 - 99.99,--,--,--,--,--,100.00,Yes
-Lung Cancer Reporting (Biopsy/Cytology Specimens),395,Registry/QCDR,Process,Y, 93.75 - 99.65, 99.66 - 99.99,--,--,--,--,--,100.00,Yes
-Lung Cancer Reporting (Resection Specimens),396,Claims,Process,N,--,--,--,--,--,--,--,--,--
-Lung Cancer Reporting (Resection Specimens),396,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Melanoma Reporting,397,Claims,Process,Y, 68.33 - 78.42, 78.43 - 95.11, 95.12 - 99.99,--,--,--,--,100.00,Yes
-Melanoma Reporting,397,Registry/QCDR,Process,Y, 47.22 - 92.67, 92.68 - 99.99,--,--,--,--,--,100.00,Yes
-Optimal Asthma Control,398,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-"Osteoporosis: Management Following Fracture of Hip, Spine or Distal Radius for Men and Women Aged 50 Years and Older",40,Claims,Process,Y, 15.00 - 27.99, 28.00 - 36.14, 36.15 - 49.99, 50.00 - 75.30, 75.31 - 92.85, 92.86 - 99.99,--,100.00,No
-"Osteoporosis: Management Following Fracture of Hip, Spine or Distal Radius for Men and Women Aged 50 Years and Older",40,Registry/QCDR,Process,Y,  5.00 -  6.95,  6.96 -  8.69,  8.70 - 16.13, 16.14 - 32.78, 32.79 - 47.40, 47.41 - 65.56, 65.57 - 88.88,>= 88.89,No
-Hepatitis C: One-Time Screening for Hepatitis C Virus (HCV) for Patients at Risk,400,Registry/QCDR,Process,Y,  1.19 -  1.33,  1.34 -  1.53,  1.54 -  1.71,  1.72 -  2.09,  2.10 -  2.92,  2.93 -  8.32,  8.33 - 20.01,>= 20.02,No
-Screening for Hepatocellular Carcinoma (HCC) in patients with Hepatitis C Cirrhosis,401,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Tobacco Use and Help with Quitting Among Adolescents,402,Registry/QCDR,Process,Y, 74.10 - 81.15, 81.16 - 87.49, 87.50 - 90.37, 90.38 - 92.72, 92.73 - 95.15, 95.16 - 97.50, 97.51 - 99.99,100.00,No
-Osteoporosis: Pharmacologic Therapy for Men and Women Aged 50 Years and Older,41,Claims,Process,Y, 33.33 - 40.45, 40.46 - 46.66, 46.67 - 58.32, 58.33 - 74.50, 74.51 - 96.45, 96.46 - 99.99,--,100.00,No
-Osteoporosis: Pharmacologic Therapy for Men and Women Aged 50 Years and Older,41,Registry/QCDR,Process,Y, 33.33 - 40.43, 40.44 - 46.28, 46.29 - 52.77, 52.78 - 59.25, 59.26 - 66.66, 66.67 - 75.58, 75.59 - 99.99,100.00,No
-Coronary Artery Bypass Graft (CABG): Use of Internal Mammary Artery (IMA) in Patients with Isolated CABG Surgery,43,Registry/QCDR,Process,Y, 98.17 - 98.69, 98.70 - 99.99,--,--,--,--,--,100.00,Yes
-Coronary Artery Bypass Graft (CABG): Preoperative Beta-Blocker in Patients with Isolated CABG Surgery,44,Claims,Process,Y, 96.84 - 99.99,--,--,--,--,--,--,100.00,Yes
-Coronary Artery Bypass Graft (CABG): Preoperative Beta-Blocker in Patients with Isolated CABG Surgery,44,Registry/QCDR,Process,Y, 91.14 - 94.99, 95.00 - 97.32, 97.33 - 98.87, 98.88 - 99.99,--,--,--,100.00,Yes
-Advance Care Plan,47,Claims,Process,Y, 13.68 - 34.57, 34.58 - 62.86, 62.87 - 86.91, 86.92 - 97.10, 97.11 - 99.59, 99.60 - 99.99,--,100.00,No
-Advance Care Plan,47,Registry/QCDR,Process,Y, 16.52 - 38.11, 38.12 - 59.14, 59.15 - 74.99, 75.00 - 88.71, 88.72 - 96.29, 96.30 - 99.17, 99.18 - 99.99,100.00,No
-Urinary Incontinence: Assessment of Presence or Absence of Urinary Incontinence in Women Aged 65 Years and Older,48,Claims,Process,Y,  6.25 - 20.42, 20.43 - 64.72, 64.73 - 96.76, 96.77 - 99.99,--,--,--,100.00,Yes
-Urinary Incontinence: Assessment of Presence or Absence of Urinary Incontinence in Women Aged 65 Years and Older,48,Registry/QCDR,Process,Y, 16.31 - 29.03, 29.04 - 42.90, 42.91 - 57.07, 57.08 - 76.52, 76.53 - 89.12, 89.13 - 96.91, 96.92 - 99.99,100.00,No
-Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy for Left Ventricular Systolic Dysfunction (LVSD),5,EHR,Process,Y, 62.16 - 66.66, 66.67 - 71.42, 71.43 - 74.90, 74.91 - 77.60, 77.61 - 82.60, 82.61 - 85.70, 85.71 - 90.90,>= 90.91,No
-Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy for Left Ventricular Systolic Dysfunction (LVSD),5,Registry/QCDR,Process,Y, 75.86 - 79.48, 79.49 - 82.13, 82.14 - 84.99, 85.00 - 87.49, 87.50 - 89.99, 90.00 - 93.53, 93.54 - 96.54,>= 96.55,No
-Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Years and Older,50,Claims,Process,Y, 92.86 - 97.02, 97.03 - 99.99,--,--,--,--,--,100.00,Yes
-Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Years and Older,50,Registry/QCDR,Process,Y, 73.48 - 86.08, 86.09 - 94.33, 94.34 - 97.66, 97.67 - 99.99,--,--,--,100.00,Yes
-Chronic Obstructive Pulmonary Disease (COPD): Spirometry Evaluation,51,Claims,Process,Y, 21.61 - 59.99, 60.00 - 85.49, 85.50 - 96.61, 96.62 - 99.99,--,--,--,100.00,Yes
-Chronic Obstructive Pulmonary Disease (COPD): Spirometry Evaluation,51,Registry/QCDR,Process,Y, 50.53 - 58.59, 58.60 - 69.43, 69.44 - 77.97, 77.98 - 86.43, 86.44 - 93.17, 93.18 - 97.65, 97.66 - 99.99,100.00,No
-Chronic Obstructive Pulmonary Disease (COPD): Inhaled Bronchodilator Therapy,52,Claims,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Chronic Obstructive Pulmonary Disease (COPD): Inhaled Bronchodilator Therapy,52,Registry/QCDR,Process,Y, 95.24 - 99.99,--,--,--,--,--,--,100.00,Yes
-Emergency Medicine: 12-Lead Electrocardiogram (ECG) Performed for Non-Traumatic Chest Pain,54,Claims,Process,Y, 95.45 - 96.87, 96.88 - 98.03, 98.04 - 99.99,--,--,--,--,100.00,Yes
-Emergency Medicine: 12-Lead Electrocardiogram (ECG) Performed for Non-Traumatic Chest Pain,54,Registry/QCDR,Process,Y, 95.45 - 98.26, 98.27 - 99.55, 99.56 - 99.99,--,--,--,--,100.00,Yes
-Coronary Artery Disease (CAD): Antiplatelet Therapy,6,Registry/QCDR,Process,Y, 76.92 - 81.75, 81.76 - 84.99, 85.00 - 87.53, 87.54 - 90.22, 90.23 - 92.54, 92.55 - 95.64, 95.65 - 99.99,100.00,No
-Appropriate Treatment for Children with Upper Respiratory Infection (URI),65,EHR,Process,Y, 70.45 - 79.99, 80.00 - 87.99, 88.00 - 93.05, 93.06 - 95.64, 95.65 - 97.29, 97.30 - 98.96, 98.97 - 99.99,100.00,No
-Appropriate Treatment for Children with Upper Respiratory Infection (URI),65,Registry/QCDR,Process,Y, 67.74 - 80.76, 80.77 - 91.07, 91.08 - 94.74, 94.75 - 99.99,--,--,--,100.00,No
-Appropriate Testing for Children with Pharyngitis,66,EHR,Process,Y, 38.12 - 52.32, 52.33 - 67.64, 67.65 - 74.56, 74.57 - 80.94, 80.95 - 85.70, 85.71 - 89.15, 89.16 - 94.20,>= 94.21,No
-Appropriate Testing for Children with Pharyngitis,66,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Hematology: Myelodysplastic Syndrome (MDS) and Acute Leukemias: Baseline Cytogenetic Testing Performed on Bone Marrow,67,Registry/QCDR,Process,Y, 95.00 - 96.87, 96.88 - 98.69, 98.70 - 99.99,--,--,--,--,100.00,Yes
-Hematology: Myelodysplastic Syndrome (MDS): Documentation of Iron Stores in Patients Receiving Erythropoietin Therapy,68,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Hematology: Multiple Myeloma: Treatment with Bisphosphonates,69,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Hematology: Chronic Lymphocytic Leukemia (CLL): Baseline Flow Cytometry,70,Registry/QCDR,Process,Y, 86.52 - 95.23, 95.24 - 99.50, 99.51 - 99.99,--,--,--,--,100.00,Yes
-Breast Cancer: Hormonal Therapy for Stage IC - IIIC Estrogen Receptor/Progesterone Receptor (ER/PR) Positive Breast Cancer,71,Claims,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Breast Cancer: Hormonal Therapy for Stage IC - IIIC Estrogen Receptor/Progesterone Receptor (ER/PR) Positive Breast Cancer,71,Registry/QCDR,Process,Y, 80.49 - 90.78, 90.79 - 96.48, 96.49 - 98.07, 98.08 - 99.99,--,--,--,100.00,Yes
-Colon Cancer: Chemotherapy for AJCC Stage III Colon Cancer Patients,72,Claims,Process,N,--,--,--,--,--,--,--,--,--
-Colon Cancer: Chemotherapy for AJCC Stage III Colon Cancer Patients,72,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Prevention of Central Venous Catheter (CVC)-Related Bloodstream Infections,76,Claims,Process,Y, 85.71 - 94.28, 94.29 - 97.17, 97.18 - 99.42, 99.43 - 99.99,--,--,--,100.00,Yes
-Prevention of Central Venous Catheter (CVC)-Related Bloodstream Infections,76,Registry/QCDR,Process,Y, 89.66 - 95.99, 96.00 - 99.99,--,--,--,--,--,100.00,Yes
-Heart Failure (HF): Beta-Blocker Therapy for Left Ventricular Systolic Dysfunction (LVSD),8,EHR,Process,Y, 58.62 - 64.70, 64.71 - 71.94, 71.95 - 78.25, 78.26 - 85.50, 85.51 - 89.99, 90.00 - 91.66, 91.67 - 95.99,>= 96.00,No
-Heart Failure (HF): Beta-Blocker Therapy for Left Ventricular Systolic Dysfunction (LVSD),8,Registry/QCDR,Process,Y, 75.68 - 81.07, 81.08 - 85.57, 85.58 - 88.43, 88.44 - 91.16, 91.17 - 94.28, 94.29 - 96.36, 96.37 - 99.99,100.00,No
-Adult Kidney Disease: Hemodialysis Adequacy: Solute,81,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Adult Kidney Disease: Peritoneal Dialysis Adequacy: Solute,82,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Acute Otitis Externa (AOE): Topical Therapy,91,Claims,Process,Y, 60.87 - 85.70, 85.71 - 96.96, 96.97 - 99.99,--,--,--,--,100.00,Yes
-Acute Otitis Externa (AOE): Topical Therapy,91,Registry/QCDR,Process,Y, 60.47 - 69.56, 69.57 - 78.25, 78.26 - 83.01, 83.02 - 87.97, 87.98 - 93.32, 93.33 - 99.99,--,100.00,No
-Acute Otitis Externa (AOE): Systemic Antimicrobial Therapy - Avoidance of Inappropriate Use,93,Claims,Process,Y, 94.29 - 95.64, 95.65 - 97.29, 97.30 - 99.99,--,--,--,--,100.00,Yes
-Acute Otitis Externa (AOE): Systemic Antimicrobial Therapy - Avoidance of Inappropriate Use,93,Registry/QCDR,Process,Y, 73.91 - 84.74, 84.75 - 90.90, 90.91 - 95.82, 95.83 - 99.99,--,--,--,100.00,Yes
-Breast Cancer Resection Pathology Reporting: pT Category (Primary Tumor) and pN Category (Regional Lymph Nodes) with Histologic Grade,99,Claims,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Breast Cancer Resection Pathology Reporting: pT Category (Primary Tumor) and pN Category (Regional Lymph Nodes) with Histologic Grade,99,Registry/QCDR,Process,Y, 97.62 - 99.99,--,--,--,--,--,--,100.00,Yes
-Asthma Assessment and Classification,AAAAI 11,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Lung Function/Spirometry Evaluation,AAAAI 12,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Asthma Control: Minimal Important Difference Improvement,AAAAI 17,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Penicillin Allergy: Appropriate Removal or Confirmation,AAAAI 18,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Asthma: Assessment of Asthma Control - Ambulatory Care Setting,AAAAI 2,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Allergen Immunotherapy Treatment: Allergen Specific Immunoglobulin E (IgE) Sensitivity Assessed and Documented Prior to Treatment,AAAAI 5,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Documentation of Clinical Response to Allergen Immunotherapy within One Year,AAAAI 6,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Achievement of Projected Effective Dose of Standardized Allergens for Patient Treated With Allergen Immunotherapy for at Least One Year,AAAAI 8,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Assessment of Asthma Symptoms Prior to Administration of Allergen Immunotherapy Injection(s),AAAAI 9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Anesthesia Safety in the Peri-Operative Period,ABG 1,Registry/QCDR,Outcome,Y, 99.44 - 99.54, 99.55 - 99.83, 99.84 - 99.99,--,--,--,--,100.00,Yes
-Anesthesia: Patient Experience Survey,ABG 12,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Corneal Abrasion,ABG 14,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-PACU Intubation Rate,ABG 4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Composite Procedural Safety for All Vascular Access Procedures,ABG 5,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Immediate Adult Post-Operative Pain Management,ABG 7,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Hypertension (HTN): Blood Pressure (BP) Management,ACCPin 1,Registry/QCDR,Process,Y, 80.04 - 84.15, 84.16 - 86.65, 86.66 - 88.55, 88.56 - 89.84, 89.85 - 91.05, 91.06 - 92.34, 92.35 - 93.89,>= 93.90,No
-Coronary Artery Disease (CAD): Blood Pressure Control,ACCPin 2,Registry/QCDR,Outcome,Y, 81.51 - 85.87, 85.88 - 88.51, 88.52 - 90.49, 90.50 - 91.71, 91.72 - 92.90, 92.91 - 94.15, 94.16 - 95.53,>= 95.54,No
-Gout: Serum Urate Target,ACR 7,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Report Turnaround Time: Ultrasound (Excluding Breast US),ACRad 16,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Report Turnaround Time: CT,ACRad 18,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Report Turnaround Time: PET,ACRad 19,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-CT Colonography Clinically Significant Extracolonic Findings,ACRad 2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Lung Cancer Screening Abnormal Interpretation Rate,ACRad 23,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Screening Mammography Cancer Detection Rate (CDR),ACRad 3,Registry/QCDR,Outcome,Y,  3.54 -  4.32,  4.33 -  4.80,  4.81 -  5.15,  5.16 -  5.47,  5.48 -  5.71,  5.72 -  6.68,  6.69 -  8.10,>=  8.11,No
-Screening Mammography Abnormal Interpretation Rate (Recall Rate),ACRad 5,Registry/QCDR,Outcome,Y, 13.98 - 11.03, 11.02 -  9.94,  9.93 -  9.24,  9.23 -  8.21,  8.20 -  7.22,  7.21 -  6.39,  6.38 -  5.27,<=  5.26,No
-Screening Mammography Positive Predictive Value 2 (PPV2 - BiopsyRecommended),ACRad 6,Registry/QCDR,Outcome,Y, 13.53 - 17.90, 17.91 - 20.33, 20.34 - 21.54, 21.55 - 24.99, 25.00 - 28.25, 28.26 - 39.46, 39.47 - 42.58,>= 42.59,No
-Screening Mammography Node Negativity Rate,ACRad 7,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Screening Mammography Minimal Cancer Rate,ACRad 8,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Coronary Artery Bypass Graft (CABG): Prolonged Intubation,AQI 18,Registry/QCDR,Outcome,Y, 91.06 - 94.96, 94.97 - 98.83, 98.84 - 99.63, 99.64 - 99.99,--,--,--,100.00,Yes
-Surgeon assessment for hereditary cause of breast cancer,ASBS 1,Registry/QCDR,Process,Y, 98.70 - 99.41, 99.42 - 99.99,--,--,--,--,--,100.00,Yes
-Unplanned 30 day re-operation after mastectomy,ASBS 7,Registry/QCDR,Outcome,Y, 95.45 - 97.05, 97.06 - 98.83, 98.84 - 99.99,--,--,--,--,100.00,Yes
-Cardiac Stress Nuclear Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low Risk Surgery Patients,ASNC 1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Cardiac Stress Nuclear Imaging Not Meeting Appropriate Use Criteria: Routine Testing After Percutaneous Coronary Intervention (PCI),ASNC 2,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-"Cardiac Stress Nuclear Imaging Not Meeting Appropriate Use Criteria: Testing in Asymptomatic, Low-Risk Patients",ASNC 3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Utilization of standardized nomenclature and reporting for nuclear cardiology imaging studies,ASNC 4,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Transfusion goal of hematocrit less than 30,ASPIRE 13,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Avoiding intraoperative hypotension,ASPIRE 16,Registry/QCDR,Process,Y, 91.67 - 92.72, 92.73 - 94.61, 94.62 - 99.54, 99.55 - 99.72, 99.73 - 99.85, 99.86 - 99.88, 99.89 - 99.99,100.00,Yes
-Avoiding myocardial Injury,ASPIRE 18,Registry/QCDR,Outcome,Y, 98.82 - 99.01, 99.02 - 99.26, 99.27 - 99.36, 99.37 - 99.41, 99.42 - 99.46, 99.47 - 99.67, 99.68 - 99.75,>= 99.76,No
-Train of Four Monitor Documented After Last Dose of Non-depolarizing Neuromuscular Blocker,ASPIRE 2,Registry/QCDR,Process,Y, 78.96 - 80.94, 80.95 - 82.72, 82.73 - 83.47, 83.48 - 84.42, 84.43 - 86.07, 86.08 - 88.08, 88.09 - 90.33,>= 90.34,No
-Avoiding medication overdose,ASPIRE 22,Registry/QCDR,Outcome,Y, 99.29 - 99.30, 99.31 - 99.37, 99.38 - 99.50, 99.51 - 99.63, 99.64 - 99.68, 99.69 - 99.75, 99.76 - 99.87,>= 99.88,No
-Administration of Neostigmine before Extubation for Cases with Nondepolarizing Neuromuscular Blockade,ASPIRE 3,Registry/QCDR,Process,Y, 89.03 - 90.25, 90.26 - 93.55, 93.56 - 96.79, 96.80 - 97.96, 97.97 - 98.41, 98.42 - 98.89, 98.90 - 99.30,>= 99.31,Yes
-Administration of insulin or glucose recheck for patients with hyperglycemia,ASPIRE 4,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Avoiding excessively high tidal volumes during positive pressure ventilation,ASPIRE 6,Registry/QCDR,Process,Y, 89.66 - 91.38, 91.39 - 92.67, 92.68 - 94.06, 94.07 - 95.28, 95.29 - 95.46, 95.47 - 95.97, 95.98 - 96.54,>= 96.55,No
-Adequate Off-loading of Diabetic Foot Ulcers at each visit,CDR 1,Registry/QCDR,Process,Y, 40.13 - 58.05, 58.06 - 72.34, 72.35 - 83.92, 83.93 - 91.29, 91.30 - 95.29, 95.30 - 97.41, 97.42 - 98.87,>= 98.88,No
-Vascular Assessment of patients with chronic leg ulcers,CDR 10,Registry/QCDR,Process,Y, 28.14 - 36.46, 36.47 - 43.95, 43.96 - 57.95, 57.96 - 68.13, 68.14 - 73.73, 73.74 - 77.31, 77.32 - 79.51,>= 79.52,No
-Diabetic Foot Ulcer (DFU) Healing or Closure,CDR 2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Adequate Compression at each visit for Patients with Venous Leg Ulcers (VLU),CDR 5,Registry/QCDR,Process,Y, 75.20 - 90.31, 90.32 - 93.58, 93.59 - 94.63, 94.64 - 95.82, 95.83 - 97.23, 97.24 - 99.09, 99.10 - 99.99,100.00,No
-Venous Leg Ulcer outcome measure: Healing or Closure,CDR 6,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Plan of Care for Venous Leg Ulcer Patients not Achieving 30% Closure at 4 Weeks,CDR 7,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Appropriate use of hyperbaric oxygen therapy for patients with diabetic foot ulcers,CDR 8,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Appropriate use of Cellular or Tissue Based Products (CTP) for patients aged 18 years or older with a diabetic foot ulcer (DFU) or venous leg ulcer (VLU),CDR 9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Three Day All Cause Return ED Visit Rate - All Patients,ECPR 11,Registry/QCDR,Outcome,Y,  6.46 -  6.05,  6.04 -  5.72,  5.71 -  5.40,  5.39 -  5.08,  5.07 -  4.76,  4.75 -  4.35,  4.34 -  3.94,<=  3.93,No
-Door to Diagnostic Evaluation by a Provider - Adult Emergency Department (ED) Patients,ECPR 2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Mean Time from Emergency Department (ED) Arrival to ED Departure for Discharged Lower Acuity ED Patients,ECPR 5,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Mean Time from Emergency Department (ED) Arrival to ED Departure for Discharged Higher Acuity ED Patients,ECPR 6,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Appropriate management of anticoagulation in the peri-procedural period rate - EGD,GIQIC 10,Registry/QCDR,Process,Y, 68.37 - 89.99, 90.00 - 97.91, 97.92 - 99.99,--,--,--,--,100.00,Yes
-Appropriate indication for colonoscopy,GIQIC 12,Registry/QCDR,Process,Y, 82.27 - 86.05, 86.06 - 89.06, 89.07 - 91.34, 91.35 - 93.27, 93.28 - 94.80, 94.81 - 96.59, 96.60 - 98.44,>= 98.45,No
-Appropriate follow-up interval of 3 years recommended based on pathology findings from screening colonoscopy in average-risk patients,GIQIC 15,Registry/QCDR,Process,Y, 68.18 - 74.32, 74.33 - 77.87, 77.88 - 80.70, 80.71 - 85.23, 85.24 - 89.17, 89.18 - 91.34, 91.35 - 94.38,>= 94.39,No
-Mean Length of Stay for Inpatients - CHF,HCPR 4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Mean Length of Stay for Inpatients - COPD,HCPR 5,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Corneal Graft: 20/40 or Better Visual Acuity within 90 Days following Corneal Graft Surgery,IRIS 1,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Exudative Age-Related Macular Degeneration: Loss of Visual Acuity,IRIS 10,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Nonexudative Age-Related Macular Degeneration: Loss of Visual Acuity,IRIS 11,Registry/QCDR,Outcome,Y, 72.97 - 79.58, 79.59 - 85.70, 85.71 - 95.58, 95.59 - 97.43, 97.44 - 99.99,--,--,100.00,No
-Diabetic Macular Edema: Loss of Visual Acuity,IRIS 13,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Acute Anterior Uveitis: Post-treatment visual acuity,IRIS 16,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Acute Anterior Uveitis: Post-treatment Grade 0 anterior chamber cells,IRIS 17,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Chronic Anterior Uveitis: Post-treatment visual acuity,IRIS 18,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Chronic Anterior Uveitis: Post-treatment Grade 0 anterior chamber cells,IRIS 19,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Open-Angle Glaucoma: Intraocular Pressure Reduction,IRIS 2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Open-Angle Glaucoma: Visual Field Progression,IRIS 3,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Open-Angle Glaucoma: Intraocular Pressure Reduction Following Laser Trabeculoplasty,IRIS 4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Acquired Involutional Ptosis: Improvement of Marginal Reflex Distance within 90 Days Following Surgery for Acquired Involutional Ptosis,IRIS 5,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Acquired Involutional Entropion: Normalization of Eyelid Position within 90 Days Following Surgery for Acquired Involutional Entropion,IRIS 6,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Amblyopia: Improvement of Corrected Interocular Visual Acuity Difference to 2 or fewer Lines,IRIS 7,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Surgical Esotropia: Patients with Postoperative Alignment of 15 PD or less,IRIS 8,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Diabetic Retinopathy: Dilated Eye Exam,IRIS 9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Procedures with statin and antiplatelet agents prescribed at discharge,M2S 1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Imaging-based maximum aortic diameter assessed at one-year following Endovascular AAA Repair procedures,M2S 11,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Ipsilateral stroke-free survival at one-year following isolated CEA for asymptomatic procedures,M2S 8,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Imaging-based maximum aortic diameter assessed at one-year following Thoracic and Complex EVAR procedures,M2S 9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-"Risk standardized rate of patients who experienced an unplanned readmission (likely related to the initial operation) to any hospital within 30 days following a Laparoscopic Roux-en-Y Gastric Bypass or Laparoscopic Sleeve Gastrectomy operation, performed as a primary (not revisional) procedure.",MBSAQIP 2,Registry/QCDR,Outcome,Y,  4.84 -  3.73,  3.72 -  3.24,  3.23 -  2.96,  2.95 -  1.86,  1.85 -  1.16,  1.15 -  0.01,--,  0.00,Yes
-"Risk standardized rate of patients who experienced a reoperation (likely related to the initial operation) within 30 days following a Laparoscopic Roux-en-Y Gastric Bypass or Laparoscopic Sleeve Gastrectomy operation, performed as a primary (not revisional) procedure.",MBSAQIP 3,Registry/QCDR,Outcome,Y,  2.38 -  1.73,  1.72 -  0.62,  0.61 -  0.01,--,--,--,--,  0.00,Yes
-"Risk standardized rate of patients who experienced an anastomotic/staple line leak within 30 days following a Laparoscopic Roux-en-Y Gastric Bypass or Laparoscopic Sleeve Gastrectomy operation, performed as a primary (not revisional) procedure.",MBSAQIP 4,Registry/QCDR,Outcome,Y,--,--,--,--,--,--,--,  0.00,Yes
-"Risk standardized rate of patients who experienced a postoperative surgical site infection (SSI) (superficial incisional, deep incisional, or organ/space SSI) within 30 days following a Laparoscopic Roux-en-Y Gastric Bypass or Laparoscopic Sleeve Gastrectomy operation, performed as a primary (not revisional) procedure.",MBSAQIP 6,Registry/QCDR,Outcome,Y,  1.61 -  0.64,  0.63 -  0.01,--,--,--,--,--,  0.00,Yes
-"Risk standardized rate of patients who experienced postoperative nausea, vomiting or fluid/electrolyte/nutritional depletion within 30 days following a Laparoscopic Roux-en-Y Gastric Bypass or Laparoscopic Sleeve Gastrectomy operation, performed as a primary (not revisional) procedure.",MBSAQIP 7,Registry/QCDR,Outcome,Y,  2.56 -  2.27,  2.26 -  1.53,  1.52 -  0.79,  0.78 -  0.01,--,--,--,  0.00,Yes
-"Risk standardized rate of patients who experienced extended length of stay (> 7 days) following a Laparoscopic Roux-en-Y Gastric Bypass or Laparoscopic Sleeve Gastrectomy operation, performed as a primary (not revisional) procedure.",MBSAQIP 8,Registry/QCDR,Outcome,Y,  1.37 -  0.54,  0.53 -  0.01,--,--,--,--,--,  0.00,Yes
-Prostate Biopsy: Compliance with AUA best practices for antibiotic prophylaxis for transrectal ultrasound-guided (TRUS) biopsy,MUSIC 1,Registry/QCDR,Process,Y, 94.12 - 97.82, 97.83 - 98.10, 98.11 - 99.28, 99.29 - 99.99,--,--,--,100.00,Yes
-Unplanned Hospital Admission within 30 Days of TRUS Biopsy:,MUSIC 2,Registry/QCDR,Outcome,Y,  1.28 -  0.01,--,--,--,--,--,--,  0.00,Yes
-Prostate Cancer: Avoidance of Overuse of CT Scan for Staging Low Risk Prostate Cancer Patients:,MUSIC 3,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Prostate Cancer: Proportion of patients with low-risk prostate cancer receiving active surveillance,MUSIC 4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Prostate Cancer: Percentage of prostate cancer cases with a length of stay > 2 days,MUSIC 5,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Unplanned Hospital Readmission within 30 Days of Radical Prostatectomy:,MUSIC 6,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Prostate Biopsy: Proportion of patients undergoing a repeat prostate biopsy within 12 months of their initial biopsy in the registry as a result of a finding of atypical small acinar proliferation (ASAP) as per the NCCN guidelines,MUSIC 9,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-CG--?CAHPS Adult Visit Composite Tracking,OBERD 12,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-30 day Readmission for Acute Myocardial Infarction,PInc 1,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-30 day Readmission for Heart Failure,PInc 2,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-30 day Readmission for Pneumonia,PInc 3,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Risk-Adjusted Average Length of Inpatient Hospital Stay for Acute Myocardial Infarction (AMI),PInc 33,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Risk-Adjusted Average Length of Inpatient Hospital Stay for Heart Failure (HF),PInc 34,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Risk-Adjusted Average Length of Inpatient Hospital Stay for Pneumonia (PN),PInc 35,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-30 day Mortality for Acute Myocardial Infarction,PInc 4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-30 day Mortality for Heart Failure,PInc 5,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-30 day Mortality for Pneumonia,PInc 6,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Chronic Kidney Disease (CKD): eGFR Monitoring,PPRNET 13,Registry/QCDR,Process,Y, 59.02 - 63.42, 63.43 - 66.66, 66.67 - 72.34, 72.35 - 74.59, 74.60 - 78.25, 78.26 - 85.05, 85.06 - 86.95,>= 86.96,No
-Chronic Kidney Disease (CKD): Hemoglobin Monitoring,PPRNET 14,Registry/QCDR,Process,Y, 66.67 - 77.26, 77.27 - 83.86, 83.87 - 87.49, 87.50 - 88.63, 88.64 - 90.47, 90.48 - 91.66, 91.67 - 93.74,>= 93.75,No
-Zoster (Shingles) Vaccination,PPRNET 20,Registry/QCDR,Process,Y, 11.15 - 32.73, 32.74 - 41.89, 41.90 - 53.56, 53.57 - 56.51, 56.52 - 58.25, 58.26 - 66.42, 66.43 - 68.85,>= 68.86,No
-Appropriate Treatment for Adults with Upper Respiratory Infection,PPRNET 24,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Use of Benzodiazepines in the Elderly,PPRNET 27,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-NSAID or Cox 2 Inhibitor Use in Patients with Heart Failure (HF) or Chronic Kidney Disease (CKD),PPRNET 28,Registry/QCDR,Process,Y, 83.51 - 84.64, 84.65 - 85.94, 85.95 - 86.97, 86.98 - 89.25, 89.26 - 89.72, 89.73 - 90.32, 90.33 - 92.93,>= 92.94,No
-Monitoring Serum Potassium,PPRNET 29,Registry/QCDR,Process,Y, 82.03 - 82.10, 82.11 - 83.01, 83.02 - 86.19, 86.20 - 88.19, 88.20 - 90.90, 90.91 - 93.78, 93.79 - 96.60,>= 96.61,No
-Treatment of Hypokalemia,PPRNET 30,Registry/QCDR,Outcome,Y, 93.55 - 95.23, 95.24 - 96.29, 96.30 - 96.87, 96.88 - 97.32, 97.33 - 98.35, 98.36 - 99.14, 99.15 - 99.48,>= 99.49,Yes
-Angiotensin Converting Enzyme (ACE) Inhibitor or AngiotensinReceptor Blocker (ARB) Therapy(PCPI Measure #: AKID-2),RPAQIR 1,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-CABG- Prolonged postoperative length of stay (PLOS),STS 1,Registry/QCDR,Outcome,Y,  8.42 -  6.59,  6.58 -  5.34,  5.33 -  4.04,  4.03 -  3.34,  3.33 -  2.48,  2.47 -  1.44,  1.43 -  0.01,  0.00,No
-CABG + Valve- Prolonged postoperative length of stay (PLOS),STS 3,Registry/QCDR,Outcome,Y, 18.75 - 13.80, 13.79 - 12.51, 12.50 - 11.12, 11.11 -  9.22,  9.21 -  6.53,  6.52 -  4.56,  4.55 -  3.71,<=  3.70,No
-Isolated Valve- Prolonged postoperative length of stay (PLOS),STS 5,Registry/QCDR,Outcome,Y,  9.84 -  8.01,  8.00 -  6.91,  6.90 -  4.89,  4.88 -  4.01,  4.00 -  3.04,  3.03 -  2.34,  2.33 -  0.01,  0.00,No
-Patient Vital Sign Assessment Prior to HBOT,USWR 13,Registry/QCDR,Process,Y, 98.74 - 99.28, 99.29 - 99.57, 99.58 - 99.70, 99.71 - 99.99,--,--,--,100.00,Yes
-"Healing or Closure of Wagner Grade 3, 4 or 5 Diabetic Foot Ulcers (DFUs) Treated with HBOT",USWR 15,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Adult Kidney Disease: Blood Pressure Management,122,Registry/QCDR,Outcome,Y, 75.78 - 93.05, 93.06 - 97.83, 97.84 - 99.99,--,--,--,--,100.00,No
-Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,Claims,Process,Y, 40.26 - 49.99, 50.00 - 71.73, 71.74 - 93.93, 93.94 - 99.99,--,--,--,100.00,No
-Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,EHR,Process,Y, 26.03 - 30.00, 30.01 - 33.32, 33.33 - 36.46, 36.47 - 39.99, 40.00 - 44.37, 44.38 - 49.99, 50.00 - 68.89,>= 68.90,No
-Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,Registry/QCDR,Process,Y, 41.76 - 51.26, 51.27 - 63.27, 63.28 - 78.15, 78.16 - 90.88, 90.89 - 98.77, 98.78 - 99.99,--,100.00,No
-Use of High-Risk Medications in the Elderly,238,EHR,Process,Y, 29.53 - 24.11, 24.10 - 18.67, 18.66 - 12.51, 12.50 -  5.50,  5.49 -  0.85,  0.84 -  0.01,--,  0.00,No
-Use of High-Risk Medications in the Elderly,238,Registry/QCDR,Process,Y, 21.34 - 15.80, 15.79 - 10.77, 10.76 -  6.07,  6.06 -  2.37,  2.36 -  0.71,  0.70 -  0.01,--,  0.00,No
-Weight Assessment and Counseling for Nutrition and Physical Activity for Children and Adolescents,239,EHR,Process,Y, 27.27 - 30.76, 30.77 - 32.51, 32.52 - 33.32,--,--,--, 33.33 - 39.04,>= 39.05,No
-Initiation and Engagement of Alcohol and Other Drug Dependence Treatment,305,EHR,Process,Y,--,--,--,--,--,--,--,>=  0.00,No
-Depression Utilization of the PHQ-9 Tool,371,EHR,Process,Y,--,--,--,--,--,  0.00 -  1.07,  1.08 - 11.53,>= 11.54,No
-Depression Utilization of the PHQ-9 Tool,371,Registry/QCDR,Process,Y,  0.32 -  0.37,  0.38 -  0.46,  0.47 -  0.55,  0.56 -  0.68,  0.69 -  0.93,  0.94 -  1.41,  1.42 - 49.99,>= 50.00,No
-Follow-up After Hospitalization for Mental Illness (FUH),391,Registry/QCDR,Process,Y, 28.00 - 55.55, 55.56 - 99.99,--,--,--,--,--,100.00,No
-Medication Reconciliation,46,Claims,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Medication Reconciliation,46,Registry/QCDR,Process,Y,--,--,--,--,--,--,--,100.00,Yes
-Coronary Artery Disease (CAD): Beta-Blocker Therapy - Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF < 40%),7,EHR,Process,Y, 62.50 - 77.41, 77.42 - 90.90, 90.91 - 99.99,--,--,--,--,100.00,No
-Coronary Artery Disease (CAD): Beta-Blocker Therapy - Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF < 40%),7,Registry/QCDR,Process,Y, 73.33 - 80.55, 80.56 - 86.66, 86.67 - 92.56, 92.57 - 99.99,--,--,--,100.00,No
-Anti-depressant Medication Management,9,EHR,Process,Y,--,--,--,--,  0.00 -  1.51,  1.52 - 49.99, 50.00 - 83.33,>= 83.34,No
-Weight Assessment and Counseling for Nutrition and Physical Activity for Children and Adolescents,239,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-HIV/AIDS: Pneumocystis Jiroveci Pneumonia (PCP) Prophylaxis,160,EHR,Process,N,--,--,--,--,--,--,--,--,--
-ADHD: Follow-Up Care for Children Prescribed Attention-Deficit/Hyperactivity Disorder (ADHD) Medication,366,EHR,Process,N,--,--,--,--,--,--,--,--,--
-Immunizations for Adolescents,394,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Unplanned Readmission Following Spine Procedure Within the 30 Day Post?Operative Period,NPA 11,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Risk -assessment for elective spine procedure,NPA 15,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-Functional Outcome Assessment for Spine Intervention,NPA 3,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Quality of Life Assessment for Spine Intervention,NPA 4,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Patient Satisfaction with Spine Care,NPA 5,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Spine?related procedure site infection,NPA 6,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Complication Following Spine?Related Procedure,NPA 7,Registry/QCDR,Outcome,N,--,--,--,--,--,--,--,--,--
-Patient Centered surgical risk assessment and communication using the STS Risk Calculator,STS 7,Registry/QCDR,Process,N,--,--,--,--,--,--,--,--,--
-,,,,,,,,,,,,,
+Table 2: Historical MIPS Quality Measure Benchmark Results; created using PY2017 data and PY2019 Eligibility Rules,,,,,,,,,,,,,,,,
+Measure_Name,Measure_ID,Collection_Type,Measure_Type,Benchmark,Standard_Deviation,Average,Decile_3,Decile_4,Decile_5,Decile_6,Decile_7,Decile_8,Decile_9,Decile_10,TOPPED_OUT,SevenPointCap
+Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,eCQM,Intermediate Outcome,Y,28.2,46.3,77.14 - 60.79,60.78 - 48.49,48.48 - 38.90,38.89 - 31.60,31.59 - 25.88,25.87 - 20.56,20.55 - 14.72,<= 14.71,No,No
+Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,Medicare Part B Claims,Intermediate Outcome,Y,24.5,24.6,44.44 - 29.04,29.03 - 19.52,19.51 - 14.72,14.71 - 11.12,11.11 - 8.34,8.33 - 5.57,5.56 - 2.79,<= 2.78,No,No
+Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,MIPS CQM,Intermediate Outcome,Y,30.1,36.5,68.31 - 50.63,50.62 - 37.51,37.50 - 28.70,28.69 - 20.01,20.00 - 13.60,13.59 - 9.03,9.02 - 2.71,<= 2.70,No,No
+Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy for Left Ventricular Systolic Dysfunction (LVSD),5,eCQM,Process,Y,13.8,82.8,74.19 - 78.56,78.57 - 82.13,82.14 - 85.18,85.19 - 87.92,87.93 - 90.90,90.91 - 93.74,93.75 - 97.72,>= 97.73,No,No
+Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy for Left Ventricular Systolic Dysfunction (LVSD),5,MIPS CQM,Process,Y,13.5,94.1,93.33 - 96.96,96.97 - 98.40,98.41 - 99.99,--,--,--,--,100,Yes,No
+Coronary Artery Disease (CAD): Antiplatelet Therapy,6,MIPS CQM,Process,Y,13.2,89.6,84.13 - 87.99,88.00 - 90.66,90.67 - 92.85,92.86 - 95.09,95.10 - 97.08,97.09 - 99.99,--,100,No,No
+Coronary Artery Disease (CAD): Beta-Blocker Therapy - Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF < 40%),7,eCQM,Process,Y,13.7,82.9,76.74 - 80.30,80.31 - 83.17,83.18 - 85.28,85.29 - 87.15,87.16 - 89.73,89.74 - 91.91,91.92 - 94.86,>= 94.87,No,No
+Coronary Artery Disease (CAD): Beta-Blocker Therapy - Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF < 40%),7,MIPS CQM,Process,Y,8.8,96.3,96.17 - 98.11,98.12 - 99.76,99.77 - 99.99,--,--,--,--,100,Yes,No
+Heart Failure (HF): Beta-Blocker Therapy for Left Ventricular Systolic Dysfunction (LVSD),8,eCQM,Process,Y,11.1,87.9,80.49 - 85.61,85.62 - 88.97,88.98 - 91.29,91.30 - 93.04,93.05 - 94.73,94.74 - 96.34,96.35 - 99.99,100,No,No
+Heart Failure (HF): Beta-Blocker Therapy for Left Ventricular Systolic Dysfunction (LVSD),8,MIPS CQM,Process,Y,10.3,95.9,95.45 - 98.05,98.06 - 99.28,99.29 - 99.99,--,--,--,--,100,Yes,No
+Anti-Depressant Medication Management,9,eCQM,Process,Y,32.4,53.9,16.67 - 31.06,31.07 - 42.18,42.19 - 53.15,53.16 - 71.73,71.74 - 82.78,82.79 - 88.88,88.89 - 94.43,>= 94.44,No,No
+Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation,12,eCQM,Process,Y,20,86.2,79.11 - 86.57,86.58 - 90.61,90.62 - 93.87,93.88 - 96.31,96.32 - 98.01,98.02 - 99.10,99.11 - 99.99,100,No,No
+Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation,12,Medicare Part B Claims,Process,Y,9.8,97.4,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation,12,MIPS CQM,Process,Y,9.8,96.2,96.47 - 99.16,99.17 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Age-Related Macular Degeneration (AMD): Dilated Macular Examination,14,Medicare Part B Claims,Process,Y,10.2,97.8,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Age-Related Macular Degeneration (AMD): Dilated Macular Examination,14,MIPS CQM,Process,Y,24.3,86.2,76.54 - 89.80,89.81 - 96.53,96.54 - 99.70,99.71 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care,19,eCQM,Process,Y,28.8,61.7,33.90 - 47.61,47.62 - 57.88,57.89 - 67.02,67.03 - 75.36,75.37 - 82.48,82.49 - 90.02,90.03 - 95.99,>= 96.00,No,No
+Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care,19,Medicare Part B Claims,Process,Y,8.6,98.2,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care,19,MIPS CQM,Process,Y,26.6,83.4,70.29 - 84.41,84.42 - 92.72,92.73 - 98.56,98.57 - 99.99,--,--,--,100,Yes,No
+Perioperative Care: Selection of Prophylactic Antibiotic - First OR Second Generation Cephalosporin,21,Medicare Part B Claims,Process,Y,22.6,92,99.17 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Perioperative Care: Selection of Prophylactic Antibiotic - First OR Second Generation Cephalosporin,21,MIPS CQM,Process,Y,17.5,94.6,98.67 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Perioperative Care: Venous Thromboembolism (VTE) Prophylaxis (When Indicated in ALL Patients),23,Medicare Part B Claims,Process,Y,19.9,94.9,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Perioperative Care: Venous Thromboembolism (VTE) Prophylaxis (When Indicated in ALL Patients),23,MIPS CQM,Process,Y,17.4,95,98.68 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Communication with the Physician or Other Clinician Managing On-going Care Post-Fracture for Men and Women Aged 50 Years and Older,24,Medicare Part B Claims,Process,Y,31.9,76.3,32.35 - 63.63,63.64 - 92.30,92.31 - 96.20,96.21 - 97.61,97.62 - 99.99,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Communication with the Physician or Other Clinician Managing On-going Care Post-Fracture for Men and Women Aged 50 Years and Older,24,MIPS CQM,Process,Y,32.4,59.6,26.32 - 45.09,45.10 - 55.31,55.32 - 60.20,60.21 - 69.99,70.00 - 80.55,80.56 - 99.99,--,100,No,No
+Screening for Osteoporosis for Women Aged 65-85 Years of Age,39,Medicare Part B Claims,Process,Y,26.5,56.2,32.79 - 42.36,42.37 - 49.00,49.01 - 55.90,55.91 - 62.54,62.55 - 70.68,70.69 - 82.88,82.89 - 95.49,>= 95.50,No,No
+Screening for Osteoporosis for Women Aged 65-85 Years of Age,39,MIPS CQM,Process,Y,31,46.2,11.38 - 22.43,22.44 - 34.71,34.72 - 45.25,45.26 - 58.10,58.11 - 67.97,67.98 - 78.45,78.46 - 88.23,>= 88.24,No,No
+Coronary Artery Bypass Graft (CABG): Preoperative Beta-Blocker in Patients with Isolated CABG Surgery,44,MIPS CQM,Process,Y,14.7,92.7,90.35 - 95.89,95.90 - 97.38,97.39 - 99.99,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Medication Reconciliation Post-Discharge,46,Medicare Part B Claims,Process,Y,16.3,94.2,95.74 - 98.40,98.41 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Medication Reconciliation Post-Discharge,46,MIPS CQM,Process,Y,17.2,93.3,94.24 - 97.62,97.63 - 99.92,99.93 - 99.99,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Care Plan,47,Medicare Part B Claims,Process,Y,33.1,78.4,50.32 - 82.60,82.61 - 92.88,92.89 - 97.45,97.46 - 99.30,99.31 - 99.99,--,--,100,Yes,No
+Care Plan,47,MIPS CQM,Process,Y,35.9,66.1,24.33 - 45.01,45.02 - 65.74,65.75 - 82.16,82.17 - 91.89,91.90 - 97.31,97.32 - 99.71,99.72 - 99.99,100,No,No
+Urinary Incontinence: Assessment of Presence or Absence of Urinary Incontinence in Women Aged 65 Years and Older,48,Medicare Part B Claims,Process,Y,43.1,65,3.88 - 13.85,13.86 - 72.40,72.41 - 96.68,96.69 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Urinary Incontinence: Assessment of Presence or Absence of Urinary Incontinence in Women Aged 65 Years and Older,48,MIPS CQM,Process,Y,37.5,59.8,12.22 - 31.74,31.75 - 52.36,52.37 - 70.44,70.45 - 84.26,84.27 - 95.10,95.11 - 99.50,99.51 - 99.99,100,No,No
+Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Years and Older,50,Medicare Part B Claims,Process,Y,18.2,94.4,97.30 - 98.87,98.88 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Years and Older,50,MIPS CQM,Process,Y,26.6,71.4,47.22 - 59.99,60.00 - 68.98,68.99 - 75.63,75.64 - 85.49,85.50 - 92.58,92.59 - 99.65,99.66 - 99.99,100,No,No
+Chronic Obstructive Pulmonary Disease (COPD): Spirometry Evaluation,51,Medicare Part B Claims,Process,Y,33.7,77,38.10 - 77.26,77.27 - 92.44,92.45 - 98.75,98.76 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Chronic Obstructive Pulmonary Disease (COPD): Spirometry Evaluation,51,MIPS CQM,Process,Y,33.4,64.9,25.00 - 45.44,45.45 - 60.42,60.43 - 75.75,75.76 - 86.45,86.46 - 93.82,93.83 - 99.35,99.36 - 99.99,100,No,No
+Chronic Obstructive Pulmonary Disease (COPD): Long-Acting Inhaled Bronchodilator Therapy,52,Medicare Part B Claims,Process,Y,21.9,89.9,90.14 - 98.14,98.15 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Chronic Obstructive Pulmonary Disease (COPD): Long-Acting Inhaled Bronchodilator Therapy,52,MIPS CQM,Process,Y,13.4,93.1,90.16 - 95.21,95.22 - 96.48,96.49 - 98.85,98.86 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Appropriate Treatment for Children with Upper Respiratory Infection (URI),65,eCQM,Process,Y,15.8,88.1,80.95 - 88.36,88.37 - 91.76,91.77 - 93.87,93.88 - 95.60,95.61 - 96.87,96.88 - 98.21,98.22 - 99.99,100,No,No
+Appropriate Treatment for Children with Upper Respiratory Infection (URI),65,MIPS CQM,Process,Y,13.9,93.2,91.49 - 95.01,95.02 - 97.02,97.03 - 97.84,97.85 - 98.69,98.70 - 99.19,99.20 - 99.74,99.75 - 99.99,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Appropriate Testing for Children with Pharyngitis,66,eCQM,Process,Y,29.6,66.7,36.71 - 60.04,60.05 - 72.40,72.41 - 78.37,78.38 - 83.32,83.33 - 87.62,87.63 - 91.42,91.43 - 94.58,>= 94.59,No,No
+Appropriate Testing for Children with Pharyngitis,66,MIPS CQM,Process,Y,17.5,77.4,64.57 - 69.60,69.61 - 75.41,75.42 - 81.74,81.75 - 85.50,85.51 - 87.95,87.96 - 91.77,91.78 - 97.54,>= 97.55,No,No
+Hematology: Myelodysplastic Syndrome (MDS) and Acute Leukemias: Baseline Cytogenetic Testing Performed on Bone Marrow,67,MIPS CQM,Process,Y,38.1,42.9,8.00 - 12.49,12.50 - 22.72,22.73 - 28.52,28.53 - 34.61,34.62 - 78.78,78.79 - 99.99,--,100,No,No
+Hematology: Myelodysplastic Syndrome (MDS): Documentation of Iron Stores in Patients Receiving Erythropoietin Therapy,68,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Hematology: Multiple Myeloma: Treatment with Bisphosphonates,69,MIPS CQM,Process,Y,21.1,61.5,42.86 - 47.49,47.50 - 64.51,64.52 - 66.66,66.67 - 71.42,71.43 - 71.87,71.88 - 76.91,76.92 - 92.30,>= 92.31,No,No
+Hematology: Chronic Lymphocytic Leukemia (CLL): Baseline Flow Cytometry,70,MIPS CQM,Process,Y,36.5,53.1,16.67 - 23.20,23.21 - 32.25,32.26 - 35.94,35.95 - 67.85,67.86 - 95.44,95.45 - 99.99,--,100,No,No
+Prevention of Central Venous Catheter (CVC) - Related Bloodstream Infections,76,Medicare Part B Claims,Process,Y,17.3,93.7,95.24 - 98.60,98.61 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Prevention of Central Venous Catheter (CVC) - Related Bloodstream Infections,76,MIPS CQM,Process,Y,15.7,94.2,95.67 - 99.08,99.09 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Acute Otitis Externa (AOE): Topical Therapy,91,Medicare Part B Claims,Process,Y,32.6,78.5,43.36 - 86.60,86.61 - 93.21,93.22 - 99.65,99.66 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Acute Otitis Externa (AOE): Topical Therapy,91,MIPS CQM,Process,Y,20,83.2,67.34 - 78.76,78.77 - 86.33,86.34 - 91.32,91.33 - 95.23,95.24 - 97.36,97.37 - 99.99,--,100,No,No
+Acute Otitis Externa (AOE): Systemic Antimicrobial Therapy - Avoidance of Inappropriate Use,93,Medicare Part B Claims,Process,Y,21.6,88.7,89.12 - 93.50,93.51 - 96.35,96.36 - 97.82,97.83 - 99.92,99.93 - 99.99,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Acute Otitis Externa (AOE): Systemic Antimicrobial Therapy - Avoidance of Inappropriate Use,93,MIPS CQM,Process,Y,23.7,80.1,63.16 - 77.35,77.36 - 83.96,83.97 - 89.65,89.66 - 93.32,93.33 - 96.14,96.15 - 99.99,--,100,No,No
+Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients,102,eCQM,Process,Y,29.8,78.3,59.34 - 75.73,75.74 - 83.90,83.91 - 91.99,92.00 - 98.30,98.31 - 99.99,--,--,100,No,No
+Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients,102,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prostate Cancer: Combination Androgen Deprivation Therapy for High Risk or Very High Risk Prostate Cancer,104,MIPS CQM,Process,Y,30.6,69,39.65 - 48.16,48.17 - 55.05,55.06 - 76.22,76.23 - 93.25,93.26 - 99.59,99.60 - 99.99,--,100,No,No
+Adult Major Depressive Disorder (MDD): Suicide Risk Assessment,107,eCQM,Process,Y,36,33.9,1.51 - 3.56,3.57 - 8.10,8.11 - 17.48,17.49 - 30.28,30.29 - 54.72,54.73 - 77.56,77.57 - 96.66,>= 96.67,No,No
+Osteoarthritis (OA): Function and Pain Assessment,109,Medicare Part B Claims,Process,Y,22.9,89.2,87.28 - 95.71,95.72 - 98.71,98.72 - 99.88,99.89 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Osteoarthritis (OA): Function and Pain Assessment,109,MIPS CQM,Process,Y,35,73.7,34.62 - 63.00,63.01 - 86.63,86.64 - 94.37,94.38 - 99.99,--,--,--,100,No,No
+Preventive Care and Screening: Influenza Immunization,110,eCQM,Process,Y,28.1,42,15.50 - 23.63,23.64 - 31.20,31.21 - 38.65,38.66 - 46.76,46.77 - 56.01,56.02 - 67.49,67.50 - 84.98,>= 84.99,No,No
+Preventive Care and Screening: Influenza Immunization,110,Medicare Part B Claims,Process,Y,32.3,64.2,29.52 - 41.41,41.42 - 56.31,56.32 - 71.18,71.19 - 82.88,82.89 - 94.14,94.15 - 99.41,99.42 - 99.99,100,No,No
+Preventive Care and Screening: Influenza Immunization,110,MIPS CQM,Process,Y,31.4,61.8,29.85 - 41.42,41.43 - 53.84,53.85 - 66.02,66.03 - 76.93,76.94 - 87.80,87.81 - 96.40,96.41 - 99.99,100,No,No
+Pneumococcal Vaccination Status for Older Adults,111,eCQM,Process,Y,30.1,50.8,19.01 - 31.06,31.07 - 42.70,42.71 - 53.43,53.44 - 62.85,62.86 - 71.81,71.82 - 80.42,80.43 - 90.40,>= 90.41,No,No
+Pneumococcal Vaccination Status for Older Adults,111,Medicare Part B Claims,Process,Y,24.8,71.6,49.76 - 61.10,61.11 - 70.10,70.11 - 77.31,77.32 - 82.95,82.96 - 89.43,89.44 - 95.66,95.67 - 99.99,100,No,No
+Pneumococcal Vaccination Status for Older Adults,111,MIPS CQM,Process,Y,28.4,58.4,30.23 - 44.52,44.53 - 55.55,55.56 - 63.63,63.64 - 70.42,70.43 - 76.37,76.38 - 83.76,83.77 - 95.44,>= 95.45,No,No
+Breast Cancer Screening,112,eCQM,Process,Y,26.7,48.4,22.28 - 32.74,32.75 - 42.31,42.32 - 51.05,51.06 - 58.43,58.44 - 65.67,65.68 - 73.43,73.44 - 82.30,>= 82.31,No,No
+Breast Cancer Screening,112,Medicare Part B Claims,Process,Y,24.7,64.6,44.44 - 52.07,52.08 - 58.44,58.45 - 64.28,64.29 - 70.96,70.97 - 79.84,79.85 - 90.23,90.24 - 99.99,100,No,No
+Breast Cancer Screening,112,MIPS CQM,Process,Y,29.3,62.9,35.99 - 48.25,48.26 - 57.57,57.58 - 67.38,67.39 - 75.24,75.25 - 85.30,85.31 - 93.44,93.45 - 99.99,100,No,No
+Colorectal Cancer Screening,113,eCQM,Process,Y,28.9,44.4,13.49 - 24.00,24.01 - 33.96,33.97 - 44.38,44.39 - 54.79,54.80 - 64.00,64.01 - 73.37,73.38 - 83.50,>= 83.51,No,No
+Colorectal Cancer Screening,113,Medicare Part B Claims,Process,Y,28.9,66.3,36.60 - 50.99,51.00 - 62.49,62.50 - 71.22,71.23 - 79.99,80.00 - 88.63,88.64 - 97.72,97.73 - 99.99,100,No,No
+Colorectal Cancer Screening,113,MIPS CQM,Process,Y,30.4,65.3,35.90 - 49.50,49.51 - 60.82,60.83 - 70.87,70.88 - 80.61,80.62 - 90.40,90.41 - 96.97,96.98 - 99.99,100,No,No
+Avoidance of Antibiotic Treatment in Adults With Acute Bronchitis,116,MIPS CQM,Process,Y,27.8,72.6,44.27 - 57.07,57.08 - 72.02,72.03 - 83.77,83.78 - 90.98,90.99 - 95.56,95.57 - 97.54,97.55 - 99.99,100,No,No
+Diabetes: Eye Exam,117,eCQM,Process,Y,35.8,60.7,20.61 - 31.99,32.00 - 45.52,45.53 - 66.01,66.02 - 89.11,89.12 - 95.64,95.65 - 98.25,98.26 - 99.72,>= 99.73,No,No
+Diabetes: Eye Exam,117,Medicare Part B Claims,Process,Y,24.9,86.9,72.00 - 96.87,96.88 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Diabetes: Eye Exam,117,MIPS CQM,Process,Y,24.7,85.8,77.26 - 89.99,90.00 - 95.81,95.82 - 98.48,98.49 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Coronary Artery Disease (CAD): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy - Diabetes or Left Ventricular Systolic Dysfunction (LVEF < 40%),118,MIPS CQM,Process,Y,11.1,83.3,76.00 - 78.56,78.57 - 81.07,81.08 - 83.90,83.91 - 86.35,86.36 - 88.72,88.73 - 92.25,92.26 - 98.17,>= 98.18,No,No
+Diabetes: Medical Attention for Nephropathy,119,eCQM,Process,Y,19.7,79,67.86 - 74.79,74.80 - 79.99,80.00 - 84.13,84.14 - 87.73,87.74 - 91.10,91.11 - 94.62,94.63 - 98.38,>= 98.39,No,No
+Diabetes: Medical Attention for Nephropathy,119,MIPS CQM,Process,Y,20.1,85.1,74.38 - 82.85,82.86 - 87.70,87.71 - 91.93,91.94 - 97.23,97.24 - 99.99,--,--,100,No,No
+"Diabetes Mellitus: Diabetic Foot and Ankle Care, Peripheral Neuropathy - Neurological Evaluation",126,MIPS CQM,Process,Y,29.3,82.5,66.15 - 85.22,85.23 - 96.42,96.43 - 99.99,--,--,--,--,100,Yes,No
+"Diabetes Mellitus: Diabetic Foot and Ankle Care, Ulcer Prevention - Evaluation of Footwear",127,MIPS CQM,Process,Y,27.9,84.8,70.59 - 92.85,92.86 - 99.45,99.46 - 99.99,--,--,--,--,100,Yes,No
+Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,eCQM,Process,Y,28.5,45.4,21.15 - 24.58,24.59 - 28.51,28.52 - 34.20,34.21 - 43.84,43.85 - 60.30,60.31 - 78.24,78.25 - 93.28,>= 93.29,No,No
+Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,Medicare Part B Claims,Process,Y,30.3,74.2,37.52 - 47.77,47.78 - 74.47,74.48 - 95.19,95.20 - 99.26,99.27 - 99.99,--,--,100,Yes,No
+Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,MIPS CQM,Process,Y,31.8,72.6,34.35 - 54.25,54.26 - 74.56,74.57 - 90.59,90.60 - 97.55,97.56 - 99.86,99.87 - 99.99,--,100,No,No
+Documentation of Current Medications in the Medical Record,130,eCQM,Process,Y,18.5,90.3,87.55 - 93.48,93.49 - 96.28,96.29 - 97.98,97.99 - 98.99,99.00 - 99.57,99.58 - 99.88,99.89 - 99.99,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Documentation of Current Medications in the Medical Record,130,Medicare Part B Claims,Process,Y,13.1,96.1,97.95 - 99.51,99.52 - 99.91,99.92 - 99.99,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Documentation of Current Medications in the Medical Record,130,MIPS CQM,Process,Y,30.5,82.6,68.06 - 90.27,90.28 - 97.23,97.24 - 99.50,99.51 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Pain Assessment and Follow-Up,131,Medicare Part B Claims,Process,Y,25,87.9,80.57 - 96.91,96.92 - 99.63,99.64 - 99.99,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Pain Assessment and Follow-Up,131,MIPS CQM,Process,Y,38.2,65.1,15.80 - 39.99,40.00 - 62.78,62.79 - 84.05,84.06 - 95.25,95.26 - 99.54,99.55 - 99.99,--,100,No,No
+Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,eCQM,Process,Y,32.2,37.1,4.88 - 10.17,10.18 - 17.59,17.60 - 28.28,28.29 - 42.29,42.30 - 56.82,56.83 - 73.29,73.30 - 87.49,>= 87.50,No,No
+Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,Medicare Part B Claims,Process,Y,39.6,69.3,12.94 - 53.91,53.92 - 80.22,80.23 - 96.98,96.99 - 99.99,--,--,--,100,Yes,No
+Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,MIPS CQM,Process,Y,38.5,67.7,17.11 - 45.64,45.65 - 73.81,73.82 - 90.05,90.06 - 98.49,98.50 - 99.99,--,--,100,No,No
+Melanoma: Continuity of Care - Recall System,137,MIPS CQM,Structure,Y,23,88.6,83.83 - 94.33,94.34 - 98.79,98.80 - 99.99,--,--,--,--,100,No,No
+Melanoma: Coordination of Care,138,MIPS CQM,Process,Y,30.2,75.8,49.44 - 63.63,63.64 - 78.25,78.26 - 92.58,92.59 - 99.99,--,--,--,100,No,No
+Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care,141,Medicare Part B Claims,Outcome,Y,10.8,97.6,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care,141,MIPS CQM,Outcome,Y,26.4,84.8,73.85 - 87.49,87.50 - 96.29,96.30 - 99.30,99.31 - 99.99,--,--,--,100,No,No
+Oncology: Medical and Radiation - Pain Intensity Quantified,143,eCQM,Process,Y,25.4,84.9,77.21 - 87.78,87.79 - 94.91,94.92 - 97.26,97.27 - 98.34,98.35 - 99.45,99.46 - 99.99,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Oncology: Medical and Radiation - Pain Intensity Quantified,143,MIPS CQM,Process,Y,17.1,91.9,90.31 - 95.39,95.40 - 97.12,97.13 - 98.56,98.57 - 99.25,99.26 - 99.99,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Oncology: Medical and Radiation - Plan of Care for Pain,144,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Radiology: Exposure Dose or Time Reported for Procedures Using Fluoroscopy,145,Medicare Part B Claims,Process,Y,26.5,81.9,66.41 - 82.92,82.93 - 90.90,90.91 - 95.17,95.18 - 97.39,97.40 - 99.06,99.07 - 99.99,--,100,Yes,No
+Radiology: Exposure Dose or Time Reported for Procedures Using Fluoroscopy,145,MIPS CQM,Process,Y,24.9,85.1,73.10 - 88.03,88.04 - 94.91,94.92 - 98.15,98.16 - 99.53,99.54 - 99.99,--,--,100,Yes,No
+"Radiology: Inappropriate Use of ""Probably Benign"" Assessment Category in Screening Mammograms",146,Medicare Part B Claims,Process,Y,1.2,0.3,0.23 - 0.01,--,--,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+"Radiology: Inappropriate Use of ""Probably Benign"" Assessment Category in Screening Mammograms",146,MIPS CQM,Process,Y,3.5,0.5,0.24 - 0.12,0.11 - 0.05,0.04 - 0.01,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Nuclear Medicine: Correlation with Existing Imaging Studies for All Patients Undergoing Bone Scintigraphy,147,Medicare Part B Claims,Process,Y,22.3,86.2,76.47 - 87.17,87.18 - 94.05,94.06 - 97.00,97.01 - 99.99,--,--,--,100,Yes,No
+Nuclear Medicine: Correlation with Existing Imaging Studies for All Patients Undergoing Bone Scintigraphy,147,MIPS CQM,Process,Y,13.7,94.1,93.04 - 97.96,97.97 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Falls: Risk Assessment,154,Medicare Part B Claims,Process,Y,18.3,94,96.95 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Falls: Risk Assessment,154,MIPS CQM,Process,Y,35.4,73.2,28.63 - 60.81,60.82 - 84.99,85.00 - 95.96,95.97 - 99.73,99.74 - 99.99,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Falls: Plan of Care,155,Medicare Part B Claims,Process,Y,30.8,81.4,55.81 - 84.61,84.62 - 99.20,99.21 - 99.99,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Falls: Plan of Care,155,MIPS CQM,Process,Y,28.8,82.7,67.86 - 86.78,86.79 - 94.99,95.00 - 98.21,98.22 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+HIV/AIDS: Pneumocystis Jiroveci Pneumonia (PCP) Prophylaxis,160,eCQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Coronary Artery Bypass Graft (CABG): Prolonged Intubation,164,MIPS CQM,Outcome,Y,5.9,7.6,11.40 - 9.10,9.09 - 7.70,7.69 - 6.81,6.80 - 5.56,5.55 - 4.29,4.28 - 3.09,3.08 - 1.55,<= 1.54,No,No
+Coronary Artery Bypass Graft (CABG): Deep Sternal Wound Infection Rate,165,MIPS CQM,Outcome,Y,1.1,0.5,0.84 - 0.01,--,--,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Coronary Artery Bypass Graft (CABG): Stroke,166,MIPS CQM,Outcome,Y,1.6,1.3,2.38 - 1.80,1.79 - 1.27,1.26 - 0.72,0.71 - 0.01,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Coronary Artery Bypass Graft (CABG): Postoperative Renal Failure,167,MIPS CQM,Outcome,Y,2.6,2.2,3.51 - 2.71,2.70 - 2.16,2.15 - 1.86,1.85 - 1.29,1.28 - 0.89,0.88 - 0.01,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Coronary Artery Bypass Graft (CABG): Surgical Re-Exploration,168,MIPS CQM,Outcome,Y,2.6,2.4,3.95 - 3.14,3.13 - 2.64,2.63 - 1.80,1.79 - 1.28,1.27 - 0.88,0.87 - 0.01,--,0,Yes,No
+Rheumatoid Arthritis (RA): Tuberculosis Screening,176,MIPS CQM,Process,Y,31,65.4,32.00 - 48.14,48.15 - 55.55,55.56 - 68.00,68.01 - 80.42,80.43 - 99.03,99.04 - 99.99,--,100,No,No
+Rheumatoid Arthritis (RA): Periodic Assessment of Disease Activity,177,MIPS CQM,Process,Y,29.4,79,57.23 - 74.99,75.00 - 88.23,88.24 - 96.01,96.02 - 99.99,--,--,--,100,Yes,No
+Rheumatoid Arthritis (RA): Functional Status Assessment,178,MIPS CQM,Process,Y,27.2,82,67.61 - 81.39,81.40 - 90.58,90.59 - 95.94,95.95 - 99.99,--,--,--,100,Yes,No
+Rheumatoid Arthritis (RA): Assessment and Classification of Disease Prognosis,179,MIPS CQM,Process,Y,30.9,76.7,44.53 - 67.88,67.89 - 85.30,85.31 - 95.21,95.22 - 99.99,--,--,--,100,Yes,No
+Rheumatoid Arthritis (RA): Glucocorticoid Management,180,MIPS CQM,Process,Y,28.6,79.3,52.68 - 75.78,75.79 - 87.95,87.96 - 95.05,95.06 - 99.57,99.58 - 99.99,--,--,100,Yes,No
+Elder Maltreatment Screen and Follow-Up Plan,181,Medicare Part B Claims,Process,Y,34.6,80.9,55.38 - 97.31,97.32 - 99.55,99.56 - 99.99,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Elder Maltreatment Screen and Follow-Up Plan,181,MIPS CQM,Process,Y,29.9,75.6,50.65 - 66.03,66.04 - 77.77,77.78 - 89.28,89.29 - 96.78,96.79 - 99.99,--,--,100,No,No
+Functional Outcome Assessment,182,Medicare Part B Claims,Process,Y,14.7,96.7,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Functional Outcome Assessment,182,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Colonoscopy Interval for Patients with a History of Adenomatous Polyps
+
+- Avoidance of Inappropriate Use",185,Medicare Part B Claims,Process,Y,8.5,97.8,98.57 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+"Colonoscopy Interval for Patients with a History of Adenomatous Polyps
+
+- Avoidance of Inappropriate Use",185,MIPS CQM,Process,Y,25.8,82,61.64 - 84.99,85.00 - 90.53,90.54 - 95.41,95.42 - 98.40,98.41 - 99.99,--,--,100,Yes,No
+Stroke and Stroke Rehabilitation: Thrombolytic Therapy,187,MIPS CQM,Process,Y,20.5,90.1,88.89 - 96.48,96.49 - 99.99,--,--,--,--,--,100,Yes,No
+Cataracts: 20/40 or Better Visual Acuity within 90 Days Following Cataract Surgery,191,eCQM,Outcome,Y,18.4,88.5,85.25 - 90.62,90.63 - 93.40,93.41 - 95.58,95.59 - 96.87,96.88 - 97.82,97.83 - 98.77,98.78 - 99.99,100,No,No
+Cataracts: 20/40 or Better Visual Acuity within 90 Days Following Cataract Surgery,191,MIPS CQM,Outcome,Y,9.3,96.1,94.37 - 96.87,96.88 - 98.97,98.98 - 99.99,--,--,--,--,100,Yes,No
+Cataracts: Complications within 30 Days Following Cataract Surgery Requiring Additional Surgical Procedures,192,eCQM,Outcome,Y,0.9,0.2,--,--,--,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Cataracts: Complications within 30 Days Following Cataract Surgery Requiring Additional Surgical Procedures,192,MIPS CQM,Outcome,Y,6.5,0.9,--,--,--,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Radiology: Stenosis Measurement in Carotid Imaging Reports,195,Medicare Part B Claims,Process,Y,16.1,92.7,91.72 - 96.22,96.23 - 98.17,98.18 - 99.99,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Radiology: Stenosis Measurement in Carotid Imaging Reports,195,MIPS CQM,Process,Y,10.7,96.6,97.81 - 99.84,99.85 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+"HIV/AIDS: Sexually Transmitted Disease Screening for Chlamydia, Gonorrhea, and Syphilis",205,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Status Change for Patients with Knee Impairments,217,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Status Change for Patients with Hip Impairments,218,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Status Change for Patients with Foot or Ankle Impairments,219,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Status Change for Patients with Lumbar Impairments,220,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Status Change for Patients with Shoulder Impairments,221,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Functional Status Change for Patients with Elbow, Wrist or Hand Impairments",222,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Status Change for Patients with Other General Orthopaedic Impairments,223,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Radiology: Reminder System for Screening Mammograms,225,Medicare Part B Claims,Structure,Y,19.3,94.3,99.36 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Radiology: Reminder System for Screening Mammograms,225,MIPS CQM,Structure,Y,13.8,97.4,--,--,--,--,--,--,--,100,Yes,No
+Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,eCQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Controlling High Blood Pressure,236,eCQM,Intermediate Outcome,Y,16.6,63,51.46 - 56.82,56.83 - 60.94,60.95 - 64.67,64.68 - 68.17,68.18 - 72.00,72.01 - 76.25,76.26 - 82.20,>= 82.21,No,No
+Controlling High Blood Pressure,236,Medicare Part B Claims,Intermediate Outcome,Y,18.6,72.2,58.57 - 63.97,63.98 - 68.82,68.83 - 73.90,73.91 - 78.56,78.57 - 83.32,83.33 - 88.31,88.32 - 94.88,>= 94.89,No,No
+Controlling High Blood Pressure,236,MIPS CQM,Intermediate Outcome,Y,24.1,69.3,52.41 - 60.04,60.05 - 65.67,65.68 - 70.61,70.62 - 76.82,76.83 - 84.61,84.62 - 93.39,93.40 - 99.99,100,No,No
+Use of High-Risk Medications in the Elderly,238,eCQM,Process,Y,9,4.7,8.04 - 4.75,4.74 - 2.68,2.67 - 1.32,1.31 - 0.54,0.53 - 0.05,0.04 - 0.01,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Use of High-Risk Medications in the Elderly,238,MIPS CQM,Process,Y,6.6,1.7,0.68 - 0.29,0.28 - 0.14,0.13 - 0.01,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Weight Assessment and Counseling for Nutrition and Physical Activity for Children and Adolescents,239,eCQM,Process,Y,19.9,37.6,26.23 - 29.51,29.52 - 31.47,31.48 - 32.79,32.80 - 33.85,33.86 - 38.72,38.73 - 47.76,47.77 - 65.52,>= 65.53,No,No
+Childhood Immunization Status,240,eCQM,Process,Y,17.3,26.9,9.30 - 14.80,14.81 - 20.49,20.50 - 26.67,26.68 - 30.66,30.67 - 37.22,37.23 - 42.41,42.42 - 50.88,>= 50.89,No,No
+Cardiac Rehabilitation Patient Referral from an Outpatient Setting,243,MIPS CQM,Process,Y,20.1,22.2,8.11 - 11.87,11.88 - 14.62,14.63 - 17.22,17.23 - 20.77,20.78 - 24.31,24.32 - 30.68,30.69 - 44.43,>= 44.44,No,No
+Barrett's Esophagus,249,Medicare Part B Claims,Process,Y,0.2,100,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Barrett's Esophagus,249,MIPS CQM,Process,Y,4.1,99.5,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Radical Prostatectomy Pathology Reporting,250,Medicare Part B Claims,Process,Y,0.7,99.9,--,--,--,--,--,--,--,100,Yes,No
+Radical Prostatectomy Pathology Reporting,250,MIPS CQM,Process,Y,1.5,99.7,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Ultrasound Determination of Pregnancy Location for Pregnant Patients with Abdominal Pain,254,MIPS CQM,Process,Y,15.3,85.1,74.42 - 80.94,80.95 - 85.36,85.37 - 88.88,88.89 - 91.99,92.00 - 95.23,95.24 - 97.66,97.67 - 99.99,100,No,No
+Ultrasound Determination of Pregnancy Location for Pregnant Patients with Abdominal Pain,254,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rh Immunoglobulin (Rhogam) for Rh-Negative Pregnant Women at Risk of Fetal Blood Exposure,255,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rh Immunoglobulin (Rhogam) for Rh-Negative Pregnant Women at Risk of Fetal Blood Exposure,255,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of Open Repair of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post-Operative Day #7),258,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post Operative Day #2),259,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Rate of Carotid Endarterectomy (CEA) for Asymptomatic Patients, without Major Complications (Discharged to Home by Post-Operative Day #2)",260,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Referral for Otologic Evaluation for Patients with Acute or Chronic Dizziness,261,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Referral for Otologic Evaluation for Patients with Acute or Chronic Dizziness,261,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Image Confirmation of Successful Excision of Image-Localized Breast Lesion,262,MIPS CQM,Process,Y,0.2,100,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Sentinel Lymph Node Biopsy for Invasive Breast Cancer,264,MIPS CQM,Process,Y,6.1,98,97.96 - 99.21,99.22 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Biopsy Follow-Up,265,MIPS CQM,Process,Y,29.5,81.8,61.23 - 83.62,83.63 - 95.64,95.65 - 99.37,99.38 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Epilepsy: Counseling for Women of Childbearing Potential with Epilepsy,268,MIPS CQM,Process,Y,35.9,65,32.00 - 45.34,45.35 - 57.13,57.14 - 78.56,78.57 - 95.99,96.00 - 99.06,99.07 - 99.99,--,100,No,No
+Epilepsy: Counseling for Women of Childbearing Potential with Epilepsy,268,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Inflammatory Bowel Disease (IBD): Preventive Care: Corticosteroid Related Iatrogenic Injury - Bone Loss Assessment,271,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Inflammatory Bowel Disease (IBD): Assessment of Hepatitis B Virus (HBV) Status Before Initiating Anti-TNF (Tumor Necrosis Factor) Therapy,275,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Sleep Apnea: Severity Assessment at Initial Diagnosis,277,MIPS CQM,Process,Y,26.9,82.1,69.01 - 81.02,81.03 - 90.62,90.63 - 99.70,99.71 - 99.99,--,--,--,100,Yes,No
+Sleep Apnea: Assessment of Adherence to Positive Airway Pressure Therapy,279,MIPS CQM,Process,Y,17.8,92,90.08 - 96.26,96.27 - 99.16,99.17 - 99.99,--,--,--,--,100,Yes,No
+Dementia: Cognitive Assessment,281,eCQM,Process,Y,35.7,46.1,5.88 - 12.89,12.90 - 26.08,26.09 - 44.99,45.00 - 59.25,59.26 - 73.32,73.33 - 88.56,88.57 - 96.76,>= 96.77,No,No
+Dementia: Functional Status Assessment,282,MIPS CQM,Process,Y,32.2,79.2,57.14 - 78.94,78.95 - 95.27,95.28 - 99.12,99.13 - 99.99,--,--,--,100,Yes,No
+Dementia Associated Behavioral and Psychiatric Symptoms Screening and Management,283,MIPS CQM,Process,Y,29.9,81.3,58.14 - 83.07,83.08 - 96.66,96.67 - 99.81,99.82 - 99.99,--,--,--,100,Yes,No
+Dementia: Safety Concerns Screening and Mitigation Recommendations or Referral for Patients with Dementia,286,MIPS CQM,Process,Y,27.3,82,62.86 - 78.68,78.69 - 89.88,89.89 - 98.20,98.21 - 99.99,--,--,--,100,Yes,No
+Dementia: Caregiver Education and Support,288,MIPS CQM,Process,Y,27.9,80.9,59.26 - 77.32,77.33 - 89.32,89.33 - 97.53,97.54 - 99.99,--,--,--,100,Yes,No
+Parkinson's Disease: Psychiatric Symptoms Assessment for Patients with Parkinson's Disease,290,MIPS CQM,Process,Y,19.2,89.7,85.09 - 92.55,92.56 - 96.91,96.92 - 99.22,99.23 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Parkinson's Disease: Cognitive Impairment or Dysfunction Assessment,291,MIPS CQM,Process,Y,13.1,93.3,86.49 - 94.99,95.00 - 99.99,--,--,--,--,--,100,Yes,No
+Parkinson's Disease: Rehabilitative Therapy Options,293,MIPS CQM,Process,Y,19.8,86.6,67.03 - 82.94,82.95 - 94.28,94.29 - 99.99,--,--,--,--,100,Yes,No
+Cataracts: Improvement in Patient's Visual Function within 90 Days Following Cataract Surgery,303,MIPS CQM,Patient Reported Outcome,Y,30.5,74,45.11 - 70.87,70.88 - 78.76,78.77 - 84.90,84.91 - 91.77,91.78 - 98.79,98.80 - 99.99,--,100,No,No
+Cataracts: Patient Satisfaction within 90 Days Following Cataract Surgery,304,MIPS CQM,Patient Engagement Experience,Y,28.4,76.6,50.00 - 72.21,72.22 - 80.29,80.30 - 87.08,87.09 - 95.41,95.42 - 99.11,99.12 - 99.99,--,100,No,No
+Initiation and Engagement of Alcohol and Other Drug Dependence Treatment,305,eCQM,Process,Y,6.2,3.3,0.31 - 0.41,0.42 - 0.67,0.68 - 1.02,1.03 - 1.34,1.35 - 2.23,2.24 - 3.84,3.85 - 6.90,>= 6.91,No,No
+Cervical Cancer Screening,309,eCQM,Process,Y,25.6,35.1,9.83 - 16.79,16.80 - 23.65,23.66 - 31.53,31.54 - 39.71,39.72 - 48.30,48.31 - 57.62,57.63 - 72.60,>= 72.61,No,No
+Chlamydia Screening for Women,310,eCQM,Process,Y,20.2,35.2,16.67 - 22.30,22.31 - 28.04,28.05 - 33.32,33.33 - 39.12,39.13 - 44.77,44.78 - 53.13,53.14 - 63.77,>= 63.78,No,No
+Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,eCQM,Process,Y,23.6,37.3,19.56 - 24.13,24.14 - 28.18,28.19 - 32.30,32.31 - 36.66,36.67 - 42.11,42.12 - 50.69,50.70 - 74.54,>= 74.55,No,No
+Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,Medicare Part B Claims,Process,Y,30.1,68,34.25 - 45.47,45.48 - 58.48,58.49 - 73.28,73.29 - 89.40,89.41 - 98.06,98.07 - 99.99,--,100,No,No
+Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,MIPS CQM,Process,Y,32.7,54.1,25.75 - 30.80,30.81 - 35.46,35.47 - 42.56,42.57 - 59.14,59.15 - 83.48,83.49 - 97.31,97.32 - 99.99,100,No,No
+Falls: Screening for Future Fall Risk,318,eCQM,Process,Y,35.4,49.8,7.24 - 20.26,20.27 - 36.40,36.41 - 52.24,52.25 - 66.72,66.73 - 78.59,78.60 - 88.50,88.51 - 96.55,>= 96.56,No,No
+Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients,320,Medicare Part B Claims,Process,Y,21.1,91.8,95.24 - 97.72,97.73 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients,320,MIPS CQM,Process,Y,19.5,88.9,85.00 - 89.73,89.74 - 93.60,93.61 - 95.94,95.95 - 97.72,97.73 - 98.95,98.96 - 99.99,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low Risk Surgery Patients,322,MIPS CQM,Efficiency,Y,16.9,4.1,1.90 - 0.01,--,--,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Routine Testing After Percutaneous Coronary Intervention (PCI),323,MIPS CQM,Efficiency,Y,16.9,4.4,2.44 - 0.01,--,--,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+"Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Testing in Asymptomatic, Low-Risk Patients",324,MIPS CQM,Efficiency,Y,13.4,5.1,6.25 - 2.02,2.01 - 0.01,--,--,--,--,--,0,Yes,No
+Adult Major Depressive Disorder (MDD): Coordination of Care of Patients with Specific Comorbid Conditions,325,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Atrial Fibrillation and Atrial Flutter: Chronic Anticoagulation Therapy,326,Medicare Part B Claims,Process,Y,20.6,89.5,84.13 - 95.28,95.29 - 98.79,98.80 - 99.99,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Atrial Fibrillation and Atrial Flutter: Chronic Anticoagulation Therapy,326,MIPS CQM,Process,Y,18,81.2,69.54 - 75.10,75.11 - 78.89,78.90 - 83.08,83.09 - 88.16,88.17 - 94.93,94.94 - 99.99,--,100,No,No
+Pediatric Kidney Disease: ESRD Patients Receiving Dialysis: Hemoglobin Level < 10g/dL,328,MIPS CQM,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Adult Kidney Disease: Catheter Use at Initiation of Hemodialysis,329,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Adult Kidney Disease: Catheter Use for Greater Than or Equal to 90 Days,330,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Adult Sinusitis: Antibiotic Prescribed for Acute Viral Sinusitis (Overuse),331,MIPS CQM,Process,Y,34.5,61.5,92.15 - 87.51,87.50 - 82.89,82.88 - 75.37,75.36 - 64.36,64.35 - 46.68,46.67 - 20.00,19.99 - 0.01,0,No,No
+Adult Sinusitis: Appropriate Choice of Antibiotic: Amoxicillin With or Without Clavulanate Prescribed for Patients with Acute Bacterial Sinusitis (Appropriate Use),332,MIPS CQM,Process,Y,15.4,93.2,93.55 - 96.19,96.20 - 97.58,97.59 - 98.39,98.40 - 99.35,99.36 - 99.99,--,--,100,Yes,No
+Adult Sinusitis: Computerized Tomography (CT) for Acute Sinusitis (Overuse),333,MIPS CQM,Efficiency,Y,6.7,2.2,2.50 - 0.91,0.90 - 0.27,0.26 - 0.01,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Maternity Care: Elective Delivery or Early Induction Without Medical Indication at >= 37 and < 39 Weeks (Overuse),335,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Maternity Care: Post-Partum Follow-Up and Care Coordination,336,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Psoriasis: Tuberculosis (TB) Prevention for Patients with Psoriasis, Psoriatic Arthritis and Rheumatoid Arthritis Patients on a Biological Immune Response Modifier",337,MIPS CQM,Process,Y,30,72.1,47.06 - 60.60,60.61 - 73.62,73.63 - 82.50,82.51 - 89.99,90.00 - 96.42,96.43 - 99.99,--,100,No,No
+HIV Viral Load Suppression,338,MIPS CQM,Outcome,Y,24.2,80.9,74.47 - 78.56,78.57 - 83.99,84.00 - 87.93,87.94 - 93.99,94.00 - 97.23,97.24 - 99.99,--,100,No,No
+HIV Medical Visit Frequency,340,MIPS CQM,Process,Y,25.8,71.5,48.97 - 52.85,52.86 - 61.08,61.09 - 82.68,82.69 - 87.99,88.00 - 92.85,92.86 - 95.91,95.92 - 99.99,100,No,No
+Pain Brought Under Control Within 48 Hours,342,MIPS CQM,Outcome,Y,9.2,96.6,98.78 - 99.99,--,--,--,--,--,--,100,Yes,No
+Screening Colonoscopy Adenoma Detection Rate,343,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Rate of Carotid Artery Stenting (CAS) for Asymptomatic Patients, Without Major Complications (Discharged to Home by Post-Operative Day #2)",344,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of Asymptomatic Patients Undergoing Carotid Artery Stenting (CAS) Who Are Stroke Free or Discharged Alive,345,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of Asymptomatic Patients Undergoing Carotid Endarterectomy (CEA) Who Are Stroke Free or Discharged Alive,346,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) Who Are Discharged Alive,347,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+HRS-3: Implantable Cardioverter-Defibrillator (ICD) Complications Rate,348,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Total Knee Replacement: Shared Decision-Making: Trial of Conservative (Non-surgical) Therapy,350,MIPS CQM,Process,Y,14.8,94.4,96.00 - 99.99,--,--,--,--,--,--,100,Yes,No
+Total Knee Replacement: Venous Thromboembolic and Cardiovascular Risk Evaluation,351,MIPS CQM,Process,Y,16.7,95.3,--,--,--,--,--,--,--,100,Yes,No
+Total Knee Replacement: Preoperative Antibiotic Infusion with Proximal Tourniquet,352,MIPS CQM,Process,Y,4.8,98.8,--,--,--,--,--,--,--,100,Yes,No
+Total Knee Replacement: Identification of Implanted Prosthesis in Operative Report,353,MIPS CQM,Process,Y,6.3,98.6,--,--,--,--,--,--,--,100,Yes,No
+Anastomotic Leak Intervention,354,MIPS CQM,Outcome,Y,4.1,2.2,3.61 - 3.24,3.23 - 0.74,0.73 - 0.01,--,--,--,--,0,Yes,No
+Unplanned Reoperation within the 30 Day Postoperative Period,355,MIPS CQM,Outcome,Y,11.9,3.5,3.15 - 2.28,2.27 - 1.22,1.21 - 0.41,0.40 - 0.01,--,--,--,0,Yes,No
+Unplanned Hospital Readmission within 30 Days of Principal Procedure,356,MIPS CQM,Outcome,Y,14.5,5,5.00 - 3.31,3.30 - 2.01,2.00 - 0.01,--,--,--,--,0,Yes,No
+Surgical Site Infection (SSI),357,MIPS CQM,Outcome,Y,16.1,4.8,3.48 - 2.28,2.27 - 0.94,0.93 - 0.01,--,--,--,--,0,Yes,No
+Patient-Centered Surgical Risk Assessment and Communication,358,MIPS CQM,Process,Y,38.6,72.2,17.29 - 61.78,61.79 - 91.42,91.43 - 97.63,97.64 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Optimizing Patient Exposure to Ionizing Radiation: Count of Potential High Dose Radiation Imaging Studies: Computed Tomography (CT) and Cardiac Nuclear Medicine Studies,360,MIPS CQM,Process,Y,34.1,75.9,31.53 - 61.37,61.38 - 90.54,90.55 - 98.82,98.83 - 99.99,--,--,--,100,Yes,No
+Optimizing Patient Exposure to Ionizing Radiation: Reporting to a Radiation Dose Index Registry,361,MIPS CQM,Structure,Y,14.3,96.5,--,--,--,--,--,--,--,100,Yes,No
+Optimizing Patient Exposure to Ionizing Radiation: Computed Tomography (CT) Images Available for Patient Follow-up and Comparison,362,MIPS CQM,Structure,Y,21.9,94.4,--,--,--,--,--,--,--,100,Yes,No
+Optimizing Patient Exposure to Ionizing Radiation: Appropriateness: Follow-up CT Imaging for Incidentally Detected Pulmonary Nodules According to Recommended Guidelines,364,MIPS CQM,Process,Y,25.3,84.6,59.02 - 93.24,93.25 - 97.64,97.65 - 99.80,99.81 - 99.99,--,--,--,100,Yes,No
+Follow-Up Care for Children Prescribed ADHD Medication (ADD),366,eCQM,Process,Y,16.4,40.2,26.67 - 30.86,30.87 - 33.95,33.96 - 38.09,38.10 - 46.45,46.46 - 48.83,48.84 - 54.54,54.55 - 65.90,>= 65.91,No,No
+Depression Remission at Twelve Months,370,eCQM,Outcome,Y,9.7,7.1,2.08 - 2.69,2.70 - 3.69,3.70 - 4.34,4.35 - 5.31,5.32 - 7.13,7.14 - 8.76,8.77 - 14.99,>= 15.00,No,No
+Depression Remission at Twelve Months,370,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Depression Utilization of the PHQ-9 Tool,371,eCQM,Process,Y,19.1,18.6,3.82 - 6.11,6.12 - 9.08,9.09 - 12.68,12.69 - 16.66,16.67 - 22.08,22.09 - 30.29,30.30 - 43.13,>= 43.14,No,No
+Maternal Depression Screening,372,eCQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Closing the Referral Loop: Receipt of Specialist Report,374,eCQM,Process,Y,31.7,41.2,7.63 - 14.97,14.98 - 26.32,26.33 - 36.73,36.74 - 48.14,48.15 - 60.24,60.25 - 74.43,74.44 - 90.74,>= 90.75,No,No
+Closing the Referral Loop: Receipt of Specialist Report,374,MIPS CQM,Process,Y,40,53.1,6.77 - 8.50,8.51 - 37.83,37.84 - 62.85,62.86 - 82.42,82.43 - 88.88,88.89 - 92.73,92.74 - 99.01,>= 99.02,No,No
+Functional Status Assessment for Total Knee Replacement,375,eCQM,Process,Y,27.7,29,5.00 - 9.67,9.68 - 15.90,15.91 - 20.30,20.31 - 24.55,24.56 - 34.37,34.38 - 53.41,53.42 - 77.26,>= 77.27,No,No
+Functional Status Assessment for Total Hip Replacement,376,eCQM,Process,Y,24.5,26.5,4.82 - 8.50,8.51 - 13.09,13.10 - 19.22,19.23 - 27.58,27.59 - 33.32,33.33 - 40.18,40.19 - 63.48,>= 63.49,No,No
+Functional Status Assessments for Congestive Heart Failure,377,eCQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Children Who Have Dental Decay or Cavities,378,eCQM,Outcome,Y,1.6,0.4,0.47 - 0.10,0.09 - 0.01,--,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+"Primary Caries Prevention Intervention as Offered by Primary Care Providers, including Dentists",379,eCQM,Process,Y,7.4,3.6,0.32 - 0.54,0.55 - 0.73,0.74 - 1.08,1.09 - 2.07,2.08 - 3.21,3.22 - 4.89,4.90 - 9.04,>= 9.05,No,No
+Child and Adolescent Major Depressive Disorder (MDD): Suicide Risk Assessment,382,eCQM,Process,Y,23.8,22.8,3.43 - 7.00,7.01 - 12.46,12.47 - 14.83,14.84 - 20.25,20.26 - 29.00,29.01 - 36.10,36.11 - 51.71,>= 51.72,No,No
+Adherence to Antipsychotic Medications For Individuals with Schizophrenia,383,MIPS CQM,Intermediate Outcome,Y,21.1,82.1,58.00 - 71.42,71.43 - 86.83,86.84 - 90.00,90.01 - 98.32,98.33 - 99.99,--,--,100,No,No
+Adult Primary Rhegmatogenous Retinal Detachment Surgery: No Return to the Operating Room Within 90 Days of Surgery,384,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Adult Primary Rhegmatogenous Retinal Detachment Surgery: Visual Acuity Improvement Within 90 Days of Surgery,385,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Amyotrophic Lateral Sclerosis (ALS) Patient Care Preferences,386,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Annual Hepatitis C Virus (HCV) Screening for Patients who are Active Injection Drug Users,387,MIPS CQM,Process,Y,20.5,7.1,0.38 - 0.45,0.46 - 0.58,0.59 - 0.76,0.77 - 1.31,1.32 - 1.40,1.41 - 1.60,1.61 - 2.86,>= 2.87,No,No
+Cataract Surgery with Intra-Operative Complications (Unplanned Rupture of Posterior Capsule Requiring Unplanned Vitrectomy),388,MIPS CQM,Outcome,Y,4.8,0.4,--,--,--,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Cataract Surgery: Difference Between Planned and Final Refraction,389,MIPS CQM,Outcome,Y,22.4,87.6,77.17 - 90.90,90.91 - 96.96,96.97 - 99.21,99.22 - 99.99,--,--,--,100,No,No
+Hepatitis C: Discussion and Shared Decision Making Surrounding Treatment Options,390,MIPS CQM,Process,Y,24.1,84.2,63.64 - 80.86,80.87 - 95.44,95.45 - 99.99,--,--,--,--,100,Yes,No
+Follow-Up After Hospitalization for Mental Illness (FUH),391,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+HRS-12: Cardiac Tamponade and/or Pericardiocentesis Following Atrial Fibrillation Ablation,392,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"HRS-9: Infection within 180 Days of Cardiac Implantable Electronic Device (CIED) Implantation, Replacement, or Revision",393,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Immunizations for Adolescents,394,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Lung Cancer Reporting (Biopsy/Cytology Specimens),395,Medicare Part B Claims,Process,Y,3.7,98.9,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Lung Cancer Reporting (Biopsy/Cytology Specimens),395,MIPS CQM,Process,Y,9.7,98,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Lung Cancer Reporting (Resection Specimens),396,MIPS CQM,Process,Y,0.5,99.9,--,--,--,--,--,--,--,100,Yes,No
+Lung Cancer Reporting (Resection Specimens),396,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Melanoma Reporting,397,Medicare Part B Claims,Process,Y,2.6,99.2,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Melanoma Reporting,397,MIPS CQM,Process,Y,25.6,89.5,91.96 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Optimal Asthma Control,398,MIPS CQM,Outcome,Y,33.8,71.9,33.52 - 59.45,59.46 - 74.99,75.00 - 95.99,96.00 - 98.98,98.99 - 99.99,--,--,100,No,No
+One-Time Screening for Hepatitis C Virus (HCV) for Patients at Risk,400,MIPS CQM,Process,Y,28.6,20.9,1.26 - 1.84,1.85 - 3.22,3.23 - 6.30,6.31 - 16.77,16.78 - 24.10,24.11 - 32.00,32.01 - 74.59,>= 74.60,No,No
+Hepatitis C: Screening for Hepatocellular Carcinoma (HCC) in Patients with Cirrhosis,401,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Tobacco Use and Help with Quitting Among Adolescents,402,MIPS CQM,Process,Y,13.8,91.2,86.36 - 91.17,91.18 - 94.11,94.12 - 96.11,96.12 - 97.58,97.59 - 98.83,98.84 - 99.99,--,100,Yes,No
+Adult Kidney Disease: Referral to Hospice,403,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Anesthesiology Smoking Abstinence,404,MIPS CQM,Intermediate Outcome,Y,24.2,61.2,39.88 - 50.58,50.59 - 57.24,57.25 - 62.99,63.00 - 69.74,69.75 - 75.26,75.27 - 82.40,82.41 - 93.37,>= 93.38,No,No
+Appropriate Follow-up Imaging for Incidental Abdominal Lesions,405,Medicare Part B Claims,Process,Y,16.7,7.8,10.26 - 4.45,4.44 - 0.73,0.72 - 0.01,--,--,--,--,0,Yes,No
+Appropriate Follow-up Imaging for Incidental Abdominal Lesions,405,MIPS CQM,Process,Y,9.8,5.8,12.11 - 6.68,6.67 - 2.64,2.63 - 0.54,0.53 - 0.01,--,--,--,0,Yes,No
+Appropriate Follow-up Imaging for Incidental Thyroid Nodules in Patients,406,Medicare Part B Claims,Process,Y,34.7,31.2,61.90 - 48.01,48.00 - 37.51,37.50 - 15.57,15.56 - 2.57,2.56 - 0.01,--,--,0,No,No
+Appropriate Follow-up Imaging for Incidental Thyroid Nodules in Patients,406,MIPS CQM,Process,Y,18.2,9.4,14.94 - 5.98,5.97 - 3.65,3.64 - 0.10,0.09 - 0.01,--,--,--,0,Yes,No
+Appropriate Treatment of Methicillin-Sensitive Staphylococcus Aureus (MSSA) Bacteremia,407,MIPS CQM,Process,Y,4.8,98.7,--,--,--,--,--,--,--,100,Yes,No
+Appropriate Treatment of Methicillin-Sensitive Staphylococcus Aureus (MSSA) Bacteremia,407,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Opioid Therapy Follow-up Evaluation,408,MIPS CQM,Process,Y,29.8,83.1,68.35 - 91.35,91.36 - 98.48,98.49 - 99.99,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Clinical Outcome Post Endovascular Stroke Treatment,409,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Psoriasis: Clinical Response to Oral Systemic or Biologic Medications,410,MIPS CQM,Outcome,Y,32.8,59.2,23.08 - 36.35,36.36 - 49.99,50.00 - 61.53,61.54 - 72.21,72.22 - 87.49,87.50 - 97.21,97.22 - 99.99,100,No,No
+Depression Remission at Six Months,411,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Documentation of Signed Opioid Treatment Agreement,412,MIPS CQM,Process,Y,32.2,81.1,61.17 - 88.34,88.35 - 97.43,97.44 - 99.66,99.67 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Door to Puncture Time for Endovascular Stroke Treatment,413,MIPS CQM,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Evaluation or Interview for Risk of Opioid Misuse,414,MIPS CQM,Process,Y,21.3,91.1,88.55 - 98.59,98.60 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older,415,Medicare Part B Claims,Efficiency,Y,3.6,98.2,96.00 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older,415,MIPS CQM,Efficiency,Y,14.9,77.7,63.41 - 69.99,70.00 - 76.18,76.19 - 80.36,80.37 - 83.45,83.46 - 86.48,86.49 - 89.60,89.61 - 98.20,>= 98.21,No,No
+Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,416,MIPS CQM,Efficiency,Y,17.8,30.5,46.67 - 40.01,40.00 - 35.01,35.00 - 28.38,28.37 - 22.82,22.81 - 18.76,18.75 - 14.82,14.81 - 9.53,<= 9.52,No,No
+Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,416,Medicare Part B Claims,Efficiency,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of Open Repair of Small or Moderate Abdominal Aortic Aneurysms (AAA) Where Patients Are Discharged Alive,417,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Osteoporosis Management in Women Who Had a Fracture,418,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Osteoporosis Management in Women Who Had a Fracture,418,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Overuse of Imaging for the Evaluation of Primary Headache,419,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Overuse of Imaging for the Evaluation of Primary Headache,419,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Varicose Vein Treatment with Saphenous Ablation: Outcome Survey,420,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate Assessment of Retrievable Inferior Vena Cava (IVC) Filters for Removal,421,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Performing Cystoscopy at the Time of Hysterectomy for Pelvic Organ Prolapse to Detect Lower Urinary Tract Injury,422,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Performing Cystoscopy at the Time of Hysterectomy for Pelvic Organ Prolapse to Detect Lower Urinary Tract Injury,422,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Perioperative Temperature Management,424,MIPS CQM,Outcome,Y,8.9,97.2,98.46 - 99.51,99.52 - 99.74,99.75 - 99.87,99.88 - 99.99,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Photodocumentation of Cecal Intubation,425,Medicare Part B Claims,Process,Y,15.6,94.7,97.44 - 98.48,98.49 - 99.15,99.16 - 99.99,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Photodocumentation of Cecal Intubation,425,MIPS CQM,Process,Y,4.4,98.1,97.59 - 98.31,98.32 - 98.73,98.74 - 99.04,99.05 - 99.29,99.30 - 99.50,99.51 - 99.76,99.77 - 99.99,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Pelvic Organ Prolapse: Preoperative Assessment of Occult Stress Urinary Incontinence,428,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Pelvic Organ Prolapse: Preoperative Screening for Uterine Malignancy,429,Medicare Part B Claims,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Pelvic Organ Prolapse: Preoperative Screening for Uterine Malignancy,429,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prevention of Post-Operative Nausea and Vomiting (PONV) - Combination Therapy,430,MIPS CQM,Process,Y,13.2,94.3,93.66 - 97.17,97.18 - 98.53,98.54 - 99.21,99.22 - 99.63,99.64 - 99.91,99.92 - 99.99,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Preventive Care and Screening: Unhealthy Alcohol Use: Screening & Brief Counseling,431,MIPS CQM,Process,Y,33,66.4,33.43 - 49.34,49.35 - 66.11,66.12 - 78.12,78.13 - 86.99,87.00 - 93.51,93.52 - 97.95,97.96 - 99.99,100,No,No
+Proportion of Patients Sustaining a Bladder Injury at the Time of any Pelvic Organ Prolapse Repair,432,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Proportion of Patients Sustaining a Bowel Injury at the time of any Pelvic Organ Prolapse Repair,433,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Proportion of Patients Sustaining a Ureter Injury at the Time of any Pelvic Organ Prolapse Repair,434,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Quality of Life Assessment For Patients With Primary Headache Disorders,435,MIPS CQM,Patient Reported Outcome,Y,42.3,38.3,2.05 - 3.02,3.03 - 5.49,5.50 - 12.43,12.44 - 25.81,25.82 - 75.85,75.86 - 99.99,--,100,No,No
+Quality of Life Assessment For Patients With Primary Headache Disorders,435,Medicare Part B Claims,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Radiation Consideration for Adult CT: Utilization of Dose Lowering Techniques,436,Medicare Part B Claims,Process,Y,23.3,88.4,85.73 - 94.12,94.13 - 97.45,97.46 - 98.95,98.96 - 99.65,99.66 - 99.99,--,--,100,Yes,No
+Radiation Consideration for Adult CT: Utilization of Dose Lowering Techniques,436,MIPS CQM,Process,Y,20.2,92,93.28 - 96.96,96.97 - 99.05,99.06 - 99.66,99.67 - 99.91,99.92 - 99.99,--,--,100,Yes,No
+Rate of Surgical Conversion from Lower Extremity Endovascular Revascularization Procedure,437,Medicare Part B Claims,Outcome,Y,6.6,2,1.32 - 0.56,0.55 - 0.01,--,--,--,--,--,0,Yes,No
+Rate of Surgical Conversion from Lower Extremity Endovascular Revascularization Procedure,437,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Statin Therapy for the Prevention and Treatment of Cardiovascular Disease,438,eCQM,Process,Y,19.1,82.2,63.75 - 71.06,71.07 - 77.11,77.12 - 84.26,84.27 - 99.99,--,--,--,100,No,No
+Statin Therapy for the Prevention and Treatment of Cardiovascular Disease,438,MIPS CQM,Process,Y,16.9,89.8,78.72 - 91.66,91.67 - 95.64,95.65 - 97.37,97.38 - 99.99,--,--,--,100,Yes,No
+Age Appropriate Screening Colonoscopy,439,MIPS CQM,Efficiency,N,--,--,--,--,--,--,--,--,--,--,--,No
+Basal Cell Carcinoma (BCC)/Squamous Cell Carcinoma (SCC): Biopsy Reporting Time - Pathologist to Clinician,440,MIPS CQM,Process,Y,21.1,92.2,96.91 - 98.95,98.96 - 99.87,99.88 - 99.99,--,--,--,--,100,Yes,No
+Ischemic Vascular Disease (IVD) All or None Outcome Measure (Optimal Control),441,MIPS CQM,Intermediate Outcome,Y,13.4,42.9,32.40 - 37.13,37.14 - 40.16,40.17 - 44.03,44.04 - 47.77,47.78 - 50.61,50.62 - 54.35,54.36 - 58.25,>= 58.26,No,No
+Persistence of Beta-Blocker Treatment After a Heart Attack,442,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Non-Recommended Cervical Cancer Screening in Adolescent Females,443,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Medication Management for People with Asthma,444,MIPS CQM,Process,Y,12.6,94.3,91.67 - 95.99,96.00 - 97.77,97.78 - 98.43,98.44 - 99.99,--,--,--,100,Yes,No
+Risk-Adjusted Operative Mortality for Coronary Artery Bypass Graft (CABG),445,MIPS CQM,Outcome,Y,2.2,2.5,3.90 - 3.17,3.16 - 2.69,2.68 - 2.25,2.24 - 1.73,1.72 - 1.23,1.22 - 0.01,--,0,No,No
+Operative Mortality Stratified by the Five STS-EACTS Mortality Categories,446,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate Work Up Prior to Endometrial Ablation,448,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+HER2 Negative or Undocumented Breast Cancer Patients Spared Treatment with HER2-Targeted Therapies,449,MIPS CQM,Process,Y,5.4,97.4,95.71 - 98.52,98.53 - 99.99,--,--,--,--,--,100,Yes,No
+Trastuzumab Received By Patients With AJCC Stage I (T1c) -  III And HER2 Positive Breast Cancer Receiving Adjuvant Chemotherapy,450,MIPS CQM,Process,Y,23.7,87.4,90.00 - 90.90,90.91 - 93.54,93.55 - 99.99,--,--,--,--,100,Yes,No
+RAS (KRAS and NRAS) Gene Mutation Testing Performed for Patients with Metastatic Colorectal Cancer who receive Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibody Therapy,451,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patients with Metastatic Colorectal Cancer and RAS (KRAS or NRAS) 4 with Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibodies,452,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Proportion Receiving Chemotherapy in the Last 14 Days of Life,453,MIPS CQM,Process,Y,6.3,8.9,15.00 - 10.43,10.42 - 9.19,9.18 - 8.00,7.99 - 7.36,7.35 - 7.04,7.03 - 2.39,2.38 - 0.01,0,No,No
+Proportion of Patients who Died from Cancer with more than One Emergency Department Visit in the Last 30 Days of Life,454,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Proportion Admitted to the Intensive Care Unit (ICU) in the Last 30 Days of Life,455,MIPS CQM,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Proportion Not Admitted To Hospice,456,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Proportion Admitted to Hospice for less than 3 days,457,MIPS CQM,Outcome,Y,7.6,10.7,15.38 - 15.01,15.00 - 13.52,13.51 - 11.11,11.10 - 9.65,9.64 - 6.46,6.45 - 0.01,--,0,No,No
+Average Change in Back Pain following Lumbar Discectomy / Laminotomy,459,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Average Change in Back Pain following Lumbar Fusion,460,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Average Change in Leg Pain following Lumbar Discectomy and/or Laminotomy,461,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Bone Density Evaluation for Patients with Prostate Cancer and Receiving Androgen Deprivation Therapy,462,eCQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prevention of Post-Operative Vomiting (POV) - Combination Therapy (Pediatrics),463,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Otitis Media with Effusion (OME): Systemic Antimicrobials- Avoidance of Inappropriate Use,464,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Uterine Artery Embolization Technique: Documentation of Angiographic Endpoints and.Interrogation of Ovarian Arteries,465,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Developmental Screening in the First Three Years of Life,467,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Continuity of Pharmacotherapy for Opioid Use Disorder (OUD),468,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Average Change in Functional Status Following Lumbar Fusion Surgery,469,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Average Change In Functional Status Following Total Knee Replacement Surgery,470,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Average Change in Functional Status Following Lumbar Discectomy/Laminotomy Surgery,471,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate Use of DXA Scans in Women Under 65 Years Who Do Not Meet the Risk Factor Profile for Osteoporotic Fracture,472,eCQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Average Change in Leg Pain Following Lumbar Fusion Surgery,473,MIPS CQM,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Zoster (Shingles) Vaccination,474,MIPS CQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+HIV Screening,475,eCQM,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Asthma Assessment and Classification,AAAAI11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Lung Function/Spirometry Evaluation,AAAAI12,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Asthma Control: Minimal Important Difference Improvement,AAAAI17,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Penicillin Allergy: Appropriate Removal or Confirmation,AAAAI18,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Asthma: Assessment of Asthma Control – Ambulatory Care Setting,AAAAI2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Documentation of Clinical Response to Allergen Immunotherapy within One Year,AAAAI6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Achievement of Projected Effective Dose of Standardized Allergens for Patient Treated With Allergen Immunotherapy for at Least One Year ,AAAAI8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Assessment of Asthma Symptoms Prior to Administration of Allergen Immunotherapy Injection(s) ,AAAAI9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Psoriasis: Assessment of Psoriasis Disease Activity,AAD1,QCDR measure,Process,Y,33,42.5,10.16 - 18.74,18.75 - 25.12,25.13 - 35.83,35.84 - 43.47,43.48 - 57.07,57.08 - 76.76,76.77 - 99.99,100,No,No
+Psoriasis: Screening for Psoriatic Arthritis,AAD2,QCDR measure,Process,Y,23.9,87.6,82.44 - 95.44,95.45 - 99.99,--,--,--,--,--,100,Yes,No
+Basal Cell Carcinoma/Squamous Cell Carcinoma: Mohs Surgery for Superficial Basal Cell Carcinoma of the Trunk for Immune Competent Patients,AAD3,QCDR measure,Process,Y,2.1,1,1.58 - 0.01,--,--,--,--,--,--,0,Yes,No
+Basal Cell Carcinoma/Squamous Cell Carcinoma: Mohs Surgery for Squamous Cell Carcinoma in Situ or Keratoacanthoma Type Squamous Cell Carcinoma 1 cm or Smaller on the Trunk,AAD4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Biopsy: Reporting Time - Clinician to Patient,AAD5,QCDR measure,Process,Y,23,87,73.58 - 90.13,90.14 - 98.61,98.62 - 99.99,--,--,--,--,100,Yes,No
+Diabetes/Pre-Diabetes Screening for Patients with DSP,AAN1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Falls screening (aggregation of AAN disease specific falls measures),AAN10,QCDR measure,Process,Y,34.3,42.1,4.09 - 11.95,11.96 - 22.21,22.22 - 30.42,30.43 - 53.84,53.85 - 65.26,65.27 - 81.94,81.95 - 90.33,>= 90.34,No,No
+Overuse of barbiturate and opioid containing medications for primary headache disorders ,AAN11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Quality of Life Assessment for Patients with Epilepsy,AAN12,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Current MS Disability Scale Score,AAN14,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Quality of Life Assessment,AAN15,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Falls Outcome for Patients with Parkinson's Disease,AAN16,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+First line treatment for infantile spasms (IS),AAN18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Botulinum Toxin Serotype A (BoNT-A) for spasticity or dystonia,AAN19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+DSP Screening for Unhealthy Alcohol Use ,AAN2,QCDR measure,Process,Y,9.7,48.4,42.45 - 46.26,46.27 - 47.02,47.03 - 49.31,49.32 - 52.30,52.31 - 53.46,53.47 - 55.12,55.13 - 59.18,>= 59.19,No,No
+Querying for co-morbid conditions of tic disorder (TD) and Tourette syndrome (TS),AAN20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Screening for Psychiatric or Behavioral Health Disorders,AAN4,QCDR measure,Process,Y,32.3,64.4,27.59 - 41.34,41.35 - 58.32,58.33 - 74.06,74.07 - 83.90,83.91 - 94.11,94.12 - 98.13,98.14 - 99.73,>= 99.74,No,No
+MEDICATION PRESCRIBED FOR ACUTE MIGRAINE ATTACK,AAN5,QCDR measure,Process,Y,16.6,30.1,14.50 - 16.66,16.67 - 22.40,22.41 - 28.43,28.44 - 32.46,32.47 - 40.19,40.20 - 45.50,45.51 - 53.00,>= 53.01,No,No
+Exercise and Appropriate Physical Activity Counseling for Patients with MS,AAN8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Querying About Symptoms of Autonomic Dysfunction for Patients with Parkinson's Disease ,AAN9,QCDR measure,Process,Y,30.2,79.9,61.54 - 82.60,82.61 - 92.85,92.86 - 94.58,94.59 - 97.49,97.50 - 99.99,--,--,100,No,No
+Otitis Media with Effusion: Avoidance of Topical Intranasal Corticosteroids,AAO11,QCDR measure,Process,Y,1.4,99.5,99.60 - 99.99,--,--,--,--,--,--,100,Yes,No
+Topical Ear Drop Monotherapy for Children with Acute Tympanostomy Tube Otorrhea ,AAO12,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Inappropriate Use of Magnetic Resonance Imaging or Computed Tomography Scan for Bell’s Palsy (Inverse Measure),AAO13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Inappropriate Use of Antiviral Monotherapy for Bell’s Palsy (Inverse Measure),AAO14,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percentage of patients with cerumen impaction and a suggestive history of a non-intact tympanic membrane who receive just manual removal.,AAO15,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Audiometric Evaluation for Older Adults with Hearing Loss ,AAO16,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Advanced Diagnostic Imaging of Bilateral Presbycusis or Symmetric Sensorineural Hearing Loss-Avoidance of Inappropriate Use ,AAO17,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percentage of visits with patients with hearing aids where otoscopy is routinely performed,AAO18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Shared Decision Making for Treatment Options for Bilateral Presbycusis or Symmetric Sensorineural Hearing Loss,AAO19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Otitis Media with Effusion: Hearing Testing,AAO20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Audiometry for Chronic Otitis Media with Effusion in Children,AAO21,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percentage of patients with allergic rhinitis who do not receive sinonasal imaging for allergic rhinitis ,AAO22,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percentage of patients with allergic rhinitis who are offered intranasal corticosteroids or oral antihistamines,AAO23,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percentage of patients with allergic rhinitis who do not receive leukotriene inhibitors,AAO24,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percentage of patients with allergic rhinitis who do not receive IgG-based immunoglobulin testing,AAO25,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Otitis Media with Effusion: Diagnostic Evaluation - Assessment of Tympanic Membrane Mobility,AAO26,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Otitis Media with Effusion: Resolution of Otitis Media with Effusion in Children,AAO27,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Otitis Media with Effusion: Resolution of Otitis Media with Effusion in Adults,AAO28,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Otitis Media with Effusion: Antihistamines or Decongestants – Avoidance of Inappropriate Use,AAO8,QCDR measure,Process,Y,0.8,99.8,--,--,--,--,--,--,--,100,Yes,No
+All Patients Who Die an Expected Death with an ICD that Has Been Deactivated,ABFM1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patients Admitted to ICU who Have Care Preferences Documented,ABFM2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patients Treated with an Opioid Who Are Given a Bowel Regimen,ABFM3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Palliative Care – Spiritual Assessment,ABFM4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Palliative Care—Treatment Preferences,ABFM5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Palliative Care Timely Dyspnea Screening & Treatment,ABFM6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Pain Brought Under Control within the first three visits,ABFM7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Measuring the Value-Functions of Primary Care: Provider Level Continuity Measure,ABFM8,QCDR measure,Structure,N,--,--,--,--,--,--,--,--,--,--,--,No
+Intra-operative anesthesia safety,ABG1,QCDR measure,Outcome,Y,0.2,100,99.98 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Planned use of difficult airway equipment,ABG16,QCDR measure,Process,Y,25.7,71.6,56.01 - 61.14,61.15 - 72.26,72.27 - 77.96,77.97 - 82.24,82.25 - 89.40,89.41 - 94.18,94.19 - 99.83,>= 99.84,No,No
+Pre-operative OSA assessment,ABG21,QCDR measure,Process,Y,34.1,67.1,29.34 - 48.18,48.19 - 62.50,62.51 - 84.86,84.87 - 90.41,90.42 - 95.13,95.14 - 99.76,99.77 - 99.99,100,No,No
+Pre-Operative Screening for GERD,ABG28,QCDR measure,Process,Y,32.2,58.2,32.09 - 44.87,44.88 - 50.15,50.16 - 52.83,52.84 - 58.27,58.28 - 87.25,87.26 - 98.87,98.88 - 99.99,100,No,No
+Pre-Operative Screening for Glaucoma,ABG29,QCDR measure,Process,Y,32.3,77.8,44.29 - 67.22,67.23 - 95.02,95.03 - 99.50,99.51 - 99.99,--,--,--,100,Yes,No
+Pre-Operative Screening for PONV Risk,ABG30,QCDR measure,Process,Y,24.9,86,76.64 - 93.46,93.47 - 97.59,97.60 - 99.05,99.06 - 99.66,99.67 - 99.99,--,--,100,Yes,No
+Pre-Operative Screening for Excessive Alcohol and Recreational Drug Use,ABG31,QCDR measure,Process,Y,25.5,87.5,89.72 - 98.87,98.88 - 99.66,99.67 - 99.97,99.98 - 99.99,--,--,--,100,Yes,No
+Pain Related Quality of Life Interference,ABG32,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Lower Body Functional Impairment (LBI),ABG33,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Mood Assessment Screening and treatment ,ABG34,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Preoperative Assessment of Frailty,ABG35,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Corneal Abrasion,ABG36,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Immediate Adult Post-Operative Pain Management,ABG7,QCDR measure,Outcome,Y,3.5,98.4,97.85 - 98.62,98.63 - 99.28,99.29 - 99.82,99.83 - 99.99,--,--,--,100,Yes,No
+ACCPin3 Heart Failure: Patient Self Care Education,ACCPin3,QCDR measure,Process,Y,0,100,--,--,--,--,--,--,--,100,Yes,No
+Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older,ACEP19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,ACEP20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Coagulation Studies in Patients Presenting with Chest Pain with No Coagulopathy or Bleeding,ACEP21,QCDR measure,Process,Y,17.5,15.5,24.61 - 19.33,19.32 - 15.93,15.92 - 9.06,9.05 - 5.75,5.74 - 3.78,3.77 - 0.01,--,0,No,No
+Appropriate Emergency Department Utilization of CT for Pulmonary Embolism,ACEP22,QCDR measure,Process,Y,18.8,25.3,8.00 - 14.99,15.00 - 18.95,18.96 - 22.72,22.73 - 26.55,26.56 - 29.46,29.47 - 36.66,36.67 - 50.58,>= 50.59,No,No
+Pregnancy Test for Female Abdominal Pain Patients,ACEP24,QCDR measure,Process,Y,18.5,65.6,55.27 - 60.22,60.23 - 64.28,64.29 - 68.37,68.38 - 73.24,73.25 - 77.93,77.94 - 80.55,80.56 - 84.76,>= 84.77,No,No
+Tobacco Use: Screening and Cessation Intervention for Patients with Asthma and COPD,ACEP25,QCDR measure,Process,Y,14.5,73.6,63.89 - 67.52,67.53 - 71.87,71.88 - 74.99,75.00 - 78.78,78.79 - 81.81,81.82 - 85.70,85.71 - 89.99,>= 90.00,No,No
+Sepsis Management: Septic Shock: Repeat Lactate Level Measurement,ACEP29,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Sepsis Management: Septic Shock: Lactate Clearance Rate of >=10%,ACEP30,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate Foley Catheter Use in the Emergency Department,ACEP31,QCDR measure,Process,Y,21.9,63,43.04 - 51.99,52.00 - 59.08,59.09 - 63.36,63.37 - 69.04,69.05 - 73.07,73.08 - 88.09,88.10 - 91.66,>= 91.67,No,No
+ED Median Time from ED arrival to ED departure for discharged ED patients for Adult Patients,ACEP32,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"ED Median Time from ED arrival to ED departure for discharged ED patients for Adult Patients in Supercenter EDs
+(80k +)",ACEP33,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"ED Median Time from ED arrival to ED departure for discharged ED patients for Adult Patients in High Volume EDs (60k-79,999)",ACEP35,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"ED Median Time from ED arrival to ED departure for discharged ED patients for Adult Patients in Average Volume EDs (40k-59,999)",ACEP36,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"ED Median Time from ED arrival to ED departure for discharged ED patients for Adult Patients in Moderate Volume EDs (20k-39,999)",ACEP37,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"ED Median Time from ED arrival to ED departure for discharged ED patients for Adult Patients in Low Volume EDs (19,999 and less)",ACEP38,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+ED Median Time from ED arrival to ED departure for discharged ED patients for Adult Patients in Freestanding Ends,ACEP39,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+ED Median Time from ED arrival to ED departure for discharged ED patients for Pediatric Patients,ACEP40,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+ED Median Time from ED arrival to ED departure for discharged ED patients for Pediatric Patients in Supercenter EDs (80k +),ACEP41,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"ED Median Time from ED arrival to ED departure for discharged ED patients for Pediatric Patients in High Volume EDs (60k-79,999)",ACEP43,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"ED Median Time from ED arrival to ED departure for discharged ED patients for Pediatric Patients in Average Volume EDs (40k-59,999)",ACEP44,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"ED Median Time from ED arrival to ED departure for discharged ED patients for Pediatric Patients in Moderate Volume EDs (20k-39,999)",ACEP45,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"ED Median Time from ED arrival to ED departure for discharged ED patients for Pediatric Patients in Low Volume EDs (19,999 and less)",ACEP46,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+ED Median Time from ED arrival to ED departure for discharged ED patients for Pediatric Patients in Freestanding EDs,ACEP47,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Sepsis Management: Septic Shock: Lactate Level Management, Antibiotics Ordered, and Fluid Resuscitation",ACEP48,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Screening for risk of opioid misuse/overuse,ACMT1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Pregnancy test in women who receive a toxicologic consult,ACMT2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+EKG assessment in acute overdoses,ACMT3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate treatment for acetaminophen ingestions,ACMT4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Assessment of suspected ethylene glycol or methanol exposures,ACMT5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Repeat assessment of salicylate concentrations in overdose patients,ACMT6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+High Risk Pneumococcal Vaccination,ACPGR1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Tdap (Tetanus, Diphtheria, Acellular Pertussis) Vaccination",ACPGR2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Fixed-dose Combination of Hydralazine and Isosorbide Dinitrate Therapy for Self-identified Black or African American Patients with Heart Failure and LVEF <40% on ACEI or ARB and Beta-blocker Therapy,ACPGR3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+COPD Exacerbation Requiring Hospital Admission: Palliative Care Evaluation,ACQR1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+COPD Exacerbation: % of patients discharged from inpatient status on Long Acting Beta Agonist (LABA) bronchodilator,ACQR2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+COPD: Steroids for no more than 5 days in COPD Exacerbation,ACQR3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CHF Exacerbation Requiring Hospital Admission: Palliative Care Evaluation,ACQR4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CHF: Document AHA/ACC staging of CHF (A-D),ACQR5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"POLST Utilization: POLST form reviewed or completed for any patients with limited code status (i.e. any status other than, ""Attempt Resuscitation"" if unresponsive, pulseless and not breathing;  and ""Full Treatment"" if patient is pulseless and breathing)",ACQR6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Sepsis Management: Septic Shock: Repeat Lactate Level Measurement within 6 hours,ACQR7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Stroke/TIA: % of patients discharged on antithrombotic therapy,ACQR8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Gout: Serum Urate Target ,ACR7,QCDR measure,Intermediate Outcome,Y,20.2,39.2,21.19 - 28.09,28.10 - 34.77,34.78 - 38.16,38.17 - 41.88,41.89 - 46.53,46.54 - 58.87,58.88 - 67.14,>= 67.15,No,No
+CT Colonography True Positive Rate,ACRad1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Report Turnaround Time: Radiography (modified),ACRad15,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Report Turnaround Time: Ultrasound (Excluding Breast US),ACRad16,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Report Turnaround Time: MRI,ACRad17,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Report Turnaround Time: CT,ACRad18,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Report Turnaround Time: PET,ACRad19,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Lung Cancer Screening Cancer Detection Rate (CDR),ACRad21,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Lung Cancer Screening Positive Predictive Value (PPV),ACRad22,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Report Turnaround Time: Mammography,ACRad25,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate venous access for hemodialysis,ACRad26,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of early peristomal infection following fluoroscopically guided gastrostomy tube placement,ACRad28,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of percutaneous nephrostomy tube replacement within 30 days secondary to dislodgement,ACRad29,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Screening Mammography Cancer Detection Rate (CDR),ACRad3,QCDR measure,Outcome,Y,0.3,0.4,0.18 - 0.23,0.24 - 0.30,0.31 - 0.42,0.43 - 0.48,0.49 - 0.53,0.54 - 0.61,0.62 - 0.79,>= 0.80,No,No
+Rate of Inadequate Percutaneous Image-Guided Biopsy,ACRad30,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent of CT Abdomen-pelvis exams with contrast (single phase scan) for which Dose Length Product is at or below the size-specific diagnostic reference level.,ACRad31,QCDR measure,Outcome,Y,0,100,--,--,--,--,--,--,--,100,Yes,No
+Percent of CT Chest exams without contrast (single phase scan) for which Dose Length Product is at or below the size-specific diagnostic reference level.,ACRad32,QCDR measure,Outcome,Y,0,100,--,--,--,--,--,--,--,100,Yes,No
+Percent of CT Head/Brain exams without contrast (single phase scan) for which Dose Length Product is at or below the size-specific diagnostic reference level,ACRad33,QCDR measure,Outcome,Y,0,100,--,--,--,--,--,--,--,100,Yes,No
+Screening Mammography Positive Predictive Value 2 (PPV2 - Biopsy Recommended),ACRad6,QCDR measure,Outcome,Y,8.6,27.3,20.00 - 21.61,21.62 - 23.07,23.08 - 26.08,26.09 - 29.89,29.90 - 31.99,32.00 - 35.58,35.59 - 37.15,>= 37.16,No,No
+Screening Mammography Node Negativity Rate,ACRad7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Screening Mammography Minimal Cancer Rate,ACRad8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Preoperative Composite,ACS15,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
+Preventative Care and Screening: Tobacco Screening and Cessation Intervention,ACS16,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Preoperative Key Medications Review for Anticoagulation Medication,ACS17,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Frailty Evaluation,ACS18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Intraoperative Composite ,ACS19,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
+Optimal Postoperative Communication Plan and Patient Care Coordination Composite,ACS20,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
+Post-Acute Recovery Composite,ACS21,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
+Unplanned Reoperation within the 30 Day Postoperative Period,ACS22,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Unplanned Hospital Readmission within 30 Days of Principal Procedure,ACS23,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Surgical Phases of Care Patient-Reported Outcome Composite Measure,ACS24,QCDR measure,Patient Engagement Experience,N,--,--,--,--,--,--,--,--,--,--,--,No
+Surgical Site Infection (SSI),ACS25,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Trauma Initial Assessment Composite,ACSTrauma1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Mortality Rate Following Blunt Traumatic Injury to the Chest and/or Abdomen,ACSTrauma2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Mortality Rate Following Penetrating Traumatic Injury to the Chest and/or Abdomen,ACSTrauma3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Splenic Salvage Rate,ACSTrauma4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Optimal Timing of Surgical or Procedural Intervention for Hemorrhage in Trauma,ACSTrauma5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Optimal Ratio of Blood Product Transfusion,ACSTrauma6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Timely Initiation of VTE Prophylaxis in Trauma Patients,ACSTrauma7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Ventral Hernia Repair: Surgical Site Occurrence Requiring Procedural Intervention within the 30 Day Postoperative Period,AHSQC1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Unplanned Hospital Readmission or Observation Visit within the 30 Day Postoperative Period,AHSQC2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Abdominal Wall Reconstruction Surgical Site Occurrence Requiring Procedural Intervention within the 30 Day Postoperative Period,AHSQC6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Ventral Hernia Repair: Biologic Mesh Prosthesis Use in Low Risk Patients,AHSQC8,QCDR measure,Cost/Resource Use,N,--,--,--,--,--,--,--,--,--,--,--,No
+Ventral Hernia Repair: Pain and Functional Status Assessment,AHSQC9,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Hip Arthroplasty: Postoperative Complications within 90 Days Following the Procedure,AJRR1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Hip Arthroplasty: Shared Decision-Making: Trial of Conservative (Non-surgical) Therapy,AJRR3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Hip Arthroplasty: Venous Thromboembolic and Cardiovascular Risk Evaluation,AJRR4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Comprehensive Diabetic Foot Examination,APMA1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Coronary Artery Bypass Graft (CABG): Prolonged Intubation – Inverse Measure,AQI18,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Coronary Artery Bypass Graft (CABG): Stroke – Inverse Measure,AQI41,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Coronary Artery Bypass Graft (CABG): Post-Operative Renal Failure – Inverse Measure,AQI42,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient-Reported Experience with Anesthesia ,AQI48,QCDR measure,Patient Reported Outcome,Y,29.9,78.8,55.23 - 60.02,60.03 - 94.51,94.52 - 99.08,99.09 - 99.98,99.99 - 99.99,--,--,100,Yes,No
+Adherence to Blood Conservation Guidelines for Cardiac Operations using Cardiopulmonary Bypass (CPB) – Composite,AQI49,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
+Application of Lung-Protective Ventilation during General Anesthesia,AQI50,QCDR measure,Intermediate Outcome,Y,5.9,98.4,99.14 - 99.45,99.46 - 99.82,99.83 - 99.99,--,--,--,--,100,Yes,No
+Assessment of Patients for Obstructive Sleep Apnea,AQI51,QCDR measure,Process,Y,31.1,83.5,79.31 - 92.61,92.62 - 96.39,96.40 - 99.34,99.35 - 99.79,99.80 - 99.94,99.95 - 99.99,--,100,Yes,No
+Documentation of Anticoagulant and Antiplatelet Medications when Performing Neuraxial Anesthesia/Analgesia or Interventional Pain Procedures,AQI53,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Use of Pencil-Point Needle for Spinal Anesthesia,AQI54,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Team-Based Implementation of a Care-and-Communication Bundle for ICU Patients,AQI55,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Use of Neuraxial Techniques and/or Peripheral Nerve Blocks for Total Knee Arthroplasty (TKA),AQI56,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Safe Opioid Prescribing Practices,AQI57,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
+Infection Control Practices for Open Interventional Pain Procedures,AQI58,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
+Multimodal Pain Management,AQI59,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+New Corneal Injury Not Diagnosed Prior to Discharge ,AQI60,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Benign Prostate Hyperplasia: IPSS improvement after diagnosis,AQUA12,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Stress Urinary Incontinence (SUI): Revision surgery within 12 months of incontinence procedure,AQUA13,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Stones: Repeat Shock Wave Lithotripsy (SWL) within 6 months of treatment,AQUA14,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Stones: Urinalysis documented 30 days before surgical stone procedures,AQUA15,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Non-Muscle Invasive Bladder Cancer: Repeat Transurethral Resection of Bladder Tumor (TURBT) for T1 disease,AQUA16,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Non-Muscle Invasive Bladder Cancer: Initiation of BCG 3 months of diagnosis of high-grade T1 bladder cancer and/or CIS,AQUA17,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Non-Muscle Invasive Bladder Cancer: Early surveillance cystoscopy within 4 months of initial diagnosis,AQUA18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Diagnosis of Type of Azoospermia and Diagnostic Testing for Obstructive Azoospermia,AQUA19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Genetic Testing  of the Azoospermic Male,AQUA20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate Management of Obstructive Azoospermia,AQUA21,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Bone imaging and soft tissue imaging at the time of diagnosis of metastatic CRPC,AQUA22,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Blood work for patients receiving abiraterone,AQUA23,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Testosterone and PSA levels checked for CRPC patients,AQUA24,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Use of Prednisone for CRPC patients on abiraterone,AQUA25,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+ Benign Prostate Hyperplasia Care: Benign Prostate Hyperplasia,AQUA26,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate Testing for Vasectomy Patients,AQUA27,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+ Hypogonadism: Testosterone and hematocrit within 6 months of starting testosterone replacement,AQUA28,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prostate Cancer: Patient Report of Urinary function after treatment,AQUA29,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cryptorchidism: Inappropriate use of scrotal/groin ultrasound on boys,AQUA3,QCDR measure,Cost/Resource Use,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prostate Cancer: Patient Report of Sexual function after treatment,AQUA30,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Hospital admissions/complications within 30 days of TRUS Biopsy,AQUA8,QCDR measure,Outcome,Y,3.5,3.2,5.13 - 4.23,4.22 - 3.22,3.21 - 2.64,2.63 - 1.02,1.01 - 0.70,0.69 - 0.01,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Risk Standardized Mortality Rate within 30 days following Trauma Operation,ARCO10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Head CT or MRI Scan Results for Acute Ischemic Stroke or Hemorrhagic Stroke Patients who Received Head CT or MRI Scan Interpretation within 45 minutes of ED Arrival,ARCO11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+STK-01: Venous Thromboembolism (VTE) Prophylaxis,ARCO12,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+STK 02: Ischemic stroke patients management - ,ARCO13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Diabetes: Nutritional, Weight Loss Counseling, Reduction of Sedentary Behavior",ARCO15,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Dyspnea or Heart Failure: Use of BNP or NT- pro BNP screening,ARCO16,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Heart Failure: Use of Aldosterone Antagonists and Diuretics for Symptom Control,ARCO17,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Heart Failure: Counseling on Self-care, Including Monitoring Blood Pressure, Weight, Sodium Intake, and Physical Activity",ARCO18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Promoting self-care for prevention and management of chronic conditions,ARCO19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Percentage of patients using self-monitoring with mobile technology or eHealth solutions to manage their diabetes, hypertension, sodium intake, nutritional status, physical activity, tobacco use, alcohol use, and sedentary behaviors",ARCO20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Antipsychotic Use in Persons with Dementia,ARCO3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Surgeon assessment for hereditary cause of breast cancer,ASBS1,QCDR measure,Process,Y,2.2,99.3,99.16 - 99.99,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Management of the axilla in breast cancer patients undergoing breast conserving surgery with a positive sentinel node biopsy,ASBS10,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Return to the operating room for re-excision of previous microscopically negative margins in invasive breast cancer patients undergoing breast conserving therapy ,ASBS12,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Sentinel Node Biopsy for Patients with Ductal Carcinoma in Situ Alone ,ASBS13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Recommendation of Neoadjuvant Chemotherapy for Her2Neu positive invasive breast cancers that are >2.0cm in size and/or have needle biopsy proven axillary metastases. ,ASBS14,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Unplanned 30 day re-operation after mastectomy,ASBS7,QCDR measure,Outcome,Y,2.4,98.6,98.15 - 98.46,98.47 - 99.99,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Cardiac Stress Nuclear Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low Risk Surgery Patients,ASNC1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Imaging Protocols for SPECT and PET MPI studies - Use of stress only protocol,ASNC19,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cardiac Stress Nuclear Imaging Not Meeting Appropriate Use Criteria: Routine Testing After Percutaneous Coronary Intervention (PCI),ASNC2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+SPECT-MPI studies performed without the use of thallium,ASNC20,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+SPECT-MPI study appropriate imaging protocol selection for morbidly obese patients,ASNC21,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+SPECT and PET MPI studies reporting Left Ventricular Ejection Fraction,ASNC22,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+SPECT-MPI study clinical utilization of Attenuation Correction image acquisition,ASNC23,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+SPECT-MPI study utilization of exercise as a stressor,ASNC24,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+SPECT-MPI study adequate exercise testing performed,ASNC25,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+SPECT and PET MPI studies meeting appropriate use criteria,ASNC26,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+SPECT and PET MPI studies not Equivocal,ASNC27,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Effective dose less than or equal to 9 millisieverts as per ASNC guideline recommendations,ASNC28,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+SPECT and PET MPI study documentation of stress perfusion defects,ASNC29,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Cardiac Stress Nuclear Imaging Not Meeting Appropriate Use Criteria: Testing in Asymptomatic, Low-Risk Patients",ASNC3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+" Transthoracic Echo (TTE) studies meeting appropriate use criteria
+",ASNC30,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Transthoracic Echo (TTE) studies reporting pulmonary artery pressures, 100% views, contrast use  
+",ASNC31,QCDR measure,Efficiency,N,--,--,--,--,--,--,--,--,--,--,--,No
+Avoiding myocardial Injury ,ASPIRE18,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Avoiding acute kidney injury,ASPIRE19,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Train of Four Monitor Documented After Last Dose of Non-depolarizing Neuromuscular Blocker,ASPIRE2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Application of Lung-Protective Ventilation during General Anesthesia,ASPIRE6,QCDR measure,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Satisfaction with Information Provided during Breast Reconstruction,ASPS10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Operative Time for Autologous Breast Reconstruction,ASPS11,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Unplanned hospital admission after panniculectomy,ASPS12,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Wound disruption rate after primary panniculectomy in patients with BMI > or = to 35,ASPS13,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Wound disruption rate after primary panniculectomy in patients with BMI < 35,ASPS14,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Seroma rate after primary panniculectomy,ASPS15,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Breast Reconstruction: Return to OR,ASPS5,QCDR measure,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Breast Reconstruction: Flap Loss,ASPS6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of Blood Transfusion for Patients Undergoing Autologous Breast Reconstruction,ASPS7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Coordination of Care for Patients Undergoing Breast Reconstruction,ASPS8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Length of Stay Following Autologous Breast Reconstruction,ASPS9,QCDR measure,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Complete assessment and evaluation of patient’s pelvic organ prolapse prior to surgical repair,AUGS1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Documentation of offering a preoperative pessary for Pelvic Organ Prolapse,AUGS10,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Documentation that a trial of conservative management was offered prior to use of procedure based therapy for urgency urinary incontinence,AUGS11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Preoperative assessment of sexual function prior to pelvic organ prolapse repair,AUGS3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Performing an intraoperative rectal examination at the time of prolapse repair,AUGS4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Performing vaginal apical suspension at the time of hysterectomy to address pelvic organ prolapse,AUGS5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Route of Hysterectomy,AUGS6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Documentation that conservative management was offered prior to fecal incontinence surgery or procedures,AUGS7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Documentation of weight loss counseling prior to surgery for stress urinary incontinence procedures for obese women,AUGS8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Over-utilization of synthetic mesh in the posterior compartment,AUGS9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Reported Comprehensive Assessment of Safety,BIVARUS27,QCDR measure,Patient Engagement Experience,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Reported Experience and Care Coordination,BIVARUS28,QCDR measure,Patient Engagement Experience,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Reported Care Team Communication,BIVARUS32,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Reported Procedure Readiness and Care ,BIVARUS33,QCDR measure,Patient Engagement Experience,N,--,--,--,--,--,--,--,--,--,--,--,No
+Turn-Around Time (TAT) - Standard biopsies,CAP1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cancer Protocol Elements for Carcinoma and Carcinosarcoma of the Endometrium,CAP2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cancer Protocol Elements for Invasive Carcinoma of Renal Tubular Origin,CAP3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cancer Protocol Elements for Carcinoma of the Intrahepatic Bile Ducts Completed,CAP4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cancer Protocol Elements for Hepatocellular Carcinoma Completed,CAP5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cancer Protocol Elements for Carcinoma of the Pancreas Completed,CAP6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Helicobacter pylori documentation rate,CAP7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Turn-Around Time (TAT) - Lactate,CAP8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Turn-Around Time (TAT) - Troponin,CAP9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+1-Year Patient-Reported Pain and Function Improvement after Total Knee Arthroplasty,CCOME1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+1-Year Patient-Reported Pain and Function Improvement after Total Hip Arthroplasty,CCOME2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+1-Year Patient-Reported Pain and Function Improvement after Total Shoulder Arthroplasty,CCOME3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+1-Year Patient-Reported Pain and Function Improvement after ACLR Surgery,CCOME4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Extent of Osteoarthritis Observed in Arthroscopic Partial Meniscectomy,CCOME5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+1-Year Patient-Reported Pain and Function Improvement after APM Surgery,CCOME6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Adequate Off-loading of Diabetic Foot Ulcer at each visit,CDR1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Diabetic Foot Ulcer (DFU) Healing or Closure ,CDR2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Plan of Care Creation for Diabetic Foot Ulcer (DFU) Patients not Achieving 30% Closure at 4 Weeks AND Plan of Care Creation for Venous Leg Ulcer (VLU) Patients not Achieving 30% Closure at 4 Weeks,CDR3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Adequate Compression at each visit for Patients with VLUs ,CDR5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Venous Leg Ulcer (VLU) outcome measure: Healing or Closure,CDR6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate Use of hyperbaric oxygen therapy for patients with diabetic foot ulcers,CDR8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate Use of Cellular and/or Tissue Based Product (CTP) in diabetic foot ulcers (DFUs) or venous leg ulcer (VLUs) among patients 18 years or older,CDR9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Post operative hypocalcemia after thyroidectomy surgery,CESQIP1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Related readmission for thyroid or parathyroid related problems,CESQIP2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Pre operative ultrasound exam of patients with thyroid cancer,CESQIP3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Persistent hypercalcemia,CESQIP4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Related readmission for adrenal related problems,CESQIP5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Vocal cord dysfunction following thyroidectomy,CESQIP7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Hematoma requiring evacuation following thyroidectomy,CESQIP8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Back Pain: Use of EMG & CNS,CLLC1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Morton's Neuroma - Avoidance of Alcohol Injections,CLLC2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cancer Patients - Survivorship Care Plan,CLLC3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Foot Bone Infection Diagnosis Without MRI,CLLC4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Global Physical Health Outcome Assessment for Shoulder Replacement,CODE1,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Global Physical Health Outcome Assessment for Shoulder Arthroscopy,CODE10,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Functional Outcome Assessment for Knee Arthroscopy,CODE11,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Functional Outcome Assessment for Hip Arthroscopy,CODE12,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Functional Outcome Assessment for ACL Repair,CODE2,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Functional Outcome Assessment for Foot/Ankle Repair,CODE3,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Global Physical Health Outcome Assessment for Spine Surgery,CODE5,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Functional Outcome Assessment for Hip Replacement,CODE6,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Functional Outcome Assessment for Knee Replacement,CODE7,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Global Physical Health Outcome Assessment for Cervical Surgery,CODE8,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Global Physical Health Outcome Assessment for Hand/Wrist/Elbow Repair,CODE9,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"CAHPS Clinician/Group Surveys - (Adult Primary Care, Pediatric Care, and Specialist Care Surveys)",CUHSM3,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+CAHPS Health Plan Survey v 4.0 - Adult questionnaire,CUHSM4,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Adherence to Mood Stabilizers for Individuals with Bipolar I Disorder,CUHSM6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cardiovascular Health Screening for People With Schizophrenia or Bipolar Disorder Who Are Prescribed Antipsychotic Medications,CUHSM8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOneEGFR,CURE1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOneNSCLCBRAFTTP,CURE10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOneMelBRAFTTP,CURE11,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOneALK,CURE2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOneROS1,CURE3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOneNSCLCBRAF,CURE4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOnePDL1,CURE5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOneMelBRAF,CURE6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOneEGFRTTP,CURE7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOneALKTTP,CURE8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+CureOneROS1TTP,CURE9,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Three Day All Cause Return ED Visit Rate,ECPR11,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Door to Diagnostic Evaluation by a Provider – Emergency Department (ED) Patients,ECPR2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Mean Time from Emergency Department (ED) Arrival to ED Departure for Discharged Lower Acuity ED Patients,ECPR5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Mean Time from Emergency Department (ED) Arrival to ED Departure for Discharged Higher Acuity ED Patients,ECPR6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Avoid Head CT for Patients with Uncomplicated Syncope,ECPR39,QCDR measure,Process,Y,8.9,87.6,83.33 - 84.77,84.78 - 87.17,87.18 - 88.44,88.45 - 90.90,90.91 - 92.67,92.68 - 94.43,94.44 - 96.98,>= 96.99,No,No
+Initiation of the Initial Sepsis Bundle,ECPR40,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rh Status Evaluation and Treatment of Pregnant Women at Risk of Fetal Blood Exposure ,ECPR41,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Restrictive Use of Blood Transfusions,ECPR42,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Avoidance of Creatine Kinase-MB (CK-MB) Testing for Non-traumatic Chest Pain ,ECPR45,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Avoidance of Opiate Prescriptions for Low Back Pain or Migraines,ECPR46,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Avoidance of Opiate Prescriptions for Greater Than 3 Days Duration for Acute Pain ,ECPR47,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Avoidance of Long-Acting (LA) or Extended-Release (ER) Opiate Prescriptions ,ECPR48,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Avoidance of Tramadol or Codeine for Children,ECPR49,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Door to Diagnostic Evaluation by a Provider Within 30 Minutes – Urgent Care Patients,ECPR50,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Preoperative Frailty Assessment,EPREOP28,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Preoperative Assessment for Opioid Dependence Risk ,EPREOP29,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Short-term Pain Management/Maximum Pain Score,EPREOP4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Review of Functional Status Assessment for Patients with Osteoarthritis,FORCE20,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Review of Pain Status Assessment for Patients with Osteoarthritis,FORCE21,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improvement in Pain after Knee Replacement,FORCE22,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improvement in Pain after Hip Replacement,FORCE23,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate management of anticoagulation in the peri-procedural period rate – EGD,GIQIC10,QCDR measure,Process,Y,31,65.2,31.25 - 52.34,52.35 - 61.53,61.54 - 66.77,66.78 - 81.35,81.36 - 90.90,90.91 - 98.90,98.91 - 99.99,100,No,No
+Appropriate indication for colonoscopy,GIQIC12,QCDR measure,Process,Y,10.5,89,83.71 - 87.91,87.92 - 90.17,90.18 - 91.82,91.83 - 93.51,93.52 - 95.00,95.01 - 96.57,96.58 - 98.14,>= 98.15,No,No
+Appropriate follow-up interval of 3 years recommended based on pathology findings from screening colonoscopy in average-risk patients,GIQIC15,QCDR measure,Process,Y,17.4,75.7,61.11 - 71.42,71.43 - 76.09,76.10 - 79.19,79.20 - 83.66,83.67 - 87.12,87.13 - 90.23,90.24 - 93.74,>= 93.75,No,No
+Appropriate follow-up interval of 5 years for colonoscopies with findings of sessile serrated polyps < 10 mm without dysplasia,GIQIC17,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate follow-up interval of not less than 5 years for colonoscopies with findings of 1-2 tubular adenomas < 10 mm,GIQIC18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate indication for esophagogastroduodenoscopy (EGD),GIQIC19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate follow-up interval of 10 years for colonoscopies with only hyperplastic polyp findings,GIQIC20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+HAdv1 - Use of high risk sleep medications in the elderly,HAdv1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+HAdv2 - Atrial Fibrillation Prevention and Treatment – Lifestyle and Disease Factor Assessment,HAdv2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Mean Length of Stay for Inpatients – Pneumonia,HCPR3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Mean Length of Stay for Inpatients – CHF,HCPR4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Mean Length of Stay for Inpatients – COPD,HCPR5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Stroke Venous Thromboembolism (VTE) Prophylaxis,HCPR13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Venous Thromboembolism (VTE) Prophylaxis,HCPR14,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Physician’s Orders for Life-Sustaining Treatment (POLST) Form,HCPR16,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Pressure Ulcers - Risk Assessment and Plan of Care,HCPR17,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Unintentional Weight Loss - Risk Assessment and Plan of Care,HCPR18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+30 Day All-Cause Readmission Rate for Discharged Inpatients,HCPR19,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Clostridium Difficile - Risk Assessment and Plan of Care,HCPR20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate Use of Telemetry for Admission or Observation Placement ,HCPR21,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Care Transfer of Care - Use of Verbal Checklist or Protocol,HCPR22,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Exclusive Breast Milk Feeding,HEF1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Surgical Reconstruction for Anterior Cruciate Ligament (ACL) Injury,HF2,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Shoulder Instability - Labral Reconstruction: Change in Validated Shoulder Patient Reported Outcome Measure Following Labral Reconstruction for Shoulder,HF3,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Shoulder Arthroscopy: Measure of Change in a Validated Shoulder Patient Reported Outcome Following Shoulder Arthroscopy,HF4,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Shoulder Arthroplasty: Change in a Validated Shoulder Patient Reported Outcome Measure Following Shoulder Arthroplasty,HF5,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Knee Arthroscopy for Meniscal Repair: Change in a Validated Knee Patient Reported Outcome Measure Following Knee Arthroscopy for Meniscal Repair,HF6,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Surgical Repair for Rotator Cuff Tear: Change in a Validated Shoulder Patient Reported Outcome Measure Following Surgical Rotator Cuff Repair,HF7,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+ACE/ARB use,HM1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+A1C treatment ,HM2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+A1C in good control,HM3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Hypogonadism: Serum T, CBC, PSA, IPSS within 6  months of Rx",IQSS1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Prostate Cancer: Newly diagnosed with document T, PSA, Gleason and Prostate Cancer: Initial Eval. Document T, PSA, Gleason",IQSS2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prostate Cancer: Treatment Options Counseling,IQSS3,QCDR measure,Patient Engagement Experience,N,--,--,--,--,--,--,--,--,--,--,--,No
+BPH: Anticholinergics,IQSS4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Counseling SUI,IQSS5,QCDR measure,Patient Engagement Experience,N,--,--,--,--,--,--,--,--,--,--,--,No
+Endothelial Keratoplasty: Post-operative improvement in best corrected visual acuity to 20/40 or greater,IRIS1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Exudative Age-Related Macular Degeneration - Loss of Visual Acuity,IRIS10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Nonexudative Age-Related Macular Degeneration - Loss of Visual Acuity ,IRIS11,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Diabetic Macular Edema - Loss of Visual Acuity,IRIS13,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Acute Anterior Uveitis - Post-treatment visual acuity,IRIS16,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Acute Anterior Uveitis - Post-treatment Grade 0 anterior chamber cells,IRIS17,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Chronic Anterior Uveitis -  Post-treatment visual acuity,IRIS18,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Glaucoma -  Intraocular Pressure (IOP) Reduction,IRIS2,QCDR measure,Outcome,Y,9.6,94.5,86.96 - 97.36,97.37 - 98.99,99.00 - 99.99,--,--,--,--,100,Yes,No
+Idiopathic Intracranial Hypertension:  No worsening or improvement of mean deviation,IRIS20,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Ocular Myasthenia Gravis:  Improvement of ocular deviation or absence of diplopia or functional improvement,IRIS21,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Giant Cell Arteritis:  Absence of fellow eye involvement after treatment ,IRIS22,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Refractive Surgery: Postoperative Improvement in Uncorrected Visual Acuity of 20/20 or better ,IRIS23,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Refractive Surgery:  Postoperative correction within + 0.5 Diopter of the Intended Correction,IRIS24,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Adenoviral Conjunctivitis:  Avoidance of Antibiotics,IRIS25,QCDR measure,Cost/Resource Use,N,--,--,--,--,--,--,--,--,--,--,--,No
+Intravitreal Injections: Avoidance of Routine Antibiotic Use,IRIS26,QCDR measure,Cost/Resource Use,N,--,--,--,--,--,--,--,--,--,--,--,No
+Adverse Events After Cataract Surgery,IRIS27,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Regaining Vision After Cataract Surgery,IRIS28,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved visual acuity after epiretinal membrane treatment within 90 days,IRIS29,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Glaucoma - Visual Field Progression,IRIS3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Return to OR within 90 days after epiretinal membrane surgical treatment,IRIS30,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Avoidance of Genetic Testing for Age-related Macular Degeneration,IRIS31,QCDR measure,Cost/Resource Use,N,--,--,--,--,--,--,--,--,--,--,--,No
+Evidence of anatomic closure of macular hole within 90 days after surgery as documented by OCT.,IRIS32,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Return to OR within 90 days after macular hole surgery,IRIS33,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Age-Related Macular Degeneration: Disease Progression,IRIS34,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Glaucoma - Intraocular Pressure Reduction Following Laser Trabeculoplasty,IRIS4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Surgery for Acquired Involutional Ptosis - Patients with an Improvement of Marginal Reflex Distance,IRIS5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Acquired Involutional Entropion -  Normalized Lid Position After Surgical Repair,IRIS6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Amblyopia - Interocular Visual Acuity,IRIS7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Surgical Esotropia - Postoperative Alignment,IRIS8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Diabetic Retinopathy - Documentation of the Presence or Absence of Macular Edema and the Level of Severity of Retinopathy,IRIS9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Functional Improvement in hip, leg or ankle rehabilitation in patients with lower extremity injury measured via the validated Lower Extremity Function Scale (LEFS) score. ",IROMS1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Improvement in low back rehabilitation of non-surgical patients with low pack pain measured via the validated Modified Low Back Pain Disability Questionnaire (MDQ).,IROMS10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Improvement in knee rehabilitation of patients with knee injury measured via their validated Knee Outcome Survey (KOS) score.,IROMS2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Functional Improvement in arm, shoulder, and hand rehabilitation in surgical patients with musculotendinous injury measured via the validated Disability of Arm Shoulder and Hand (DASH) score.",IROMS8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Improvement in neck pain/injury patients rehabilitation measured via the validated Neck Disability Index (NDI).,IROMS9,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+M2S 1: Procedures with statin and antiplatelet agents prescribed at discharge,M2S1,QCDR measure,Process,Y,12.3,79.4,70.25 - 77.54,77.55 - 80.46,80.47 - 81.25,81.26 - 81.61,81.62 - 84.56,84.57 - 89.82,89.83 - 92.81,>= 92.82,No,No
+M2S 10: Survival at least 9 months after elective repair of small thoracic aortic aneurysms ,M2S10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+M2S 11: Imaging-based maximum aortic diameter assessed at least 9 months following Endovascular AAA Repair procedures,M2S11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"M2S 12: Survival at least 9 months after elective repair Endovascular AAA Repair of small abdominal aortic aneurysms
+",M2S12,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"M2S 13: Survival at least 9 months after elective Open AAA repair of small abdominal aortic aneurysms
+
+",M2S13,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Absence of unplanned reoperation after closed lower extremity major amputation,M2S16,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+M2S 17: Absence of serious technical complications during peripheral arterial intervention,M2S17,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+M2S 19: Proper patient selection for perforator vein ablation,M2S19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"M2S 2: Amputation-free survival assessed at least 9 months following Infra-Inguinal Bypass for intermittent claudication
+
+",M2S2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+M2S 5: Amputation-free survival at assessed at least 9 months following Peripheral Vascular Intervention for intermittent claudication,M2S5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"M2S 7: Ipsilateral stroke-free survival at assessed at least 9 months following Carotid Artery Stenting for asymptomatic procedures 
+
+",M2S7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+" M2S 8: Ipsilateral stroke-free survival assessed at least 9 months following isolated Carotid Endarterectomy for asymptomatic procedures 
+
+",M2S8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+M2S 9: Imaging-based maximum aortic diameter assessed at least 9 months following Thoracic and Complex EVAR procedures,M2S9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Case Delay,MA1,QCDR measure,Efficiency,N,--,--,--,--,--,--,--,--,--,--,--,No
+Corneal Abrasion,MA3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Anxiety Utilization of the GAD-7 Tool,MBHR1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Anxiety Response at 6-months,MBHR2,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk standardized rate of patients who experienced a postoperative escalation in care event following a primary Laparoscopic Roux-en-Y Gastric Bypass or  Laparoscopic Sleeve Gastrectomy operation,MBSAQIP10,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk standardized rate of patients who experienced a pulmonary complication following a primary Laparoscopic Roux-en-Y Gastric Bypass or  Laparoscopic Sleeve Gastrectomy,MBSAQIP11,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk standardized rate of patients who experienced a postoperative complication following a primary Laparoscopic Roux-en-Y Gastric Bypass or  Laparoscopic Sleeve Gastrectomy operation,MBSAQIP12,QCDR measure,Composite,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Risk standardized rate of patients who experienced postoperative nausea, vomiting or fluid/electrolyte/nutritional depletion following a primary Laparoscopic Roux-en-Y Gastric Bypass or  Laparoscopic Sleeve Gastrectomy operation",MBSAQIP7,QCDR measure,Outcome,Y,1.4,1.2,2.13 - 1.85,1.84 - 1.29,1.28 - 0.40,0.39 - 0.01,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Risk standardized rate of patients who experienced an extended length of stay (> 3 days) following a primary Laparoscopic Roux-en-Y Gastric Bypass or  Laparoscopic Sleeve Gastrectomy operation,MBSAQIP8,QCDR measure,Outcome,Y,1.4,0.5,--,--,--,--,--,--,--,0,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Use of a “PEG Test” to Manage Patients Receiving Opioids,MEDNAX52,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX1: Heel Pain Treatment Outcomes for Adults,MEX1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Vascular Testing Outcome Measure Supervised Programs,MEX10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX2018-19: Non-Invasive Vascular Testing in Patients with Abnormal CVI Screening That Completed Hyperbaric Oxygen Therapy ,MEX11,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Peripheral Vascular Assessment % of Diabetic Patients 50+ ,MEX12,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX2018-22: Patients with Lower Limb Ulceration with a Previously Abnormal Vascular Study Receiving Negative Pressure Wound Therapy ,MEX13,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX2: Heel Pain Treatment Outcomes for Pediatric Patients,MEX2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX3: Identification of Flat Foot in Pediatric Patients,MEX3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX2018-2: Bunion Outcome - Adult and Adolescent,MEX4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX2018-3: Hammer Toe Outcome,MEX5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX2018-11: Peripheral Vascular Assessment - Patients 70+,MEX6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX2018-6: Foot Wound Outcome,MEX7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX2018-20: Non-Invasive Vascular Testing Follow-up in Patients After Revascularization,MEX8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+MEX2018-16: Non-Invasive Vascular Testing in Patients Diagnosed with Intermittent Claudication Who Use Cilostazol or Pentoxifylline,MEX9,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Plan All Cause Readmissions,MHAN3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+General Health Postoperative Improvement,MICS1,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Surgery Specific Postoperative Improvement in Pain Levels,MICS2,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Surgery Specific Postoperative Improvement in Function Levels,MICS3,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Perioperative Pain Plan,MIRAMED16,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of witnessed gastric aspiration,MIRAMED17,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Unplanned Conversion to General Anesthesia from Regional or MAC for all scheduled cases,MIRAMED18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Onset atrial fibrillation or dysrthymia requiring unanticipated therapy,MIRAMED19,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Perioperative cognitive function test in elderly,MIRAMED20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Ischemic Vascular Disease Use of Aspirin or Anti-platelet Medication,MNCM5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Diabetes A1c Control (<8.0),MNCM6,QCDR measure,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Objectifying pain and/or functionality to determine manipulative medicine efficacy with correlative treatment adjustment,MOA1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Treatment of spinal stenosis with manipulative medicine and alternative medicine modalities,MOA12,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Urine Drug Screen Utilization in Pain Management and Substance Use Disorders; no less than quarterly for pain and no less than monthly for substance use disorders,MOA13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Addressing anxiety in pain patients with SNRI and SSRIs and reducing/eliminating benzodiazepines for chronic anxiety,MOA14,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Weight loss in pain patients with BMI > = 30 with opiate utilization for weight related pain conditions rather than opiate dose escalation for improved pain control,MOA15,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate use of advanced imaging by ordering provider with glucocorticoid management to spare motor neuron loss when physical findings suggest neuropathic etiology,MOA2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate controlled substance prescribing (definitive diagnosis(es)) via adherence to Controlled Substance Agreements (CSA) or (OA's) with corrective action taken for pain and/or substance use disorder patients when violations occur,MOA7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Pre-surgical screening for depression,MSSIC1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent of patients achieving MCID for pain-related disability (ODI/NDI),MSSIC10,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent Satisfied with Result,MSSIC11,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-adjusted rate of hospital readmission,MSSIC12,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-adjusted rate of surgical site infection,MSSIC13,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-adjusted rate of urinary retention,MSSIC14,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent of patients achieving MCID for myelopathy,MSSIC16,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent same-day ambulation,MSSIC6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of use of Pre-op skin preparation/wash,MSSIC7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent of patients achieving MCID for back or neck pain,MSSIC8,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent of patients achieving MCID for leg or arm pain,MSSIC9,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prostate Biopsy Antibiotic Compliance,MUSIC1,QCDR measure,Process,Y,0.4,99.8,--,--,--,--,--,--,--,100,Yes,"Yes - see ""Scoring Examples"" tab of spreadsheet"
+Prostate Cancer: Confirmation Testing in low risk AS eligible patients,MUSIC10,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prostate Cancer: Follow-Up Testing for patients on active surveillance for at least 30 months,MUSIC11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prostate Cancer: Avoidance of Overuse of CT Scan for Staging Low Risk Prostate Cancer Patients,MUSIC3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prostate Cancer: Active Surveillance/Watchful Waiting for Low Risk Prostate Cancer Patients,MUSIC4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prostate Cancer:  Radical Prostatectomy Cases LOS,MUSIC5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prostate Biopsy: Repeat Biopsy for Patients with Atypical Small Acinar Proliferation (ASAP),MUSIC9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Telephone Contact, Virtual, or In-person Visit Within 48 Hours of Hospital Discharge of Home-Based Primary Care and Palliative Care Patients",NHBPC10,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Interdisciplinary Team Assessment for Home-Based Primary care and Palliative Care Patients,NHBPC13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cognitive Assessment for Home-Based Primary Care and Palliative Care Patients,NHBPC14,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+A Functional Assessment (Basic and Instrumental Activities of Daily Living [ADL]) for Home-Based Primary Care and Palliative Care Patients (Multiperformance Measure),NHBPC15,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Reported Outcome for Home-Based Primary Care and Palliative Care Practices   ,NHBPC16,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Screening for Depression and Follow-up Plan in Home-Based Primary Care and Palliative Care Patients,NHBPC17,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Alcohol Problem Use Assessment for Home-Based Primary Care and Palliative Care Patients,NHBPC2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Screen for Risk of Future Fall for Home-Based Primary Care and Palliative Care Patients,NHBPC6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Delirium Assessment in Home-Based Primary Care and Palliative Care Patients: Medication List Reviewed & Offending Medications Discontinued (Multiperformance-Rate Measure),NHBPC7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Referral to Hospice for Appropriate Home-Based Primary Care and Palliative Care Patients,NHBPC9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+NHCR4: Repeat screening or surveillance colonoscopy recommended within one year due to inadequate/poor bowel preparation ,NHCR4,QCDR measure,Process,Y,27.4,38.5,12.50 - 19.37,19.38 - 23.66,23.67 - 33.98,33.99 - 40.33,40.34 - 49.38,49.39 - 68.20,68.21 - 80.29,>= 80.30,No,No
+NHCR5: Repeat colonoscopy recommended due to piecemeal resection,NHCR5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate indication for colonoscopy,NHCR9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+COMMUNICATING CONCURRENT OPIOID AND BENZODIAZEPINE PRESCRIBING TO OTHER PRESCRIBERS,NIPM10,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+PATIENT COUNSELING REGARDING RISKS OF CO-PRESCRIBED OPIOIDS AND BENZODIAZEPINES,NIPM11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+FUNCTIONAL STATUS ASSESSMENT FOR SPINAL CORD STIMULATOR IMPLANTATION,NIPM12,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+FUNCTIONAL STATUS ASSESSMENT FOR LUMBAR MEDIAL BRANCH RADIOFREQUENCY ABLATION,NIPM13,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+FUNCTIONAL STATUS ASSESSMENT FOR CERVICAL MEDIAL BRANCH RADIOFREQUENCY ABLATION,NIPM14,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+REDUCTION IN PATIENT REPORTED PAIN FOLLOWING SPINAL CORD STIMULATOR IMPLANTATION FOR FAILED BACK SURGERY SYNDROME,NIPM15,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+REDUCTION IN PATIENT REPORTED PAIN FOLLOWING LUMBAR MEDIAL BRANCH RADIOFREQUENCY ABLATION,NIPM16,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+REDUCTION IN PATIENT REPORTED PAIN FOLLOWING CERVICAL/THORACIC MEDIAL BRANCH RADIOFREQUENCY ABLATION,NIPM17,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+APPROPRIATE PATIENT SELECTION FOR DIAGNOSTIC FACET JOINT PROCEDURES,NIPM4,QCDR measure,Cost/Resource Use,N,--,--,--,--,--,--,--,--,--,--,--,No
+AVOIDING EXCESSIVE USE OF EPIDURAL INJECTIONS IN MANAGING CHRONIC PAIN ORIGINATING IN THE CERVICAL AND THORACIC SPINE,NIPM8,QCDR measure,Cost/Resource Use,N,--,--,--,--,--,--,--,--,--,--,--,No
+AVOIDING EXCESSIVE USE OF THERAPEUTIC FACET JOINT INTERVENTIONS IN MANAGING CHRONIC CERVICAL AND THORACIC SPINAL PAIN ,NIPM9,QCDR measure,Cost/Resource Use,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: Pulmonary Embolism,NJIISMD1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: Ruptured Ectopic Pregnancy,NJIISMD10,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: New Deep Venous Thrombosis (DVT),NJIISMD11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: Ectopic Pregnancy,NJIISMD12,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Result Requiring Follow Up Protocol,NJIISMD17,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: Cord Compression,NJIISMD19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: ICH,NJIISMD2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: CTA of GI bleed,NJIISMD20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: Positive bleeding scan,NJIISMD21,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: Acute Ocular injury,NJIISMD22,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: Aortic Dissection,NJIISMD3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: Occlusive Intracranial Stroke,NJIISMD8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result: Placental abruption,NJIISMD9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Substance Use Screening,NNEPTN1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Transforming Clinical Practice Initiative Common Measure Name: Substance Use Screening and Intervention Composite,NNEPTN2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Transforming Clinical Practice Initiative Common Measure Name: TCP01: Documentation of a Comprehensive Health and Life Plan Developed Collaboratively by the Patient and the Health Professional Team,NNEPTN3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Median Time to Pain Management for Long Bone Fracture,NOF12,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Osteoporosis: Management Following Fracture of Hip, Spine or Distal Radius for Men and Women Aged 50 Years and Older",NOF13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Hip Fracture Mortality Rate (IQI 19),NOF6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Osteoporosis: percentage of patients, any age, with a diagnosis of osteoporosis who are either receiving both calcium & vitamin D intake, & exercise at least once within 12 months.",NOF7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Unplanned Readmission Following Spine Procedure within the 30-Day Postoperative Period,NPA11,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Selection of Prophylactic Antibiotic Prior to Spine Procedure,NPA12,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Medicine Reconciliation Following Spine Related Procedure,NPA14,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk Assessment for Elective Spine Procedure,NPA15,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Depression and Anxiety Assessment Prior to Spine-Related Therapies,NPA16,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Narcotic Pain Medicine Management Following Elective Spine Procedure,NPA17,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Smoking Assessment and Cessation Coincident With Spine-Related Therapies,NPA18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Body Mass Assessment and Follow-up Coincident With Spine-Related Therapies,NPA19,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Unhealthy Alcohol Use Assessment Coincident With Spine Care,NPA20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Spine/Extremity Pain Assessment,NPA23,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Outcome Assessment for Spine Intervention,NPA3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Quality-of-Life Assessment for Spine Intervention,NPA4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Satisfaction With Spine Care,NPA5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Spine-Related Procedure Site Infection,NPA6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Spine/Extremity Pain Assessment ,NPAGSC10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Outcome Assessment for Spine Intervention ,NPAGSC3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Quality-of-Life Assessment for Spine Intervention ,NPAGSC4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Satisfaction with Spine Care ,NPAGSC5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Depression and Anxiety Assessment Prior to Spine-Related Therapies,NPAGSC6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Narcotic Pain Medicine Management Prior to and Following Spine Therapy ,NPAGSC7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Complication Following Percutaneous Spine-Related Procedure ,NPAGSC8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Unplanned Admission to Hospital Following Percutaneous Spine Procedure within the 30-Day Post-procedure Period ,NPAGSC9,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Notification to the ordering provider requesting myoglobin or CK-MB in the diagnosis of suspected acute myocardial infarction (AMI). ,NPQR1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of amended pathology reports with a major discrepancy,NPQR10,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of communicating results of an amended report with a major discrepancy to the responsible provider ,NPQR11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of cytopathology case review,NPQR12,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of notification to clinical provider of a new diagnosis of malignancy ,NPQR13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Frozen section diagnosis within 20 minutes of receipt in lab (single block frozen section),NPQR14,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Notification to the ordering provider requesting thyroid screening tests other than only a Thyroid Stimulating Hormone (TSH) test in the initial screening of a patient with a suspected thyroid disorder,NPQR2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Notification to the ordering provider requesting amylase testing in the diagnosis of suspected acute pancreatitis,NPQR3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Time interval: critical value reporting for chemistry,NPQR4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Time interval: critical value reporting for cerebrospinal fluid - white blood cell (CSF - WBC),NPQR5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Time interval: critical value reporting for toxicology,NPQR6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Time interval: critical value reporting for troponin,NPQR7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of review of slides with high-grade squamous intraepithelial lesion (HSIL) with negative cervical biopsies,NPQR8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Rate of follow up letter after high-grade squamous intraepithelial lesion (HSIL) pap test,NPQR9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Post Stroke Outcome and Follow-Up,OBERD22,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Health Related Quality of Life: Patient Defined Outcomes,OBERD23,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Tracking Satisfaction Improvement with CG-CAHPS,OBERD25,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cervical Spine Functional Outcomes,OBERD26,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Foot/Ankle Functional Outcomes,OBERD27,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Hip Functional Outcomes,OBERD28,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Knee Functional Outcomes,OBERD29,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Lumbar Spine Functional Outcomes,OBERD30,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Quality of Life-Mental Health Outcomes,OBERD31,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Quality of Life - Physical Health Outcomes,OBERD32,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Acceptable Symptom State Outcomes,OBERD33,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Upper Extremity Functional Outcomes,OBERD34,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Emergent transfer from an outpatient, ambulatory surgical center, or office setting",OEIS2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Antiplatelet Therapy,OEIS3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+ Lipid-Lowering Medications for Patients with PAD,OEIS4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+ Appropriate non-invasive arterial testing for patients with intermittent claudication who are undergoing a LE peripheral vascular intervention,OEIS6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Goal Setting and Attainment for Cancer Survivors,ONSQIR18,QCDR measure,Patient Engagement Experience,N,--,--,--,--,--,--,--,--,--,--,--,No
+Fatigue Improvement,ONSQIR20,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Advance Care Planning in Stage 4 Disease,PIMSH1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Utilization of GCSF in Metastatic Colon Cancer,PIMSH2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Combination chemotherapy is recommended or administered within 4 months (120 days) of diagnosis for women under 70 with AJCC T1cN0M0 or Stage IB-III hormone receptor negative breast cancer,PIMSH3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-adjusted 30 day Readmission for Acute Myocardial Infarction,Pinc1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-adjusted 30 day Readmission for Heart Failure,Pinc2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-adjusted 30 day Readmission for Pneumonia,Pinc3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-Adjusted Average Length of Inpatient Hospital Stay for Acute Myocardial Infarction,Pinc33,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-Adjusted Average Length of Inpatient Hospital Stay for Heart Failure,Pinc34,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-Adjusted Average Length of Inpatient Hospital Stay for Pneumonia,Pinc35,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-adjusted 30 day Inpatient Mortality for Acute Myocardial Infarction,Pinc4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-adjusted 30 day Inpatient Mortality for Heart Failure ,Pinc5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risk-adjusted 30 day Inpatient Mortality for Pneumonia,Pinc6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Annual Monitoring for Patients on Persistent Medications (MPM),PP1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Follow-Up After Hospitalization for Schizophrenia (7- and 30-day),PP2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+ADHD: Symptom Reduction in Follow up Period,PP3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Risky Behavior Assessment or Counseling by Age 18 Years,PP4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Bipolar disorder: the percentage of patients diagnosed and treated for bipolar disorder who are monitored for change in their symptom complex within 12 weeks of initiating treatment; AND if there is no change or deterioration in symptoms, a revised care plan is documented following the 12 week monitoring phase",PP5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Pharmacological Treatment of Dementia,PP6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Use of Multiple Concurrent Antipsychotics in Children and Adolescents (APC),PP7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Chronic Kidney Disease (CKD): eGFR Monitoring,PPRNET13,QCDR measure,Process,Y,14.6,71.4,62.50 - 64.85,64.86 - 70.58,70.59 - 73.32,73.33 - 76.04,76.05 - 80.18,80.19 - 84.23,84.24 - 89.05,>= 89.06,No,No
+Chronic Kidney Disease (CKD): Hemoglobin Monitoring,PPRNET14,QCDR measure,Process,Y,12.4,82.7,72.62 - 77.21,77.22 - 82.85,82.86 - 87.29,87.30 - 89.86,89.87 - 90.53,90.54 - 93.09,93.10 - 94.58,>= 94.59,No,No
+Appropriate Treatment for Adults with Upper Respiratory Infection,PPRNET24,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"NSAID or Cox 2 Inhibitor Use in Patients with Heart Failure (HF), Hypertension (HTN), or Chronic Kidney Disease (CKD)",PPRNET28,QCDR measure,Process,Y,7.1,84.4,80.00 - 81.80,81.81 - 82.91,82.92 - 84.83,84.84 - 85.94,85.95 - 86.76,86.77 - 91.40,91.41 - 93.07,>= 93.08,No,No
+Monitoring Serum Creatinine,PPRNET29,QCDR measure,Process,Y,22.1,80.3,73.35 - 78.88,78.89 - 84.40,84.41 - 86.29,86.30 - 88.09,88.10 - 90.88,90.89 - 93.85,93.86 - 96.29,>= 96.30,No,No
+Screening for Type 2 Diabetes,PPRNET31,QCDR measure,Process,Y,18.8,83.4,82.72 - 84.17,84.18 - 85.53,85.54 - 87.24,87.25 - 90.70,90.71 - 92.15,92.16 - 93.92,93.93 - 96.19,>= 96.20,No,No
+Screening for albuminuria in patients at risk for CKD (DM and/or HTN),PPRNET32,QCDR measure,Process,Y,26.8,46.9,18.26 - 26.78,26.79 - 47.26,47.27 - 56.41,56.42 - 61.65,61.66 - 66.11,66.12 - 72.25,72.26 - 75.06,>= 75.07,No,No
+Avoiding Use of CNS Depressants in Patients on Long-Term Opioids,PPRNET33,QCDR measure,Process,Y,12,60.7,50.51 - 54.54,54.55 - 55.58,55.59 - 57.79,57.80 - 60.14,60.15 - 65.24,65.25 - 72.38,72.39 - 81.62,>= 81.63,No,No
+Zoster (Shingles) Vaccination,PPRNET34,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Antiplatelet Medication for High Risk Patients,PPRNET8,QCDR measure,Process,Y,18.2,47.4,27.68 - 36.18,36.19 - 41.59,41.60 - 47.90,47.91 - 50.61,50.62 - 59.08,59.09 - 67.67,67.68 - 74.60,>= 74.61,No,No
+Combination chemotherapy received within 4 months of diagnosis by women under 70 with AJCC stage IA (T1c) to III ER/PR negative breast cancer,QOPI11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+GCSF administered to patients who received chemotherapy for metastatic cancer (Lower Score -Better),QOPI15,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Oncology: Treatment Summary Communication – Radiation Oncology,QOPI21,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+External Beam Radiotherapy for Bone Metastases,QOPI22,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Chemotherapy administered to patients with metastatic solid tumor with performance status of 3, 4, or undocumented  (Lower Score - Better)",QOPI5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Central Line Ultrasound Guidance,Quantum31,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Case Cancellation on Day of Surgery,Quantum41,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+CKD 3-5 Patients Seen at the Recommended Frequency Levels,RCOIR1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Upper Extremity Edema Improvement,RCOIR10,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Optimal End Stage Renal Disease (ESRD) Starts,RCOIR11,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CKD 3-5 Patients with a Urine ACR or Urine PCR Lab Test,RCOIR3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+CKD 4-5 Patients with Transplant Referral,RCOIR4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+ESRD Prevalence of Home Dialysis or Self-Care,RCOIR5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Improved Access Site Bleeding,RCOIR7,QCDR measure,Outcome,Y,21.2,54.1,37.04 - 40.21,40.22 - 44.52,44.53 - 59.99,60.00 - 63.63,63.64 - 66.66,66.67 - 69.22,69.23 - 74.99,>= 75.00,No,No
+Post Procedure Bleeding,RCOIR8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Angiotensin Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy,RPAQIR1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Hospitalization Rate Following Procedures Performed under Procedure Sedation Analgesia,RPAQIR11,QCDR measure,Outcome,Y,0.6,0.3,0.58 - 0.27,0.26 - 0.08,0.07 - 0.01,--,--,--,--,0,Yes,No
+Arterial Complication Rate Following Arteriovenous Access Intervention,RPAQIR12,QCDR measure,Outcome,Y,0.7,0.6,0.99 - 0.74,0.73 - 0.55,0.54 - 0.40,0.39 - 0.01,--,--,--,0,Yes,No
+Rate of Timely Documentation Transmission to Dialysis Unit/Referring Physician,RPAQIR13,QCDR measure,Process,Y,7,94.2,92.85 - 94.06,94.07 - 94.94,94.95 - 95.86,95.87 - 97.27,97.28 - 97.88,97.89 - 99.20,99.21 - 99.76,>= 99.77,Yes,No
+Arteriovenous Graft Thrombectomy Success Rate,RPAQIR14,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Arteriovenous Fistulae Thrombectomy Success Rate,RPAQIR15,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Peritoneal Dialysis Catheter Success Rate,RPAQIR16,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Peritoneal Dialysis Catheter Exit Site Infection Rate,RPAQIR17,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Advance Directives Completed,RPAQIR18,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Adequacy of Volume Management,RPAQIR2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Arteriovenous Fistula Rate,RPAQIR4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Transplant Referral,RPAQIR5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Advance Care Planning (Pediatric Kidney Disease),RPAQIR9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Improvement in Quality of Life from Partial Foot, Prosthetics ",SCG05,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+SCG1 Evaluation of High Risk Pain Medications for MME,SCG1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+SCG2 Outcome Assessment for Patients Prescribed Ankle Orthosis for Ambulation and Functional Improvement,SCG2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Outcome Assessment for Patients Prescribed Foot Orthosis for Ambulation and Functional Improvement ,SCG3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prevention of Antibiotic or Herbal Supplement Impairment of Anesthesia ,SCG4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Outcome of High Risk Pain Medications Prescribed in Last 6 Months,SCG6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Education of patients with inflammatory diseases regarding increased cardiovascular risk and the need for PCP evaluation,SDPAD1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+HCV testing in Lichen Planus,SDPAD2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Avoiding antibiotic use in rupture epidermal inclusion cyst,SDPAD3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Appropriate Testing and Treatment of Nail tinea infection,SDPAD4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Urgent Result:  Breast Specimen Radiography,SMD23,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result:  Testicular Torsion,SMD24,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Critical Result:  Subdural hematoma,SMD25,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"GI Radiography Result Notification
+•Critical Result:  Bowel Obstruction
+•Critical Result:  Sigmoid Volvulus",SMD26,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Chest Imaging Result Notification:
+•Critical Result:  Pneumothorax
+•Critical Result:  Tension Pneumothorax
+•Follow Up Result:  Suspicious Lung Nodule",SMD27,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Musculoskeletal Radiology Result Notification:
+•Critical Result:  Fracture C-Spine
+•Urgent Result: Osteomyelitis
+•Urgent Result:  Meniscal Tear
+",SMD28,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Cardiovascular Monitoring for People with Cardiovascular Disease and Schizophrenia,SMX1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Diabetes Screening for People With Schizophrenia or Bipolar Disorder Who Are Using Antipsychotic Medications,SMX2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+SMX1004: Use of Multiple Concurrent Antipsychotics in Children and Adolescents,SMX3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Medication Adherence for Diabetes Medication,SMX5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Screening for Psychiatric or Behavioral Health Disorders,SMX6,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Medication Adherence for Hypertension,SMX7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Assessment and Intervention for Psychosocial Distress in Adults Receiving Cancer Treatment ,SMX8,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Mental Health Assessment for Patients with orthopedic conditions,SMX9,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Repeated X-ray Imaging,SPINEIQ3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Change in Functional Outcomes,SPINEIQ5,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Change in Pain Intensity,SPINEIQ6,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+MRI  of the lumbar spine without prior conservative care,SPINEIQ7,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Assessment and Management of Muscle Spasticity--Inpatient,SQOD1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Management of Muscle Spasticity--Outpatient,SQOD2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Post-Acute Brain Injury: Depression Screening and Follow-Up Plan of Care,SQOD3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Family Training—Inpatient Rehabilitation/Skilled Nursing Facility-Discharged to Home,SQOD4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Functional Assessment to Determine Rehabilitation Needs,SQOD5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prolonged Length of Stay Following Coronary Artery Bypass Grafting,STS1,QCDR measure,Outcome,Y,4.8,5.4,8.26 - 6.97,6.96 - 5.89,5.88 - 4.63,4.62 - 3.50,3.49 - 2.74,2.73 - 1.84,1.83 - 0.01,0,No,No
+Operative Mortality for Lobectomy,STS10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Lobectomy – Air Leak Greater than 5 Days,STS11,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Lobectomy – Unplanned Return to OR,STS12,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Recording Performance Status Prior to Lung Cancer Resection,STS13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Prolonged Length of Stay for Coronary Artery Bypass Grafting (CABG) + Valve Replacement,STS3,QCDR measure,Outcome,Y,9,10.3,21.21 - 14.30,14.29 - 9.10,9.09 - 7.46,7.45 - 5.01,5.00 - 4.77,4.76 - 2.71,2.70 - 0.01,0,Yes,No
+Prolonged Length of Stay following Valve Surgery,STS5,QCDR measure,Outcome,Y,4.6,5.2,8.00 - 5.89,5.88 - 5.27,5.26 - 4.09,4.08 - 3.46,3.45 - 3.04,3.03 - 1.62,1.61 - 0.01,0,No,No
+Patient Centered Surgical Risk Assessment and Communication for Cardiac Surgery ,STS7,QCDR measure,Patient Engagement Experience,Y,39.5,47.2,2.73 - 6.55,6.56 - 22.77,22.78 - 51.51,51.52 - 69.99,70.00 - 83.77,83.78 - 92.47,92.48 - 99.16,>= 99.17,No,No
+Operative Mortality for Esophageal Resection,STS8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Recording Performance Status prior to Esophageal Cancer Resection,STS9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent of patients meeting MCID thresholds for back or neck pain,SpineTRACK1,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent of patients meeting MCID thresholds for leg or arm pain,SpineTRACK2,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Percent of patients meeting MCID thresholds for pain-related disability (ODI/NDI)
+",SpineTRACK3,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Percent of patients meeting SCB thresholds for back or neck pain
+",SpineTRACK4,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent of patients meeting SCB thresholds for leg or arm pain,SpineTRACK5,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Percent of patients meeting SCB thresholds for pain-related disability (ODI/NDI),SpineTRACK6,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+UR002 - Ankylosing Spondylitis: Controlled Disease,UREQA1,QCDR measure,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+UR003 - Ankylosing Spondylitis: Appropriate Pharmacologic Therapy,UREQA2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+UR008 - Controlled Gout for Patients on Urate-Lowering Pharmacologic Therapy ,UREQA3,QCDR measure,Intermediate Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+UR007 - Folic or Folinic Acid Therapy for Patients Treated with Methotrexate,UREQA4,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+UR006 - Regular Evaluation of Psoriatic Arthritis (PsA),UREQA5,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Vital Sign Assessment and Blood Glucose Check Prior to HBOT Treatment,USWR13,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Major Amputation in Wagner 3, 4, or 5 Diabetic Foot Ulcers (DFUs) Treated with HBOT
+",USWR16,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Nutritional Screening and Intervention Plan in Patients with Chronic Wounds and Ulcers,USWR20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Reported Nutritional Assessment in Patients with Wounds and Ulcers,USWR22,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Non Invasive Arterial Assessment of patients with lower extremity wounds or ulcers for determination of healing potential ,USWR23,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Patient Reported Experience of Care: Wound Outcome,USWR24,QCDR measure,Patient Reported Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+"Advance Care planning: Electronic submission of new POLST/MOLST/POST/MOST (""orders for life-sustaining treatment"" or ""orders for scope of treatment"") into an eRegistry powered by Medcordance",VCMAHEMR1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Diabetes Care All or None Outcome Measure: Optimal Control ,WCHQ10,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
+Screening For Osteoporosis ,WCHQ15,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Controlling High Blood Pressure: eGFR Test Annually,WCHQ32,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Diabetes Care All or None Process Measure: Optimal Testing,WCHQ9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No

--- a/test/scripts/benchmarks/format-benchmark-record-spec.js
+++ b/test/scripts/benchmarks/format-benchmark-record-spec.js
@@ -53,7 +53,8 @@ describe('formatBenchmarkRecord', function() {
         decile8: ' -- ',
         decile9: ' -- ',
         decile10: '100',
-        isToppedOut: 'Yes'
+        isToppedOut: 'Yes',
+        isToppedOutByProgram: 'No'
       };
       const benchmark = formatBenchmarkRecord(record, options);
 
@@ -75,7 +76,8 @@ describe('formatBenchmarkRecord', function() {
         decile8: ' -- ',
         decile9: ' -- ',
         decile10: '100',
-        isToppedOut: 'Yes'
+        isToppedOut: 'Yes',
+        isToppedOutByProgram: 'No'
       };
       const benchmark = formatBenchmarkRecord(record, options);
 
@@ -88,7 +90,7 @@ describe('formatBenchmarkRecord', function() {
       const record = {
         measureName: 'Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients',
         qualityId: '102',
-        submissionMethod: 'EHR',
+        submissionMethod: 'eCQM',
         measureType: 'Process',
         benchmark: 'N',
         decile3: ' -- ',
@@ -99,7 +101,8 @@ describe('formatBenchmarkRecord', function() {
         decile8: ' -- ',
         decile9: ' -- ',
         decile10: ' -- ',
-        isToppedOut: ' -- '
+        isToppedOut: ' -- ',
+        isToppedOutByProgram: '--'
       };
       const benchmark = formatBenchmarkRecord(record, options);
 
@@ -112,7 +115,7 @@ describe('formatBenchmarkRecord', function() {
       const record = {
         measureName: 'Diabetes: Hemoglobin A1c Poor Control',
         qualityId: '1',
-        submissionMethod: 'EHR',
+        submissionMethod: 'eCQM',
         measureType: 'Outcome',
         benchmark: 'Y',
         decile3: '54.67 - 35.91',
@@ -123,7 +126,8 @@ describe('formatBenchmarkRecord', function() {
         decile8: '9.09 -  3.34',
         decile9: '3.33 -  0.01',
         decile10: '0',
-        isToppedOut: 'No'
+        isToppedOut: 'No',
+        isToppedOutByProgram: 'No'
       };
       const benchmark1 = formatBenchmarkRecord(record, {benchmarkYear: 2002, performanceYear: 2017});
       const benchmark2 = formatBenchmarkRecord(record, {benchmarkYear: 2004, performanceYear: 2018});
@@ -135,7 +139,7 @@ describe('formatBenchmarkRecord', function() {
       const record = {
         measureName: 'Diabetes: Hemoglobin A1c Poor Control',
         qualityId: '1',
-        submissionMethod: 'EHR',
+        submissionMethod: 'eCQM',
         measureType: 'Outcome',
         benchmark: 'Y',
         decile3: '54.67 - 35.91',
@@ -146,7 +150,8 @@ describe('formatBenchmarkRecord', function() {
         decile8: '9.09 -  3.34',
         decile9: '3.33 -  0.01',
         decile10: '0',
-        isToppedOut: 'No'
+        isToppedOut: 'No',
+        isToppedOutByProgram: 'No'
       };
       const benchmark1 = formatBenchmarkRecord(record, {benchmarkYear: 2002, performanceYear: 2017});
       const benchmark2 = formatBenchmarkRecord(record, {benchmarkYear: 2004, performanceYear: 2018});
@@ -160,7 +165,7 @@ describe('formatBenchmarkRecord', function() {
         const record = {
           measureName: 'Documentation of Current Medications in the Medical Record',
           qualityId: '130',
-          submissionMethod: 'EHR',
+          submissionMethod: 'eCQM',
           measureType: 'Process',
           benchmark: 'Y',
           decile3: '76.59 - 87.88',
@@ -171,7 +176,8 @@ describe('formatBenchmarkRecord', function() {
           decile8: '98.28 - 99.12',
           decile9: '99.13 - 99.75',
           decile10: '>= 99.76',
-          isToppedOut: 'Yes'
+          isToppedOut: 'Yes',
+          isToppedOutByProgram: 'No'
         };
         const benchmark = formatBenchmarkRecord(record, options);
 
@@ -182,6 +188,7 @@ describe('formatBenchmarkRecord', function() {
           assert.equal(benchmark.benchmarkYear, 2016, 'benchmarkYear');
           assert.equal(benchmark.performanceYear, 2018, 'performanceYear');
           assert.deepEqual(benchmark.deciles, [0, 76.59, 87.89, 92.74, 95.36, 97.09, 98.28, 99.13, 99.76], 'deciles');
+          assert.equal(benchmark.isToppedOutByProgram, false);
         });
       });
 
@@ -189,7 +196,7 @@ describe('formatBenchmarkRecord', function() {
         const record = {
           measureName: 'Breast Cancer Resection Pathology Reporting: pT Category (Primary Tumor) and pN Category (Regional Lymph Nodes) with Histologic Grade',
           qualityId: '99',
-          submissionMethod: 'Claims',
+          submissionMethod: 'Medicare Part B Claims',
           measureType: 'Process',
           benchmark: 'Y',
           decile3: '--',
@@ -200,7 +207,8 @@ describe('formatBenchmarkRecord', function() {
           decile8: '--',
           decile9: '--',
           decile10: '100',
-          isToppedOut: 'Yes'
+          isToppedOut: 'Yes',
+          isToppedOutByProgram: 'No'
         };
         const benchmark = formatBenchmarkRecord(record, options);
 
@@ -222,7 +230,7 @@ describe('formatBenchmarkRecord', function() {
             const record = {
               measureName: 'Diabetes: Hemoglobin A1c Poor Control',
               qualityId: '1',
-              submissionMethod: 'EHR',
+              submissionMethod: 'eCQM',
               measureType: 'Outcome',
               benchmark: 'Y',
               decile3: '54.67 - 35.91',
@@ -233,7 +241,8 @@ describe('formatBenchmarkRecord', function() {
               decile8: '9.09 -  3.34',
               decile9: '3.33 -  0.01',
               decile10: '0',
-              isToppedOut: 'No'
+              isToppedOut: 'No',
+              isToppedOutByProgram: 'Yes - words'
             };
             const benchmark = formatBenchmarkRecord(record, options);
 
@@ -243,6 +252,7 @@ describe('formatBenchmarkRecord', function() {
             assert.equal(benchmark.benchmarkYear, 2016, 'benchmarkYear');
             assert.equal(benchmark.performanceYear, 2018, 'performanceYear');
             assert.deepEqual(benchmark.deciles, [100, 54.67, 35.90, 25.62, 19.33, 14.14, 9.09, 3.33, 0], 'deciles');
+            assert.equal(benchmark.isToppedOutByProgram, true);
           });
         });
         describe('When Decile 10 is less than or equal to x', function() {
@@ -250,7 +260,7 @@ describe('formatBenchmarkRecord', function() {
             const record = {
               measureName: 'Diabetes: Hemoglobin A1c Poor Control',
               qualityId: '1',
-              submissionMethod: 'Claims',
+              submissionMethod: 'Medicare Part B Claims',
               measureType: 'Outcome',
               benchmark: 'Y',
               decile3: '35.00 - 25.72',
@@ -261,7 +271,8 @@ describe('formatBenchmarkRecord', function() {
               decile8: '10.00 -  7.42',
               decile9: '7.41 -  4.01',
               decile10: '<=  4.00',
-              isToppedOut: 'No'
+              isToppedOut: 'No',
+              isToppedOutByProgram: 'No'
             };
             const benchmark = formatBenchmarkRecord(record, options);
 
@@ -279,7 +290,7 @@ describe('formatBenchmarkRecord', function() {
         const record = {
           measureName: 'Anaphylaxis During Anesthesia Care',
           qualityId: '1', // ABG 11
-          submissionMethod: 'Registry/QCDR',
+          submissionMethod: 'MIPS CQM',
           measureType: 'Outcome',
           benchmark: 'Y',
           decile3: '--',
@@ -290,7 +301,8 @@ describe('formatBenchmarkRecord', function() {
           decile8: '--',
           decile9: '--',
           decile10: '0',
-          isToppedOut: 'Yes'
+          isToppedOut: 'Yes',
+          isToppedOutByProgram: 'No'
         };
 
         it('should return the correct benchmark object', function() {
@@ -308,7 +320,7 @@ describe('formatBenchmarkRecord', function() {
         const record = {
           measureName: 'Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation',
           qualityId: '12',
-          submissionMethod: 'Claims',
+          submissionMethod: 'Medicare Part B Claims',
           measureType: 'Process',
           benchmark: 'Y',
           decile3: '99.01 - 99.99',
@@ -319,7 +331,8 @@ describe('formatBenchmarkRecord', function() {
           decile8: '--',
           decile9: '--',
           decile10: '100',
-          isToppedOut: 'Y'
+          isToppedOut: 'Y',
+          isToppedOutByProgram: 'No'
         };
         const benchmark = formatBenchmarkRecord(record, options);
 
@@ -336,7 +349,7 @@ describe('formatBenchmarkRecord', function() {
         const record = {
           measureName: 'CT IV Contrast Extravasation Rate (Low Osmolar Contrast Media)',
           qualityId: '1', // ACRad 20
-          submissionMethod: 'Registry/QCDR',
+          submissionMethod: 'QCDR Measure',
           measureType: 'Outcome',
           benchmark: 'Y',
           decile3: '0.13 -  0.13',
@@ -347,7 +360,8 @@ describe('formatBenchmarkRecord', function() {
           decile8: '--',
           decile9: '--',
           decile10: '0',
-          isToppedOut: 'Y'
+          isToppedOut: 'Y',
+          isToppedOutByProgram: 'No'
         };
         const benchmark = formatBenchmarkRecord(record, options);
 

--- a/test/scripts/benchmarks/parse-benchmark-data-spec.js
+++ b/test/scripts/benchmarks/parse-benchmark-data-spec.js
@@ -15,7 +15,7 @@ const runTest = function(benchmarksCsv) {
 describe('parse benchmark data', function() {
   it('should create new measures and ignore duplicate measureIds', () => {
     const measures = runTest(testCsv);
-    // 279 rows with Y in Benchmark column
-    assert.equal(measures.length, 279);
+    // 311 rows with Y in Benchmark column
+    assert.equal(measures.length, 311);
   });
 });


### PR DESCRIPTION
https://jira.cms.gov/browse/QPPA-3580
https://jira.cms.gov/browse/QPPA-3536

#### Motivation for change
#### What is being changed

This adds an isToppedOutByProgram field to various benchmarks which is the new 'SevenPointCap' column in the input file.

Additionally, the submission method is now determined using the collection type column. The mapping of new names back to the old is from https://confluence.cms.gov/pages/viewpage.action?spaceKey=QPPARCH&title=Task%3A+Aggregate+Multiple+Submissions+and+Update+Terminology
We are sticking with the older naming schema as the API expects that still.

This also reverts the benchmark changes from #283 as the program has decided to not update these values.

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [ ] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [x] Unit tests added/passing
* [x] Verified working locally

