### PR TITLE
QPPA-3532: Remove More Benchmarks from 2019 

### DIFF
--- a/benchmarks/2019.json
+++ b/benchmarks/2019.json
@@ -4958,25 +4958,6 @@
     ]
   },
   {
-    "measureId": "AAO8",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
     "measureId": "ABG16",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -4993,25 +4974,6 @@
       89.41,
       94.19,
       99.84
-    ]
-  },
-  {
-    "measureId": "ABG30",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      76.64,
-      93.47,
-      97.6,
-      99.06,
-      99.67,
-      100,
-      100,
-      100
     ]
   },
   {
@@ -5069,25 +5031,6 @@
       29.47,
       36.67,
       50.59
-    ]
-  },
-  {
-    "measureId": "ACEP24",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      55.27,
-      60.23,
-      64.29,
-      68.38,
-      73.25,
-      77.94,
-      80.56,
-      84.77
     ]
   },
   {
@@ -5700,44 +5643,6 @@
       66.67,
       69.23,
       75
-    ]
-  },
-  {
-    "measureId": "RPAQIR11",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      0.58,
-      0.26,
-      0.07,
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "measureId": "RPAQIR12",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      0.99,
-      0.73,
-      0.54,
-      0.39,
-      0,
-      0,
-      0,
-      0
     ]
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/staging/2019/benchmarks/benchmarks.csv
+++ b/staging/2019/benchmarks/benchmarks.csv
@@ -393,7 +393,6 @@ Percentage of patients with allergic rhinitis who do not receive IgG-based immun
 Otitis Media with Effusion: Diagnostic Evaluation - Assessment of Tympanic Membrane Mobility,AAO26,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Otitis Media with Effusion: Resolution of Otitis Media with Effusion in Children,AAO27,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 Otitis Media with Effusion: Resolution of Otitis Media with Effusion in Adults,AAO28,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
-Otitis Media with Effusion: Antihistamines or Decongestants – Avoidance of Inappropriate Use,AAO8,QCDR measure,Process,Y,0.8,99.8,--,--,--,--,--,--,--,100,Yes,No
 All Patients Who Die an Expected Death with an ICD that Has Been Deactivated,ABFM1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Patients Admitted to ICU who Have Care Preferences Documented,ABFM2,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Patients Treated with an Opioid Who Are Given a Bowel Regimen,ABFM3,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
@@ -403,7 +402,6 @@ Palliative Care Timely Dyspnea Screening & Treatment,ABFM6,QCDR measure,Process,
 Pain Brought Under Control within the first three visits,ABFM7,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 Measuring the Value-Functions of Primary Care: Provider Level Continuity Measure,ABFM8,QCDR measure,Structure,N,--,--,--,--,--,--,--,--,--,--,--,No
 Planned use of difficult airway equipment,ABG16,QCDR measure,Process,Y,25.7,71.6,56.01 - 61.14,61.15 - 72.26,72.27 - 77.96,77.97 - 82.24,82.25 - 89.40,89.41 - 94.18,94.19 - 99.83,>= 99.84,No,No
-Pre-Operative Screening for PONV Risk,ABG30,QCDR measure,Process,Y,24.9,86,76.64 - 93.46,93.47 - 97.59,97.60 - 99.05,99.06 - 99.66,99.67 - 99.99,--,--,100,Yes,No
 Pain Related Quality of Life Interference,ABG32,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Lower Body Functional Impairment (LBI),ABG33,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 Mood Assessment Screening and treatment ,ABG34,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
@@ -414,7 +412,6 @@ Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients 
 Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,ACEP20,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Coagulation Studies in Patients Presenting with Chest Pain with No Coagulopathy or Bleeding,ACEP21,QCDR measure,Process,Y,17.5,15.5,24.61 - 19.33,19.32 - 15.93,15.92 - 9.06,9.05 - 5.75,5.74 - 3.78,3.77 - 0.01,--,0,No,No
 Appropriate Emergency Department Utilization of CT for Pulmonary Embolism,ACEP22,QCDR measure,Process,Y,18.8,25.3,8.00 - 14.99,15.00 - 18.95,18.96 - 22.72,22.73 - 26.55,26.56 - 29.46,29.47 - 36.66,36.67 - 50.58,>= 50.59,No,No
