### PR TITLE
Add back the 2019 cmsWebInterface benchmarks

### DIFF
--- a/benchmarks/2019.json
+++ b/benchmarks/2019.json
@@ -22,6 +22,25 @@
     "measureId": "001",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      100,
+      70,
+      60,
+      50,
+      40,
+      30,
+      20,
+      10
+    ]
+  },
+  {
+    "measureId": "001",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
     "isToppedOutByProgram": false,
@@ -1124,6 +1143,25 @@
     "measureId": "110",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "110",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
     "isToppedOutByProgram": false,
@@ -1238,6 +1276,25 @@
     "measureId": "112",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "112",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
     "isToppedOutByProgram": false,
@@ -1289,6 +1346,25 @@
       88.64,
       97.73,
       100
+    ]
+  },
+  {
+    "measureId": "113",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
     ]
   },
   {
@@ -1669,6 +1745,25 @@
       100,
       100,
       100
+    ]
+  },
+  {
+    "measureId": "134",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
     ]
   },
   {
@@ -2492,6 +2587,25 @@
     "measureId": "236",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "236",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
     "isToppedOutByProgram": false,
@@ -3132,6 +3246,25 @@
       83.49,
       97.32,
       100
+    ]
+  },
+  {
+    "measureId": "318",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      43.42,
+      50.42,
+      58.45,
+      66,
+      73.39,
+      81.79,
+      90.73
     ]
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/scripts/benchmarks/format-benchmark-record.js
+++ b/scripts/benchmarks/format-benchmark-record.js
@@ -16,7 +16,8 @@ const SUBMISSION_METHOD_MAP = {
   'ecqm': 'electronicHealthRecord',
   'medicarepartbclaims': 'claims',
   'mipscqm': 'registry',
-  'qcdrmeasure': 'registry'
+  'qcdrmeasure': 'registry',
+  'cmswebinterface': 'cmsWebInterface'
 };
 
 /**

--- a/staging/2019/benchmarks/benchmarks.csv
+++ b/staging/2019/benchmarks/benchmarks.csv
@@ -1049,3 +1049,11 @@ Diabetes Care All or None Outcome Measure: Optimal Control ,WCHQ10,QCDR measure,
 Screening For Osteoporosis ,WCHQ15,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Controlling High Blood Pressure: eGFR Test Annually,WCHQ32,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Diabetes Care All or None Process Measure: Optimal Testing,WCHQ9,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
+Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,cmsWebInterface,Intermediate Outcome,Y,--,--,100 - 70,70 - 60,60 - 50,50 - 40,40 - 30,30 - 20,20 - 10,<= 10,No,No
+Preventive Care and Screening: Influenza Immunization,110,cmsWebInterface,Process,Y,--,--,0 - 30,30 - 40,40 - 50,50 - 60,60 - 70,70 - 80,80 - 90,>= 90,No,No
+Breast Cancer Screening,112,cmsWebInterface,Process,Y,--,--,0 - 30,30 - 40,40 - 50,50 - 60,60 - 70,70 - 80,80 - 90,>= 90,No,No
+Colorectal Cancer Screening,113,cmsWebInterface,Process,Y,--,--,0 - 30,30 - 40,40 - 50,50 - 60,60 - 70,70 - 80,80 - 90,>= 90,No,No
+Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,cmsWebInterface,Process,Y,--,--,0 - 30,30 - 40,40 - 50,50 - 60,60 - 70,70 - 80,80 - 90,>= 90,No,No
+Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,cmsWebInterface,Process,N,--,--,--,--,--,--,--,--,--,--,--,--
+Controlling High Blood Pressure,236,cmsWebInterface,Intermediate Outcome,Y,--,--,0 - 30,30 - 40,40 - 50,50 - 60,60 - 70,70 - 80,80 - 90,>= 90,No,No
+Falls: Screening for Future Fall Risk,318,cmsWebInterface,Process,Y,--,--,0 - 43.42,43.42 - 50.42,50.42 - 58.45,58.45 - 66,66 - 73.39,73.39 - 81.79,81.79 - 90.73,>= 90.73,No,No

--- a/staging/2019/benchmarks/json/benchmarks.json
+++ b/staging/2019/benchmarks/json/benchmarks.json
@@ -22,6 +22,25 @@
     "measureId": "001",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      100,
+      70,
+      60,
+      50,
+      40,
+      30,
+      20,
+      10
+    ]
+  },
+  {
+    "measureId": "001",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
     "isToppedOutByProgram": false,
@@ -1124,6 +1143,25 @@
     "measureId": "110",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "110",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
     "isToppedOutByProgram": false,
@@ -1238,6 +1276,25 @@
     "measureId": "112",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "112",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
     "isToppedOutByProgram": false,
@@ -1289,6 +1346,25 @@
       88.64,
       97.73,
       100
+    ]
+  },
+  {
+    "measureId": "113",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
     ]
   },
   {
@@ -1669,6 +1745,25 @@
       100,
       100,
       100
+    ]
+  },
+  {
+    "measureId": "134",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
     ]
   },
   {
@@ -2492,6 +2587,25 @@
     "measureId": "236",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "236",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
     "isToppedOutByProgram": false,
@@ -3132,6 +3246,25 @@
       83.49,
       97.32,
       100
+    ]
+  },
+  {
+    "measureId": "318",
+    "benchmarkYear": 2017,
+    "performanceYear": 2019,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      43.42,
+      50.42,
+      58.45,
+      66,
+      73.39,
+      81.79,
+      90.73
     ]
   },
   {


### PR DESCRIPTION
#### Motivation for change

#310 Mistakenly removed web interface benchmarks from the repo.

#### What is being changed

The previous WI benchmarks have been added back. Note that we are assuming that the SevenPointCap/isToppedOutByProgram is always false for these values. The average + standard deviation columns are also left blank (and unused in any case).

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [x] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [x] Unit tests added/passing
* [x] Verified working locally

