### PR TITLE
Updating publish action with CMSgov/beneficiary-reporting-client

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,7 @@ jobs:
         repo: 
           - CMSgov/qpp-scoring-engines
           - CMSgov/beneficiary-reporting-api
+          - CMSgov/beneficiary-reporting-client
           - CMSgov/qpp-submissions-api
     steps:
       - name: Repository Dispatch


### PR DESCRIPTION
What is the problem being solved? What is the feature being added?
Adding `CMSgov/beneficiary-reporting-client` to the publish github action so that we can get fancy automatic created PRs when this lib is updated.

#### What is being changed

Detailed information about what is being changed and rationale for interesting decisions made

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [ ] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [ ] Unit tests added/passing
* [ ] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-XXXX