-Pregnancy Test for Female Abdominal Pain Patients,ACEP24,QCDR measure,Process,Y,18.5,65.6,55.27 - 60.22,60.23 - 64.28,64.29 - 68.37,68.38 - 73.24,73.25 - 77.93,77.94 - 80.55,80.56 - 84.76,>= 84.77,No,No
 Tobacco Use: Screening and Cessation Intervention for Patients with Asthma and COPD,ACEP25,QCDR measure,Process,Y,14.5,73.6,63.89 - 67.52,67.53 - 71.87,71.88 - 74.99,75.00 - 78.78,78.79 - 81.81,81.82 - 85.70,85.71 - 89.99,>= 90.00,No,No
 Sepsis Management: Septic Shock: Repeat Lactate Level Measurement,ACEP29,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
 Sepsis Management: Septic Shock: Lactate Clearance Rate of >=10%,ACEP30,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
@@ -960,8 +957,6 @@ ESRD Prevalence of Home Dialysis or Self-Care,RCOIR5,QCDR measure,Process,N,--,-
 Improved Access Site Bleeding,RCOIR7,QCDR measure,Outcome,Y,21.2,54.1,37.04 - 40.21,40.22 - 44.52,44.53 - 59.99,60.00 - 63.63,63.64 - 66.66,66.67 - 69.22,69.23 - 74.99,>= 75.00,No,No
 Post Procedure Bleeding,RCOIR8,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 Angiotensin Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy,RPAQIR1,QCDR measure,Process,N,--,--,--,--,--,--,--,--,--,--,--,No
-Hospitalization Rate Following Procedures Performed under Procedure Sedation Analgesia,RPAQIR11,QCDR measure,Outcome,Y,0.6,0.3,0.58 - 0.27,0.26 - 0.08,0.07 - 0.01,--,--,--,--,0,Yes,No
-Arterial Complication Rate Following Arteriovenous Access Intervention,RPAQIR12,QCDR measure,Outcome,Y,0.7,0.6,0.99 - 0.74,0.73 - 0.55,0.54 - 0.40,0.39 - 0.01,--,--,--,0,Yes,No
 Rate of Timely Documentation Transmission to Dialysis Unit/Referring Physician,RPAQIR13,QCDR measure,Process,Y,7,94.2,92.85 - 94.06,94.07 - 94.94,94.95 - 95.86,95.87 - 97.27,97.28 - 97.88,97.89 - 99.20,99.21 - 99.76,>= 99.77,Yes,No
 Arteriovenous Graft Thrombectomy Success Rate,RPAQIR14,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No
 Arteriovenous Fistulae Thrombectomy Success Rate,RPAQIR15,QCDR measure,Outcome,N,--,--,--,--,--,--,--,--,--,--,--,No

--- a/staging/2019/benchmarks/json/benchmarks.json
+++ b/staging/2019/benchmarks/json/benchmarks.json
@@ -4940,25 +4940,6 @@
     ]
   },
   {
-    "measureId": "AAO8",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
     "measureId": "ABG16",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -4975,25 +4956,6 @@
       89.41,
       94.19,
       99.84
-    ]
-  },
-  {
-    "measureId": "ABG30",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      76.64,
-      93.47,
-      97.6,
-      99.06,
-      99.67,
-      100,
-      100,
-      100
     ]
   },
   {
@@ -5051,25 +5013,6 @@
       29.47,
       36.67,
       50.59
-    ]
-  },
-  {
-    "measureId": "ACEP24",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      55.27,
-      60.23,
-      64.29,
-      68.38,
-      73.25,
-      77.94,
-      80.56,
-      84.77
     ]
   },
   {
@@ -5412,44 +5355,6 @@
       66.67,
       69.23,
       75
-    ]
-  },
-  {
-    "measureId": "RPAQIR11",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      0.58,
-      0.26,
-      0.07,
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "measureId": "RPAQIR12",
-    "benchmarkYear": 2017,
-    "performanceYear": 2019,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      0.99,
-      0.73,
-      0.54,
-      0.39,
-      0,
-      0,
-      0,
-      0
     ]
   },
   {


### PR DESCRIPTION
#### Motivation for change

There are some unexpected results from the GET public /benchmarks endpoint when trying to filter by certain ids. 

#### What is being changed

Previously, a number of benchmarks were deleted from 2019 because they existed for measureIds that are no longer valid for 2019. This issue still exists for a few ids. They are deleted in this PR.

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [x] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [x] Unit tests added/passing
* [ ] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-3532
