### PR TITLE
QPPA-3756 Github Action Workflow

### DIFF
--- a/.github/release-draft.yml
+++ b/.github/release-draft.yml
@@ -1,8 +1,8 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 replacers:
-  - search: '/QPPA-(\d+)/gi'
-    replace: '[QPPA-$1](https://jira.cms.gov/browse/QPPA-$1)'
+  - search: '/QPP([^\-]+)-(\d+)/gi'
+    replace: '[QPP$1-$2](https://jira.cms.gov/browse/QPP$1-$2)'
 change-template: '- $TITLE (#$NUMBER)'
 version-resolver:
   major:

--- a/.github/release-draft.yml
+++ b/.github/release-draft.yml
@@ -1,0 +1,21 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+replacers:
+  - search: '/QPPA-(\d+)/gi'
+    replace: '[QPPA-$1](https://jira.cms.gov/browse/QPPA-$1)'
+change-template: '- $TITLE (#$NUMBER)'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -15,10 +15,10 @@ jobs:
 
       - name: Detect and tag new version
         id: package-version
-        uses: salsify/action-detect-and-tag-new-version@v1.0.3
+        uses: salsify/action-detect-and-tag-new-version@68bbe8670f415d304e02942186441939c4692aa6 #v1.0.3
 
       - name: Draft release notes
