### PR TITLE
[QPPSF-5831] Duplicate Benchmark Fix

### DIFF
--- a/benchmarks/2019.json
+++ b/benchmarks/2019.json
@@ -20,23 +20,6 @@
   },
   {
     "measureId": "001",
-    "submissionMethod": "claims",
-    "deciles": [
-      90.9090909090909,
-      51.89873417721519,
-      34.61538461538461,
-      17.391304347826086,
-      10,
-      5.88235294117647,
-      3.125,
-      2.3255813953488373,
-      1.098901098901099
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "001",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "cmsWebInterface",
@@ -75,23 +58,6 @@
   },
   {
     "measureId": "001",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      99.82138300586885,
-      98.79518072289156,
-      96.49122807017544,
-      66.26106194690266,
-      37.278637076888586,
-      24.742268041237114,
-      16.551724137931036,
-      11.76470588235294,
-      3.9215686274509802
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "001",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -108,23 +74,6 @@
       9.02,
       2.7
     ]
-  },
-  {
-    "measureId": "001",
-    "submissionMethod": "registry",
-    "deciles": [
-      99.59183673469387,
-      96.29629629629629,
-      86.98224852071006,
-      62.82051282051282,
-      27.906976744186046,
-      13.917525773195877,
-      4.25531914893617,
-      1.6666666666666667,
-      0
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "005",
@@ -147,23 +96,6 @@
   },
   {
     "measureId": "005",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      46.601941747572816,
-      58.05867439333575,
-      61.53846153846154,
-      70.62937062937063,
-      77.28070175438596,
-      81.57894736842105,
-      88.48039215686273,
-      90.85903083700441,
-      96.29629629629629
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "005",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -180,23 +112,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "005",
-    "submissionMethod": "registry",
-    "deciles": [
-      40.909090909090914,
-      58.08383233532935,
-      69.56521739130434,
-      92.3076923076923,
-      97.02970297029702,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "006",
@@ -216,23 +131,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "006",
-    "submissionMethod": "registry",
-    "deciles": [
-      44.18145956607495,
-      63.29113924050633,
-      71.13636363636363,
-      85.43589743589743,
-      93.20388349514563,
-      98.27586206896551,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "007",
@@ -255,23 +153,6 @@
   },
   {
     "measureId": "007",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      44.53125,
-      63.888888888888886,
-      72.72727272727273,
-      85.24590163934427,
-      89.39873417721519,
-      92.20779220779221,
-      94.73684210526316,
-      96.29629629629629,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "007",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -288,23 +169,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "007",
-    "submissionMethod": "registry",
-    "deciles": [
-      67.17325227963526,
-      80.08658008658008,
-      83.17025440313111,
-      88.55218855218855,
-      92.6470588235294,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "008",
@@ -327,23 +191,6 @@
   },
   {
     "measureId": "008",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      50,
-      77.6595744680851,
-      81.72043010752688,
-      89.47368421052632,
-      93.75,
-      96.49122807017544,
-      98.07692307692307,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "008",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -360,23 +207,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "008",
-    "submissionMethod": "registry",
-    "deciles": [
-      63.63636363636363,
-      88.46153846153845,
-      93.33333333333333,
-      97.5,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "009",
@@ -398,23 +228,6 @@
     ]
   },
   {
-    "measureId": "009",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      12.820512820512821,
-      47.826086956521735,
-      57.89473684210526,
-      68.7878787878788,
-      77.41935483870968,
-      84.2401907652287,
-      88.70967741935485,
-      94.33962264150944,
-      97.5
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "012",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -432,23 +245,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "012",
-    "submissionMethod": "claims",
-    "deciles": [
-      55.26315789473685,
-      88.88888888888889,
-      96.51162790697676,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "012",
@@ -471,23 +267,6 @@
   },
   {
     "measureId": "012",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      10.079575596816976,
-      65.87556125721616,
-      77.8688524590164,
-      88,
-      95,
-      98.7012987012987,
-      99.84939759036145,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "012",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -506,23 +285,6 @@
     ]
   },
   {
-    "measureId": "012",
-    "submissionMethod": "registry",
-    "deciles": [
-      68.22429906542055,
-      89.26746166950596,
-      95.78313253012048,
-      98.50746268656717,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "014",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -540,23 +302,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "014",
-    "submissionMethod": "claims",
-    "deciles": [
-      30.434782608695656,
-      84,
-      95.34883720930233,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "014",
@@ -578,23 +323,6 @@
     ]
   },
   {
-    "measureId": "014",
-    "submissionMethod": "registry",
-    "deciles": [
-      9.30232558139535,
-      53.13432835820896,
-      78.76106194690266,
-      88.88888888888889,
-      96.40522875816994,
-      99.81308411214953,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "019",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -612,23 +340,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "019",
-    "submissionMethod": "claims",
-    "deciles": [
-      76.74418604651163,
-      96.7741935483871,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "019",
@@ -651,23 +362,6 @@
   },
   {
     "measureId": "019",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      6.552706552706552,
-      30,
-      42.30769230769231,
-      64.8854961832061,
-      81.33333333333333,
-      91.85840707964601,
-      96.7032967032967,
-      98.42342342342343,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "019",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -684,23 +378,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "019",
-    "submissionMethod": "registry",
-    "deciles": [
-      31.16279069767442,
-      68.19571865443424,
-      89.74358974358975,
-      97.14285714285714,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "021",
@@ -723,23 +400,6 @@
   },
   {
     "measureId": "021",
-    "submissionMethod": "claims",
-    "deciles": [
-      2.4390243902439024,
-      78.70370370370371,
-      96.92307692307692,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "021",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -758,23 +418,6 @@
     ]
   },
   {
-    "measureId": "021",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.85995085995086,
-      69.79166666666666,
-      93.51145038167938,
-      98.59154929577466,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "023",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -792,23 +435,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "023",
-    "submissionMethod": "claims",
-    "deciles": [
-      0.8264462809917356,
-      27.848101265822784,
-      95.83333333333334,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "023",
@@ -830,23 +456,6 @@
     ]
   },
   {
-    "measureId": "023",
-    "submissionMethod": "registry",
-    "deciles": [
-      70.8029197080292,
-      86.31415241057543,
-      93.4640522875817,
-      98.0392156862745,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "024",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -864,23 +473,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "024",
-    "submissionMethod": "claims",
-    "deciles": [
-      33.33333333333333,
-      54.054054054054056,
-      76.31578947368422,
-      92.45283018867924,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "024",
@@ -922,23 +514,6 @@
   },
   {
     "measureId": "039",
-    "submissionMethod": "claims",
-    "deciles": [
-      1.6574585635359116,
-      10.59322033898305,
-      21.541010770505387,
-      46.21848739495798,
-      69.44444444444444,
-      96,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "039",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -955,23 +530,6 @@
       78.46,
       88.24
     ]
-  },
-  {
-    "measureId": "039",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.13404825737265416,
-      0.5154639175257731,
-      5.263157894736842,
-      37.71289537712895,
-      62.04081632653061,
-      87.01657458563537,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "044",
@@ -1013,23 +571,6 @@
   },
   {
     "measureId": "046",
-    "submissionMethod": "claims",
-    "deciles": [
-      20.481927710843372,
-      94.01709401709401,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "046",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -1046,23 +587,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "046",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.4522328999434709,
-      0.5149330587023687,
-      0.7956661587946504,
-      12.5,
-      99.90882151812173,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "047",
@@ -1085,23 +609,6 @@
   },
   {
     "measureId": "047",
-    "submissionMethod": "claims",
-    "deciles": [
-      0.7518796992481203,
-      5.444126074498568,
-      20.309477756286267,
-      94.91228070175438,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "047",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -1118,23 +625,6 @@
       99.72,
       100
     ]
-  },
-  {
-    "measureId": "047",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.2222222222222222,
-      1.3677811550151975,
-      5.006418485237484,
-      50.48409405255878,
-      89.50749464668094,
-      99.5505617977528,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "048",
@@ -1157,23 +647,6 @@
   },
   {
     "measureId": "048",
-    "submissionMethod": "claims",
-    "deciles": [
-      0.38461538461538464,
-      2.5,
-      10.526315789473683,
-      97.6878612716763,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "048",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -1190,23 +663,6 @@
       99.51,
       100
     ]
-  },
-  {
-    "measureId": "048",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.8620689655172413,
-      11.682242990654206,
-      25.874125874125873,
-      55.92105263157895,
-      85.13881328252586,
-      99.75124378109453,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "050",
@@ -1229,23 +685,6 @@
   },
   {
     "measureId": "050",
-    "submissionMethod": "claims",
-    "deciles": [
-      2.898550724637681,
-      80.95238095238095,
-      92.3076923076923,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "050",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -1262,23 +701,6 @@
       99.66,
       100
     ]
-  },
-  {
-    "measureId": "050",
-    "submissionMethod": "registry",
-    "deciles": [
-      3.225806451612903,
-      6.289308176100629,
-      18.956521739130437,
-      57.77777777777777,
-      89.85507246376811,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "051",
@@ -1301,23 +723,6 @@
   },
   {
     "measureId": "051",
-    "submissionMethod": "claims",
-    "deciles": [
-      2.2388059701492535,
-      9.375,
-      32.432432432432435,
-      88.46153846153845,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "051",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -1334,23 +739,6 @@
       99.36,
       100
     ]
-  },
-  {
-    "measureId": "051",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.5494505494505495,
-      5.28169014084507,
-      9.67741935483871,
-      54.649827784156145,
-      79.1044776119403,
-      96.66666666666667,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "052",
@@ -1373,23 +761,6 @@
   },
   {
     "measureId": "052",
-    "submissionMethod": "claims",
-    "deciles": [
-      89.01734104046243,
-      94.5945945945946,
-      96.49122807017544,
-      99.8798076923077,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "052",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -1406,23 +777,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "052",
-    "submissionMethod": "registry",
-    "deciles": [
-      37.295081967213115,
-      62.86836935166994,
-      70.41420118343196,
-      80.64516129032258,
-      97.08029197080292,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "065",
@@ -1442,23 +796,6 @@
       98.22,
       100
     ]
-  },
-  {
-    "measureId": "065",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      45.28301886792453,
-      57.279693486590034,
-      68.53768415925971,
-      77.29096453217782,
-      85.43689320388349,
-      91.30434782608695,
-      95.92566118656183,
-      97.6608187134503,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "065",
@@ -1497,23 +834,6 @@
       91.43,
       94.59
     ]
-  },
-  {
-    "measureId": "066",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      2.525724976613658,
-      19.047619047619047,
-      36.96741854636591,
-      66.61721068249258,
-      82.6923076923077,
-      89.11870503597122,
-      92.82868525896414,
-      94.89867225716281,
-      97.35576923076923
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "066",
@@ -1612,23 +932,6 @@
   },
   {
     "measureId": "076",
-    "submissionMethod": "claims",
-    "deciles": [
-      3.125,
-      56.32183908045977,
-      93.61702127659575,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "076",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -1645,23 +948,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "076",
-    "submissionMethod": "registry",
-    "deciles": [
-      62.19839142091153,
-      80.4245283018868,
-      89.43820224719101,
-      99.34383202099738,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "091",
@@ -1684,23 +970,6 @@
   },
   {
     "measureId": "091",
-    "submissionMethod": "claims",
-    "deciles": [
-      1.9230769230769231,
-      28.205128205128204,
-      44.44444444444444,
-      78.84615384615384,
-      97.67441860465115,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "091",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -1717,23 +986,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "091",
-    "submissionMethod": "registry",
-    "deciles": [
-      20.833333333333336,
-      37.5,
-      54.066985645933016,
-      78.78787878787878,
-      93.54838709677419,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "093",
@@ -1756,23 +1008,6 @@
   },
   {
     "measureId": "093",
-    "submissionMethod": "claims",
-    "deciles": [
-      12.857142857142856,
-      54.736842105263165,
-      88.37209302325581,
-      95.65217391304348,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "093",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -1789,23 +1024,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "093",
-    "submissionMethod": "registry",
-    "deciles": [
-      69.8224852071006,
-      83.87096774193549,
-      86.18421052631578,
-      94.4560669456067,
-      97.40259740259741,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "102",
@@ -1865,23 +1083,6 @@
     ]
   },
   {
-    "measureId": "107",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.34843205574912894,
-      0.6802721088435374,
-      1.161817039983253,
-      9.394081728511038,
-      31.27853881278539,
-      66.38074156059768,
-      87.64044943820225,
-      96.99666295884316,
-      99.46808510638297
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "109",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -1899,23 +1100,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "109",
-    "submissionMethod": "claims",
-    "deciles": [
-      1.0101010101010102,
-      12.941176470588237,
-      58.82352941176471,
-      97.47474747474747,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "109",
@@ -1937,23 +1121,6 @@
     ]
   },
   {
-    "measureId": "109",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.1579778830963665,
-      2.5,
-      24.015748031496063,
-      46.633416458852864,
-      99.82547993019197,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "110",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -1971,23 +1138,6 @@
       99.42,
       100
     ]
-  },
-  {
-    "measureId": "110",
-    "submissionMethod": "claims",
-    "deciles": [
-      0.8771929824561403,
-      14.145383104125736,
-      31.493506493506494,
-      72.22222222222221,
-      94.37229437229438,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "110",
@@ -2029,23 +1179,6 @@
   },
   {
     "measureId": "110",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.2079002079002079,
-      2.0771513353115725,
-      8.877995642701524,
-      26.52439024390244,
-      47.229551451187334,
-      67.02127659574468,
-      87.5,
-      95.6989247311828,
-      99.91489361702128
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "110",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -2062,23 +1195,6 @@
       96.41,
       100
     ]
-  },
-  {
-    "measureId": "110",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.2638522427440633,
-      5.823389021479714,
-      12.602739726027398,
-      30.407523510971785,
-      59.6252129471891,
-      95.2755905511811,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "111",
@@ -2101,23 +1217,6 @@
   },
   {
     "measureId": "111",
-    "submissionMethod": "claims",
-    "deciles": [
-      2.2123893805309733,
-      32.35294117647059,
-      51.79282868525896,
-      74.48275862068967,
-      88.84057971014492,
-      99.88002399520096,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "111",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
@@ -2134,23 +1233,6 @@
       80.43,
       90.41
     ]
-  },
-  {
-    "measureId": "111",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.17825311942959002,
-      2.5210084033613445,
-      9.235668789808917,
-      33.6405529953917,
-      60.68601583113457,
-      77.92667145938174,
-      91.09916367980884,
-      97.47706422018348,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "111",
@@ -2172,23 +1254,6 @@
     ]
   },
   {
-    "measureId": "111",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.4807692307692308,
-      2.8301886792452833,
-      13.543140028288544,
-      41.29554655870445,
-      68.29554339327599,
-      86.75213675213675,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "112",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -2206,23 +1271,6 @@
       90.24,
       100
     ]
-  },
-  {
-    "measureId": "112",
-    "submissionMethod": "claims",
-    "deciles": [
-      2.586206896551724,
-      29.78723404255319,
-      46.42857142857143,
-      75,
-      91.17647058823529,
-      99.14163090128756,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "112",
@@ -2264,23 +1312,6 @@
   },
   {
     "measureId": "112",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.3134796238244514,
-      1.4705882352941175,
-      8.571428571428571,
-      35.82510578279267,
-      57.85123966942148,
-      73.1203007518797,
-      83.61111111111111,
-      91.11111111111111,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "112",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -2297,23 +1328,6 @@
       93.45,
       100
     ]
-  },
-  {
-    "measureId": "112",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.544959128065395,
-      3.1746031746031744,
-      11.11111111111111,
-      43.25726141078838,
-      62.93340199107449,
-      85.09316770186336,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "113",
@@ -2333,23 +1347,6 @@
       97.73,
       100
     ]
-  },
-  {
-    "measureId": "113",
-    "submissionMethod": "claims",
-    "deciles": [
-      4.49438202247191,
-      24.811083123425693,
-      44.303797468354425,
-      75.40983606557377,
-      95.13274336283186,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "113",
@@ -2391,23 +1388,6 @@
   },
   {
     "measureId": "113",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.13614703880190604,
-      1.2640449438202246,
-      5.78345662407532,
-      31.353135313531354,
-      56.611570247933884,
-      77.36777367773678,
-      90.23136246786633,
-      95.57613168724279,
-      99.82817869415808
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "113",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -2424,23 +1404,6 @@
       96.98,
       100
     ]
-  },
-  {
-    "measureId": "113",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.42253521126760557,
-      3.222094361334868,
-      10.714285714285714,
-      38.49557522123894,
-      72.59194395796847,
-      95.14978601997147,
-      99.41451990632318,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "116",
@@ -2482,23 +1445,6 @@
   },
   {
     "measureId": "117",
-    "submissionMethod": "claims",
-    "deciles": [
-      8.333333333333332,
-      55.10204081632652,
-      86.7298578199052,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "117",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
@@ -2515,23 +1461,6 @@
       98.26,
       99.73
     ]
-  },
-  {
-    "measureId": "117",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.6993006993006993,
-      7.06713780918728,
-      20.398009950248756,
-      63.41818181818182,
-      97.38762965808682,
-      99.69465648854961,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "117",
@@ -2553,23 +1482,6 @@
     ]
   },
   {
-    "measureId": "117",
-    "submissionMethod": "registry",
-    "deciles": [
-      2.203856749311295,
-      23,
-      64.54545454545455,
-      97.5609756097561,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "118",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -2587,23 +1499,6 @@
       92.26,
       98.18
     ]
-  },
-  {
-    "measureId": "118",
-    "submissionMethod": "registry",
-    "deciles": [
-      51.515151515151516,
-      60,
-      64.2346208869814,
-      74.32432432432432,
-      80.83333333333333,
-      87.77777777777777,
-      94.79843953185956,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "119",
@@ -2626,23 +1521,6 @@
   },
   {
     "measureId": "119",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      13.777777777777779,
-      50,
-      60.320855614973254,
-      74.0506329113924,
-      86.09625668449198,
-      92.7710843373494,
-      98.47715736040608,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "119",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -2659,23 +1537,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "119",
-    "submissionMethod": "registry",
-    "deciles": [
-      54.54545454545454,
-      61.56521739130435,
-      67.14285714285714,
-      78.02739726027397,
-      92.5,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "126",
@@ -2697,23 +1558,6 @@
     ]
   },
   {
-    "measureId": "126",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.3939592908732764,
-      18.0327868852459,
-      30.909090909090907,
-      68.18181818181817,
-      96.58536585365853,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "127",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -2731,23 +1575,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "127",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.5485687470671048,
-      9.036144578313253,
-      35.655253837072024,
-      81.84713375796179,
-      98.94514767932489,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "128",
@@ -2770,23 +1597,6 @@
   },
   {
     "measureId": "128",
-    "submissionMethod": "claims",
-    "deciles": [
-      17.894736842105264,
-      40.13840830449827,
-      63.65914786967418,
-      97.27891156462584,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "128",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
@@ -2806,23 +1616,6 @@
   },
   {
     "measureId": "128",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      5.073170731707317,
-      16.2,
-      20.716685330347147,
-      27.28055077452668,
-      45.16320474777448,
-      88,
-      98.49397590361446,
-      99.89506820566632,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "128",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -2839,23 +1632,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "128",
-    "submissionMethod": "registry",
-    "deciles": [
-      6.77731673582296,
-      20.12830793905373,
-      25.952380952380956,
-      58.73261205564142,
-      90.4642409033877,
-      99.46282767511818,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "130",
@@ -2878,23 +1654,6 @@
   },
   {
     "measureId": "130",
-    "submissionMethod": "claims",
-    "deciles": [
-      9.250585480093678,
-      86.02150537634408,
-      97.47427502338635,
-      99.85538684020246,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "130",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
@@ -2914,23 +1673,6 @@
   },
   {
     "measureId": "130",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      2.089298971258882,
-      45.133408493047725,
-      69.33389191453708,
-      88.53519025118129,
-      96.5659908978072,
-      99.5442930153322,
-      99.99194198227237,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "130",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -2947,23 +1689,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "130",
-    "submissionMethod": "registry",
-    "deciles": [
-      49.48702474351237,
-      83.46839546191248,
-      94.52142548776582,
-      99.29390997352162,
-      99.91776315789474,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "131",
@@ -2986,23 +1711,6 @@
   },
   {
     "measureId": "131",
-    "submissionMethod": "claims",
-    "deciles": [
-      0.3469210754553339,
-      50.97694411879641,
-      94.21965317919076,
-      99.83093829247676,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "131",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -3019,23 +1727,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "131",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.19230769230769232,
-      6.952150923689536,
-      28.019632949210415,
-      83.41880341880342,
-      97.95918367346938,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "134",
@@ -3058,23 +1749,6 @@
   },
   {
     "measureId": "134",
-    "submissionMethod": "claims",
-    "deciles": [
-      0.38167938931297707,
-      22.413793103448278,
-      81.15746971736203,
-      99.44903581267218,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "134",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
@@ -3091,23 +1765,6 @@
       73.3,
       87.5
     ]
-  },
-  {
-    "measureId": "134",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.10330578512396695,
-      1.0832383124287344,
-      2.736726874657909,
-      11.657559198542804,
-      39.57446808510638,
-      69.23076923076923,
-      89.8489425981873,
-      97.27272727272728,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "134",
@@ -3129,23 +1786,6 @@
     ]
   },
   {
-    "measureId": "134",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.5865102639296188,
-      1.9920318725099602,
-      15.078407720144751,
-      43.67185933007956,
-      82.86014721345951,
-      99.57968476357269,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "137",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -3165,23 +1805,6 @@
     ]
   },
   {
-    "measureId": "137",
-    "submissionMethod": "registry",
-    "deciles": [
-      20.113314447592067,
-      63.63636363636363,
-      92.11618257261411,
-      99.4475138121547,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "138",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -3199,23 +1822,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "138",
-    "submissionMethod": "registry",
-    "deciles": [
-      7.142857142857142,
-      42.10526315789473,
-      64.76190476190476,
-      93.4010152284264,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "141",
@@ -3238,23 +1844,6 @@
   },
   {
     "measureId": "141",
-    "submissionMethod": "claims",
-    "deciles": [
-      22.857142857142858,
-      86.22448979591837,
-      96.15384615384616,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "141",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -3271,23 +1860,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "141",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.07686395080707148,
-      0.7407407407407408,
-      6.277056277056277,
-      59.437086092715234,
-      97.28546409807356,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "143",
@@ -3310,23 +1882,6 @@
   },
   {
     "measureId": "143",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      4.23728813559322,
-      34,
-      56.067758955845605,
-      90.15625,
-      97.13740458015268,
-      98.83720930232558,
-      99.89094874591058,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "143",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -3346,20 +1901,22 @@
   },
   {
     "measureId": "144",
+    "performanceYear": 2019,
+    "benchmarkYear": 2019,
     "submissionMethod": "registry",
     "deciles": [
-      3.8461538461538463,
+      3.8462,
       37.5,
-      48.38709677419355,
-      68.18181818181817,
-      89.85507246376811,
-      99.07834101382488,
+      48.3871,
+      68.1818,
+      89.8551,
+      99.0783,
       100,
       100,
       100
     ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "145",
@@ -3382,23 +1939,6 @@
   },
   {
     "measureId": "145",
-    "submissionMethod": "claims",
-    "deciles": [
-      2.7777777777777777,
-      26.666666666666668,
-      61.66666666666667,
-      91.2621359223301,
-      99.23664122137404,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "145",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -3415,23 +1955,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "145",
-    "submissionMethod": "registry",
-    "deciles": [
-      46.07329842931937,
-      83.44132469402447,
-      85.5072463768116,
-      96.5034965034965,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "146",
@@ -3454,23 +1977,6 @@
   },
   {
     "measureId": "146",
-    "submissionMethod": "claims",
-    "deciles": [
-      7.142857142857142,
-      2.7027027027027026,
-      1.6129032258064515,
-      0.6896551724137931,
-      0.25510204081632654,
-      0.0889679715302491,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "146",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -3487,23 +1993,6 @@
       0,
       0
     ]
-  },
-  {
-    "measureId": "146",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.9784172661870503,
-      1.3686911890504705,
-      1.0216203373722974,
-      0.20935101186322402,
-      0.02566405748748877,
-      0,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "147",
@@ -3526,23 +2015,6 @@
   },
   {
     "measureId": "147",
-    "submissionMethod": "claims",
-    "deciles": [
-      8.88888888888889,
-      26.08695652173913,
-      42.592592592592595,
-      82.5,
-      98.91304347826086,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "147",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -3559,23 +2031,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "147",
-    "submissionMethod": "registry",
-    "deciles": [
-      27.165354330708663,
-      75,
-      81.9672131147541,
-      88.84297520661157,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "154",
@@ -3598,23 +2053,6 @@
   },
   {
     "measureId": "154",
-    "submissionMethod": "claims",
-    "deciles": [
-      10.526315789473683,
-      72.91666666666666,
-      90.47619047619048,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "154",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -3631,23 +2069,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "154",
-    "submissionMethod": "registry",
-    "deciles": [
-      5.128205128205128,
-      29.411764705882355,
-      55.26315789473685,
-      87.85529715762273,
-      98.48484848484848,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "155",
@@ -3670,23 +2091,6 @@
   },
   {
     "measureId": "155",
-    "submissionMethod": "claims",
-    "deciles": [
-      2.242152466367713,
-      13.571428571428571,
-      31.818181818181817,
-      95.23809523809523,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "155",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -3703,23 +2107,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "155",
-    "submissionMethod": "registry",
-    "deciles": [
-      8.212560386473431,
-      35,
-      57.14285714285714,
-      84.07960199004975,
-      97.82608695652173,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "164",
@@ -3836,23 +2223,6 @@
     ]
   },
   {
-    "measureId": "176",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.2048192771084338,
-      9.090909090909092,
-      11.538461538461538,
-      60.71428571428571,
-      99.02597402597402,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "177",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -3870,23 +2240,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "177",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.6494845360824744,
-      8.053691275167784,
-      11.212814645308924,
-      72.81486579490709,
-      98.32402234636871,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "178",
@@ -3908,23 +2261,6 @@
     ]
   },
   {
-    "measureId": "178",
-    "submissionMethod": "registry",
-    "deciles": [
-      8.13953488372093,
-      47.651006711409394,
-      80.55555555555556,
-      97.9741136747327,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "179",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -3944,23 +2280,6 @@
     ]
   },
   {
-    "measureId": "179",
-    "submissionMethod": "registry",
-    "deciles": [
-      25.979381443298973,
-      48.85556432517759,
-      80.27006751687922,
-      99.15682967959528,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "180",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -3978,23 +2297,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "180",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.3184713375796179,
-      16.977225672877847,
-      77.97619047619048,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "181",
@@ -4017,23 +2319,6 @@
   },
   {
     "measureId": "181",
-    "submissionMethod": "claims",
-    "deciles": [
-      0.25316455696202533,
-      6.315789473684211,
-      41.935483870967744,
-      99.76470588235294,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "181",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -4050,23 +2335,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "181",
-    "submissionMethod": "registry",
-    "deciles": [
-      11.11111111111111,
-      25.185185185185183,
-      34.78260869565217,
-      66.51100733822548,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "182",
@@ -4089,37 +2357,22 @@
   },
   {
     "measureId": "182",
-    "submissionMethod": "claims",
-    "deciles": [
-      4.56140350877193,
-      84.80138169257341,
-      97.6897689768977,
-      99.90605918271488,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
     "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "182",
+    "benchmarkYear": 2019,
     "submissionMethod": "registry",
     "deciles": [
-      84.23716558206796,
-      96.52820830750156,
-      98.63945578231292,
-      99.8193315266486,
+      84.2372,
+      96.5282,
+      98.6395,
+      99.8193,
       100,
       100,
       100,
       100,
       100
     ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "185",
@@ -4158,23 +2411,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "185",
-    "submissionMethod": "registry",
-    "deciles": [
-      5.038022813688213,
-      45.28301886792453,
-      65.14161220043573,
-      92.3076923076923,
-      97.10312862108921,
-      99.89165763813651,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "187",
@@ -4216,23 +2452,6 @@
   },
   {
     "measureId": "191",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      32.94117647058823,
-      62.41830065359477,
-      82.05128205128204,
-      93.93939393939394,
-      97.92176039119805,
-      99.47643979057592,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "191",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -4251,23 +2470,6 @@
     ]
   },
   {
-    "measureId": "191",
-    "submissionMethod": "registry",
-    "deciles": [
-      60.99071207430341,
-      93.5064935064935,
-      95.8005249343832,
-      98.0392156862745,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "192",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -4288,23 +2490,6 @@
   },
   {
     "measureId": "192",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      4.761904761904762,
-      1.8617021276595744,
-      0.9803921568627451,
-      0.34965034965034963,
-      0,
-      0,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "192",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -4321,23 +2506,6 @@
       0,
       0
     ]
-  },
-  {
-    "measureId": "192",
-    "submissionMethod": "registry",
-    "deciles": [
-      2.1739130434782608,
-      1.6304347826086956,
-      1.350093109869646,
-      0.6024096385542169,
-      0,
-      0,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "195",
@@ -4360,23 +2528,6 @@
   },
   {
     "measureId": "195",
-    "submissionMethod": "claims",
-    "deciles": [
-      20.833333333333336,
-      73.07692307692307,
-      89.13043478260869,
-      98.75,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "195",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -4393,23 +2544,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "195",
-    "submissionMethod": "registry",
-    "deciles": [
-      57.96370967741935,
-      71.80355630821337,
-      87.91208791208791,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "225",
@@ -4432,23 +2566,6 @@
   },
   {
     "measureId": "225",
-    "submissionMethod": "claims",
-    "deciles": [
-      8.812260536398467,
-      88.32997987927565,
-      99.51338199513383,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "225",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -4467,72 +2584,61 @@
     ]
   },
   {
-    "measureId": "225",
-    "submissionMethod": "registry",
-    "deciles": [
-      90.60240963855422,
-      92.394967423051,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "226",
+    "performanceYear": 2019,
+    "benchmarkYear": 2019,
     "submissionMethod": "claims",
     "deciles": [
-      29.23728813559322,
-      89.13043478260869,
-      96.29629629629629,
-      99.609375,
+      29.2373,
+      89.1304,
+      96.2963,
+      99.6094,
       100,
       100,
       100,
       100,
       100
     ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "226",
+    "performanceYear": 2019,
+    "benchmarkYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "deciles": [
-      1.0869565217391304,
-      4.484304932735426,
-      9.187279151943462,
-      22.857142857142858,
-      52.459016393442624,
-      86.73469387755102,
-      97.79411764705883,
+      1.087,
+      4.4843,
+      9.1873,
+      22.8571,
+      52.459,
+      86.7347,
+      97.7941,
       100,
       100
     ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "226",
+    "performanceYear": 2019,
+    "benchmarkYear": 2019,
     "submissionMethod": "registry",
     "deciles": [
-      4.918032786885246,
-      9.67741935483871,
-      13.636363636363635,
-      30.693069306930692,
-      76.51006711409396,
-      98.38709677419355,
+      4.918,
+      9.6774,
+      13.6364,
+      30.6931,
+      76.5101,
+      98.3871,
       100,
       100,
       100
     ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "236",
@@ -4552,23 +2658,6 @@
       88.32,
       94.89
     ]
-  },
-  {
-    "measureId": "236",
-    "submissionMethod": "claims",
-    "deciles": [
-      20.33898305084746,
-      44.680851063829785,
-      53.03030303030303,
-      65.49295774647888,
-      78.42741935483872,
-      90.22346368715084,
-      98.63945578231292,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "236",
@@ -4610,23 +2699,6 @@
   },
   {
     "measureId": "236",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      5.88235294117647,
-      35.38461538461539,
-      44.06779661016949,
-      55.45274289491078,
-      65.3061224489796,
-      75.75757575757575,
-      85.79823702252693,
-      90.9967845659164,
-      98.43953185955787
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "236",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -4643,23 +2715,6 @@
       93.4,
       100
     ]
-  },
-  {
-    "measureId": "236",
-    "submissionMethod": "registry",
-    "deciles": [
-      20.689655172413794,
-      40.74074074074074,
-      47.61904761904761,
-      58.50515463917526,
-      70.28571428571428,
-      82.24852071005917,
-      92.20272904483431,
-      96.44670050761421,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "238",
@@ -4682,23 +2737,6 @@
   },
   {
     "measureId": "238",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      41.57608695652174,
-      27.329974811083126,
-      21.07329842931937,
-      7.128284389489954,
-      0.5908419497784343,
-      0,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "238",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -4715,23 +2753,6 @@
       0,
       0
     ]
-  },
-  {
-    "measureId": "238",
-    "submissionMethod": "registry",
-    "deciles": [
-      32.52595155709342,
-      21.36222910216718,
-      15.308151093439365,
-      7.454786060873402,
-      1.4308426073131957,
-      0.18148820326678766,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "239",
@@ -4753,23 +2774,6 @@
     ]
   },
   {
-    "measureId": "239",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      1.7543859649122806,
-      18.627450980392158,
-      22.764227642276424,
-      29.973919523099852,
-      33.39529120198265,
-      48.529411764705884,
-      70.74542897327707,
-      81.37254901960785,
-      98.05352798053529
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "240",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -4787,23 +2791,6 @@
       42.42,
       50.89
     ]
-  },
-  {
-    "measureId": "240",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      1.5625,
-      4.838709677419355,
-      8.98876404494382,
-      25.454545454545453,
-      36.95652173913043,
-      44.81792717086835,
-      53.67647058823529,
-      58.6195616617599,
-      69.87341772151898
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "243",
@@ -4845,23 +2832,6 @@
   },
   {
     "measureId": "249",
-    "submissionMethod": "claims",
-    "deciles": [
-      96.29629629629629,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "249",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -4878,23 +2848,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "249",
-    "submissionMethod": "registry",
-    "deciles": [
-      58.70967741935483,
-      99.77375565610859,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "250",
@@ -4917,23 +2870,6 @@
   },
   {
     "measureId": "250",
-    "submissionMethod": "claims",
-    "deciles": [
-      32.075471698113205,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "250",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -4950,23 +2886,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "250",
-    "submissionMethod": "registry",
-    "deciles": [
-      90.74074074074075,
-      99.5,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "254",
@@ -5045,23 +2964,6 @@
     ]
   },
   {
-    "measureId": "265",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.33003300330033003,
-      26.923076923076923,
-      45.2887537993921,
-      95.95278246205734,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "268",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5100,23 +3002,6 @@
     ]
   },
   {
-    "measureId": "277",
-    "submissionMethod": "registry",
-    "deciles": [
-      5.288461538461538,
-      5.442176870748299,
-      5.938697318007663,
-      30.952380952380953,
-      57.453416149068325,
-      89.69072164948454,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "279",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5134,23 +3019,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "279",
-    "submissionMethod": "registry",
-    "deciles": [
-      11.63604549431321,
-      12.5,
-      79.16666666666666,
-      91.30434782608695,
-      98.58490566037736,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "281",
@@ -5172,23 +3040,6 @@
     ]
   },
   {
-    "measureId": "281",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      1.639344262295082,
-      2.843016069221261,
-      7.079646017699115,
-      16.431924882629108,
-      41.75824175824176,
-      70.35175879396985,
-      92.5925925925926,
-      97.63313609467455,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "282",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5208,23 +3059,6 @@
     ]
   },
   {
-    "measureId": "282",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.13568521031207598,
-      1.5873015873015872,
-      2.7027027027027026,
-      32.78688524590164,
-      99.18032786885246,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "283",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5242,23 +3076,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "283",
-    "submissionMethod": "registry",
-    "deciles": [
-      90.19607843137256,
-      95.74468085106383,
-      97.8021978021978,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "286",
@@ -5299,23 +3116,6 @@
     ]
   },
   {
-    "measureId": "288",
-    "submissionMethod": "registry",
-    "deciles": [
-      2.247191011235955,
-      2.857142857142857,
-      13.06532663316583,
-      76.21951219512195,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "290",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5333,23 +3133,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "290",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.7543859649122806,
-      1.8181818181818181,
-      2.571428571428571,
-      18.9873417721519,
-      53.333333333333336,
-      85.71428571428571,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "291",
@@ -5371,23 +3154,6 @@
     ]
   },
   {
-    "measureId": "291",
-    "submissionMethod": "registry",
-    "deciles": [
-      3.3333333333333335,
-      5.737704918032787,
-      10.526315789473683,
-      30.357142857142854,
-      76.19047619047619,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "293",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5405,23 +3171,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "293",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.398406374501992,
-      1.0940919037199124,
-      1.4522821576763485,
-      3.977272727272727,
-      69.56521739130434,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "303",
@@ -5481,23 +3230,6 @@
     ]
   },
   {
-    "measureId": "305",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.024962556165751375,
-      0.07936507936507936,
-      0.10101010101010101,
-      0.2613240418118467,
-      0.5233494363929146,
-      1.0353227771010962,
-      3.5483870967741935,
-      9.10904255319149,
-      22.727272727272727
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "309",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5517,23 +3249,6 @@
     ]
   },
   {
-    "measureId": "309",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.2638522427440633,
-      1.1884550084889642,
-      3.793103448275862,
-      15.789473684210526,
-      38.63080684596577,
-      56.37268524366521,
-      71.52777777777779,
-      81.9222326748197,
-      94.84536082474226
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "310",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5551,23 +3266,6 @@
       53.14,
       63.78
     ]
-  },
-  {
-    "measureId": "310",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      1.4705882352941175,
-      7.6923076923076925,
-      11.428571428571429,
-      23.929471032745592,
-      37.18032786885246,
-      55.25114155251142,
-      65.86741889985895,
-      74.97255762897915,
-      86.48648648648648
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "317",
@@ -5590,23 +3288,6 @@
   },
   {
     "measureId": "317",
-    "submissionMethod": "claims",
-    "deciles": [
-      1.282051282051282,
-      23.985239852398525,
-      51.67785234899329,
-      96.69291338582677,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "317",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "electronicHealthRecord",
@@ -5626,23 +3307,6 @@
   },
   {
     "measureId": "317",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.2004008016032064,
-      6.0606060606060606,
-      14.83375959079284,
-      24.03846153846154,
-      32.17391304347826,
-      41.340782122905026,
-      60,
-      73.43941248470011,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "317",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -5659,23 +3323,6 @@
       97.32,
       100
     ]
-  },
-  {
-    "measureId": "317",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.8532423208191127,
-      13.916500994035786,
-      22.502448579823703,
-      33.72093023255814,
-      50.4320987654321,
-      83.1896551724138,
-      99.72850678733032,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "318",
@@ -5716,23 +3363,6 @@
     ]
   },
   {
-    "measureId": "318",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.13486176668914363,
-      1.1235955056179776,
-      5.396825396825397,
-      33.5559265442404,
-      65.45801526717557,
-      90,
-      98.10481984089846,
-      99.58932238193019,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "320",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -5753,23 +3383,6 @@
   },
   {
     "measureId": "320",
-    "submissionMethod": "claims",
-    "deciles": [
-      6,
-      50,
-      85,
-      97.05882352941177,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "320",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -5786,23 +3399,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "320",
-    "submissionMethod": "registry",
-    "deciles": [
-      3.0303030303030303,
-      4.721435316336167,
-      60.71428571428571,
-      87.17948717948718,
-      96.57142857142857,
-      99.45652173913044,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "322",
@@ -5882,23 +3478,6 @@
   },
   {
     "measureId": "326",
-    "submissionMethod": "claims",
-    "deciles": [
-      56.52173913043478,
-      86.20689655172413,
-      94.91525423728814,
-      99.32885906040269,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "326",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -5915,23 +3494,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "326",
-    "submissionMethod": "registry",
-    "deciles": [
-      62.23776223776224,
-      62.98701298701299,
-      82.24956063268893,
-      97.85407725321889,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "331",
@@ -5951,23 +3513,6 @@
       19.99,
       0
     ]
-  },
-  {
-    "measureId": "331",
-    "submissionMethod": "registry",
-    "deciles": [
-      96.875,
-      77.08333333333334,
-      74.41271627514419,
-      68.19278870767207,
-      30.434782608695656,
-      7.6923076923076925,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "332",
@@ -6008,23 +3553,6 @@
     ]
   },
   {
-    "measureId": "333",
-    "submissionMethod": "registry",
-    "deciles": [
-      19.00826446280992,
-      13.157894736842104,
-      12.39193083573487,
-      1.8518518518518516,
-      0,
-      0,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "337",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -6042,23 +3570,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "337",
-    "submissionMethod": "registry",
-    "deciles": [
-      6.7164179104477615,
-      37.2093023255814,
-      78.65168539325843,
-      92,
-      99.75247524752476,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "338",
@@ -6119,20 +3630,22 @@
   },
   {
     "measureId": "343",
+    "performanceYear": 2019,
+    "benchmarkYear": 2019,
     "submissionMethod": "registry",
     "deciles": [
       8,
-      9.090909090909092,
-      29.333333333333332,
-      42.390078917700116,
-      65.51204819277109,
+      9.0909,
+      29.3333,
+      42.3901,
+      65.512,
       100,
       100,
       100,
       100
     ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "350",
@@ -6152,23 +3665,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "350",
-    "submissionMethod": "registry",
-    "deciles": [
-      78.24675324675324,
-      83.80952380952381,
-      88.15533980582524,
-      93.93939393939394,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "351",
@@ -6228,23 +3724,6 @@
     ]
   },
   {
-    "measureId": "353",
-    "submissionMethod": "registry",
-    "deciles": [
-      95.34883720930233,
-      99.56772334293949,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "354",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -6281,23 +3760,6 @@
       0,
       0
     ]
-  },
-  {
-    "measureId": "355",
-    "submissionMethod": "registry",
-    "deciles": [
-      81.6867469879518,
-      56.25,
-      3.6585365853658534,
-      1.0309278350515463,
-      0.5232992773486169,
-      0,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "356",
@@ -6338,23 +3800,6 @@
     ]
   },
   {
-    "measureId": "357",
-    "submissionMethod": "registry",
-    "deciles": [
-      81.92771084337349,
-      54.6875,
-      44.306930693069305,
-      3.6585365853658534,
-      0,
-      0,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "358",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -6372,23 +3817,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "358",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.9259259259259258,
-      1.639344262295082,
-      14.240506329113925,
-      25.53191489361702,
-      99.91935483870968,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "360",
@@ -6486,23 +3914,6 @@
     ]
   },
   {
-    "measureId": "366",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      1.8644067796610169,
-      10.655737704918034,
-      15.625,
-      24.137931034482758,
-      37.106918238993714,
-      46.92653673163418,
-      60,
-      70,
-      95.37037037037037
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "370",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -6520,23 +3931,6 @@
       8.77,
       15
     ]
-  },
-  {
-    "measureId": "370",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.4830917874396135,
-      1.5706806282722514,
-      1.7707362534948743,
-      3.3333333333333335,
-      7.874015748031496,
-      11.902985074626866,
-      20.28985507246377,
-      28.093434343434343,
-      44.884488448844884
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "371",
@@ -6558,38 +3952,23 @@
     ]
   },
   {
-    "measureId": "371",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.1918333790079474,
-      1.0407993338884263,
-      1.9771863117870723,
-      9.23913043478261,
-      20.198463508322664,
-      33.65758754863813,
-      48,
-      63.63636363636363,
-      90.47619047619048
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "372",
+    "performanceYear": 2019,
+    "benchmarkYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "deciles": [
-      0.041701417848206836,
-      0.21023125437981782,
-      0.26399155227032733,
-      1.2244897959183674,
-      8.374142997061703,
-      13.7738483015356,
-      45.56962025316456,
-      63.61809045226131,
-      74.31693989071039
+      0.0417,
+      0.2102,
+      0.264,
+      1.2245,
+      8.3741,
+      13.7738,
+      45.5696,
+      63.6181,
+      74.3169
     ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "374",
@@ -6612,23 +3991,6 @@
   },
   {
     "measureId": "374",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.19083969465648853,
-      1.6331658291457287,
-      3.571428571428571,
-      17.729083665338646,
-      46.596858638743456,
-      76.68393782383419,
-      94.5945945945946,
-      98.14814814814815,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "374",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -6645,23 +4007,6 @@
       92.74,
       99.02
     ]
-  },
-  {
-    "measureId": "374",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.5345268542199488,
-      46.44444444444444,
-      57.95454545454546,
-      94.44444444444444,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "375",
@@ -6721,23 +4066,6 @@
     ]
   },
   {
-    "measureId": "378",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      5.416576027844246,
-      2.8031779343426773,
-      2.127659574468085,
-      1.0447761194029852,
-      0,
-      0,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "379",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -6757,23 +4085,6 @@
     ]
   },
   {
-    "measureId": "379",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.004442667377493447,
-      0.02319109461966605,
-      0.07936507936507936,
-      0.3796095444685466,
-      2.086677367576244,
-      5.535055350553505,
-      8.94918303102983,
-      18.353349077935782,
-      25.55431443730801
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "382",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -6791,23 +4102,6 @@
       36.11,
       51.72
     ]
-  },
-  {
-    "measureId": "382",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.036483035388544326,
-      1.9920318725099602,
-      3.8834951456310676,
-      13.538461538461538,
-      38.333333333333336,
-      54.74768280123584,
-      94.64958553127354,
-      95.75757575757575,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "383",
@@ -6830,11 +4124,13 @@
   },
   {
     "measureId": "384",
+    "performanceYear": 2019,
+    "benchmarkYear": 2019,
     "submissionMethod": "registry",
     "deciles": [
       72.5,
-      81.34328358208955,
-      92.98245614035088,
+      81.3433,
+      92.9825,
       100,
       100,
       100,
@@ -6842,8 +4138,8 @@
       100,
       100
     ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "387",
@@ -6884,23 +4180,6 @@
     ]
   },
   {
-    "measureId": "388",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.1363636363636365,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "389",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -6918,23 +4197,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "389",
-    "submissionMethod": "registry",
-    "deciles": [
-      35,
-      77.90697674418605,
-      88.67924528301887,
-      95.16129032258065,
-      99.1825613079019,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "390",
@@ -6976,23 +4238,6 @@
   },
   {
     "measureId": "395",
-    "submissionMethod": "claims",
-    "deciles": [
-      78.46153846153847,
-      95.65217391304348,
-      97.22222222222221,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "395",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -7011,28 +4256,13 @@
     ]
   },
   {
-    "measureId": "395",
-    "submissionMethod": "registry",
-    "deciles": [
-      69.28571428571428,
-      97.87234042553192,
-      99.30555555555556,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "396",
+    "performanceYear": 2019,
+    "benchmarkYear": 2019,
     "submissionMethod": "claims",
     "deciles": [
-      95.23809523809523,
-      96.96969696969697,
+      95.2381,
+      96.9697,
       100,
       100,
       100,
@@ -7041,8 +4271,8 @@
       100,
       100
     ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "396",
@@ -7064,23 +4294,6 @@
     ]
   },
   {
-    "measureId": "396",
-    "submissionMethod": "registry",
-    "deciles": [
-      91.83673469387756,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "397",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -7098,23 +4311,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "397",
-    "submissionMethod": "claims",
-    "deciles": [
-      80.95238095238095,
-      86.95652173913044,
-      95.83333333333334,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "397",
@@ -7134,23 +4330,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "397",
-    "submissionMethod": "registry",
-    "deciles": [
-      4.433497536945813,
-      97.82608695652173,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "398",
@@ -7191,23 +4370,6 @@
     ]
   },
   {
-    "measureId": "400",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.49180327868852464,
-      0.966183574879227,
-      1.9747899159663864,
-      9.63302752293578,
-      22.602739726027394,
-      45.13888888888889,
-      83.97435897435898,
-      92.5,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "402",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -7225,23 +4387,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "402",
-    "submissionMethod": "registry",
-    "deciles": [
-      3.374777975133215,
-      31.565847035751997,
-      45.91476336237344,
-      81.36200716845879,
-      95.87628865979381,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "404",
@@ -7283,23 +4428,6 @@
   },
   {
     "measureId": "405",
-    "submissionMethod": "claims",
-    "deciles": [
-      80.64516129032258,
-      37.03703703703704,
-      29.411764705882355,
-      13.953488372093023,
-      6.741573033707865,
-      1.282051282051282,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "405",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -7335,23 +4463,6 @@
       0,
       0
     ]
-  },
-  {
-    "measureId": "406",
-    "submissionMethod": "claims",
-    "deciles": [
-      61.904761904761905,
-      52,
-      40,
-      13.793103448275861,
-      2.631578947368421,
-      0.3676470588235294,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "406",
@@ -7411,23 +4522,6 @@
     ]
   },
   {
-    "measureId": "408",
-    "submissionMethod": "registry",
-    "deciles": [
-      47.9328165374677,
-      50,
-      63.05732484076433,
-      91.37351557248488,
-      98.9145183175034,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "410",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -7445,23 +4539,6 @@
       97.22,
       100
     ]
-  },
-  {
-    "measureId": "410",
-    "submissionMethod": "registry",
-    "deciles": [
-      5.555555555555555,
-      51.724137931034484,
-      65.38461538461539,
-      81.92771084337349,
-      96.03960396039604,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "412",
@@ -7483,23 +4560,6 @@
     ]
   },
   {
-    "measureId": "412",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.2333722287047841,
-      1.9886363636363635,
-      7.865168539325842,
-      62.86427976686095,
-      99.57356076759062,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "414",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -7519,23 +4579,6 @@
     ]
   },
   {
-    "measureId": "414",
-    "submissionMethod": "registry",
-    "deciles": [
-      47.71830985915493,
-      66.12903225806451,
-      77.6937618147448,
-      96.30561345504205,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "415",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -7553,23 +4596,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "415",
-    "submissionMethod": "claims",
-    "deciles": [
-      47.45762711864407,
-      80.95238095238095,
-      86.20689655172413,
-      90.32258064516128,
-      95,
-      98.12206572769952,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "415",
@@ -7611,20 +4637,22 @@
   },
   {
     "measureId": "419",
+    "performanceYear": 2019,
+    "benchmarkYear": 2019,
     "submissionMethod": "registry",
     "deciles": [
-      96.42857142857143,
-      62.22222222222222,
-      53.896103896103895,
-      32.69230769230769,
-      10.455764075067025,
-      3.289473684210526,
-      0.8361204013377926,
-      0.2614867388868136,
+      96.4286,
+      62.2222,
+      53.8961,
+      32.6923,
+      10.4558,
+      3.2895,
+      0.8361,
+      0.2615,
       0
     ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "424",
@@ -7646,23 +4674,6 @@
     ]
   },
   {
-    "measureId": "424",
-    "submissionMethod": "registry",
-    "deciles": [
-      95.90145345840635,
-      97.09367996414164,
-      98.24454911863253,
-      99.0437469507237,
-      99.94865870876653,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "425",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -7680,23 +4691,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "425",
-    "submissionMethod": "claims",
-    "deciles": [
-      87.8048780487805,
-      94.44444444444444,
-      96.36363636363636,
-      99.14529914529915,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "425",
@@ -7737,23 +4731,6 @@
     ]
   },
   {
-    "measureId": "430",
-    "submissionMethod": "registry",
-    "deciles": [
-      80.65612338256437,
-      89.4758563763929,
-      93.56237130161482,
-      97.62820767064609,
-      98.61241400875547,
-      99.45205479452055,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "431",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -7771,23 +4748,6 @@
       97.96,
       100
     ]
-  },
-  {
-    "measureId": "431",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.303951367781155,
-      8,
-      26.845637583892618,
-      68.15703380588877,
-      91.60554197229014,
-      99.04306220095694,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "435",
@@ -7829,23 +4789,6 @@
   },
   {
     "measureId": "436",
-    "submissionMethod": "claims",
-    "deciles": [
-      0.6557377049180327,
-      54.90654205607477,
-      82.77439024390245,
-      97.75687409551375,
-      99.88165680473374,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "436",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -7862,23 +4805,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "436",
-    "submissionMethod": "registry",
-    "deciles": [
-      91.07052257737189,
-      97.63513513513513,
-      97.70738175924562,
-      99.98911031253404,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "437",
@@ -7920,23 +4846,6 @@
   },
   {
     "measureId": "438",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      1.257861635220126,
-      35.07306889352819,
-      46.83195592286501,
-      62.26912928759894,
-      69.93464052287581,
-      76.01156069364163,
-      81.68350168350167,
-      84.28571428571429,
-      97.2972972972973
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
-    "measureId": "438",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
     "submissionMethod": "registry",
@@ -7972,23 +4881,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "440",
-    "submissionMethod": "registry",
-    "deciles": [
-      66.66666666666666,
-      90.625,
-      93.65567356064841,
-      98.69706840390879,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "441",
@@ -8105,38 +4997,23 @@
     ]
   },
   {
-    "measureId": "453",
-    "submissionMethod": "registry",
-    "deciles": [
-      45.94594594594595,
-      25,
-      22.54335260115607,
-      18.181818181818183,
-      14.814814814814813,
-      8.695652173913043,
-      4,
-      3.9215686274509802,
-      0
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "456",
+    "performanceYear": 2019,
+    "benchmarkYear": 2019,
     "submissionMethod": "registry",
     "deciles": [
-      97.62845849802372,
-      97.36842105263158,
-      97.14285714285714,
-      69.89795918367348,
-      61.76470588235294,
-      54.054054054054056,
-      43.47826086956522,
-      38.23529411764706,
-      37.83783783783784
+      97.6285,
+      97.3684,
+      97.1429,
+      69.898,
+      61.7647,
+      54.0541,
+      43.4783,
+      38.2353,
+      37.8378
     ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "457",
@@ -8177,23 +5054,27 @@
   },
   {
     "measureId": "463",
+    "performanceYear": 2019,
+    "benchmarkYear": 2019,
     "submissionMethod": "registry",
     "deciles": [
       87.5,
-      90.27128157156221,
-      92.38525730180807,
-      96.44322845417237,
-      98.35205992509364,
-      99.34158546220701,
+      90.2713,
+      92.3853,
+      96.4432,
+      98.3521,
+      99.3416,
       100,
       100,
       100
     ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "472",
+    "performanceYear": 2019,
+    "benchmarkYear": 2019,
     "submissionMethod": "electronicHealthRecord",
     "deciles": [
       0,
@@ -8206,8 +5087,8 @@
       0,
       0
     ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "AAD2",
@@ -8229,23 +5110,6 @@
     ]
   },
   {
-    "measureId": "AAD2",
-    "submissionMethod": "registry",
-    "deciles": [
-      3.234501347708895,
-      5.813953488372093,
-      18.39080459770115,
-      63.26530612244898,
-      99.25925925925925,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "AAD5",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -8263,23 +5127,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "AAD5",
-    "submissionMethod": "registry",
-    "deciles": [
-      24.675324675324674,
-      81.95876288659794,
-      82.51748251748252,
-      88.6178861788618,
-      97.6545842217484,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "AAN10",
@@ -8301,23 +5148,6 @@
     ]
   },
   {
-    "measureId": "AAN10",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.683371298405467,
-      3.614457831325301,
-      6.866416978776529,
-      19.818878439568095,
-      39.295392953929536,
-      59.447983014862,
-      84.21955403087479,
-      86.6906474820144,
-      95.20383693045564
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "AAN5",
     "benchmarkYear": 2017,
     "performanceYear": 2019,
@@ -8337,38 +5167,23 @@
     ]
   },
   {
-    "measureId": "AAN5",
-    "submissionMethod": "registry",
-    "deciles": [
-      16.666666666666664,
-      30.37974683544304,
-      43.39622641509434,
-      54.09836065573771,
-      66.23376623376623,
-      78.88888888888889,
-      87.34177215189874,
-      90.57239057239057,
-      95.22342064714945
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "AAN8",
+    "performanceYear": 2019,
+    "benchmarkYear": 2019,
     "submissionMethod": "registry",
     "deciles": [
-      22.502870264064295,
-      41.86046511627907,
-      52.22222222222223,
-      65.71428571428571,
-      81.81818181818183,
+      22.5029,
+      41.8605,
+      52.2222,
+      65.7143,
+      81.8182,
       93.75,
-      98.20859872611464,
+      98.2086,
       100,
       100
     ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "AAN9",
@@ -8388,23 +5203,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "AAN9",
-    "submissionMethod": "registry",
-    "deciles": [
-      3.7037037037037033,
-      6.0606060606060606,
-      17.599999999999998,
-      57.14285714285714,
-      85.52631578947368,
-      92.72727272727272,
-      97.68160741885626,
-      98.14814814814815,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
   },
   {
     "measureId": "ABG16",
@@ -8924,38 +5722,23 @@
     ]
   },
   {
-    "measureId": "IRIS2",
-    "submissionMethod": "registry",
-    "deciles": [
-      57.505773672055426,
-      61.904761904761905,
-      71.27371273712737,
-      89.52042628774423,
-      93.01447451227187,
-      97.71689497716895,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
-  },
-  {
     "measureId": "IRIS27",
+    "performanceYear": 2019,
+    "benchmarkYear": 2019,
     "submissionMethod": "registry",
     "deciles": [
-      9.734513274336283,
-      8.823529411764707,
-      6.451612903225806,
-      1.839464882943144,
-      1.0869565217391304,
-      0.2805049088359046,
+      9.7345,
+      8.8235,
+      6.4516,
+      1.8395,
+      1.087,
+      0.2805,
       0,
       0,
       0
     ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "MBSAQIP8",
@@ -8997,54 +5780,60 @@
   },
   {
     "measureId": "PIMSH1",
+    "performanceYear": 2019,
+    "benchmarkYear": 2019,
     "submissionMethod": "registry",
     "deciles": [
-      0.5319148936170213,
-      0.6944444444444444,
-      1.0600706713780919,
-      1.9230769230769231,
-      6.172839506172839,
-      36.94779116465863,
-      60.86956521739131,
-      70.96774193548387,
-      85.18518518518519
+      0.5319,
+      0.6944,
+      1.0601,
+      1.9231,
+      6.1728,
+      36.9478,
+      60.8696,
+      70.9677,
+      85.1852
     ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "PIMSH4",
+    "performanceYear": 2019,
+    "benchmarkYear": 2019,
     "submissionMethod": "registry",
     "deciles": [
-      11.965811965811966,
-      21.634615384615387,
-      24.21383647798742,
-      32.29166666666667,
-      41.269841269841265,
+      11.9658,
+      21.6346,
+      24.2138,
+      32.2917,
+      41.2698,
       50,
-      58.620689655172406,
-      62.121212121212125,
-      70.37037037037037
+      58.6207,
+      62.1212,
+      70.3704
     ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "PIMSH5",
+    "performanceYear": 2019,
+    "benchmarkYear": 2019,
     "submissionMethod": "registry",
     "deciles": [
-      15.686274509803921,
-      13.636363636363635,
+      15.6863,
+      13.6364,
       12,
       8,
-      4.761904761904762,
-      2.4390243902439024,
+      4.7619,
+      2.439,
       0,
       0,
       0
     ],
-    "performanceYear": 2019,
-    "benchmarkYear": 2017
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "PPRNET13",

--- a/benchmarks/2019/benchmarks-schema.yaml
+++ b/benchmarks/2019/benchmarks-schema.yaml
@@ -16,7 +16,7 @@ definitions:
       isToppedOut:
         description: isToppedOut is a boolean value that describes whether a benchmark's latter deciles repeat a value of 100 or, in the case of inverse measures, a value of 0.
         type: boolean
-        isToppedOutByProgram:
+      isToppedOutByProgram:
         description: isToppedOutByProgram is a boolean value that indicates whether or not a Topped Out Measure will receive special scoring. If “true” the measure cannot earn more than 7 points.
         type: boolean
       benchmarkYear:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.41.0",
+  "version": "1.41.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "1.41.1",
+  "version": "1.41.2",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js
+++ b/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js
@@ -159,12 +159,13 @@ const mergeBenchmarkFiles = (benchmarkFileNames, benchmarkJsonDir) => {
  * @returns {void}
  */
 const validateUniqueConstraints = (benchmarks) => {
-  benchmarks = [];
+  benchmarks = benchmarks || [];
   let failedCount = 0;
   for (const benchmark of benchmarks) {
-    if (!benchmarks
-      .some(b => UNIQUE_COLUMN_CONSTRAINT
-        .every(key => benchmark[key] === b[key]))) {
+    if (benchmarks
+      .filter(b => UNIQUE_COLUMN_CONSTRAINT
+        .every(key => benchmark[key] === b[key]))
+      .length === 1) {
       continue;
     } else {
       console.log('Duplicate key constraint failed for benchmark:');

--- a/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js
+++ b/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js
@@ -9,21 +9,34 @@ const UNIQUE_COLUMN_CONSTRAINT = [
   'submissionMethod'
 ];
 
-// Returns an alphabetically-ordered list of files in the given pat
-const getOrderedFileNames = (currentDir, relativePath) => {
-  return fs.readdirSync(path.join(currentDir, relativePath));
-};
+/**
+ * Function to get an alphabetically-ordered list of files in a given path
+ *
+ * @param {String} currentDir The path of the current directory
+ * @param {String} relativePath The relative path to the target directory
+ * @returns {[String]} a collection of files in the target directory
+ */
+const getOrderedFileNames = (currentDir, relativePath) => fs.readdirSync(path.join(currentDir, relativePath));
 
-// Generate a key in an object to store benchmarks in.
-// Benchmarks with the same key will overwrite one another base
-// which was loaded last. See mergeBenchmarkLayers for more details.
-const getBenchmarkKey = (benchmark, isPerformanceBenchmark = false) => {
+/**
+ * Generates a key in an object to store benchmarks in. Benchmarks with the same key will overwrite one another, based on which was added
+ * first. See mergeBenchmarkLayers() for more details.
+ * @param {{
+  *   measureId: String,
+  *   performanceYear: Number,
+  *   benchmarkYear: Number,
+  *   submissionMethod: String,
+  *   deciles: [Number],
+  *   isToppedOut: Boolean,
+  *   isToppedOutByProgram: Boolean
+  * }} benchmark The benchmark to get the key for
+  * @returns {String} The benchmark key based on unique column constraints
+ */
+const getBenchmarkKey = (benchmark) => {
   let benchmarkKey = '';
   UNIQUE_COLUMN_CONSTRAINT.forEach((keyName) => {
     // For performance benchmarks, the benchmark year and the performance year are the same
-    if (keyName === 'benchmarkYear' && isPerformanceBenchmark && 'performanceYear' in benchmark) {
-      benchmarkKey = `${benchmarkKey}${benchmark['performanceYear']}|`;
-    } else if (keyName in benchmark) {
+    if (keyName in benchmark) {
       benchmarkKey = `${benchmarkKey}${benchmark[keyName]}|`;
     } else {
       throw new Error('Key is missing: ' + keyName);
@@ -33,30 +46,91 @@ const getBenchmarkKey = (benchmark, isPerformanceBenchmark = false) => {
   return benchmarkKey;
 };
 
-// Accepts an array of relative file paths, loads json files,
-// returns a composite collection of benchmarks.
-// Subsequent JSON files can add but not overwrite benchmarks from previous JSON files.
-// Uniqueness is checked by the composite key in UNIQUE_COLUMN_CONSTRAINT.
-// Note: Benchmarks with the same key will raise a collective error.
-// Note: Perforamnce benchmarks are processed with data from the same year, so require special handling
-const mergeBenchmarkLayers = (benchmarkLayers, benchmarkJsonDir) => {
+/**
+ * Function to populate the missing fields on a performance benchmark
+ * @param {{
+ *   measureId: String,
+ *   performanceYear: Number,
+ *   submissionMethod: String,
+ *   deciles: [Number]
+ * }} benchmark the performance benchmark to process
+ * @returns {{
+  *   measureId: String,
+  *   performanceYear: Number,
+  *   benchmarkYear: Number,
+  *   submissionMethod: String,
+  *   deciles: [Number],
+  *   isToppedOut: Boolean,
+  *   isToppedOutByProgram: Boolean
+  * }}
+ */
+const processPerformanceBenchmark = (benchmark) => {
+  return {
+    measureId: benchmark.measureId,
+    performanceYear: benchmark.performanceYear,
+    benchmarkYear: benchmark.performanceYear,
+    submissionMethod: benchmark.submissionMethod,
+    deciles: benchmark.deciles.map(d => _.round(d, (benchmark.performanceYear >= 2019 ? 4 : 2))),
+    isToppedOut: false,
+    isToppedOutByProgram: false
+  };
+};
+
+/**
+ * Function to read a JSON file
+ * @param {String} dir The target directory
+ * @param {String} file The target file
+ * @returns {[{
+ *   measureId: String,
+ *   benchmarkYear?: Number,
+ *   performanceYear: Number,
+ *   submissionMethod: String,
+ *   deciles: [Number],
+ *   isToppedOut?: Boolean,
+ *   isToppedOutByProgram?: Boolean
+ * }]}
+ */
+const loadBenchmark = (dir, file) => JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
+
+/**
+ * Loads in each JSON from the staging directory passed in, compares them by unique column constraints, and returns a collection of
+ * formatted benchmarks.
+ *
+ * **Notes:**
+ * * Benchmarks with the same key will raise a collective error
+ * * Performance benchmarks from Final Scoring require special processing
+ * @param {[String]} benchmarkFileNames An array of relative file paths to load JSONs from
+ * @param {String} benchmarkJsonDir The directory to load JSON files from
+ * @returns {[{
+ *   measureId: String,
+ *   benchmarkYear: Number,
+ *   performanceYear: Number,
+ *   submissionMethod: String,
+ *   deciles: [Number],
+ *   isToppedOut: Boolean,
+ *   isToppedOutByProgram: Boolean
+ * }]} a composite collection of benchmarks
+ */
+const mergeBenchmarkFiles = (benchmarkFileNames, benchmarkJsonDir) => {
   const mergedBenchmarks = new Map();
   const mergeConflicts = [];
 
-  benchmarkLayers.forEach((benchmarkLayer) => {
-    const benchmarkFile = JSON.parse(fs.readFileSync(path.join(benchmarkJsonDir, benchmarkLayer), 'utf8'));
-    const isPerformanceBenchmark = benchmarkLayer.indexOf('performance-benchmarks.json') > -1;
+  benchmarkFileNames.forEach((filename) => {
+    const benchmarkFile = loadBenchmark(benchmarkJsonDir, filename);
+    const isPerformanceBenchmark = filename.indexOf('performance-benchmarks.json') > -1;
     benchmarkFile.forEach((benchmark) => {
-      const benchmarkKey = getBenchmarkKey(benchmark, isPerformanceBenchmark);
       if (isPerformanceBenchmark) {
-        benchmark.benchmarkYear = benchmark.performanceYear - 2;
+        benchmark = processPerformanceBenchmark(benchmark);
       }
+      const benchmarkKey = getBenchmarkKey(!isPerformanceBenchmark ? benchmark : {...benchmark, benchmarkYear: benchmark.performanceYear - 2});
       if (mergedBenchmarks.has(benchmarkKey) && !_.isEqual(mergedBenchmarks.get(benchmarkKey), benchmark)) {
-        mergeConflicts.push({
-          existing: mergedBenchmarks.get(benchmarkKey),
-          conflicting: benchmark,
-          conflictingFile: benchmarkLayer
-        });
+        if (!isPerformanceBenchmark) {
+          mergeConflicts.push({
+            existing: mergedBenchmarks.get(benchmarkKey),
+            conflicting: benchmark,
+            conflictingFile: filename
+          });
+        }
       } else {
         mergedBenchmarks.set(benchmarkKey, benchmark);
       }
@@ -71,8 +145,44 @@ const mergeBenchmarkLayers = (benchmarkLayers, benchmarkJsonDir) => {
   }
 };
 
+/**
+ * Function to ensure that the benchmarks are all unique according to the column constraints outlined above
+ * @param {[{
+  *   measureId: String,
+  *   performanceYear: Number,
+  *   benchmarkYear: Number,
+  *   submissionMethod: String,
+  *   deciles: [Number],
+  *   isToppedOut: Boolean,
+  *   isToppedOutByProgram: Boolean
+  * }]} benchmarks - the collection of benchmarks to evaluate
+ * @returns {void}
+ */
+const validateUniqueConstraints = (benchmarks) => {
+  benchmarks = [];
+  let failedCount = 0;
+  for (const benchmark of benchmarks) {
+    if (!benchmarks
+      .some(b => UNIQUE_COLUMN_CONSTRAINT
+        .every(key => benchmark[key] === b[key]))) {
+      continue;
+    } else {
+      console.log('Duplicate key constraint failed for benchmark:');
+      UNIQUE_COLUMN_CONSTRAINT.forEach(key => {
+        console.log(`  ${key}: ${benchmark[key]}`);
+      });
+      failedCount++;
+    }
+  }
+  if (failedCount > 0) {
+    console.log('Duplicate benchmarks found. This is usually the result of an error in modifying the benchmarks script. Exiting.');
+    process.exit(failedCount);
+  }
+};
+
 module.exports = {
   getOrderedFileNames,
   getBenchmarkKey,
-  mergeBenchmarkLayers
+  mergeBenchmarkFiles,
+  validateUniqueConstraints
 };

--- a/scripts/benchmarks/merge-benchmark-data.js
+++ b/scripts/benchmarks/merge-benchmark-data.js
@@ -1,4 +1,4 @@
-const { getOrderedFileNames, mergeBenchmarkLayers } = require('./helpers/merge-benchmark-data-helpers.js');
+const { getOrderedFileNames, mergeBenchmarkFiles, validateUniqueConstraints } = require('./helpers/merge-benchmark-data-helpers.js');
 const path = require('path');
 
 const performanceYear = process.argv[2];
@@ -20,7 +20,9 @@ if (performanceYear) {
         return 0;
       }
     });
-  const formattedBenchmarks = mergeBenchmarkLayers(benchmarkLayerFiles, jsonDir);
+  const formattedBenchmarks = mergeBenchmarkFiles(benchmarkLayerFiles, jsonDir);
+
+  validateUniqueConstraints(formattedBenchmarks);
 
   process.stdout.write(JSON.stringify(formattedBenchmarks, null, 2));
 } else {

--- a/test/benchmarks/benchmarks-spec.js
+++ b/test/benchmarks/benchmarks-spec.js
@@ -1,5 +1,6 @@
 // Libraries
 const chai = require('chai');
+const fs = require('fs');
 const assert = chai.assert;
 // functions being tested
 const main = require('./../../index');
@@ -25,5 +26,33 @@ describe('benchmarks getter functions', function() {
     it('should return a string', function() {
       assert.isObject(getBenchmarksSchema());
     });
+  });
+});
+
+describe('data validation', () => {
+  describe('benchmarks should not have duplicate measures in any file', () => {
+    const UNIQUE_COLUMN_CONSTRAINT = [
+      'measureId',
+      'benchmarkYear',
+      'performanceYear',
+      'submissionMethod'
+    ];
+    // const benchmark = require('../../benchmarks/2019.json');
+    const benchmarkFiles = fs.readdirSync(`${__dirname}/../../benchmarks/`);
+    for (const file of benchmarkFiles) {
+      if (file.indexOf('.json') !== -1) {
+        describe(`File: ./benchmarks/${file}`, () => {
+          const benchmarks = require(`../../benchmarks/${file}`);
+          for (const benchmark of benchmarks) {
+            it(`should not duplicate ${benchmark.measureId} - ${benchmark.submissionMethod}`, () => {
+              assert.isTrue(benchmarks
+                .filter(b => UNIQUE_COLUMN_CONSTRAINT
+                  .every(key => benchmark[key] === b[key]))
+                .length === 1);
+            });
+          }
+        });
+      }
+    }
   });
 });

--- a/test/benchmarks/files/performance-benchmarks.json
+++ b/test/benchmarks/files/performance-benchmarks.json
@@ -1,0 +1,33 @@
+[{
+  "measureId": "001",
+  "performanceYear": 2017,
+  "submissionMethod": "claims",
+  "deciles": [
+    100,
+    90,
+    80,
+    70,
+    60,
+    50,
+    40,
+    30,
+    20,
+    10
+  ]
+}, {
+  "measureId": "dummy",
+  "performanceYear": 2017,
+  "submissionMethod": "dummy",
+  "deciles": [
+    100,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ]
+}]


### PR DESCRIPTION
#### Motivation for change

After the previous PR for this ticket, numerous benchmarks were being duplicated in the published data. This has been corrected, and a validation has been added to ensure that such data should never be written again.

#### What is being changed

Performance Benchmarks lack the `benchmarkYear` attribute, and so were not being properly flagged as duplicates by the script. This has been corrected, and special handling has been added to ensure that these benchmarks do not overwrite previously-written benchmarks.

In addition, a validation step has been added to the benchmark generation script to ensure that duplicate benchmarks do not make it into the final file.

Numerous code comments were added, the formatting was corrected on some files.

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [x] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [x] Documentation updated
* [x] Unit tests added/passing
* [x] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-5831