-        uses: release-drafter/release-drafter@v5
+        uses: release-drafter/release-drafter@06d4616a80cd7c09ea3cf12214165ad6c1859e67 #v5.11
         with:
           config-name: release-draft.yml
           version: v${{ steps.package-version.outputs.current-version }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,27 @@
+name: QPP Measures Release Notes Drafter
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  release_draft:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout Codebase
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: Detect and tag new version
+        id: package-version
+        uses: salsify/action-detect-and-tag-new-version@v1.0.3
+
+      - name: Draft release notes
+        uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-draft.yml
+          version: v${{ steps.package-version.outputs.current-version }}
+          tag: v${{ steps.package-version.outputs.current-version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-feature.yml
+++ b/.github/workflows/pr-feature.yml
@@ -9,9 +9,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - name: Checkout Codebase
+        uses: actions/checkout@v2
+      - name: Configure Node version and registry
+        uses: actions/setup-node@v1
         with:
           node-version: 12
-      - run: npm ci
-      - run: npm test
+      - name: Install Dependencies
+        run: npm ci
+      - name: Run Tests
+        run: npm test

--- a/.github/workflows/pr-feature.yml
+++ b/.github/workflows/pr-feature.yml
@@ -1,0 +1,17 @@
+name: QPP Measures Data Feature PR CI/Checks
+on: 
+  pull_request:
+    types: [opened, synchronize]
+    branches: [ develop ]
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm ci
+      - run: npm test

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -9,14 +9,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - name: Checkout Codebase
+        uses: actions/checkout@v2
+      - name: Configure Node version and registry
+        uses: actions/setup-node@v1
         with:
           node-version: 12
-      - run: npm ci
-      - run: npm test
+      - name: Install Dependencies
+        run: npm ci
+      - name: Run Tests
+        run: npm test
       - name: Version Check
-        uses: EndBug/version-check@v1
+        uses: EndBug/version-check@a45f6f582d50047e42a4534ffb74b77a2c3af811 #v1.3.0
         id: check
       - name: Version Not Updated
         if: steps.check.outputs.changed == 'false'

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -1,0 +1,25 @@
+name: QPP Measures Data PR CI/Checks
+on: 
+  pull_request:
+    types: [opened, synchronize]
+    branches: [ master ]
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm ci
+      - run: npm test
+      - name: Version Check
+        uses: EndBug/version-check@v1
+        id: check
+      - name: Version Not Updated
+        if: steps.check.outputs.changed == 'false'
+        run: 'echo "No version change found!"'
+
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,9 +60,9 @@ jobs:
           - CMSgov/qpp-submissions-api
     steps:
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v1.1.0
+        uses: peter-evans/repository-dispatch@1708dda5703a768a0fb0ef6a7a03a0c3805ebc59 #v1.1.1
         with:
-          token: ${{ secrets.GITHUB_USER_TOKEN }}
+          token: ${{ secrets.GH_USER_TOKEN }}
           repository: ${{ matrix.repo }}
           event-type: lib-update-event
           client-payload: '{"ref": "${{ github.ref }}", "private_package": "@CMSGov/qpp-measures-data", "public_package":"qpp-measures-data" ,"tag_name": "${{ github.event.release.tag_name }}", "html_url": "${{github.event.release.html_url}}"}'
@@ -71,19 +71,12 @@ jobs:
   notify-slack:
     runs-on: ubuntu-latest
     needs: publish-npm
-    strategy:
-      matrix:
-        channel:
-          - p-qppsf-scoring
-          - p-wi
-          - p-qppsf-api-team
     steps:
-    - uses: actions/checkout@v2
-    - name: Slack Notification
-      uses: rtCamp/action-slack-notify@v2.0.2
+    - name: Notify APP Submissions API Channel
+      uses: rtCamp/action-slack-notify@96d5e2a64fc78a6b7ac13265f55bee296869967a #v2.0.2
       env:
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-        SLACK_CHANNEL: ${{ matrix.channel }}
+        SLACK_WEBHOOK: ${{ secrets.SUBMISSIONS_API_SLACK_WEBHOOK }}
+        SLACK_CHANNEL: "p-qppsf-api"
         SLACK_MESSAGE: "`qpp-measures-data` has been updated to version <${{github.event.release.html_url}}|${{ github.event.release.tag_name }}>"
         SLACK_TITLE: New qpp-measures-data release
         SLACK_USERNAME: releaseNotify

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,89 @@
+name: QPP Measures Data Publish
+
+on:
+  release:
+    types: [ prereleased ]
+
+jobs:
+
+  publish-gpr:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout Codebase
+        uses: actions/checkout@v2
+
+      - name: Configure Node version and registry
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://npm.pkg.github.com/
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Publish to GitHub Package Registry
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout Codebase
+        uses: actions/checkout@v2
+
+      - name: Configure Node version and registry
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Publish to NPM
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+  # Make an announcement to other repositories of interest
+  repo-dispatch:
+    runs-on: ubuntu-latest
+    needs: publish-npm
+    strategy:
+      matrix:
+        repo: 
+          - CMSgov/qpp-scoring-engines
+          - CMSgov/beneficiary-reporting-api
+          - CMSgov/qpp-submissions-api
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1.1.0
+        with:
+          token: ${{ secrets.GITHUB_USER_TOKEN }}
+          repository: ${{ matrix.repo }}
+          event-type: lib-update-event
+          client-payload: '{"ref": "${{ github.ref }}", "private_package": "@CMSGov/qpp-measures-data", "public_package":"qpp-measures-data" ,"tag_name": "${{ github.event.release.tag_name }}", "html_url": "${{github.event.release.html_url}}"}'
+  
+  # make an announcement to relevant slack channels
+  notify-slack:
+    runs-on: ubuntu-latest
+    needs: publish-npm
+    strategy:
+      matrix:
+        channel:
+          - p-qppsf-scoring
+          - p-wi
+          - p-qppsf-api-team
+    steps:
+    - uses: actions/checkout@v2
+    - name: Slack Notification
+      uses: rtCamp/action-slack-notify@v2.0.2
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_CHANNEL: ${{ matrix.channel }}
+        SLACK_MESSAGE: "`qpp-measures-data` has been updated to version <${{github.event.release.html_url}}|${{ github.event.release.tag_name }}>"
+        SLACK_TITLE: New qpp-measures-data release
+        SLACK_USERNAME: releaseNotify


### PR DESCRIPTION
#### Motivation for change

Github workflow for automating release management and notifications.
[Tech Spec](https://confluence.cms.gov/display/QPPARCH/Tech+Spec%3A+Automated+Publication+of+New+Measures+and+updates)

#### What is being changed
* test runs for both feature and release PRs
    - additional version bump check for release PRs
* draft of release page on release merge to master
* on prerelease:
  - publish to gpr
  - publish to npm
  - dispatch of event to dependent projects
  - notification of relevant slack channels of publish

#### Configuration
The following secrets need to be set by an admin:
* `NPM_TOKEN` for publishing to npm
* `GITHUB_USER_TOKEN` for dispatching of events to other repos
* `SLACK_WEBHOOK` for dispatching notifications to slack

#### Notes
The slack webhook needs to be created by someone with permissions, and the integration will likely require additional configuration/testing. Additional build steps such as actually building the json could be done in the feature branch pr action should we want to do that/are ok with the risks associated with it.


##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-3756
