### PR TITLE
QPPA-4432 update performance benchmarks 17 18

### DIFF
--- a/benchmarks/2017.json
+++ b/benchmarks/2017.json
@@ -51,6 +51,1145 @@
     ]
   },
   {
+    "measureId": "002",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      0.83,
+      1.07,
+      1.36,
+      1.83,
+      2.52,
+      3.54,
+      6.46,
+      25.58
+    ]
+  },
+  {
+    "measureId": "005",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0,
+      62.16,
+      66.67,
+      71.43,
+      74.91,
+      77.61,
+      82.61,
+      85.71,
+      90.91
+    ]
+  },
+  {
+    "measureId": "005",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      75.86,
+      79.49,
+      82.14,
+      85,
+      87.5,
+      90,
+      93.54,
+      96.55
+    ]
+  },
+  {
+    "measureId": "006",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      76.92,
+      81.76,
+      85,
+      87.54,
+      90.23,
+      92.55,
+      95.65,
+      100
+    ]
+  },
+  {
+    "measureId": "007",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0,
+      48.54,
+      60.87,
+      69.23,
+      76.63,
+      80.95,
+      85,
+      89.47,
+      95.24
+    ]
+  },
+  {
+    "measureId": "007",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      74.39,
+      77.87,
+      80,
+      82.72,
+      85.11,
+      87.24,
+      89.69,
+      93.24
+    ]
+  },
+  {
+    "measureId": "008",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0,
+      58.62,
+      64.71,
+      71.95,
+      78.26,
+      85.51,
+      90,
+      91.67,
+      96
+    ]
+  },
+  {
+    "measureId": "008",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      75.68,
+      81.08,
+      85.58,
+      88.44,
+      91.17,
+      94.29,
+      96.37,
+      100
+    ]
+  },
+  {
+    "measureId": "009",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0,
+      1.06,
+      1.35,
+      1.62,
+      1.93,
+      2.5,
+      5,
+      62.69,
+      80.77
+    ]
+  },
+  {
+    "measureId": "012",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      99.01,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "012",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0,
+      73.33,
+      82.42,
+      87.4,
+      90.91,
+      94.17,
+      96.58,
+      98.26,
+      99.58
+    ]
+  },
+  {
+    "measureId": "012",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      95.07,
+      98.11,
+      99.36,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "014",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "014",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      31.01,
+      55.13,
+      77.25,
+      91.18,
+      98.19,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "018",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0,
+      31.69,
+      41.33,
+      50,
+      56.98,
+      64.18,
+      70.59,
+      76.98,
+      85.16
+    ]
+  },
+  {
+    "measureId": "019",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "019",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0,
+      20,
+      29.79,
+      38.36,
+      45.71,
+      52.54,
+      60.8,
+      68.81,
+      79.31
+    ]
+  },
+  {
+    "measureId": "019",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      36.21,
+      60,
+      78.57,
+      89.81,
+      96.23,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "021",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "021",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      91.17,
+      99.11,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "022",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "022",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      45.69,
+      77.38,
+      97.78,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "023",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "023",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      89.74,
+      96.67,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "024",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      75,
+      91.3,
+      96.43,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "024",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      8,
+      10.34,
+      12.5,
+      17.07,
+      21.88,
+      50,
+      82.5,
+      100
+    ]
+  },
+  {
+    "measureId": "032",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      51.16,
+      63.64,
+      88,
+      96.43,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "032",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      27.17,
+      46.3,
+      67.86,
+      80.86,
+      90.91,
+      96.43,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "033",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      29.55,
+      43.19,
+      55.78,
+      73.76,
+      87.8,
+      95.23,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "039",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      30.77,
+      39.55,
+      46.75,
+      53.97,
+      61.9,
+      70.87,
+      82.54,
+      95.88
+    ]
+  },
+  {
+    "measureId": "039",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      13.39,
+      16.67,
+      20.4,
+      25.32,
+      34,
+      47.95,
+      64.66,
+      82.54
+    ]
+  },
+  {
+    "measureId": "040",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      15,
+      28,
+      36.15,
+      50,
+      75.31,
+      92.86,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "040",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      5,
+      6.96,
+      8.7,
+      16.14,
+      32.79,
+      47.41,
+      65.57,
+      88.89
+    ]
+  },
+  {
+    "measureId": "041",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      33.33,
+      40.46,
+      46.67,
+      58.33,
+      74.51,
+      96.46,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "041",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      33.33,
+      40.44,
+      46.29,
+      52.78,
+      59.26,
+      66.67,
+      75.59,
+      100
+    ]
+  },
+  {
+    "measureId": "043",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      98.17,
+      98.7,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "044",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      96.84,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "044",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      91.14,
+      95,
+      97.33,
+      98.88,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "046",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "046",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "047",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      13.68,
+      34.58,
+      62.87,
+      86.92,
+      97.11,
+      99.6,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "047",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      16.52,
+      38.12,
+      59.15,
+      75,
+      88.72,
+      96.3,
+      99.18,
+      100
+    ]
+  },
+  {
+    "measureId": "048",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      6.25,
+      20.43,
+      64.73,
+      96.77,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "048",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      16.31,
+      29.04,
+      42.91,
+      57.08,
+      76.53,
+      89.13,
+      96.92,
+      100
+    ]
+  },
+  {
+    "measureId": "050",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      92.86,
+      97.03,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "050",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      73.48,
+      86.09,
+      94.34,
+      97.67,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "051",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      21.61,
+      60,
+      85.5,
+      96.62,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "051",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      50.53,
+      58.6,
+      69.44,
+      77.98,
+      86.44,
+      93.18,
+      97.66,
+      100
+    ]
+  },
+  {
+    "measureId": "052",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "052",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      95.24,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "054",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      95.45,
+      96.88,
+      98.04,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "054",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      95.45,
+      98.27,
+      99.56,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "065",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0,
+      70.45,
+      80,
+      88,
+      93.06,
+      95.65,
+      97.3,
+      98.97,
+      100
+    ]
+  },
+  {
+    "measureId": "065",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      67.74,
+      80.77,
+      91.08,
+      94.75,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "066",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0,
+      38.12,
+      52.33,
+      67.65,
+      74.57,
+      80.95,
+      85.71,
+      89.16,
+      94.21
+    ]
+  },
+  {
+    "measureId": "067",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      95,
+      96.88,
+      98.7,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "070",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      86.52,
+      95.24,
+      99.51,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "071",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "071",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      80.49,
+      90.79,
+      96.49,
+      98.08,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "076",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      85.71,
+      94.29,
+      97.18,
+      99.43,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "076",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      89.66,
+      96,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "091",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      60.87,
+      85.71,
+      96.97,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "091",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      60.47,
+      69.57,
+      78.26,
+      83.02,
+      87.98,
+      93.33,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "093",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      94.29,
+      95.65,
+      97.3,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "093",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      73.91,
+      84.75,
+      90.91,
+      95.83,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "099",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "099",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      97.62,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
     "measureId": "100",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -190,6 +1329,23 @@
     "measureId": "110",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
+    "submissionMethod": "cmsWebInterface",
+    "deciles": [
+      0,
+      30,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "110",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
     "submissionMethod": "electronicHealthRecord",
     "deciles": [
       0,
@@ -235,6 +1391,23 @@
       84.5,
       92,
       99.07
+    ]
+  },
+  {
+    "measureId": "111",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "cmsWebInterface",
+    "deciles": [
+      0,
+      30,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
     ]
   },
   {
@@ -292,6 +1465,23 @@
     "measureId": "112",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
+    "submissionMethod": "cmsWebInterface",
+    "deciles": [
+      0,
+      30,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "112",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
     "submissionMethod": "electronicHealthRecord",
     "deciles": [
       0,
@@ -337,6 +1527,23 @@
       84.68,
       93.14,
       100
+    ]
+  },
+  {
+    "measureId": "113",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "cmsWebInterface",
+    "deciles": [
+      0,
+      30,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
     ]
   },
   {
@@ -510,53 +1717,19 @@
     ]
   },
   {
-    "measureId": "012",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      99.01,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "012",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0,
-      73.33,
-      82.42,
-      87.4,
-      90.91,
-      94.17,
-      96.58,
-      98.26,
-      99.58
-    ]
-  },
-  {
-    "measureId": "012",
+    "measureId": "121",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
     "submissionMethod": "registry",
     "deciles": [
       0,
-      95.07,
-      98.11,
-      99.36,
-      100,
-      100,
-      100,
-      100,
+      20,
+      34.27,
+      45.71,
+      58.97,
+      69.49,
+      78.61,
+      90.16,
       100
     ]
   },
@@ -626,6 +1799,23 @@
       98.61,
       100,
       100
+    ]
+  },
+  {
+    "measureId": "128",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "cmsWebInterface",
+    "deciles": [
+      0,
+      30,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
     ]
   },
   {
@@ -768,6 +1958,23 @@
     "measureId": "134",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
+    "submissionMethod": "cmsWebInterface",
+    "deciles": [
+      0,
+      30,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "134",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
     "submissionMethod": "electronicHealthRecord",
     "deciles": [
       0,
@@ -827,40 +2034,6 @@
       88.89,
       96.55,
       100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "014",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "014",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      31.01,
-      55.13,
-      77.25,
-      91.18,
-      98.19,
       100,
       100,
       100
@@ -1309,6 +2482,40 @@
     ]
   },
   {
+    "measureId": "172",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      88.54,
+      95.45,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "173",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      48.93,
+      62.4,
+      71.87,
+      80.72,
+      88.22,
+      94.44,
+      98.49,
+      100
+    ]
+  },
+  {
     "measureId": "178",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -1323,23 +2530,6 @@
       87.83,
       92.35,
       99.72
-    ]
-  },
-  {
-    "measureId": "018",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0,
-      31.69,
-      41.33,
-      50,
-      56.98,
-      64.18,
-      70.59,
-      76.98,
-      85.16
     ]
   },
   {
@@ -1462,57 +2652,6 @@
     ]
   },
   {
-    "measureId": "019",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "019",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0,
-      20,
-      29.79,
-      38.36,
-      45.71,
-      52.54,
-      60.8,
-      68.81,
-      79.31
-    ]
-  },
-  {
-    "measureId": "019",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      36.21,
-      60,
-      78.57,
-      89.81,
-      96.23,
-      100,
-      100,
-      100
-    ]
-  },
-  {
     "measureId": "191",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -1581,6 +2720,57 @@
     ]
   },
   {
+    "measureId": "193",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      0,
+      92.5,
+      95.83,
+      97.65,
+      98.72,
+      99.46,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "193",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      98.18,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "194",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      5,
+      9.82,
+      23.89,
+      62.5,
+      83.02,
+      94.87,
+      99.83,
+      100
+    ]
+  },
+  {
     "measureId": "195",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -1635,6 +2825,23 @@
     "measureId": "204",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
+    "submissionMethod": "cmsWebInterface",
+    "deciles": [
+      0,
+      30,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "204",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
     "submissionMethod": "electronicHealthRecord",
     "deciles": [
       0,
@@ -1662,40 +2869,6 @@
       87.93,
       90.95,
       94.74,
-      100
-    ]
-  },
-  {
-    "measureId": "021",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "021",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      91.17,
-      99.11,
-      100,
-      100,
-      100,
-      100,
-      100,
       100
     ]
   },
@@ -1771,6 +2944,23 @@
     "measureId": "226",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
+    "submissionMethod": "cmsWebInterface",
+    "deciles": [
+      0,
+      30,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "226",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
     "submissionMethod": "electronicHealthRecord",
     "deciles": [
       0,
@@ -1802,40 +2992,6 @@
     ]
   },
   {
-    "measureId": "023",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "023",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      89.74,
-      96.67,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
     "measureId": "236",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -1850,6 +3006,23 @@
       81.48,
       86.76,
       93.43
+    ]
+  },
+  {
+    "measureId": "236",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "cmsWebInterface",
+    "deciles": [
+      0,
+      30,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
     ]
   },
   {
@@ -1935,40 +3108,6 @@
       32.83,
       33.33,
       34.46
-    ]
-  },
-  {
-    "measureId": "024",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      75,
-      91.3,
-      96.43,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "024",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      8,
-      10.34,
-      12.5,
-      17.07,
-      21.88,
-      50,
-      82.5,
-      100
     ]
   },
   {
@@ -2278,6 +3417,23 @@
     ]
   },
   {
+    "measureId": "311",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0,
+      16.67,
+      41.03,
+      58.06,
+      69.06,
+      75.49,
+      81.82,
+      87.5,
+      92.98
+    ]
+  },
+  {
     "measureId": "312",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -2366,6 +3522,23 @@
     "measureId": "318",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
+    "submissionMethod": "cmsWebInterface",
+    "deciles": [
+      0,
+      25.26,
+      25.26,
+      32.36,
+      40.02,
+      47.62,
+      57.7,
+      67.64,
+      82.3
+    ]
+  },
+  {
+    "measureId": "318",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
     "submissionMethod": "electronicHealthRecord",
     "deciles": [
       0,
@@ -2394,40 +3567,6 @@
       0.51,
       55.24,
       92.21
-    ]
-  },
-  {
-    "measureId": "032",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      51.16,
-      63.64,
-      88,
-      96.43,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "032",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      27.17,
-      46.3,
-      67.86,
-      80.86,
-      90.91,
-      96.43,
-      100,
-      100
     ]
   },
   {
@@ -2873,6 +4012,23 @@
     ]
   },
   {
+    "measureId": "381",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0,
+      19.47,
+      27.85,
+      33.43,
+      42.86,
+      76.27,
+      85,
+      90.32,
+      92.5
+    ]
+  },
+  {
     "measureId": "382",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -2938,40 +4094,6 @@
       100,
       100,
       100
-    ]
-  },
-  {
-    "measureId": "039",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      30.77,
-      39.55,
-      46.75,
-      53.97,
-      61.9,
-      70.87,
-      82.54,
-      95.88
-    ]
-  },
-  {
-    "measureId": "039",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      13.39,
-      16.67,
-      20.4,
-      25.32,
-      34,
-      47.95,
-      64.66,
-      82.54
     ]
   },
   {
@@ -3094,805 +4216,6 @@
     ]
   },
   {
-    "measureId": "043",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      98.17,
-      98.7,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "044",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      96.84,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "044",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      91.14,
-      95,
-      97.33,
-      98.88,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "046",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "046",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "047",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      13.68,
-      34.58,
-      62.87,
-      86.92,
-      97.11,
-      99.6,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "047",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      16.52,
-      38.12,
-      59.15,
-      75,
-      88.72,
-      96.3,
-      99.18,
-      100
-    ]
-  },
-  {
-    "measureId": "048",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      6.25,
-      20.43,
-      64.73,
-      96.77,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "048",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      16.31,
-      29.04,
-      42.91,
-      57.08,
-      76.53,
-      89.13,
-      96.92,
-      100
-    ]
-  },
-  {
-    "measureId": "005",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0,
-      62.16,
-      66.67,
-      71.43,
-      74.91,
-      77.61,
-      82.61,
-      85.71,
-      90.91
-    ]
-  },
-  {
-    "measureId": "005",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      75.86,
-      79.49,
-      82.14,
-      85,
-      87.5,
-      90,
-      93.54,
-      96.55
-    ]
-  },
-  {
-    "measureId": "050",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      92.86,
-      97.03,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "050",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      73.48,
-      86.09,
-      94.34,
-      97.67,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "051",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      21.61,
-      60,
-      85.5,
-      96.62,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "051",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      50.53,
-      58.6,
-      69.44,
-      77.98,
-      86.44,
-      93.18,
-      97.66,
-      100
-    ]
-  },
-  {
-    "measureId": "052",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "052",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      95.24,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "006",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      76.92,
-      81.76,
-      85,
-      87.54,
-      90.23,
-      92.55,
-      95.65,
-      100
-    ]
-  },
-  {
-    "measureId": "065",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0,
-      70.45,
-      80,
-      88,
-      93.06,
-      95.65,
-      97.3,
-      98.97,
-      100
-    ]
-  },
-  {
-    "measureId": "065",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      67.74,
-      80.77,
-      91.08,
-      94.75,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "066",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0,
-      38.12,
-      52.33,
-      67.65,
-      74.57,
-      80.95,
-      85.71,
-      89.16,
-      94.21
-    ]
-  },
-  {
-    "measureId": "067",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      95,
-      96.88,
-      98.7,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "007",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0,
-      48.54,
-      60.87,
-      69.23,
-      76.63,
-      80.95,
-      85,
-      89.47,
-      95.24
-    ]
-  },
-  {
-    "measureId": "007",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      74.39,
-      77.87,
-      80,
-      82.72,
-      85.11,
-      87.24,
-      89.69,
-      93.24
-    ]
-  },
-  {
-    "measureId": "070",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      86.52,
-      95.24,
-      99.51,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "076",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      85.71,
-      94.29,
-      97.18,
-      99.43,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "076",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      89.66,
-      96,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "008",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0,
-      58.62,
-      64.71,
-      71.95,
-      78.26,
-      85.51,
-      90,
-      91.67,
-      96
-    ]
-  },
-  {
-    "measureId": "008",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      75.68,
-      81.08,
-      85.58,
-      88.44,
-      91.17,
-      94.29,
-      96.37,
-      100
-    ]
-  },
-  {
-    "measureId": "009",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0,
-      1.06,
-      1.35,
-      1.62,
-      1.93,
-      2.5,
-      5,
-      62.69,
-      80.77
-    ]
-  },
-  {
-    "measureId": "091",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      60.87,
-      85.71,
-      96.97,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "091",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      60.47,
-      69.57,
-      78.26,
-      83.02,
-      87.98,
-      93.33,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "093",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      94.29,
-      95.65,
-      97.3,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "093",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      73.91,
-      84.75,
-      90.91,
-      95.83,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "099",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "099",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      97.62,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "318",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "cmsWebInterface",
-    "deciles": [
-      0,
-      25.26,
-      25.26,
-      32.36,
-      40.02,
-      47.62,
-      57.7,
-      67.64,
-      82.3
-    ]
-  },
-  {
-    "measureId": "dmComposite",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "cmsWebInterface",
-    "deciles": [
-      0,
-      27.81,
-      27.81,
-      32.3,
-      37.13,
-      41.54,
-      46.93,
-      52.41,
-      60.3
-    ]
-  },
-  {
-    "measureId": "236",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "cmsWebInterface",
-    "deciles": [
-      0,
-      30,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
-    ]
-  },
-  {
-    "measureId": "204",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "cmsWebInterface",
-    "deciles": [
-      0,
-      30,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
-    ]
-  },
-  {
-    "measureId": "112",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "cmsWebInterface",
-    "deciles": [
-      0,
-      30,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
-    ]
-  },
-  {
-    "measureId": "113",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "cmsWebInterface",
-    "deciles": [
-      0,
-      30,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
-    ]
-  },
-  {
-    "measureId": "110",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "cmsWebInterface",
-    "deciles": [
-      0,
-      30,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
-    ]
-  },
-  {
-    "measureId": "111",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "cmsWebInterface",
-    "deciles": [
-      0,
-      30,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
-    ]
-  },
-  {
-    "measureId": "128",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "cmsWebInterface",
-    "deciles": [
-      0,
-      30,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
-    ]
-  },
-  {
-    "measureId": "226",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "cmsWebInterface",
-    "deciles": [
-      0,
-      30,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
-    ]
-  },
-  {
-    "measureId": "134",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "cmsWebInterface",
-    "deciles": [
-      0,
-      30,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
-    ]
-  },
-  {
     "measureId": "458",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -3907,346 +4230,6 @@
       14.45,
       14.16,
       13.82
-    ]
-  },
-  {
-    "measureId": "121",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      20,
-      34.27,
-      45.71,
-      58.97,
-      69.49,
-      78.61,
-      90.16,
-      100
-    ]
-  },
-  {
-    "measureId": "172",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      88.54,
-      95.45,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "173",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      48.93,
-      62.4,
-      71.87,
-      80.72,
-      88.22,
-      94.44,
-      98.49,
-      100
-    ]
-  },
-  {
-    "measureId": "193",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      92.5,
-      95.83,
-      97.65,
-      98.72,
-      99.46,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "193",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      98.18,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "194",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      5,
-      9.82,
-      23.89,
-      62.5,
-      83.02,
-      94.87,
-      99.83,
-      100
-    ]
-  },
-  {
-    "measureId": "002",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      0.83,
-      1.07,
-      1.36,
-      1.83,
-      2.52,
-      3.54,
-      6.46,
-      25.58
-    ]
-  },
-  {
-    "measureId": "022",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "022",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      45.69,
-      77.38,
-      97.78,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "311",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0,
-      16.67,
-      41.03,
-      58.06,
-      69.06,
-      75.49,
-      81.82,
-      87.5,
-      92.98
-    ]
-  },
-  {
-    "measureId": "033",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      29.55,
-      43.19,
-      55.78,
-      73.76,
-      87.8,
-      95.23,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "381",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0,
-      19.47,
-      27.85,
-      33.43,
-      42.86,
-      76.27,
-      85,
-      90.32,
-      92.5
-    ]
-  },
-  {
-    "measureId": "040",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      15,
-      28,
-      36.15,
-      50,
-      75.31,
-      92.86,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "040",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      5,
-      6.96,
-      8.7,
-      16.14,
-      32.79,
-      47.41,
-      65.57,
-      88.89
-    ]
-  },
-  {
-    "measureId": "041",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      33.33,
-      40.46,
-      46.67,
-      58.33,
-      74.51,
-      96.46,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "041",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      33.33,
-      40.44,
-      46.29,
-      52.78,
-      59.26,
-      66.67,
-      75.59,
-      100
-    ]
-  },
-  {
-    "measureId": "054",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      95.45,
-      96.88,
-      98.04,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "054",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      95.45,
-      98.27,
-      99.56,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "071",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "claims",
-    "deciles": [
-      0,
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "071",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      80.49,
-      90.79,
-      96.49,
-      98.08,
-      100,
-      100,
-      100,
-      100
     ]
   },
   {
@@ -4298,6 +4281,40 @@
       92.91,
       94.16,
       95.54
+    ]
+  },
+  {
+    "measureId": "ACEP21",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      92.79,
+      89.9,
+      87.34,
+      61.62,
+      52,
+      42.22,
+      31.97,
+      27.09
+    ]
+  },
+  {
+    "measureId": "ACEP24",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      44.35,
+      52.68,
+      59.33,
+      67.3,
+      72.63,
+      84.73,
+      87.14,
+      89.24
     ]
   },
   {
@@ -4437,23 +4454,6 @@
     ]
   },
   {
-    "measureId": "ASPIRE2",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      78.96,
-      80.95,
-      82.73,
-      83.48,
-      84.43,
-      86.08,
-      88.09,
-      90.34
-    ]
-  },
-  {
     "measureId": "ASPIRE22",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -4468,6 +4468,23 @@
       99.69,
       99.76,
       99.88
+    ]
+  },
+  {
+    "measureId": "ASPIRE2",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      78.96,
+      80.95,
+      82.73,
+      83.48,
+      84.43,
+      86.08,
+      88.09,
+      90.34
     ]
   },
   {
@@ -4505,20 +4522,207 @@
     ]
   },
   {
-    "measureId": "CDR1",
+    "measureId": "CAHPS_10",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "registry",
+    "submissionMethod": "certifiedSurveyVendor",
     "deciles": [
       0,
-      40.13,
-      58.06,
-      72.35,
-      83.93,
-      91.3,
-      95.3,
-      97.42,
-      98.88
+      73.39,
+      74.09,
+      74.81,
+      75.38,
+      76.08,
+      76.83,
+      77.58,
+      78.91
+    ]
+  },
+  {
+    "measureId": "CAHPS_11",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      22.71,
+      24.29,
+      25.54,
+      26.68,
+      28,
+      29.19,
+      30.5,
+      33.38
+    ]
+  },
+  {
+    "measureId": "CAHPS_12",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      52.02,
+      54.33,
+      56.01,
+      57.61,
+      59.37,
+      61.53,
+      63.88,
+      67.19
+    ]
+  },
+  {
+    "measureId": "CAHPS_1",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      77.08,
+      78.39,
+      79.48,
+      80.49,
+      81.26,
+      82.39,
+      83.54,
+      84.97
+    ]
+  },
+  {
+    "measureId": "CAHPS_2",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      91.07,
+      91.72,
+      92.18,
+      92.63,
+      92.95,
+      93.3,
+      93.73,
+      94.35
+    ]
+  },
+  {
+    "measureId": "CAHPS_3",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      90.28,
+      91.02,
+      91.53,
+      91.99,
+      92.36,
+      92.74,
+      93.19,
+      93.73
+    ]
+  },
+  {
+    "measureId": "CAHPS_4",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      81.16,
+      82.25,
+      82.92,
+      83.54,
+      84.06,
+      84.61,
+      85.36,
+      86.48
+    ]
+  },
+  {
+    "measureId": "CAHPS_5",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      55.86,
+      57.23,
+      58.33,
+      59.63,
+      60.97,
+      62.02,
+      63.43,
+      65.04
+    ]
+  },
+  {
+    "measureId": "CAHPS_6",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      72.86,
+      73.72,
+      74.33,
+      75.01,
+      75.63,
+      76.29,
+      77.22,
+      78.38
+    ]
+  },
+  {
+    "measureId": "CAHPS_7",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      68.18,
+      69.17,
+      70.04,
+      70.8,
+      71.64,
+      72.26,
+      73.01,
+      74.09
+    ]
+  },
+  {
+    "measureId": "CAHPS_8",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      84.55,
+      85.5,
+      86.12,
+      86.78,
+      87.4,
+      87.91,
+      88.48,
+      89.17
+    ]
+  },
+  {
+    "measureId": "CAHPS_9",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      90.2,
+      91.05,
+      91.7,
+      92.25,
+      92.74,
+      93.24,
+      93.74,
+      94.44
     ]
   },
   {
@@ -4536,6 +4740,23 @@
       73.74,
       77.32,
       79.52
+    ]
+  },
+  {
+    "measureId": "CDR1",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      40.13,
+      58.06,
+      72.35,
+      83.93,
+      91.3,
+      95.3,
+      97.42,
+      98.88
     ]
   },
   {
@@ -4947,241 +5168,20 @@
     ]
   },
   {
-    "measureId": "ACEP21",
+    "measureId": "dmComposite",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      100,
-      92.79,
-      89.9,
-      87.34,
-      61.62,
-      52,
-      42.22,
-      31.97,
-      27.09
-    ]
-  },
-  {
-    "measureId": "ACEP24",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
+    "submissionMethod": "cmsWebInterface",
     "deciles": [
       0,
-      44.35,
-      52.68,
-      59.33,
-      67.3,
-      72.63,
-      84.73,
-      87.14,
-      89.24
-    ]
-  },
-  {
-    "measureId": "CAHPS_1",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "certifiedSurveyVendor",
-    "deciles": [
-      0,
-      77.08,
-      78.39,
-      79.48,
-      80.49,
-      81.26,
-      82.39,
-      83.54,
-      84.97
-    ]
-  },
-  {
-    "measureId": "CAHPS_2",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "certifiedSurveyVendor",
-    "deciles": [
-      0,
-      91.07,
-      91.72,
-      92.18,
-      92.63,
-      92.95,
-      93.3,
-      93.73,
-      94.35
-    ]
-  },
-  {
-    "measureId": "CAHPS_3",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "certifiedSurveyVendor",
-    "deciles": [
-      0,
-      90.28,
-      91.02,
-      91.53,
-      91.99,
-      92.36,
-      92.74,
-      93.19,
-      93.73
-    ]
-  },
-  {
-    "measureId": "CAHPS_4",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "certifiedSurveyVendor",
-    "deciles": [
-      0,
-      81.16,
-      82.25,
-      82.92,
-      83.54,
-      84.06,
-      84.61,
-      85.36,
-      86.48
-    ]
-  },
-  {
-    "measureId": "CAHPS_5",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "certifiedSurveyVendor",
-    "deciles": [
-      0,
-      55.86,
-      57.23,
-      58.33,
-      59.63,
-      60.97,
-      62.02,
-      63.43,
-      65.04
-    ]
-  },
-  {
-    "measureId": "CAHPS_6",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "certifiedSurveyVendor",
-    "deciles": [
-      0,
-      72.86,
-      73.72,
-      74.33,
-      75.01,
-      75.63,
-      76.29,
-      77.22,
-      78.38
-    ]
-  },
-  {
-    "measureId": "CAHPS_7",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "certifiedSurveyVendor",
-    "deciles": [
-      0,
-      68.18,
-      69.17,
-      70.04,
-      70.8,
-      71.64,
-      72.26,
-      73.01,
-      74.09
-    ]
-  },
-  {
-    "measureId": "CAHPS_8",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "certifiedSurveyVendor",
-    "deciles": [
-      0,
-      84.55,
-      85.5,
-      86.12,
-      86.78,
-      87.4,
-      87.91,
-      88.48,
-      89.17
-    ]
-  },
-  {
-    "measureId": "CAHPS_9",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "certifiedSurveyVendor",
-    "deciles": [
-      0,
-      90.2,
-      91.05,
-      91.7,
-      92.25,
-      92.74,
-      93.24,
-      93.74,
-      94.44
-    ]
-  },
-  {
-    "measureId": "CAHPS_10",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "certifiedSurveyVendor",
-    "deciles": [
-      0,
-      73.39,
-      74.09,
-      74.81,
-      75.38,
-      76.08,
-      76.83,
-      77.58,
-      78.91
-    ]
-  },
-  {
-    "measureId": "CAHPS_11",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "certifiedSurveyVendor",
-    "deciles": [
-      0,
-      22.71,
-      24.29,
-      25.54,
-      26.68,
-      28,
-      29.19,
-      30.5,
-      33.38
-    ]
-  },
-  {
-    "measureId": "CAHPS_12",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "certifiedSurveyVendor",
-    "deciles": [
-      0,
-      52.02,
-      54.33,
-      56.01,
-      57.61,
-      59.37,
-      61.53,
-      63.88,
-      67.19
+      27.81,
+      27.81,
+      32.3,
+      37.13,
+      41.54,
+      46.93,
+      52.41,
+      60.3
     ]
   }
 ]

--- a/benchmarks/2017.json
+++ b/benchmarks/2017.json
@@ -986,6 +986,25 @@
     ]
   },
   {
+    "measureId": "066",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      53.72,
+      64.37,
+      69.64,
+      75.58,
+      82.14,
+      85.58,
+      87.98,
+      91.98,
+      97.87
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "067",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -1001,6 +1020,44 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "068",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      15,
+      22.22,
+      22.22,
+      33.33,
+      56.85,
+      80.36,
+      86.36,
+      86.36,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "069",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      34.78,
+      42.86,
+      45.71,
+      64.52,
+      66.67,
+      71.43,
+      72.73,
+      77.27,
+      95.38
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "070",
@@ -1222,6 +1279,25 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "102",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      8.2,
+      50.99,
+      74.31,
+      83.01,
+      89.42,
+      97.37,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "102",
@@ -2330,6 +2406,25 @@
   },
   {
     "measureId": "156",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "156",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
     "submissionMethod": "registry",
@@ -2344,6 +2439,25 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "160",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      62.75,
+      62.75,
+      62.75,
+      62.75,
+      73.37,
+      84,
+      84,
+      84,
+      84
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "163",
@@ -2516,6 +2630,44 @@
     ]
   },
   {
+    "measureId": "176",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      21.57,
+      37.04,
+      50,
+      60,
+      72.7,
+      86.67,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "177",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      28.21,
+      58.1,
+      76,
+      88.72,
+      97.47,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "178",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -2531,6 +2683,44 @@
       92.35,
       99.72
     ]
+  },
+  {
+    "measureId": "179",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      23.53,
+      45.73,
+      70.95,
+      88.31,
+      97,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "180",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      29.74,
+      56.25,
+      78.43,
+      90.22,
+      96.5,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "181",
@@ -2873,6 +3063,158 @@
     ]
   },
   {
+    "measureId": "205",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      60,
+      77.1,
+      82.25,
+      94.21,
+      96.4,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "217",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      83.82,
+      83.82,
+      83.82,
+      90.48,
+      90.48,
+      90.48,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "218",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "219",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "220",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "221",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      69.77,
+      69.77,
+      69.77,
+      69.77,
+      84.88,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "222",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "223",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      99.24,
+      99.24,
+      99.24,
+      99.24,
+      99.62,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "224",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -3128,6 +3470,25 @@
     ]
   },
   {
+    "measureId": "243",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      4.17,
+      8.23,
+      12.92,
+      15.63,
+      17.94,
+      21.43,
+      25.37,
+      30.85,
+      48.96
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "249",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -3179,6 +3540,25 @@
     ]
   },
   {
+    "measureId": "250",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "251",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -3211,6 +3591,120 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "254",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      68.06,
+      76.92,
+      83.97,
+      87.27,
+      91.3,
+      94,
+      96.24,
+      98.22,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "255",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      71.93,
+      71.93,
+      77.27,
+      77.27,
+      82.82,
+      88.37,
+      88.37,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "257",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      80.95,
+      80.95,
+      81.25,
+      81.25,
+      83.05,
+      84.85,
+      84.85,
+      88.89,
+      88.89
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "259",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      64,
+      78.15,
+      81.25,
+      82.8,
+      82.83,
+      82.86,
+      86.11,
+      90.48,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "260",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      78.79,
+      86.96,
+      89.47,
+      90.91,
+      91.67,
+      92.59,
+      92.86,
+      92.94,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "261",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      15,
+      29.03,
+      85.71,
+      95.45,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "262",
@@ -3281,6 +3775,139 @@
     ]
   },
   {
+    "measureId": "268",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "268",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      2.17,
+      28.43,
+      38.1,
+      45.45,
+      66.04,
+      82.09,
+      98.61,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "275",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      8.54,
+      10,
+      30.91,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "276",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      9.09,
+      38.52,
+      61.98,
+      83.25,
+      95.17,
+      99.89,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "277",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      27.27,
+      68.48,
+      81.03,
+      88.18,
+      99.72,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "278",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      84.65,
+      95.08,
+      98,
+      99.5,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "279",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      58.62,
+      82.61,
+      94.44,
+      98.59,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "281",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -3296,6 +3923,177 @@
       95.56,
       100
     ]
+  },
+  {
+    "measureId": "282",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      14.04,
+      59.38,
+      84.62,
+      98.04,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "283",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      32.05,
+      77.78,
+      96.3,
+      99.21,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "284",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      83.03,
+      91.29,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "286",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      40,
+      73.47,
+      86.21,
+      96.2,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "288",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      39.29,
+      73.4,
+      86.21,
+      95.94,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "290",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      63.64,
+      85,
+      91.8,
+      96.15,
+      98.33,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "291",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      77.5,
+      85.49,
+      95,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "293",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      51.85,
+      67.03,
+      81.82,
+      91.3,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "294",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      77.5,
+      85.19,
+      96.88,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "303",
@@ -3706,6 +4504,44 @@
     ]
   },
   {
+    "measureId": "329",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      71.79,
+      67.5,
+      67.16,
+      60.42,
+      57.69,
+      52.17,
+      43.48,
+      42.86,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "330",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      79.17,
+      75,
+      67.92,
+      67.92,
+      64.44,
+      51.85,
+      51.85,
+      51.72,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "331",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -3791,6 +4627,63 @@
     ]
   },
   {
+    "measureId": "338",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      42.5,
+      74.47,
+      79.42,
+      84,
+      87.94,
+      92.5,
+      97.22,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "340",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      46.81,
+      51.38,
+      55.95,
+      69.09,
+      83.77,
+      90,
+      95.56,
+      98.61,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "342",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      86.76,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "343",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -3806,6 +4699,196 @@
       63.41,
       80.33
     ]
+  },
+  {
+    "measureId": "346",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      4.35,
+      1.49,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "347",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      17.14,
+      2.15,
+      2.15,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "350",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      84.68,
+      97.1,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "351",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      91.14,
+      99.94,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "352",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "353",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      99.11,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "354",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      5,
+      3.57,
+      3.03,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "355",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      5.17,
+      3.33,
+      2.27,
+      1.12,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "356",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      8.7,
+      4.76,
+      2.95,
+      1.72,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "357",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      6.62,
+      3.39,
+      2.26,
+      1,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "358",
@@ -3842,6 +4925,44 @@
     ]
   },
   {
+    "measureId": "360",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      16.28,
+      36.56,
+      63.64,
+      90.55,
+      98.58,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "361",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      92.98,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "362",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -3876,6 +4997,120 @@
     ]
   },
   {
+    "measureId": "364",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      48.28,
+      62.5,
+      93.6,
+      97.73,
+      99.93,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "366",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      12.22,
+      20,
+      23.18,
+      27.19,
+      30.55,
+      34.55,
+      41.95,
+      51.03,
+      59.8
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "367",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.26,
+      0.72,
+      2.63,
+      7.32,
+      15.38,
+      19.18,
+      36.11,
+      44.93,
+      65
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "369",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      37.44,
+      71.05,
+      78.75,
+      84.35,
+      86.74,
+      89.9,
+      91.4,
+      95.24,
+      97.39
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "370",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      1.08,
+      2.22,
+      2.88,
+      3.77,
+      4.45,
+      5.45,
+      7.27,
+      9.38,
+      14.68
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "370",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      18.18,
+      38.12,
+      75.41,
+      97.56,
+      99.2,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "371",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -3908,6 +5143,25 @@
       0.84,
       1.16
     ]
+  },
+  {
+    "measureId": "372",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.19,
+      0.51,
+      1.5,
+      1.5,
+      1.64,
+      13.19,
+      13.19,
+      67.66,
+      96.3
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "373",
@@ -3976,6 +5230,44 @@
       66.05,
       85.19
     ]
+  },
+  {
+    "measureId": "376",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      3.45,
+      4.88,
+      8.51,
+      14.56,
+      19.62,
+      27.91,
+      33.33,
+      39.77,
+      63.49
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "377",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      1.92,
+      21.04,
+      46.07,
+      46.07,
+      57.38,
+      60,
+      60,
+      76,
+      79.35
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "378",
@@ -4063,6 +5355,63 @@
     ]
   },
   {
+    "measureId": "384",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      68.18,
+      76.09,
+      83.33,
+      90,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "385",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      40.63,
+      60.71,
+      77.5,
+      77.5,
+      78.72,
+      82.22,
+      82.22,
+      85,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "387",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0.3,
+      0.41,
+      0.59,
+      0.81,
+      1.04,
+      1.32,
+      1.46,
+      2.87,
+      90.45
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "388",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -4097,6 +5446,25 @@
     ]
   },
   {
+    "measureId": "390",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      17.24,
+      45.24,
+      67.44,
+      88.52,
+      98.44,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "391",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -4112,6 +5480,25 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "394",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      3.57,
+      8.33,
+      10.17,
+      11.11,
+      15.38,
+      18.75,
+      24.32,
+      32,
+      35
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "395",
@@ -4148,6 +5535,44 @@
     ]
   },
   {
+    "measureId": "396",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "396",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "397",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -4182,6 +5607,25 @@
     ]
   },
   {
+    "measureId": "398",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      27.66,
+      52.94,
+      65.47,
+      80,
+      96,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "400",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -4197,6 +5641,25 @@
       8.33,
       20.02
     ]
+  },
+  {
+    "measureId": "401",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      62.96,
+      88.64,
+      88.64,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "402",
@@ -4216,6 +5679,1051 @@
     ]
   },
   {
+    "measureId": "403",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      34.62,
+      34.62,
+      34.62,
+      34.62,
+      34.62,
+      34.62,
+      34.62,
+      34.62,
+      34.62
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "404",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      25.93,
+      39.24,
+      50,
+      57.14,
+      64.52,
+      71.43,
+      78.43,
+      87.5,
+      97.1
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "405",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      23.08,
+      10.87,
+      4.65,
+      0.63,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "405",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      19.15,
+      11.11,
+      6.45,
+      2.44,
+      0.24,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "406",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      89.64,
+      60.68,
+      47.91,
+      41.43,
+      22.77,
+      3.46,
+      1.22,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "406",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      27.59,
+      14.94,
+      5.97,
+      3.64,
+      0.09,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "407",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "407",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "408",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      26.92,
+      74.97,
+      94.08,
+      99.07,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "410",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      13.33,
+      22.92,
+      36,
+      48.84,
+      60.16,
+      72.22,
+      87.5,
+      97.14,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "411",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      16.17,
+      37.78,
+      59.43,
+      86.2,
+      99.17,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "412",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      19.64,
+      66.13,
+      91.94,
+      98.25,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "414",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      73.08,
+      88.92,
+      98.57,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "415",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      93.55,
+      96,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "415",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      57.03,
+      64.65,
+      70.83,
+      76.58,
+      80.32,
+      83.36,
+      86.32,
+      89.55,
+      98.21
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "416",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      52.17,
+      46.55,
+      40,
+      34.69,
+      28.35,
+      22.31,
+      18.6,
+      14.47,
+      9.52
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "418",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      25,
+      25,
+      25,
+      61.11,
+      61.11,
+      61.11,
+      71.43,
+      71.43,
+      71.43
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "418",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      2.08,
+      2.56,
+      5,
+      5.45,
+      7.18,
+      7.89,
+      11.9,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "419",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      84,
+      85.19,
+      91.67,
+      92.86,
+      96.15,
+      97.5,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "419",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      68.18,
+      74.71,
+      83.33,
+      91.04,
+      95.43,
+      98.25,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "420",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      3.31,
+      93.75,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "422",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      76.81,
+      83.43,
+      89.77,
+      93.21,
+      96.96,
+      99.4,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "423",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "423",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      95.24,
+      96.19,
+      97.44,
+      98.35,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "424",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      89.83,
+      98.42,
+      99.6,
+      99.93,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "425",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      94.23,
+      97.37,
+      98.46,
+      99.16,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "425",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      95.93,
+      97.56,
+      98.32,
+      98.76,
+      99.11,
+      99.32,
+      99.59,
+      99.81,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "426",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      98.34,
+      99.6,
+      99.89,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "427",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      89.66,
+      96,
+      98.5,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "428",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      91.67,
+      96.3,
+      96.34,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "430",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      87.34,
+      95.35,
+      98.13,
+      99.32,
+      99.86,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "431",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      8.98,
+      34.53,
+      50.57,
+      66.63,
+      78.39,
+      87.32,
+      93.64,
+      98.04,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "432",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      1.36,
+      0.17,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "433",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      1.72,
+      0.32,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "434",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "435",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      60.71,
+      86.11,
+      86.96,
+      96.83,
+      98.41,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "435",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      1.06,
+      2.36,
+      3.03,
+      6.41,
+      14.96,
+      25.82,
+      92.15,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "436",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      56.36,
+      84.07,
+      93.62,
+      97.4,
+      98.98,
+      99.7,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "436",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      75.17,
+      92.46,
+      96.45,
+      98.72,
+      99.55,
+      99.89,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "437",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "claims",
+    "deciles": [
+      2.77,
+      1.32,
+      0.55,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "437",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      37.93,
+      3.92,
+      3.67,
+      3.57,
+      1.64,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "438",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      57.5,
+      69.07,
+      78.5,
+      88.89,
+      96.08,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "439",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      61.16,
+      9.51,
+      0.17,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "440",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      78.5,
+      97,
+      99.07,
+      99.96,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "441",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      25.58,
+      32.4,
+      37.15,
+      40.42,
+      44.44,
+      47.8,
+      50.62,
+      54.59,
+      59.73
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "443",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      40.43,
+      14.77,
+      2.86,
+      0.95,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "444",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      43.48,
+      85.71,
+      91.43,
+      97.14,
+      98.44,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "445",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      5.36,
+      3.9,
+      3.13,
+      2.51,
+      2.04,
+      1.64,
+      1.09,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "449",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      89.66,
+      94.59,
+      98.33,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "450",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      13.79,
+      52.17,
+      90,
+      92.86,
+      97.86,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "451",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "452",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      85.19,
+      85.19,
+      85.19,
+      85.19,
+      92.59,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "453",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      17.78,
+      15,
+      10.42,
+      8.97,
+      7.79,
+      7.35,
+      6.47,
+      2.38,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "456",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      92.86,
+      84.21,
+      77.78,
+      75,
+      66.72,
+      58.44,
+      46.15,
+      38.98,
+      4.32
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "457",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      20,
+      15.27,
+      15,
+      13.01,
+      10,
+      8.87,
+      6.45,
+      2.16,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "458",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -4233,6 +6741,291 @@
     ]
   },
   {
+    "measureId": "AAD1",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      3.57,
+      10.49,
+      18.75,
+      26.92,
+      35.19,
+      42.93,
+      57.08,
+      74.29,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAD2",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      39.58,
+      58,
+      94.85,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAD3",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      5,
+      1.93,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAD4",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      4.35,
+      3.64,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAD5",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      48.48,
+      73.17,
+      87.7,
+      97.86,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAN1",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      5.92,
+      13.27,
+      16.39,
+      20.24,
+      32.22,
+      46,
+      63.51,
+      74.89,
+      81.05
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAN10",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      1.75,
+      5.56,
+      13.33,
+      23.56,
+      38.03,
+      56.78,
+      68.1,
+      83.84,
+      90.34
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAN2",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      31.07,
+      42.45,
+      46.27,
+      47.03,
+      49.32,
+      52.31,
+      53.47,
+      55.13,
+      59.19
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAN4",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      15.91,
+      26.53,
+      41.35,
+      53.7,
+      70.98,
+      81.69,
+      90.32,
+      97.39,
+      99.53
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAN5",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      10.94,
+      15,
+      18.52,
+      24.59,
+      28.96,
+      35.42,
+      40.7,
+      47.34,
+      55.7
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAN9",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      21.43,
+      58.54,
+      78.23,
+      90.91,
+      93.94,
+      97.06,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAO10",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      85.71,
+      94.62,
+      97.58,
+      98.72,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAO11",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      98.52,
+      99.59,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAO8",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAO9",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      99.57,
+      99.83,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "ABG1",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -4248,6 +7041,215 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "ABG14",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ABG15",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ABG16",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      35.51,
+      56.01,
+      61.15,
+      72.27,
+      77.97,
+      82.25,
+      93.51,
+      95.66,
+      99.55
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ABG21",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      6.11,
+      42.19,
+      60.79,
+      79.09,
+      90.22,
+      94.9,
+      97.74,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ABG28",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      9.8,
+      35.6,
+      46.08,
+      51.52,
+      55.26,
+      61.81,
+      89.41,
+      99.65,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ABG29",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      34.46,
+      46.91,
+      68.79,
+      92.59,
+      97.69,
+      99.2,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ABG30",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      42.41,
+      65.21,
+      95.76,
+      98.43,
+      99.48,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ABG31",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      55.04,
+      96.93,
+      98.86,
+      99.63,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ABG4",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ABG5",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ABG7",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      98.39,
+      99.49,
+      99.87,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ACCPin1",
@@ -4284,6 +7286,44 @@
     ]
   },
   {
+    "measureId": "ACCPin3",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACCPin4",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "ACEP21",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -4299,6 +7339,25 @@
       31.97,
       27.09
     ]
+  },
+  {
+    "measureId": "ACEP22",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      3.76,
+      5,
+      10.71,
+      18.37,
+      22.22,
+      25.81,
+      28.36,
+      35.14,
+      48
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ACEP24",
@@ -4318,6 +7377,215 @@
     ]
   },
   {
+    "measureId": "ACEP25",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      57.14,
+      63.61,
+      67.53,
+      72,
+      75,
+      78.32,
+      81.82,
+      85.45,
+      90
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACEP26",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      50,
+      78.57,
+      81.03,
+      84.44,
+      87.5,
+      90.69,
+      91.94,
+      94.64,
+      96.43
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACEP27",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      41.07,
+      43.48,
+      60,
+      65.63,
+      73.4,
+      84,
+      87.18,
+      91.3,
+      96.18
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACEP28",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      56.25,
+      72.43,
+      83.73,
+      85.71,
+      88.12,
+      89.74,
+      93.55,
+      94.64,
+      95.51
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACEP29",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      73.64,
+      75.61,
+      75.61,
+      81.75,
+      82.16,
+      82.58,
+      85,
+      85,
+      91.67
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACEP30",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      84.04,
+      84.04,
+      84.04,
+      84.04,
+      90.1,
+      96.15,
+      96.15,
+      96.15,
+      96.15
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACEP31",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      30.43,
+      43.04,
+      52,
+      59.26,
+      64.93,
+      69.88,
+      76.19,
+      89.29,
+      91.58
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACR7",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      16.67,
+      21.19,
+      28.1,
+      34.78,
+      38.17,
+      41.89,
+      46.54,
+      58.88,
+      67.15
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACRad21",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0.16,
+      0.48,
+      0.64,
+      0.8,
+      0.84,
+      0.89,
+      1.18,
+      1.29,
+      1.64
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACRad22",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      2.44,
+      2.5,
+      2.84,
+      2.84,
+      4.44,
+      5,
+      5,
+      9.62,
+      10.27
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACRad23",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      27.97,
+      20.97,
+      20,
+      18.18,
+      17.5,
+      16,
+      14.33,
+      12.5,
+      9.38
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "ACRad3",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -4333,6 +7601,63 @@
       6.69,
       8.11
     ]
+  },
+  {
+    "measureId": "ACRad31",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACRad32",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACRad33",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ACRad5",
@@ -4369,6 +7694,44 @@
     ]
   },
   {
+    "measureId": "ACRad7",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      81.08,
+      81.56,
+      86.96,
+      86.96,
+      90.32,
+      90.63,
+      90.63,
+      92.59,
+      93.44
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACRad8",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      40.91,
+      62.73,
+      64.02,
+      64.87,
+      68.46,
+      73.67,
+      78.26,
+      86.22,
+      89.74
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "AQI18",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -4386,6 +7749,272 @@
     ]
   },
   {
+    "measureId": "AQI28",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      99.76,
+      99.94,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQI29",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      72.73,
+      89.31,
+      94.57,
+      97.38,
+      98.83,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQI31",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0.98,
+      0.28,
+      0.04,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQI32",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      97.44,
+      99.2,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQI34",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0.29,
+      0.08,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQI35",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0.06,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQI37",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      99.3,
+      99.87,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQI42",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQI48",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      41.23,
+      57.71,
+      62,
+      88.48,
+      92.17,
+      96.35,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQI50",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      96.67,
+      98.75,
+      99.23,
+      99.58,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQI51",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      30.23,
+      86.69,
+      95.61,
+      99.02,
+      99.76,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQUA5",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      6.82,
+      3.6,
+      2.94,
+      2.27,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQUA6",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      9.09,
+      6.84,
+      3.25,
+      0.31,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQUA8",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      9.22,
+      5.13,
+      4.22,
+      3.21,
+      2.63,
+      1.01,
+      0.69,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "ASBS1",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -4401,6 +8030,25 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "ASBS10",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      77.27,
+      86.36,
+      96.43,
+      97.18,
+      98.64,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ASBS7",
@@ -4454,23 +8102,6 @@
     ]
   },
   {
-    "measureId": "ASPIRE22",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "registry",
-    "deciles": [
-      0,
-      99.29,
-      99.31,
-      99.38,
-      99.51,
-      99.64,
-      99.69,
-      99.76,
-      99.88
-    ]
-  },
-  {
     "measureId": "ASPIRE2",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -4485,6 +8116,23 @@
       86.08,
       88.09,
       90.34
+    ]
+  },
+  {
+    "measureId": "ASPIRE22",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      99.29,
+      99.31,
+      99.38,
+      99.51,
+      99.64,
+      99.69,
+      99.76,
+      99.88
     ]
   },
   {
@@ -4519,6 +8167,23 @@
       95.47,
       95.98,
       96.55
+    ]
+  },
+  {
+    "measureId": "CAHPS_1",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "certifiedSurveyVendor",
+    "deciles": [
+      0,
+      77.08,
+      78.39,
+      79.48,
+      80.49,
+      81.26,
+      82.39,
+      83.54,
+      84.97
     ]
   },
   {
@@ -4570,23 +8235,6 @@
       61.53,
       63.88,
       67.19
-    ]
-  },
-  {
-    "measureId": "CAHPS_1",
-    "benchmarkYear": 2015,
-    "performanceYear": 2017,
-    "submissionMethod": "certifiedSurveyVendor",
-    "deciles": [
-      0,
-      77.08,
-      78.39,
-      79.48,
-      80.49,
-      81.26,
-      82.39,
-      83.54,
-      84.97
     ]
   },
   {
@@ -4726,6 +8374,23 @@
     ]
   },
   {
+    "measureId": "CDR1",
+    "benchmarkYear": 2015,
+    "performanceYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      40.13,
+      58.06,
+      72.35,
+      83.93,
+      91.3,
+      95.3,
+      97.42,
+      98.88
+    ]
+  },
+  {
     "measureId": "CDR10",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -4743,21 +8408,42 @@
     ]
   },
   {
-    "measureId": "CDR1",
-    "benchmarkYear": 2015,
+    "measureId": "CDR2",
     "performanceYear": 2017,
+    "benchmarkYear": 2017,
     "submissionMethod": "registry",
     "deciles": [
-      0,
-      40.13,
-      58.06,
-      72.35,
-      83.93,
-      91.3,
-      95.3,
-      97.42,
-      98.88
-    ]
+      33.85,
+      61.45,
+      69.19,
+      73.32,
+      75.31,
+      79.88,
+      82.97,
+      84.17,
+      86.62
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "CDR3",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      90.63,
+      90.63,
+      90.63,
+      90.63,
+      90.63,
+      90.63,
+      90.63,
+      90.63,
+      90.63
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "CDR5",
@@ -4777,6 +8463,63 @@
     ]
   },
   {
+    "measureId": "CDR6",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      50,
+      58.82,
+      64.52,
+      66.67,
+      69.22,
+      70.97,
+      72.58,
+      75,
+      79.17
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "CDR7",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      14.29,
+      14.29,
+      14.29,
+      14.29,
+      32.14,
+      50,
+      50,
+      50,
+      50
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "CDR8",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      4.55,
+      4.55,
+      8.33,
+      8.33,
+      17.24,
+      31.37,
+      41.67,
+      46.58,
+      48.44
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "ECPR11",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -4792,6 +8535,177 @@
       4.34,
       3.93
     ]
+  },
+  {
+    "measureId": "ECPR39",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      65.71,
+      80.56,
+      84.21,
+      86.36,
+      88.52,
+      90.78,
+      92.31,
+      94.05,
+      95.83
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ECPR40",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      79.71,
+      82.33,
+      85.66,
+      89.32,
+      90.91,
+      93.1,
+      95.12,
+      95.99,
+      98.84
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ECPR41",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      65.86,
+      65.86,
+      65.86,
+      65.86,
+      65.86,
+      65.86,
+      65.86,
+      65.86,
+      65.86
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ECPR42",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      85.64,
+      85.64,
+      85.64,
+      85.64,
+      92.82,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ECPR43",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      24.72,
+      16.1,
+      11.52,
+      7.44,
+      5.35,
+      3.03,
+      1.67,
+      0.87,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "EPREOP14",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0.01,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "EPREOP26",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "EPREOP27",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "EPREOP9",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      99.43,
+      99.77,
+      99.9,
+      99.98,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "GIQIC10",
@@ -4845,6 +8759,25 @@
     ]
   },
   {
+    "measureId": "IRIS10",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      73.13,
+      81.81,
+      86.8,
+      91.34,
+      97.22,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "IRIS11",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -4860,6 +8793,196 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "IRIS13",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      93.51,
+      96.75,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS16",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      68.25,
+      68.25,
+      68.25,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS2",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      76.74,
+      85.71,
+      92,
+      97.63,
+      99.17,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS26",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0.02,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS3",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      93.59,
+      71.56,
+      51.56,
+      29.17,
+      6.67,
+      3.93,
+      2.1,
+      0.67,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS4",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      41.38,
+      62.96,
+      72.73,
+      85,
+      87.5,
+      88.89,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS5",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      90.63,
+      98.85,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS6",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      97.73,
+      97.73,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "M2S1",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      66.43,
+      70.25,
+      77.55,
+      80.47,
+      81.26,
+      81.62,
+      84.57,
+      89.83,
+      92.82
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "M2S11",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      80,
+      80,
+      80,
+      80,
+      80,
+      80,
+      80,
+      80,
+      80
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "MBSAQIP2",
@@ -4964,6 +9087,140 @@
     ]
   },
   {
+    "measureId": "MEX1",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      10,
+      13.8,
+      19.77,
+      22.54,
+      26.09,
+      35,
+      35.82,
+      53.05,
+      85.71
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "MIRAMED3",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      99.83,
+      99.89,
+      99.97,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "MIRAMED4",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      99.98,
+      99.98,
+      99.96,
+      99.95,
+      99.94,
+      99.94,
+      99.87,
+      99.84,
+      99.72
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "MIRAMED5",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      99.35,
+      99.85,
+      99.94,
+      99.98,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "MIRAMED7",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      99.95,
+      99.98,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "MIRAMED9",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      89.39,
+      93.75,
+      95.33,
+      97.14,
+      98.08,
+      98.84,
+      99.59,
+      99.89,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "MSPB_1",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "administrativeClaims",
+    "deciles": [
+      24430,
+      23208,
+      22405,
+      21767,
+      21214.5,
+      20675,
+      20116,
+      19458,
+      18562,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "MUSIC1",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -4981,6 +9238,25 @@
     ]
   },
   {
+    "measureId": "MUSIC10",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      4.35,
+      4.76,
+      6.67,
+      12.5,
+      13.21,
+      20,
+      21.43,
+      25.93,
+      48.48
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "MUSIC2",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -4996,6 +9272,367 @@
       0,
       0
     ]
+  },
+  {
+    "measureId": "MUSIC4",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      18.37,
+      18.37,
+      40,
+      40,
+      61.67,
+      83.33,
+      83.33,
+      91.3,
+      91.3
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "MUSIC5",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      25,
+      18.97,
+      17.39,
+      10.26,
+      10.13,
+      10,
+      7.14,
+      7.14,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "MUSIC6",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      17.86,
+      9.38,
+      5.56,
+      3.85,
+      3.45,
+      3.33,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "NHCR4",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      6.25,
+      12.5,
+      19.61,
+      25.58,
+      35.61,
+      41.11,
+      54.55,
+      73.13,
+      83.87
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "NIPM1",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "NIPM2",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      99.28,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "NIPM3",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "NIPM8",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "NIPM9",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "NPA11",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      13.3,
+      12.61,
+      11.24,
+      9.76,
+      8.35,
+      7.29,
+      5.98,
+      4.58,
+      2.78
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "NPA3",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      22.17,
+      26.85,
+      40.79,
+      63.75,
+      66.79,
+      70.38,
+      77.5,
+      82.34,
+      86.49
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "NPA4",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      18.78,
+      25.63,
+      41.9,
+      72.08,
+      75.89,
+      80,
+      80.63,
+      86.02,
+      90.89
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "NPA5",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      23.5,
+      29.76,
+      55.79,
+      80,
+      90.49,
+      92.43,
+      94.76,
+      95.55,
+      96.72
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "NPA6",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      4.71,
+      3.56,
+      2.43,
+      1.58,
+      0.49,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "OBERD25",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      74.29,
+      74.29,
+      79,
+      79,
+      83.18,
+      87.37,
+      87.37,
+      87.65,
+      87.65
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "OEIS1",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "OEIS3",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "OEIS4",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "OEIS6",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "PPRNET13",
@@ -5049,6 +9686,44 @@
     ]
   },
   {
+    "measureId": "PPRNET24",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      30.99,
+      37.62,
+      50,
+      54.55,
+      62.16,
+      63.41,
+      66.67,
+      70,
+      78.43
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "PPRNET27",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      85.71,
+      88.57,
+      90.44,
+      91.4,
+      93.18,
+      96.77,
+      97.62,
+      98.84,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "PPRNET28",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -5098,6 +9773,329 @@
       99.15,
       99.49
     ]
+  },
+  {
+    "measureId": "PPRNET31",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      74.16,
+      82.72,
+      84.69,
+      85.59,
+      88.03,
+      90.75,
+      92.16,
+      93.93,
+      96.2
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "PPRNET32",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      8.43,
+      18.34,
+      30.81,
+      51.34,
+      58.78,
+      62.74,
+      66.43,
+      72.73,
+      78.66
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "PPRNET33",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      48.76,
+      51.91,
+      54.55,
+      55.59,
+      58.25,
+      61.19,
+      64.49,
+      70,
+      77.82
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "PPRNET8",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      25.49,
+      27.68,
+      36.19,
+      41.6,
+      48.99,
+      51.32,
+      62.07,
+      67.68,
+      74.61
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "QUANTUM31",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      25.84,
+      31.91,
+      60.65,
+      70.3,
+      78,
+      83.29,
+      87.74,
+      89.78,
+      95.12
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "QUANTUM37",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0.52,
+      0.27,
+      0.24,
+      0.21,
+      0.09,
+      0.07,
+      0.07,
+      0.05,
+      0.03
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "QUANTUM41",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0.06,
+      0.05,
+      0.04,
+      0.03,
+      0.03,
+      0.03,
+      0.02,
+      0.02,
+      0.01
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "QUANTUM42",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0.12,
+      0.03,
+      0.02,
+      0.02,
+      0.01,
+      0.01,
+      0.01,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "QUANTUM51",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0.15,
+      0.04,
+      0.03,
+      0.03,
+      0.02,
+      0.02,
+      0.02,
+      0.01,
+      0.01
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "RCOIR10",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      5,
+      38.46,
+      55,
+      55.03,
+      58.63,
+      62.22,
+      64.71,
+      76,
+      77.42
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "RCOIR7",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      29.27,
+      37.04,
+      40.22,
+      44.53,
+      60,
+      63.64,
+      66.67,
+      69.23,
+      75
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "RCOIR8",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0.26,
+      0.26,
+      0.26,
+      0.54,
+      0.54,
+      0.54,
+      0.72,
+      0.72,
+      0.72
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "RCOIR9",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      99.86,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "RPAQIR11",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      0.93,
+      0.58,
+      0.26,
+      0.07,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "RPAQIR12",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      1.59,
+      0.99,
+      0.73,
+      0.54,
+      0.39,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "RPAQIR13",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      86.51,
+      92.85,
+      94.07,
+      94.95,
+      95.87,
+      97.28,
+      97.89,
+      99.21,
+      99.77
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "SCG4",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "STS1",
@@ -5151,6 +10149,45 @@
     ]
   },
   {
+    "measureId": "STS7",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      1.49,
+      4,
+      8.7,
+      27.94,
+      47.44,
+      70,
+      84.06,
+      93.18,
+      99.21
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "TPCC_1",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "administrativeClaims",
+    "deciles": [
+      18827.8,
+      16018.7,
+      14668.5,
+      13750.8,
+      12976.8,
+      12234.1,
+      11423.9,
+      10375.9,
+      8664.94,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "USWR13",
     "benchmarkYear": 2015,
     "performanceYear": 2017,
@@ -5166,6 +10203,44 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "USWR15",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      77.27,
+      77.27,
+      77.27,
+      77.27,
+      77.27,
+      77.27,
+      77.27,
+      77.27,
+      77.27
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "USWR20",
+    "performanceYear": 2017,
+    "benchmarkYear": 2017,
+    "submissionMethod": "registry",
+    "deciles": [
+      1.04,
+      1.56,
+      1.76,
+      1.96,
+      4.58,
+      7.83,
+      10.92,
+      26.71,
+      71.07
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "dmComposite",

--- a/benchmarks/2017/benchmarks-schema.yaml
+++ b/benchmarks/2017/benchmarks-schema.yaml
@@ -22,7 +22,7 @@ definitions:
         items:
           type: [number]
         minItems: 9
-        maxItems: 9
+        maxItems: 10
       submissionMethod:
         enum: [claims, registry, cmsWebInterface, administrativeClaims, electronicHealthRecord, certifiedSurveyVendor]
     required: [measureId, performanceYear, benchmarkYear, submissionMethod, deciles]

--- a/benchmarks/2018.json
+++ b/benchmarks/2018.json
@@ -810,6 +810,25 @@
     ]
   },
   {
+    "measureId": "066",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      56,
+      65.88,
+      72.85,
+      77.78,
+      81.98,
+      85.71,
+      89.29,
+      92.72,
+      96.02
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "067",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -2304,6 +2323,44 @@
     ]
   },
   {
+    "measureId": "176",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      27.78,
+      42.08,
+      59.09,
+      74.46,
+      89.16,
+      95.74,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "177",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      40.91,
+      67.05,
+      78.73,
+      87.96,
+      93.13,
+      96.76,
+      99.61,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "178",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -2320,6 +2377,44 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "179",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      31.81,
+      56.73,
+      73.67,
+      81.86,
+      89.78,
+      96.89,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "180",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      40.91,
+      61.48,
+      73.23,
+      80.83,
+      87.22,
+      91.79,
+      96.7,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "181",
@@ -2682,6 +2777,63 @@
     ]
   },
   {
+    "measureId": "226",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "claims",
+    "deciles": [
+      95.86,
+      98.56,
+      99.72,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "226",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      7.27,
+      17.36,
+      33.33,
+      55.83,
+      73.98,
+      82.96,
+      88.09,
+      92.47,
+      97.12
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "226",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      10.45,
+      19.72,
+      32.08,
+      46.91,
+      65.7,
+      82.98,
+      94.23,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "236",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -2826,6 +2978,25 @@
     ]
   },
   {
+    "measureId": "243",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      2.6,
+      5.65,
+      8.89,
+      14.37,
+      20.75,
+      28.84,
+      38.94,
+      52.9,
+      71.88
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "249",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -2860,6 +3031,25 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "250",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "claims",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "250",
@@ -2934,6 +3124,25 @@
     ]
   },
   {
+    "measureId": "260",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      85,
+      85.71,
+      88.24,
+      88.51,
+      91.95,
+      95.24,
+      96,
+      97.87,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "262",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -3006,6 +3215,101 @@
     ]
   },
   {
+    "measureId": "268",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      8.33,
+      26.47,
+      33.33,
+      38.3,
+      64.71,
+      81.82,
+      90,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "276",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      4.98,
+      17.78,
+      47.19,
+      64.71,
+      79.02,
+      87.54,
+      95.7,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "277",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      5.68,
+      23.94,
+      54.33,
+      80.47,
+      90.63,
+      99.24,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "278",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      91,
+      96.48,
+      97.21,
+      98.25,
+      99.34,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "279",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      49,
+      73.81,
+      88.56,
+      94.01,
+      98.67,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "281",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -3024,6 +3328,82 @@
     ]
   },
   {
+    "measureId": "282",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      28.17,
+      57.93,
+      77.89,
+      89.86,
+      96.67,
+      98.68,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "283",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      51.36,
+      83.83,
+      94.09,
+      98.05,
+      99.78,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "286",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      19.57,
+      39.08,
+      78.3,
+      90.91,
+      98.3,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "288",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      13.68,
+      38.63,
+      56,
+      76.47,
+      86.84,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "290",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -3040,6 +3420,44 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "291",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      10,
+      33.06,
+      63.47,
+      89.9,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "293",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      23.12,
+      37.18,
+      70,
+      83.87,
+      95.66,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "303",
@@ -3456,6 +3874,44 @@
     ]
   },
   {
+    "measureId": "338",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      49.37,
+      59.09,
+      81.82,
+      83.97,
+      86.6,
+      92.69,
+      95.77,
+      99.29,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "340",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      40.26,
+      48.4,
+      56.03,
+      62.44,
+      70.21,
+      76.92,
+      90.38,
+      95.35,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "342",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -3472,6 +3928,177 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "343",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      17.95,
+      28.6,
+      33.64,
+      37.5,
+      41.74,
+      45.3,
+      49.42,
+      60.13,
+      95.34
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "350",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      88.87,
+      98.03,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "351",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      92.23,
+      98.81,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "352",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      96.76,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "353",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      97.14,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "354",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      8.7,
+      5,
+      1.7,
+      0.5,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "355",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      4.69,
+      2.58,
+      1.67,
+      0.95,
+      0.36,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "356",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      6.19,
+      3.7,
+      2.62,
+      1.59,
+      0.88,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "357",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      5.58,
+      2.25,
+      1.35,
+      0.68,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "358",
@@ -3492,6 +4119,196 @@
     ]
   },
   {
+    "measureId": "359",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "360",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      2.45,
+      5.2,
+      37.9,
+      93.77,
+      98.91,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "361",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      98.77,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "362",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      97.32,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "363",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      93.53,
+      99.33,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "364",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      52.4,
+      68.09,
+      78.41,
+      85.71,
+      91.8,
+      98.08,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "366",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      10,
+      13.46,
+      16.67,
+      23.27,
+      26.42,
+      29.66,
+      31.67,
+      38.4,
+      50
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "367",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.32,
+      0.74,
+      2.01,
+      2.82,
+      3.62,
+      4.96,
+      13.1,
+      26.92,
+      33.53
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "369",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      41,
+      63.76,
+      75.76,
+      83.78,
+      88,
+      90.84,
+      93.92,
+      95.75,
+      97.55
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "370",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      1.42,
+      2.33,
+      3.21,
+      4.62,
+      7,
+      9.6,
+      14.29,
+      20.26,
+      31.93
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "371",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -3508,6 +4325,25 @@
       15,
       48.15
     ]
+  },
+  {
+    "measureId": "372",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      3.54,
+      5,
+      17,
+      23,
+      30.7,
+      35.71,
+      42.59,
+      58.38,
+      81.94
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "373",
@@ -3600,6 +4436,25 @@
     ]
   },
   {
+    "measureId": "377",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.63,
+      1.22,
+      2,
+      3,
+      4.12,
+      5.28,
+      5.87,
+      9.8,
+      17.86
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "378",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -3636,6 +4491,25 @@
     ]
   },
   {
+    "measureId": "382",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      1.49,
+      5.36,
+      12.84,
+      20.37,
+      27.97,
+      36,
+      46.15,
+      65.88,
+      83.56
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "383",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -3652,6 +4526,44 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "384",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      91.43,
+      97.71,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "385",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      9.09,
+      13.09,
+      16.33,
+      19.23,
+      21.76,
+      24.73,
+      30.25,
+      34.78,
+      40.68
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "388",
@@ -3690,6 +4602,44 @@
     ]
   },
   {
+    "measureId": "390",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      36.62,
+      53.59,
+      76.24,
+      89.17,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "394",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      1.75,
+      2.44,
+      4.76,
+      6.67,
+      13.79,
+      15,
+      16.67,
+      27.59,
+      37.5
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "395",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -3726,6 +4676,25 @@
     ]
   },
   {
+    "measureId": "396",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "397",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -3760,6 +4729,25 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "398",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      15.5,
+      41.12,
+      54.17,
+      73.49,
+      84.58,
+      96.72,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "400",
@@ -3888,6 +4876,25 @@
     ]
   },
   {
+    "measureId": "407",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      80.95,
+      96.06,
+      98.41,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "408",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -3996,6 +5003,25 @@
     ]
   },
   {
+    "measureId": "416",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      40.82,
+      33.55,
+      27.73,
+      22.59,
+      15.63,
+      9.38,
+      3.92,
+      1.45,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "418",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -4030,6 +5056,25 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "423",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      93.94,
+      96.15,
+      99.79,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "424",
@@ -4158,6 +5203,63 @@
     ]
   },
   {
+    "measureId": "432",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "433",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      0.45,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "435",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      3.13,
+      4.76,
+      14.29,
+      36.84,
+      49.09,
+      80.56,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "436",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -4194,6 +5296,63 @@
     ]
   },
   {
+    "measureId": "437",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "claims",
+    "deciles": [
+      2.94,
+      2.08,
+      1.85,
+      1.08,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "437",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      7.36,
+      2.86,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "438",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      42.18,
+      57.14,
+      63.2,
+      66.85,
+      69.83,
+      72.96,
+      75.59,
+      78.57,
+      83.55
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "438",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -4212,6 +5371,196 @@
     ]
   },
   {
+    "measureId": "439",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      36.84,
+      0.63,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "440",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      91.93,
+      98.72,
+      99.62,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "441",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      20.64,
+      36.95,
+      45.53,
+      52.78,
+      58.98,
+      63.64,
+      66.9,
+      71.83,
+      77.78
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "443",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      3.68,
+      2.74,
+      1.92,
+      1.72,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "444",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      55.33,
+      73.71,
+      80.34,
+      91.3,
+      96.67,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "445",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      5.56,
+      3.17,
+      2.81,
+      2.33,
+      1.87,
+      1.39,
+      1.02,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "449",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      89.29,
+      93.48,
+      97.69,
+      98.87,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "453",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      20,
+      17.28,
+      14.29,
+      12,
+      10,
+      8.82,
+      7,
+      5.45,
+      4.35
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "456",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      93.22,
+      84,
+      77.27,
+      75.6,
+      68.33,
+      64.52,
+      60.68,
+      54.55,
+      29.03
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "457",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      18.9,
+      15.82,
+      14.48,
+      12.31,
+      10,
+      8.55,
+      6.7,
+      4.77,
+      3.4
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "458",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -4228,6 +5577,177 @@
       14.01,
       13.63
     ]
+  },
+  {
+    "measureId": "463",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      91.18,
+      94.82,
+      96.32,
+      97.86,
+      98.57,
+      99.18,
+      99.74,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "464",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      80,
+      86.73,
+      89.01,
+      92.01,
+      94.81,
+      96.05,
+      97.71,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAD1",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      6.74,
+      13.46,
+      28.3,
+      45.18,
+      60.33,
+      72.77,
+      84.05,
+      90.12,
+      98.77
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAD2",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      6.64,
+      15.94,
+      36.18,
+      59.74,
+      78.2,
+      85.36,
+      91.86,
+      98.78,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAD3",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      6.15,
+      4,
+      1.8,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAD4",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      11.11,
+      3.16,
+      1.39,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAD5",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      82.93,
+      95.65,
+      98.31,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAN1",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      4.35,
+      9.43,
+      11.11,
+      17.86,
+      20.51,
+      22.41,
+      35.29,
+      63.16,
+      84.09
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAN10",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      2.01,
+      3.81,
+      6.58,
+      9.44,
+      15.26,
+      19.82,
+      33.99,
+      41.19,
+      64.96
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "AAN4",
@@ -4284,6 +5804,215 @@
     ]
   },
   {
+    "measureId": "AAN9",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      3.13,
+      13.21,
+      35.48,
+      53.66,
+      78.67,
+      88,
+      92.59,
+      95.56,
+      98.9
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAO11",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      99.23,
+      99.7,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAO15",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAO17",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      97.59,
+      98.51,
+      98.84,
+      99.38,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAO22",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      92.7,
+      95.12,
+      96.73,
+      97.7,
+      98.55,
+      99.7,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAO23",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      47.1,
+      62.79,
+      67.56,
+      70.5,
+      74.55,
+      75.65,
+      78.53,
+      83.2,
+      85.94
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAO24",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      87.66,
+      91.53,
+      93.14,
+      95.48,
+      96.57,
+      97.17,
+      98.14,
+      98.75,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAO25",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      99.94,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAO26",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      4.76,
+      40.5,
+      49.57,
+      53.33,
+      65.64,
+      74.29,
+      79.13,
+      81.44,
+      87.5
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAO28",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      5,
+      10,
+      12.12,
+      15.91,
+      18.94,
+      21.81,
+      26.92,
+      38.71,
+      51.22
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AAO8",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "ABG1",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -4300,6 +6029,139 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "ABG16",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      29.49,
+      43.99,
+      63.33,
+      73.17,
+      80.23,
+      84.42,
+      90.7,
+      93.3,
+      97.62
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ABG21",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      69.61,
+      85.55,
+      92.79,
+      96.73,
+      99.08,
+      99.92,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ABG28",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      68.08,
+      82,
+      93.22,
+      97.6,
+      99.77,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ABG29",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      33.65,
+      57.51,
+      73.57,
+      85.36,
+      93.76,
+      99.75,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ABG30",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      10.49,
+      40.8,
+      73.12,
+      99.75,
+      99.95,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ABG31",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      56.98,
+      72.58,
+      84.62,
+      93.02,
+      99.92,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ABG36",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ABG7",
@@ -4336,6 +6198,25 @@
       95.71,
       98.48
     ]
+  },
+  {
+    "measureId": "ACEP19",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      50.45,
+      53.87,
+      54.78,
+      57.77,
+      59.79,
+      62.89,
+      68.13,
+      74.08,
+      76.96
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ACEP21",
@@ -4410,6 +6291,348 @@
     ]
   },
   {
+    "measureId": "ACEP29",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      63.27,
+      72.86,
+      78.26,
+      84.91,
+      87.23,
+      89.29,
+      90.63,
+      92.68,
+      95.6
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACEP30",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      68.56,
+      70.32,
+      72.55,
+      73.68,
+      76.44,
+      77.57,
+      80.95,
+      82.22,
+      85.59
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACEP31",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      63.27,
+      81.82,
+      84.06,
+      87.25,
+      91.02,
+      97.67,
+      99.68,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACEP32",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      281,
+      212,
+      189,
+      177,
+      169,
+      158,
+      148,
+      140,
+      129
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACEP40",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      196,
+      151,
+      135.5,
+      128,
+      118,
+      114,
+      108.5,
+      99,
+      90.5
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACEP48",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      60,
+      68.37,
+      74.36,
+      77.27,
+      81.8,
+      84.85,
+      86.6,
+      88.71,
+      92.31
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACQR2",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      91.3,
+      94.35,
+      94.92,
+      95.17,
+      95.85,
+      96.15,
+      96.83,
+      97.61,
+      98.58
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACQR3",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      86.25,
+      88.14,
+      89.08,
+      90.97,
+      92.67,
+      93.66,
+      93.75,
+      95.4,
+      97.22
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACQR5",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      67.28,
+      77.12,
+      80.65,
+      81.63,
+      83.71,
+      85.8,
+      87.15,
+      90.42,
+      95.45
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACQR8",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACR7",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      24.19,
+      35.71,
+      45.31,
+      50,
+      55.44,
+      60,
+      63.33,
+      69.34,
+      73.08
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACRAD15",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      53,
+      8,
+      4,
+      2,
+      2,
+      1,
+      1,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACRAD16",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      82,
+      6,
+      4,
+      3,
+      2,
+      1,
+      1,
+      1,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACRAD17",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      111,
+      15,
+      9,
+      7,
+      6,
+      5,
+      4,
+      3,
+      1
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACRAD18",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      37,
+      6,
+      3,
+      2,
+      1,
+      1,
+      1,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACRAD19",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      111,
+      43,
+      25,
+      19,
+      16,
+      8.5,
+      6,
+      4,
+      3
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACRAD23",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      25.24,
+      21.44,
+      18.15,
+      17.13,
+      15.69,
+      14.14,
+      12.5,
+      11.42,
+      9.82
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACRAD25",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      1573,
+      50,
+      33,
+      20,
+      15,
+      11,
+      8,
+      5,
+      2
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "ACRAD3",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -4428,6 +6651,82 @@
     ]
   },
   {
+    "measureId": "ACRAD31",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      59.36,
+      72.36,
+      80.97,
+      86.44,
+      87.15,
+      87.15,
+      92.57,
+      96.29,
+      96.29
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACRAD32",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      70.52,
+      73.89,
+      75.83,
+      76.35,
+      84.81,
+      88.02,
+      95.38,
+      98.75,
+      99.74
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACRAD33",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      30.73,
+      30.73,
+      61.21,
+      75.72,
+      80.4,
+      91.13,
+      93.63,
+      97.53,
+      99.62
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "ACRAD5",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      14.91,
+      12.95,
+      10.3,
+      8.96,
+      8.61,
+      7.66,
+      5.97,
+      4.23,
+      3.3
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "ACRAD6",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -4444,6 +6743,215 @@
       36.48,
       39.58
     ]
+  },
+  {
+    "measureId": "AQI48",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      91.07,
+      92.33,
+      93.22,
+      94.21,
+      94.95,
+      95.56,
+      95.95,
+      96.69,
+      97.65
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQI50",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      98.96,
+      99.5,
+      99.72,
+      99.86,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQI51",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      39.23,
+      79.15,
+      90.56,
+      95.9,
+      99.12,
+      99.79,
+      99.98,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQI53",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      56.25,
+      74.01,
+      76.87,
+      94.46,
+      98.08,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQI54",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      90.22,
+      97.44,
+      98.53,
+      99.37,
+      99.81,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQI56",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      72.61,
+      91.72,
+      94.75,
+      96.49,
+      98.16,
+      98.59,
+      99.85,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQI59",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      69.14,
+      80.47,
+      85.12,
+      89.45,
+      92.76,
+      95.88,
+      97.72,
+      99.69,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQI60",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      99.87,
+      99.94,
+      99.98,
+      99.99,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQUA15",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      34.55,
+      52.46,
+      65.57,
+      72.73,
+      76.86,
+      82.23,
+      85.97,
+      88.62,
+      92.77
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQUA18",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      78.05,
+      80.77,
+      88.14,
+      91.48,
+      93.94,
+      96.3,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "AQUA26",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      16.45,
+      10.06,
+      8.73,
+      7.36,
+      6.82,
+      5.16,
+      3.47,
+      3.01,
+      1.88
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "AQUA8",
@@ -4482,6 +6990,25 @@
     ]
   },
   {
+    "measureId": "ASBS12",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      96.12,
+      98.15,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "ASBS7",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -4500,24 +7027,6 @@
     ]
   },
   {
-    "measureId": "CAHPS_11",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
-    "submissionMethod": "certifiedSurveyVendor",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      23.16,
-      24.31,
-      25.14,
-      26.18,
-      27.41,
-      28.94,
-      30.78,
-      35.52
-    ]
-  },
-  {
     "measureId": "CAHPS_1",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -4533,6 +7042,24 @@
       87.12,
       88.07,
       89.22
+    ]
+  },
+  {
+    "measureId": "CAHPS_11",
+    "benchmarkYear": 2016,
+    "performanceYear": 2018,
+    "submissionMethod": "certifiedSurveyVendor",
+    "isToppedOut": false,
+    "deciles": [
+      0,
+      23.16,
+      24.31,
+      25.14,
+      26.18,
+      27.41,
+      28.94,
+      30.78,
+      35.52
     ]
   },
   {
@@ -4680,24 +7207,6 @@
     ]
   },
   {
-    "measureId": "CAHPS_ACO_34",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
-    "submissionMethod": "certifiedSurveyVendor",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      24.25,
-      24.25,
-      25.57,
-      26.74,
-      28.12,
-      29.43,
-      31.08,
-      33.43
-    ]
-  },
-  {
     "measureId": "CAHPS_ACO_3",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -4713,6 +7222,24 @@
       70,
       80,
       90
+    ]
+  },
+  {
+    "measureId": "CAHPS_ACO_34",
+    "benchmarkYear": 2016,
+    "performanceYear": 2018,
+    "submissionMethod": "certifiedSurveyVendor",
+    "isToppedOut": false,
+    "deciles": [
+      0,
+      24.25,
+      24.25,
+      25.57,
+      26.74,
+      28.12,
+      29.43,
+      31.08,
+      33.43
     ]
   },
   {
@@ -4824,6 +7351,25 @@
     ]
   },
   {
+    "measureId": "ECPR45",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      77.89,
+      91.33,
+      96.95,
+      97.14,
+      98.17,
+      99.07,
+      99.33,
+      99.57,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "GIQIC10",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -4878,6 +7424,557 @@
     ]
   },
   {
+    "measureId": "GIQIC17",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      71.23,
+      80,
+      84.62,
+      86.36,
+      90.48,
+      93.75,
+      95.65,
+      97.5,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "GIQIC18",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      83.13,
+      89.29,
+      92.31,
+      95,
+      97.1,
+      97.92,
+      99.24,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "GIQIC19",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      26.88,
+      34.13,
+      41.86,
+      49.11,
+      60.1,
+      68.36,
+      83.57,
+      92.85,
+      96.95
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "GIQIC20",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      25,
+      70.9,
+      80.54,
+      86.84,
+      91.3,
+      95.18,
+      96.97,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IQSS1",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      1.09,
+      1.59,
+      2.63,
+      3.03,
+      3.7,
+      5.41,
+      6.25,
+      8.33,
+      10.26
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IQSS2",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      1.21,
+      2.25,
+      3.06,
+      3.68,
+      4.76,
+      5,
+      8.52,
+      12.64,
+      22.26
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IQSS3",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      56,
+      68.73,
+      75.9,
+      80.6,
+      84,
+      90.91,
+      93.26,
+      95.78,
+      99.19
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IQSS4",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      25.76,
+      39.58,
+      52.38,
+      60,
+      64,
+      68,
+      72.73,
+      79.55,
+      83.33
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS1",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      9.52,
+      22.73,
+      32.08,
+      37.04,
+      50.72,
+      53.97,
+      58,
+      75,
+      78.13
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS10",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS11",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      80.13,
+      86.21,
+      88.8,
+      90.7,
+      92.55,
+      93.94,
+      95.3,
+      96.55,
+      98.01
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS13",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      73.68,
+      79.35,
+      83.33,
+      86.94,
+      89.18,
+      90.48,
+      91.84,
+      93.75,
+      96.3
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS16",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      86.67,
+      91.3,
+      93.83,
+      95.24,
+      95.98,
+      96.97,
+      98.5,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS17",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      19.23,
+      32.14,
+      46.32,
+      55,
+      63.33,
+      69.57,
+      74.32,
+      81.82,
+      88.97
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS2",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      51.59,
+      69.78,
+      78.79,
+      84.65,
+      88.89,
+      91.53,
+      93.59,
+      95.32,
+      96.99
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS23",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      19.02,
+      45.9,
+      55,
+      65.22,
+      75.49,
+      81.58,
+      87.69,
+      94.87,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS25",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      37.5,
+      16.67,
+      7.14,
+      2.78,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS26",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      5.45,
+      3.03,
+      1.57,
+      0.6,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS27",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      1.57,
+      0.64,
+      0.21,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS28",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      20.61,
+      31.07,
+      37.99,
+      44.65,
+      51.05,
+      56.72,
+      62.66,
+      69.78,
+      78.29
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS29",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      15.38,
+      19.61,
+      20.83,
+      27.78,
+      31.58,
+      32.91,
+      34.38,
+      50,
+      95.15
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS3",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      20.67,
+      17.14,
+      14.39,
+      12,
+      9.19,
+      7.14,
+      5.32,
+      4,
+      2.56
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS30",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      1.2,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS31",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS33",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      5.26,
+      2.02,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS34",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      6.52,
+      4.29,
+      2.88,
+      1.85,
+      0.77,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS4",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      13.48,
+      18.25,
+      23.81,
+      27.27,
+      30.99,
+      34.94,
+      39.02,
+      43.33,
+      53.85
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS7",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      16.13,
+      20.83,
+      26.92,
+      29.8,
+      32.14,
+      33.33,
+      35.19,
+      37.2,
+      42.86
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "IRIS9",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "M2S1",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -4894,6 +7991,82 @@
       87.66,
       93.75
     ]
+  },
+  {
+    "measureId": "MA1",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      12.16,
+      9.62,
+      6.77,
+      4.37,
+      3.17,
+      2.34,
+      1.11,
+      0.48,
+      0.03
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "MBSAQIP10",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      8.45,
+      7.89,
+      6.9,
+      5,
+      3.93,
+      3.08,
+      2.17,
+      1.61,
+      0.94
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "MBSAQIP11",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      2.63,
+      1.9,
+      1.41,
+      1,
+      0.24,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "MBSAQIP12",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      4,
+      3.33,
+      2.5,
+      2.27,
+      1.45,
+      1.09,
+      0.97,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "MBSAQIP7",
@@ -4932,6 +8105,140 @@
     ]
   },
   {
+    "measureId": "MEX1",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      2.26,
+      12,
+      23.9,
+      37.29,
+      46.81,
+      57.25,
+      66.1,
+      75,
+      82.86
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "MEX4",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      1.96,
+      4.03,
+      6.83,
+      12.46,
+      18.88,
+      23.47,
+      31.22,
+      41.8,
+      68.78
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "MEX5",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      1.69,
+      2.86,
+      7.89,
+      10.34,
+      15.38,
+      18.6,
+      27.27,
+      45.71,
+      69.01
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "MIRAMED17",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      0.41,
+      0.26,
+      0.16,
+      0.12,
+      0.1,
+      0.08,
+      0.06,
+      0.02,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "MIRAMED18",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      96.78,
+      98.19,
+      98.37,
+      98.96,
+      99.3,
+      99.72,
+      99.83,
+      99.93,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "MIRAMED19",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      0.47,
+      0.3,
+      0.19,
+      0.14,
+      0.11,
+      0.09,
+      0.08,
+      0.04,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "MSPB_1",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "administrativeClaims",
+    "deciles": [
+      43284,
+      24418,
+      23155,
+      22358,
+      21726,
+      21180,
+      20670,
+      20136,
+      19511,
+      18657
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "MUSIC1",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -4948,6 +8255,25 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "MUSIC11",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      4.55,
+      5.13,
+      7.69,
+      9.52,
+      12.37,
+      16,
+      20.07,
+      26.09,
+      29.63
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "MUSIC3",
@@ -4984,6 +8310,120 @@
       27.38,
       33.33
     ]
+  },
+  {
+    "measureId": "NHCR4",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      7.69,
+      16,
+      20.89,
+      29.51,
+      39.29,
+      50,
+      63.41,
+      74.91,
+      88.89
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "NIPM8",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      99.2,
+      99.61,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "NIPM9",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "NPAGSC9",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      28.15,
+      19.31,
+      2.7,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "PIMSH1",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      0.65,
+      1.4,
+      2.8,
+      9.01,
+      20.96,
+      34.31,
+      43.44,
+      58.33,
+      82.42
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "PIMSH2",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      57.14,
+      36.05,
+      30.43,
+      27.5,
+      24.14,
+      22,
+      16.9,
+      13.43,
+      7.69
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "PPRNET13",
@@ -5094,6 +8534,139 @@
     ]
   },
   {
+    "measureId": "QUANTUM31",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      55.26,
+      78.55,
+      92.76,
+      95.36,
+      98.45,
+      99.31,
+      100,
+      100,
+      100
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "RCOIR10",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      36.62,
+      48.19,
+      52.27,
+      56.63,
+      60.93,
+      67.74,
+      73.08,
+      75,
+      78.95
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "RCOIR7",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      48.28,
+      53.73,
+      62.67,
+      68.18,
+      73.46,
+      75.76,
+      83.19,
+      86.42,
+      90.63
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "RCOIR8",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      0.3,
+      0.24,
+      0.19,
+      0.11,
+      0.08,
+      0,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "RPAQIR11",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      0.77,
+      0.47,
+      0.36,
+      0.23,
+      0.17,
+      0.12,
+      0,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "RPAQIR12",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      0.81,
+      0.47,
+      0.37,
+      0.24,
+      0.16,
+      0.11,
+      0.06,
+      0,
+      0
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "RPAQIR13",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      69.09,
+      75.37,
+      79.19,
+      82.22,
+      83.8,
+      85.07,
+      87.94,
+      89.03,
+      99.59
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "STS1",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -5164,6 +8737,83 @@
       89.19,
       96.69
     ]
+  },
+  {
+    "measureId": "TPCC_1",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "administrativeClaims",
+    "deciles": [
+      79929.9,
+      18838.8,
+      15754.4,
+      14355,
+      13447.8,
+      12712.2,
+      11998.9,
+      11197,
+      10082.4,
+      8065.99
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "UREQA3",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      45.1,
+      55.24,
+      57.94,
+      62.76,
+      65.22,
+      66.42,
+      67.86,
+      71.19,
+      76
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "UREQA4",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      69.77,
+      78.1,
+      85.34,
+      90.58,
+      93.3,
+      94.31,
+      94.97,
+      96.83,
+      99.12
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
+    "measureId": "UREQA5",
+    "performanceYear": 2018,
+    "benchmarkYear": 2018,
+    "submissionMethod": "registry",
+    "deciles": [
+      6.17,
+      7.76,
+      10.34,
+      12.13,
+      15.15,
+      17.87,
+      24.36,
+      28.25,
+      40
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "dmComposite",

--- a/benchmarks/2018.json
+++ b/benchmarks/2018.json
@@ -4500,24 +4500,6 @@
     ]
   },
   {
-    "measureId": "CAHPS_1",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
-    "submissionMethod": "certifiedSurveyVendor",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      81.4,
-      82.64,
-      83.82,
-      84.88,
-      85.83,
-      87.12,
-      88.07,
-      89.22
-    ]
-  },
-  {
     "measureId": "CAHPS_11",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -4533,6 +4515,24 @@
       28.94,
       30.78,
       35.52
+    ]
+  },
+  {
+    "measureId": "CAHPS_1",
+    "benchmarkYear": 2016,
+    "performanceYear": 2018,
+    "submissionMethod": "certifiedSurveyVendor",
+    "isToppedOut": false,
+    "deciles": [
+      0,
+      81.4,
+      82.64,
+      83.82,
+      84.88,
+      85.83,
+      87.12,
+      88.07,
+      89.22
     ]
   },
   {
@@ -4680,24 +4680,6 @@
     ]
   },
   {
-    "measureId": "CAHPS_ACO_3",
-    "benchmarkYear": 2016,
-    "performanceYear": 2018,
-    "submissionMethod": "certifiedSurveyVendor",
-    "isToppedOut": false,
-    "deciles": [
-      0,
-      30,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
-    ]
-  },
-  {
     "measureId": "CAHPS_ACO_34",
     "benchmarkYear": 2016,
     "performanceYear": 2018,
@@ -4713,6 +4695,24 @@
       29.43,
       31.08,
       33.43
+    ]
+  },
+  {
+    "measureId": "CAHPS_ACO_3",
+    "benchmarkYear": 2016,
+    "performanceYear": 2018,
+    "submissionMethod": "certifiedSurveyVendor",
+    "isToppedOut": false,
+    "deciles": [
+      0,
+      30,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
     ]
   },
   {

--- a/benchmarks/2018/benchmarks-schema.yaml
+++ b/benchmarks/2018/benchmarks-schema.yaml
@@ -25,7 +25,7 @@ definitions:
         items:
           type: [number]
         minItems: 9
-        maxItems: 9
+        maxItems: 10
       submissionMethod:
         enum: [claims, registry, cmsWebInterface, administrativeClaims, electronicHealthRecord, certifiedSurveyVendor]
     required: [measureId, performanceYear, benchmarkYear, submissionMethod, deciles]

--- a/staging/2017/benchmarks/json/performance-benchmarks.json
+++ b/staging/2017/benchmarks/json/performance-benchmarks.json
@@ -1,0 +1,4276 @@
+[
+  {
+    "measureId": "102",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      8.2,
+      50.99,
+      74.31,
+      83.01,
+      89.42,
+      97.37,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "156",
+    "submissionMethod": "claims",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "160",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      62.75,
+      62.75,
+      62.75,
+      62.75,
+      73.37,
+      84,
+      84,
+      84,
+      84
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "176",
+    "submissionMethod": "registry",
+    "deciles": [
+      21.57,
+      37.04,
+      50,
+      60,
+      72.7,
+      86.67,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "177",
+    "submissionMethod": "registry",
+    "deciles": [
+      28.21,
+      58.1,
+      76,
+      88.72,
+      97.47,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "179",
+    "submissionMethod": "registry",
+    "deciles": [
+      23.53,
+      45.73,
+      70.95,
+      88.31,
+      97,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "180",
+    "submissionMethod": "registry",
+    "deciles": [
+      29.74,
+      56.25,
+      78.43,
+      90.22,
+      96.5,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "205",
+    "submissionMethod": "registry",
+    "deciles": [
+      60,
+      77.1,
+      82.25,
+      94.21,
+      96.4,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "217",
+    "submissionMethod": "registry",
+    "deciles": [
+      83.82,
+      83.82,
+      83.82,
+      90.48,
+      90.48,
+      90.48,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "218",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "219",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "220",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "221",
+    "submissionMethod": "registry",
+    "deciles": [
+      69.77,
+      69.77,
+      69.77,
+      69.77,
+      84.88,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "222",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "223",
+    "submissionMethod": "registry",
+    "deciles": [
+      99.24,
+      99.24,
+      99.24,
+      99.24,
+      99.62,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "243",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.17,
+      8.23,
+      12.92,
+      15.63,
+      17.94,
+      21.43,
+      25.37,
+      30.85,
+      48.96
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "250",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "254",
+    "submissionMethod": "registry",
+    "deciles": [
+      68.06,
+      76.92,
+      83.97,
+      87.27,
+      91.3,
+      94,
+      96.24,
+      98.22,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "255",
+    "submissionMethod": "registry",
+    "deciles": [
+      71.93,
+      71.93,
+      77.27,
+      77.27,
+      82.82,
+      88.37,
+      88.37,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "257",
+    "submissionMethod": "registry",
+    "deciles": [
+      80.95,
+      80.95,
+      81.25,
+      81.25,
+      83.05,
+      84.85,
+      84.85,
+      88.89,
+      88.89
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "259",
+    "submissionMethod": "registry",
+    "deciles": [
+      64,
+      78.15,
+      81.25,
+      82.8,
+      82.83,
+      82.86,
+      86.11,
+      90.48,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "260",
+    "submissionMethod": "registry",
+    "deciles": [
+      78.79,
+      86.96,
+      89.47,
+      90.91,
+      91.67,
+      92.59,
+      92.86,
+      92.94,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "261",
+    "submissionMethod": "claims",
+    "deciles": [
+      15,
+      29.03,
+      85.71,
+      95.45,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "268",
+    "submissionMethod": "claims",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "268",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.17,
+      28.43,
+      38.1,
+      45.45,
+      66.04,
+      82.09,
+      98.61,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "275",
+    "submissionMethod": "registry",
+    "deciles": [
+      8.54,
+      10,
+      30.91,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "276",
+    "submissionMethod": "registry",
+    "deciles": [
+      9.09,
+      38.52,
+      61.98,
+      83.25,
+      95.17,
+      99.89,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "277",
+    "submissionMethod": "registry",
+    "deciles": [
+      27.27,
+      68.48,
+      81.03,
+      88.18,
+      99.72,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "278",
+    "submissionMethod": "registry",
+    "deciles": [
+      84.65,
+      95.08,
+      98,
+      99.5,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "279",
+    "submissionMethod": "registry",
+    "deciles": [
+      58.62,
+      82.61,
+      94.44,
+      98.59,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "282",
+    "submissionMethod": "registry",
+    "deciles": [
+      14.04,
+      59.38,
+      84.62,
+      98.04,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "283",
+    "submissionMethod": "registry",
+    "deciles": [
+      32.05,
+      77.78,
+      96.3,
+      99.21,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "284",
+    "submissionMethod": "registry",
+    "deciles": [
+      83.03,
+      91.29,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "286",
+    "submissionMethod": "registry",
+    "deciles": [
+      40,
+      73.47,
+      86.21,
+      96.2,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "288",
+    "submissionMethod": "registry",
+    "deciles": [
+      39.29,
+      73.4,
+      86.21,
+      95.94,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "290",
+    "submissionMethod": "registry",
+    "deciles": [
+      63.64,
+      85,
+      91.8,
+      96.15,
+      98.33,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "291",
+    "submissionMethod": "registry",
+    "deciles": [
+      77.5,
+      85.49,
+      95,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "293",
+    "submissionMethod": "registry",
+    "deciles": [
+      51.85,
+      67.03,
+      81.82,
+      91.3,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "294",
+    "submissionMethod": "registry",
+    "deciles": [
+      77.5,
+      85.19,
+      96.88,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "329",
+    "submissionMethod": "registry",
+    "deciles": [
+      71.79,
+      67.5,
+      67.16,
+      60.42,
+      57.69,
+      52.17,
+      43.48,
+      42.86,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "330",
+    "submissionMethod": "registry",
+    "deciles": [
+      79.17,
+      75,
+      67.92,
+      67.92,
+      64.44,
+      51.85,
+      51.85,
+      51.72,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "338",
+    "submissionMethod": "registry",
+    "deciles": [
+      42.5,
+      74.47,
+      79.42,
+      84,
+      87.94,
+      92.5,
+      97.22,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "340",
+    "submissionMethod": "registry",
+    "deciles": [
+      46.81,
+      51.38,
+      55.95,
+      69.09,
+      83.77,
+      90,
+      95.56,
+      98.61,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "342",
+    "submissionMethod": "registry",
+    "deciles": [
+      86.76,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "346",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.35,
+      1.49,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "347",
+    "submissionMethod": "registry",
+    "deciles": [
+      17.14,
+      2.15,
+      2.15,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "350",
+    "submissionMethod": "registry",
+    "deciles": [
+      84.68,
+      97.1,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "351",
+    "submissionMethod": "registry",
+    "deciles": [
+      91.14,
+      99.94,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "352",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "353",
+    "submissionMethod": "registry",
+    "deciles": [
+      99.11,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "354",
+    "submissionMethod": "registry",
+    "deciles": [
+      5,
+      3.57,
+      3.03,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "355",
+    "submissionMethod": "registry",
+    "deciles": [
+      5.17,
+      3.33,
+      2.27,
+      1.12,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "356",
+    "submissionMethod": "registry",
+    "deciles": [
+      8.7,
+      4.76,
+      2.95,
+      1.72,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "357",
+    "submissionMethod": "registry",
+    "deciles": [
+      6.62,
+      3.39,
+      2.26,
+      1,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "360",
+    "submissionMethod": "registry",
+    "deciles": [
+      16.28,
+      36.56,
+      63.64,
+      90.55,
+      98.58,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "361",
+    "submissionMethod": "registry",
+    "deciles": [
+      92.98,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "364",
+    "submissionMethod": "registry",
+    "deciles": [
+      48.28,
+      62.5,
+      93.6,
+      97.73,
+      99.93,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "366",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      12.22,
+      20,
+      23.18,
+      27.19,
+      30.55,
+      34.55,
+      41.95,
+      51.03,
+      59.8
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "367",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.26,
+      0.72,
+      2.63,
+      7.32,
+      15.38,
+      19.18,
+      36.11,
+      44.93,
+      65
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "369",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      37.44,
+      71.05,
+      78.75,
+      84.35,
+      86.74,
+      89.9,
+      91.4,
+      95.24,
+      97.39
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "370",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      1.08,
+      2.22,
+      2.88,
+      3.77,
+      4.45,
+      5.45,
+      7.27,
+      9.38,
+      14.68
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "370",
+    "submissionMethod": "registry",
+    "deciles": [
+      18.18,
+      38.12,
+      75.41,
+      97.56,
+      99.2,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "372",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.19,
+      0.51,
+      1.5,
+      1.5,
+      1.64,
+      13.19,
+      13.19,
+      67.66,
+      96.3
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "376",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      3.45,
+      4.88,
+      8.51,
+      14.56,
+      19.62,
+      27.91,
+      33.33,
+      39.77,
+      63.49
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "377",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      1.92,
+      21.04,
+      46.07,
+      46.07,
+      57.38,
+      60,
+      60,
+      76,
+      79.35
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "384",
+    "submissionMethod": "registry",
+    "deciles": [
+      68.18,
+      76.09,
+      83.33,
+      90,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "385",
+    "submissionMethod": "registry",
+    "deciles": [
+      40.63,
+      60.71,
+      77.5,
+      77.5,
+      78.72,
+      82.22,
+      82.22,
+      85,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "387",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.3,
+      0.41,
+      0.59,
+      0.81,
+      1.04,
+      1.32,
+      1.46,
+      2.87,
+      90.45
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "390",
+    "submissionMethod": "registry",
+    "deciles": [
+      17.24,
+      45.24,
+      67.44,
+      88.52,
+      98.44,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "394",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.57,
+      8.33,
+      10.17,
+      11.11,
+      15.38,
+      18.75,
+      24.32,
+      32,
+      35
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "396",
+    "submissionMethod": "claims",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "396",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "398",
+    "submissionMethod": "registry",
+    "deciles": [
+      27.66,
+      52.94,
+      65.47,
+      80,
+      96,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "401",
+    "submissionMethod": "registry",
+    "deciles": [
+      62.96,
+      88.64,
+      88.64,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "403",
+    "submissionMethod": "registry",
+    "deciles": [
+      34.62,
+      34.62,
+      34.62,
+      34.62,
+      34.62,
+      34.62,
+      34.62,
+      34.62,
+      34.62
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "404",
+    "submissionMethod": "registry",
+    "deciles": [
+      25.93,
+      39.24,
+      50,
+      57.14,
+      64.52,
+      71.43,
+      78.43,
+      87.5,
+      97.1
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "405",
+    "submissionMethod": "claims",
+    "deciles": [
+      23.08,
+      10.87,
+      4.65,
+      0.63,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "405",
+    "submissionMethod": "registry",
+    "deciles": [
+      19.15,
+      11.11,
+      6.45,
+      2.44,
+      0.24,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "406",
+    "submissionMethod": "claims",
+    "deciles": [
+      89.64,
+      60.68,
+      47.91,
+      41.43,
+      22.77,
+      3.46,
+      1.22,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "406",
+    "submissionMethod": "registry",
+    "deciles": [
+      27.59,
+      14.94,
+      5.97,
+      3.64,
+      0.09,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "407",
+    "submissionMethod": "claims",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "407",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "408",
+    "submissionMethod": "registry",
+    "deciles": [
+      26.92,
+      74.97,
+      94.08,
+      99.07,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "410",
+    "submissionMethod": "registry",
+    "deciles": [
+      13.33,
+      22.92,
+      36,
+      48.84,
+      60.16,
+      72.22,
+      87.5,
+      97.14,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "411",
+    "submissionMethod": "registry",
+    "deciles": [
+      16.17,
+      37.78,
+      59.43,
+      86.2,
+      99.17,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "412",
+    "submissionMethod": "registry",
+    "deciles": [
+      19.64,
+      66.13,
+      91.94,
+      98.25,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "414",
+    "submissionMethod": "registry",
+    "deciles": [
+      73.08,
+      88.92,
+      98.57,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "415",
+    "submissionMethod": "claims",
+    "deciles": [
+      93.55,
+      96,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "415",
+    "submissionMethod": "registry",
+    "deciles": [
+      57.03,
+      64.65,
+      70.83,
+      76.58,
+      80.32,
+      83.36,
+      86.32,
+      89.55,
+      98.21
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "416",
+    "submissionMethod": "registry",
+    "deciles": [
+      52.17,
+      46.55,
+      40,
+      34.69,
+      28.35,
+      22.31,
+      18.6,
+      14.47,
+      9.52
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "418",
+    "submissionMethod": "claims",
+    "deciles": [
+      25,
+      25,
+      25,
+      61.11,
+      61.11,
+      61.11,
+      71.43,
+      71.43,
+      71.43
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "418",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.08,
+      2.56,
+      5,
+      5.45,
+      7.18,
+      7.89,
+      11.9,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "419",
+    "submissionMethod": "claims",
+    "deciles": [
+      84,
+      85.19,
+      91.67,
+      92.86,
+      96.15,
+      97.5,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "419",
+    "submissionMethod": "registry",
+    "deciles": [
+      68.18,
+      74.71,
+      83.33,
+      91.04,
+      95.43,
+      98.25,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "420",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.31,
+      93.75,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "422",
+    "submissionMethod": "registry",
+    "deciles": [
+      76.81,
+      83.43,
+      89.77,
+      93.21,
+      96.96,
+      99.4,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "423",
+    "submissionMethod": "claims",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "423",
+    "submissionMethod": "registry",
+    "deciles": [
+      95.24,
+      96.19,
+      97.44,
+      98.35,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "424",
+    "submissionMethod": "registry",
+    "deciles": [
+      89.83,
+      98.42,
+      99.6,
+      99.93,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "425",
+    "submissionMethod": "claims",
+    "deciles": [
+      94.23,
+      97.37,
+      98.46,
+      99.16,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "425",
+    "submissionMethod": "registry",
+    "deciles": [
+      95.93,
+      97.56,
+      98.32,
+      98.76,
+      99.11,
+      99.32,
+      99.59,
+      99.81,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "426",
+    "submissionMethod": "registry",
+    "deciles": [
+      98.34,
+      99.6,
+      99.89,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "427",
+    "submissionMethod": "registry",
+    "deciles": [
+      89.66,
+      96,
+      98.5,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "428",
+    "submissionMethod": "registry",
+    "deciles": [
+      91.67,
+      96.3,
+      96.34,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "430",
+    "submissionMethod": "registry",
+    "deciles": [
+      87.34,
+      95.35,
+      98.13,
+      99.32,
+      99.86,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "431",
+    "submissionMethod": "registry",
+    "deciles": [
+      8.98,
+      34.53,
+      50.57,
+      66.63,
+      78.39,
+      87.32,
+      93.64,
+      98.04,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "432",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.36,
+      0.17,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "433",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.72,
+      0.32,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "434",
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "435",
+    "submissionMethod": "claims",
+    "deciles": [
+      60.71,
+      86.11,
+      86.96,
+      96.83,
+      98.41,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "435",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.06,
+      2.36,
+      3.03,
+      6.41,
+      14.96,
+      25.82,
+      92.15,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "436",
+    "submissionMethod": "claims",
+    "deciles": [
+      56.36,
+      84.07,
+      93.62,
+      97.4,
+      98.98,
+      99.7,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "436",
+    "submissionMethod": "registry",
+    "deciles": [
+      75.17,
+      92.46,
+      96.45,
+      98.72,
+      99.55,
+      99.89,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "437",
+    "submissionMethod": "claims",
+    "deciles": [
+      2.77,
+      1.32,
+      0.55,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "437",
+    "submissionMethod": "registry",
+    "deciles": [
+      37.93,
+      3.92,
+      3.67,
+      3.57,
+      1.64,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "438",
+    "submissionMethod": "registry",
+    "deciles": [
+      57.5,
+      69.07,
+      78.5,
+      88.89,
+      96.08,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "439",
+    "submissionMethod": "registry",
+    "deciles": [
+      61.16,
+      9.51,
+      0.17,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "440",
+    "submissionMethod": "registry",
+    "deciles": [
+      78.5,
+      97,
+      99.07,
+      99.96,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "441",
+    "submissionMethod": "registry",
+    "deciles": [
+      25.58,
+      32.4,
+      37.15,
+      40.42,
+      44.44,
+      47.8,
+      50.62,
+      54.59,
+      59.73
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "443",
+    "submissionMethod": "registry",
+    "deciles": [
+      40.43,
+      14.77,
+      2.86,
+      0.95,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "444",
+    "submissionMethod": "registry",
+    "deciles": [
+      43.48,
+      85.71,
+      91.43,
+      97.14,
+      98.44,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "445",
+    "submissionMethod": "registry",
+    "deciles": [
+      5.36,
+      3.9,
+      3.13,
+      2.51,
+      2.04,
+      1.64,
+      1.09,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "449",
+    "submissionMethod": "registry",
+    "deciles": [
+      89.66,
+      94.59,
+      98.33,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "450",
+    "submissionMethod": "registry",
+    "deciles": [
+      13.79,
+      52.17,
+      90,
+      92.86,
+      97.86,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "451",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "452",
+    "submissionMethod": "registry",
+    "deciles": [
+      85.19,
+      85.19,
+      85.19,
+      85.19,
+      92.59,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "453",
+    "submissionMethod": "registry",
+    "deciles": [
+      17.78,
+      15,
+      10.42,
+      8.97,
+      7.79,
+      7.35,
+      6.47,
+      2.38,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "456",
+    "submissionMethod": "registry",
+    "deciles": [
+      92.86,
+      84.21,
+      77.78,
+      75,
+      66.72,
+      58.44,
+      46.15,
+      38.98,
+      4.32
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "457",
+    "submissionMethod": "registry",
+    "deciles": [
+      20,
+      15.27,
+      15,
+      13.01,
+      10,
+      8.87,
+      6.45,
+      2.16,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "MSPB_1",
+    "submissionMethod": "administrativeClaims",
+    "deciles": [
+      24430,
+      23208,
+      22405,
+      21767,
+      21214.5,
+      20675,
+      20116,
+      19458,
+      18562,
+      null
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "TPCC_1",
+    "submissionMethod": "administrativeClaims",
+    "deciles": [
+      18827.8,
+      16018.7,
+      14668.5,
+      13750.8,
+      12976.8,
+      12234.1,
+      11423.9,
+      10375.9,
+      8664.94,
+      null
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "066",
+    "submissionMethod": "registry",
+    "deciles": [
+      53.72,
+      64.37,
+      69.64,
+      75.58,
+      82.14,
+      85.58,
+      87.98,
+      91.98,
+      97.87
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "069",
+    "submissionMethod": "registry",
+    "deciles": [
+      34.78,
+      42.86,
+      45.71,
+      64.52,
+      66.67,
+      71.43,
+      72.73,
+      77.27,
+      95.38
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "068",
+    "submissionMethod": "registry",
+    "deciles": [
+      15,
+      22.22,
+      22.22,
+      33.33,
+      56.85,
+      80.36,
+      86.36,
+      86.36,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AAD1",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.57,
+      10.49,
+      18.75,
+      26.92,
+      35.19,
+      42.93,
+      57.08,
+      74.29,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AAD2",
+    "submissionMethod": "registry",
+    "deciles": [
+      39.58,
+      58,
+      94.85,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AAD3",
+    "submissionMethod": "registry",
+    "deciles": [
+      5,
+      1.93,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AAD4",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.35,
+      3.64,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AAD5",
+    "submissionMethod": "registry",
+    "deciles": [
+      48.48,
+      73.17,
+      87.7,
+      97.86,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ACR7",
+    "submissionMethod": "registry",
+    "deciles": [
+      16.67,
+      21.19,
+      28.1,
+      34.78,
+      38.17,
+      41.89,
+      46.54,
+      58.88,
+      67.15
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AAN4",
+    "submissionMethod": "registry",
+    "deciles": [
+      15.91,
+      26.53,
+      41.35,
+      53.7,
+      70.98,
+      81.69,
+      90.32,
+      97.39,
+      99.53
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AAN9",
+    "submissionMethod": "registry",
+    "deciles": [
+      21.43,
+      58.54,
+      78.23,
+      90.91,
+      93.94,
+      97.06,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AAN10",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.75,
+      5.56,
+      13.33,
+      23.56,
+      38.03,
+      56.78,
+      68.1,
+      83.84,
+      90.34
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AAN1",
+    "submissionMethod": "registry",
+    "deciles": [
+      5.92,
+      13.27,
+      16.39,
+      20.24,
+      32.22,
+      46,
+      63.51,
+      74.89,
+      81.05
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AAN2",
+    "submissionMethod": "registry",
+    "deciles": [
+      31.07,
+      42.45,
+      46.27,
+      47.03,
+      49.32,
+      52.31,
+      53.47,
+      55.13,
+      59.19
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AAN5",
+    "submissionMethod": "registry",
+    "deciles": [
+      10.94,
+      15,
+      18.52,
+      24.59,
+      28.96,
+      35.42,
+      40.7,
+      47.34,
+      55.7
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "IRIS2",
+    "submissionMethod": "registry",
+    "deciles": [
+      76.74,
+      85.71,
+      92,
+      97.63,
+      99.17,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "IRIS3",
+    "submissionMethod": "registry",
+    "deciles": [
+      93.59,
+      71.56,
+      51.56,
+      29.17,
+      6.67,
+      3.93,
+      2.1,
+      0.67,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "IRIS4",
+    "submissionMethod": "registry",
+    "deciles": [
+      41.38,
+      62.96,
+      72.73,
+      85,
+      87.5,
+      88.89,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "IRIS5",
+    "submissionMethod": "registry",
+    "deciles": [
+      90.63,
+      98.85,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "IRIS6",
+    "submissionMethod": "registry",
+    "deciles": [
+      97.73,
+      97.73,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "IRIS10",
+    "submissionMethod": "registry",
+    "deciles": [
+      73.13,
+      81.81,
+      86.8,
+      91.34,
+      97.22,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "IRIS13",
+    "submissionMethod": "registry",
+    "deciles": [
+      93.51,
+      96.75,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "IRIS16",
+    "submissionMethod": "registry",
+    "deciles": [
+      68.25,
+      68.25,
+      68.25,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "IRIS26",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.02,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ACEP22",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.76,
+      5,
+      10.71,
+      18.37,
+      22.22,
+      25.81,
+      28.36,
+      35.14,
+      48
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ACEP25",
+    "submissionMethod": "registry",
+    "deciles": [
+      57.14,
+      63.61,
+      67.53,
+      72,
+      75,
+      78.32,
+      81.82,
+      85.45,
+      90
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ACEP26",
+    "submissionMethod": "registry",
+    "deciles": [
+      50,
+      78.57,
+      81.03,
+      84.44,
+      87.5,
+      90.69,
+      91.94,
+      94.64,
+      96.43
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ACEP27",
+    "submissionMethod": "registry",
+    "deciles": [
+      41.07,
+      43.48,
+      60,
+      65.63,
+      73.4,
+      84,
+      87.18,
+      91.3,
+      96.18
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ACEP28",
+    "submissionMethod": "registry",
+    "deciles": [
+      56.25,
+      72.43,
+      83.73,
+      85.71,
+      88.12,
+      89.74,
+      93.55,
+      94.64,
+      95.51
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ACEP29",
+    "submissionMethod": "registry",
+    "deciles": [
+      73.64,
+      75.61,
+      75.61,
+      81.75,
+      82.16,
+      82.58,
+      85,
+      85,
+      91.67
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ACEP30",
+    "submissionMethod": "registry",
+    "deciles": [
+      84.04,
+      84.04,
+      84.04,
+      84.04,
+      90.1,
+      96.15,
+      96.15,
+      96.15,
+      96.15
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ACEP31",
+    "submissionMethod": "registry",
+    "deciles": [
+      30.43,
+      43.04,
+      52,
+      59.26,
+      64.93,
+      69.88,
+      76.19,
+      89.29,
+      91.58
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ACRad23",
+    "submissionMethod": "registry",
+    "deciles": [
+      27.97,
+      20.97,
+      20,
+      18.18,
+      17.5,
+      16,
+      14.33,
+      12.5,
+      9.38
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ACRad21",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.16,
+      0.48,
+      0.64,
+      0.8,
+      0.84,
+      0.89,
+      1.18,
+      1.29,
+      1.64
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ACRad22",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.44,
+      2.5,
+      2.84,
+      2.84,
+      4.44,
+      5,
+      5,
+      9.62,
+      10.27
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ACRad31",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ACRad32",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ACRad33",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ACRad8",
+    "submissionMethod": "registry",
+    "deciles": [
+      40.91,
+      62.73,
+      64.02,
+      64.87,
+      68.46,
+      73.67,
+      78.26,
+      86.22,
+      89.74
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ACRad7",
+    "submissionMethod": "registry",
+    "deciles": [
+      81.08,
+      81.56,
+      86.96,
+      86.96,
+      90.32,
+      90.63,
+      90.63,
+      92.59,
+      93.44
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "CDR2",
+    "submissionMethod": "registry",
+    "deciles": [
+      33.85,
+      61.45,
+      69.19,
+      73.32,
+      75.31,
+      79.88,
+      82.97,
+      84.17,
+      86.62
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AQUA5",
+    "submissionMethod": "registry",
+    "deciles": [
+      6.82,
+      3.6,
+      2.94,
+      2.27,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AQUA6",
+    "submissionMethod": "registry",
+    "deciles": [
+      9.09,
+      6.84,
+      3.25,
+      0.31,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AQUA8",
+    "submissionMethod": "registry",
+    "deciles": [
+      9.22,
+      5.13,
+      4.22,
+      3.21,
+      2.63,
+      1.01,
+      0.69,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "MUSIC4",
+    "submissionMethod": "registry",
+    "deciles": [
+      18.37,
+      18.37,
+      40,
+      40,
+      61.67,
+      83.33,
+      83.33,
+      91.3,
+      91.3
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ABG28",
+    "submissionMethod": "registry",
+    "deciles": [
+      9.8,
+      35.6,
+      46.08,
+      51.52,
+      55.26,
+      61.81,
+      89.41,
+      99.65,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ABG29",
+    "submissionMethod": "registry",
+    "deciles": [
+      34.46,
+      46.91,
+      68.79,
+      92.59,
+      97.69,
+      99.2,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ABG30",
+    "submissionMethod": "registry",
+    "deciles": [
+      42.41,
+      65.21,
+      95.76,
+      98.43,
+      99.48,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ABG31",
+    "submissionMethod": "registry",
+    "deciles": [
+      55.04,
+      96.93,
+      98.86,
+      99.63,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AQI35",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.06,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ABG4",
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ABG5",
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ABG7",
+    "submissionMethod": "registry",
+    "deciles": [
+      98.39,
+      99.49,
+      99.87,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AQI48",
+    "submissionMethod": "registry",
+    "deciles": [
+      41.23,
+      57.71,
+      62,
+      88.48,
+      92.17,
+      96.35,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ABG14",
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ABG15",
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ABG16",
+    "submissionMethod": "registry",
+    "deciles": [
+      35.51,
+      56.01,
+      61.15,
+      72.27,
+      77.97,
+      82.25,
+      93.51,
+      95.66,
+      99.55
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ABG21",
+    "submissionMethod": "registry",
+    "deciles": [
+      6.11,
+      42.19,
+      60.79,
+      79.09,
+      90.22,
+      94.9,
+      97.74,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AQI50",
+    "submissionMethod": "registry",
+    "deciles": [
+      96.67,
+      98.75,
+      99.23,
+      99.58,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AQI51",
+    "submissionMethod": "registry",
+    "deciles": [
+      30.23,
+      86.69,
+      95.61,
+      99.02,
+      99.76,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AQI42",
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AQI28",
+    "submissionMethod": "registry",
+    "deciles": [
+      99.76,
+      99.94,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AQI34",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.29,
+      0.08,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AQI31",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.98,
+      0.28,
+      0.04,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AQI29",
+    "submissionMethod": "registry",
+    "deciles": [
+      72.73,
+      89.31,
+      94.57,
+      97.38,
+      98.83,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AQI32",
+    "submissionMethod": "registry",
+    "deciles": [
+      97.44,
+      99.2,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AQI37",
+    "submissionMethod": "registry",
+    "deciles": [
+      99.3,
+      99.87,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "EPREOP9",
+    "submissionMethod": "registry",
+    "deciles": [
+      99.43,
+      99.77,
+      99.9,
+      99.98,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "EPREOP14",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.01,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "EPREOP26",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "EPREOP27",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "NHCR4",
+    "submissionMethod": "registry",
+    "deciles": [
+      6.25,
+      12.5,
+      19.61,
+      25.58,
+      35.61,
+      41.11,
+      54.55,
+      73.13,
+      83.87
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "M2S1",
+    "submissionMethod": "registry",
+    "deciles": [
+      66.43,
+      70.25,
+      77.55,
+      80.47,
+      81.26,
+      81.62,
+      84.57,
+      89.83,
+      92.82
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "M2S11",
+    "submissionMethod": "registry",
+    "deciles": [
+      80,
+      80,
+      80,
+      80,
+      80,
+      80,
+      80,
+      80,
+      80
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ECPR39",
+    "submissionMethod": "registry",
+    "deciles": [
+      65.71,
+      80.56,
+      84.21,
+      86.36,
+      88.52,
+      90.78,
+      92.31,
+      94.05,
+      95.83
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ECPR43",
+    "submissionMethod": "registry",
+    "deciles": [
+      24.72,
+      16.1,
+      11.52,
+      7.44,
+      5.35,
+      3.03,
+      1.67,
+      0.87,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ECPR40",
+    "submissionMethod": "registry",
+    "deciles": [
+      79.71,
+      82.33,
+      85.66,
+      89.32,
+      90.91,
+      93.1,
+      95.12,
+      95.99,
+      98.84
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ECPR42",
+    "submissionMethod": "registry",
+    "deciles": [
+      85.64,
+      85.64,
+      85.64,
+      85.64,
+      92.82,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ECPR41",
+    "submissionMethod": "registry",
+    "deciles": [
+      65.86,
+      65.86,
+      65.86,
+      65.86,
+      65.86,
+      65.86,
+      65.86,
+      65.86,
+      65.86
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "MIRAMED3",
+    "submissionMethod": "registry",
+    "deciles": [
+      99.83,
+      99.89,
+      99.97,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "MEX1",
+    "submissionMethod": "registry",
+    "deciles": [
+      10,
+      13.8,
+      19.77,
+      22.54,
+      26.09,
+      35,
+      35.82,
+      53.05,
+      85.71
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "MUSIC6",
+    "submissionMethod": "registry",
+    "deciles": [
+      17.86,
+      9.38,
+      5.56,
+      3.85,
+      3.45,
+      3.33,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "MUSIC5",
+    "submissionMethod": "registry",
+    "deciles": [
+      25,
+      18.97,
+      17.39,
+      10.26,
+      10.13,
+      10,
+      7.14,
+      7.14,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "MUSIC10",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.35,
+      4.76,
+      6.67,
+      12.5,
+      13.21,
+      20,
+      21.43,
+      25.93,
+      48.48
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "MIRAMED5",
+    "submissionMethod": "registry",
+    "deciles": [
+      99.35,
+      99.85,
+      99.94,
+      99.98,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "MIRAMED9",
+    "submissionMethod": "registry",
+    "deciles": [
+      89.39,
+      93.75,
+      95.33,
+      97.14,
+      98.08,
+      98.84,
+      99.59,
+      99.89,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "MIRAMED7",
+    "submissionMethod": "registry",
+    "deciles": [
+      99.95,
+      99.98,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "MIRAMED4",
+    "submissionMethod": "registry",
+    "deciles": [
+      99.98,
+      99.98,
+      99.96,
+      99.95,
+      99.94,
+      99.94,
+      99.87,
+      99.84,
+      99.72
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "NPA6",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.71,
+      3.56,
+      2.43,
+      1.58,
+      0.49,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "NPA11",
+    "submissionMethod": "registry",
+    "deciles": [
+      13.3,
+      12.61,
+      11.24,
+      9.76,
+      8.35,
+      7.29,
+      5.98,
+      4.58,
+      2.78
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "NPA3",
+    "submissionMethod": "registry",
+    "deciles": [
+      22.17,
+      26.85,
+      40.79,
+      63.75,
+      66.79,
+      70.38,
+      77.5,
+      82.34,
+      86.49
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "NPA4",
+    "submissionMethod": "registry",
+    "deciles": [
+      18.78,
+      25.63,
+      41.9,
+      72.08,
+      75.89,
+      80,
+      80.63,
+      86.02,
+      90.89
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "NPA5",
+    "submissionMethod": "registry",
+    "deciles": [
+      23.5,
+      29.76,
+      55.79,
+      80,
+      90.49,
+      92.43,
+      94.76,
+      95.55,
+      96.72
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "OEIS1",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "OEIS3",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "OEIS4",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "OEIS6",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ACCPin3",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ACCPin4",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "PPRNET8",
+    "submissionMethod": "registry",
+    "deciles": [
+      25.49,
+      27.68,
+      36.19,
+      41.6,
+      48.99,
+      51.32,
+      62.07,
+      67.68,
+      74.61
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "PPRNET32",
+    "submissionMethod": "registry",
+    "deciles": [
+      8.43,
+      18.34,
+      30.81,
+      51.34,
+      58.78,
+      62.74,
+      66.43,
+      72.73,
+      78.66
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "PPRNET31",
+    "submissionMethod": "registry",
+    "deciles": [
+      74.16,
+      82.72,
+      84.69,
+      85.59,
+      88.03,
+      90.75,
+      92.16,
+      93.93,
+      96.2
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "PPRNET33",
+    "submissionMethod": "registry",
+    "deciles": [
+      48.76,
+      51.91,
+      54.55,
+      55.59,
+      58.25,
+      61.19,
+      64.49,
+      70,
+      77.82
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "PPRNET27",
+    "submissionMethod": "registry",
+    "deciles": [
+      85.71,
+      88.57,
+      90.44,
+      91.4,
+      93.18,
+      96.77,
+      97.62,
+      98.84,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "PPRNET24",
+    "submissionMethod": "registry",
+    "deciles": [
+      30.99,
+      37.62,
+      50,
+      54.55,
+      62.16,
+      63.41,
+      66.67,
+      70,
+      78.43
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "QUANTUM41",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.06,
+      0.05,
+      0.04,
+      0.03,
+      0.03,
+      0.03,
+      0.02,
+      0.02,
+      0.01
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "QUANTUM31",
+    "submissionMethod": "registry",
+    "deciles": [
+      25.84,
+      31.91,
+      60.65,
+      70.3,
+      78,
+      83.29,
+      87.74,
+      89.78,
+      95.12
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "QUANTUM37",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.52,
+      0.27,
+      0.24,
+      0.21,
+      0.09,
+      0.07,
+      0.07,
+      0.05,
+      0.03
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "QUANTUM42",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.12,
+      0.03,
+      0.02,
+      0.02,
+      0.01,
+      0.01,
+      0.01,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "QUANTUM51",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.15,
+      0.04,
+      0.03,
+      0.03,
+      0.02,
+      0.02,
+      0.02,
+      0.01,
+      0.01
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AAO8",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AAO9",
+    "submissionMethod": "registry",
+    "deciles": [
+      99.57,
+      99.83,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AAO10",
+    "submissionMethod": "registry",
+    "deciles": [
+      85.71,
+      94.62,
+      97.58,
+      98.72,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "AAO11",
+    "submissionMethod": "registry",
+    "deciles": [
+      98.52,
+      99.59,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "RPAQIR11",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.93,
+      0.58,
+      0.26,
+      0.07,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "RPAQIR12",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.59,
+      0.99,
+      0.73,
+      0.54,
+      0.39,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "RPAQIR13",
+    "submissionMethod": "registry",
+    "deciles": [
+      86.51,
+      92.85,
+      94.07,
+      94.95,
+      95.87,
+      97.28,
+      97.89,
+      99.21,
+      99.77
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "RCOIR7",
+    "submissionMethod": "registry",
+    "deciles": [
+      29.27,
+      37.04,
+      40.22,
+      44.53,
+      60,
+      63.64,
+      66.67,
+      69.23,
+      75
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "RCOIR8",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.26,
+      0.26,
+      0.26,
+      0.54,
+      0.54,
+      0.54,
+      0.72,
+      0.72,
+      0.72
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "RCOIR9",
+    "submissionMethod": "registry",
+    "deciles": [
+      99.86,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "RCOIR10",
+    "submissionMethod": "registry",
+    "deciles": [
+      5,
+      38.46,
+      55,
+      55.03,
+      58.63,
+      62.22,
+      64.71,
+      76,
+      77.42
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "SCG4",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "STS7",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.49,
+      4,
+      8.7,
+      27.94,
+      47.44,
+      70,
+      84.06,
+      93.18,
+      99.21
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "ASBS10",
+    "submissionMethod": "registry",
+    "deciles": [
+      77.27,
+      86.36,
+      96.43,
+      97.18,
+      98.64,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "NIPM8",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "NIPM1",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "NIPM9",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "NIPM3",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "NIPM2",
+    "submissionMethod": "registry",
+    "deciles": [
+      99.28,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "OBERD25",
+    "submissionMethod": "registry",
+    "deciles": [
+      74.29,
+      74.29,
+      79,
+      79,
+      83.18,
+      87.37,
+      87.37,
+      87.65,
+      87.65
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "CDR8",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.55,
+      4.55,
+      8.33,
+      8.33,
+      17.24,
+      31.37,
+      41.67,
+      46.58,
+      48.44
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "USWR15",
+    "submissionMethod": "registry",
+    "deciles": [
+      77.27,
+      77.27,
+      77.27,
+      77.27,
+      77.27,
+      77.27,
+      77.27,
+      77.27,
+      77.27
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "USWR20",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.04,
+      1.56,
+      1.76,
+      1.96,
+      4.58,
+      7.83,
+      10.92,
+      26.71,
+      71.07
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "CDR3",
+    "submissionMethod": "registry",
+    "deciles": [
+      90.63,
+      90.63,
+      90.63,
+      90.63,
+      90.63,
+      90.63,
+      90.63,
+      90.63,
+      90.63
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "CDR7",
+    "submissionMethod": "registry",
+    "deciles": [
+      14.29,
+      14.29,
+      14.29,
+      14.29,
+      32.14,
+      50,
+      50,
+      50,
+      50
+    ],
+    "performanceYear": 2017
+  },
+  {
+    "measureId": "CDR6",
+    "submissionMethod": "registry",
+    "deciles": [
+      50,
+      58.82,
+      64.52,
+      66.67,
+      69.22,
+      70.97,
+      72.58,
+      75,
+      79.17
+    ],
+    "performanceYear": 2017
+  }
+]

--- a/staging/2018/benchmarks/json/performance-benchmarks.json
+++ b/staging/2018/benchmarks/json/performance-benchmarks.json
@@ -1,0 +1,3076 @@
+[
+  {
+    "measureId": "176",
+    "submissionMethod": "registry",
+    "deciles": [
+      27.78,
+      42.08,
+      59.09,
+      74.46,
+      89.16,
+      95.74,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "177",
+    "submissionMethod": "registry",
+    "deciles": [
+      40.91,
+      67.05,
+      78.73,
+      87.96,
+      93.13,
+      96.76,
+      99.61,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "179",
+    "submissionMethod": "registry",
+    "deciles": [
+      31.81,
+      56.73,
+      73.67,
+      81.86,
+      89.78,
+      96.89,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "180",
+    "submissionMethod": "registry",
+    "deciles": [
+      40.91,
+      61.48,
+      73.23,
+      80.83,
+      87.22,
+      91.79,
+      96.7,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "226",
+    "submissionMethod": "claims",
+    "deciles": [
+      95.86,
+      98.56,
+      99.72,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "226",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      7.27,
+      17.36,
+      33.33,
+      55.83,
+      73.98,
+      82.96,
+      88.09,
+      92.47,
+      97.12
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "226",
+    "submissionMethod": "registry",
+    "deciles": [
+      10.45,
+      19.72,
+      32.08,
+      46.91,
+      65.7,
+      82.98,
+      94.23,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "243",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.6,
+      5.65,
+      8.89,
+      14.37,
+      20.75,
+      28.84,
+      38.94,
+      52.9,
+      71.88
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "250",
+    "submissionMethod": "claims",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "260",
+    "submissionMethod": "registry",
+    "deciles": [
+      85,
+      85.71,
+      88.24,
+      88.51,
+      91.95,
+      95.24,
+      96,
+      97.87,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "268",
+    "submissionMethod": "registry",
+    "deciles": [
+      8.33,
+      26.47,
+      33.33,
+      38.3,
+      64.71,
+      81.82,
+      90,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "276",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.98,
+      17.78,
+      47.19,
+      64.71,
+      79.02,
+      87.54,
+      95.7,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "277",
+    "submissionMethod": "registry",
+    "deciles": [
+      5.68,
+      23.94,
+      54.33,
+      80.47,
+      90.63,
+      99.24,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "278",
+    "submissionMethod": "registry",
+    "deciles": [
+      91,
+      96.48,
+      97.21,
+      98.25,
+      99.34,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "279",
+    "submissionMethod": "registry",
+    "deciles": [
+      49,
+      73.81,
+      88.56,
+      94.01,
+      98.67,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "282",
+    "submissionMethod": "registry",
+    "deciles": [
+      28.17,
+      57.93,
+      77.89,
+      89.86,
+      96.67,
+      98.68,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "283",
+    "submissionMethod": "registry",
+    "deciles": [
+      51.36,
+      83.83,
+      94.09,
+      98.05,
+      99.78,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "286",
+    "submissionMethod": "registry",
+    "deciles": [
+      19.57,
+      39.08,
+      78.3,
+      90.91,
+      98.3,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "288",
+    "submissionMethod": "registry",
+    "deciles": [
+      13.68,
+      38.63,
+      56,
+      76.47,
+      86.84,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "291",
+    "submissionMethod": "registry",
+    "deciles": [
+      10,
+      33.06,
+      63.47,
+      89.9,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "293",
+    "submissionMethod": "registry",
+    "deciles": [
+      23.12,
+      37.18,
+      70,
+      83.87,
+      95.66,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "338",
+    "submissionMethod": "registry",
+    "deciles": [
+      49.37,
+      59.09,
+      81.82,
+      83.97,
+      86.6,
+      92.69,
+      95.77,
+      99.29,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "340",
+    "submissionMethod": "registry",
+    "deciles": [
+      40.26,
+      48.4,
+      56.03,
+      62.44,
+      70.21,
+      76.92,
+      90.38,
+      95.35,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "343",
+    "submissionMethod": "registry",
+    "deciles": [
+      17.95,
+      28.6,
+      33.64,
+      37.5,
+      41.74,
+      45.3,
+      49.42,
+      60.13,
+      95.34
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "350",
+    "submissionMethod": "registry",
+    "deciles": [
+      88.87,
+      98.03,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "351",
+    "submissionMethod": "registry",
+    "deciles": [
+      92.23,
+      98.81,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "352",
+    "submissionMethod": "registry",
+    "deciles": [
+      96.76,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "353",
+    "submissionMethod": "registry",
+    "deciles": [
+      97.14,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "354",
+    "submissionMethod": "registry",
+    "deciles": [
+      8.7,
+      5,
+      1.7,
+      0.5,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "355",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.69,
+      2.58,
+      1.67,
+      0.95,
+      0.36,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "356",
+    "submissionMethod": "registry",
+    "deciles": [
+      6.19,
+      3.7,
+      2.62,
+      1.59,
+      0.88,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "357",
+    "submissionMethod": "registry",
+    "deciles": [
+      5.58,
+      2.25,
+      1.35,
+      0.68,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "359",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "360",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.45,
+      5.2,
+      37.9,
+      93.77,
+      98.91,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "361",
+    "submissionMethod": "registry",
+    "deciles": [
+      98.77,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "362",
+    "submissionMethod": "registry",
+    "deciles": [
+      97.32,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "363",
+    "submissionMethod": "registry",
+    "deciles": [
+      93.53,
+      99.33,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "364",
+    "submissionMethod": "registry",
+    "deciles": [
+      52.4,
+      68.09,
+      78.41,
+      85.71,
+      91.8,
+      98.08,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "366",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      10,
+      13.46,
+      16.67,
+      23.27,
+      26.42,
+      29.66,
+      31.67,
+      38.4,
+      50
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "367",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.32,
+      0.74,
+      2.01,
+      2.82,
+      3.62,
+      4.96,
+      13.1,
+      26.92,
+      33.53
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "369",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      41,
+      63.76,
+      75.76,
+      83.78,
+      88,
+      90.84,
+      93.92,
+      95.75,
+      97.55
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "370",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      1.42,
+      2.33,
+      3.21,
+      4.62,
+      7,
+      9.6,
+      14.29,
+      20.26,
+      31.93
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "372",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      3.54,
+      5,
+      17,
+      23,
+      30.7,
+      35.71,
+      42.59,
+      58.38,
+      81.94
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "377",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.63,
+      1.22,
+      2,
+      3,
+      4.12,
+      5.28,
+      5.87,
+      9.8,
+      17.86
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "382",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      1.49,
+      5.36,
+      12.84,
+      20.37,
+      27.97,
+      36,
+      46.15,
+      65.88,
+      83.56
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "384",
+    "submissionMethod": "registry",
+    "deciles": [
+      91.43,
+      97.71,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "385",
+    "submissionMethod": "registry",
+    "deciles": [
+      9.09,
+      13.09,
+      16.33,
+      19.23,
+      21.76,
+      24.73,
+      30.25,
+      34.78,
+      40.68
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "390",
+    "submissionMethod": "registry",
+    "deciles": [
+      36.62,
+      53.59,
+      76.24,
+      89.17,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "394",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.75,
+      2.44,
+      4.76,
+      6.67,
+      13.79,
+      15,
+      16.67,
+      27.59,
+      37.5
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "396",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "398",
+    "submissionMethod": "registry",
+    "deciles": [
+      15.5,
+      41.12,
+      54.17,
+      73.49,
+      84.58,
+      96.72,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "407",
+    "submissionMethod": "registry",
+    "deciles": [
+      80.95,
+      96.06,
+      98.41,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "416",
+    "submissionMethod": "registry",
+    "deciles": [
+      40.82,
+      33.55,
+      27.73,
+      22.59,
+      15.63,
+      9.38,
+      3.92,
+      1.45,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "423",
+    "submissionMethod": "registry",
+    "deciles": [
+      93.94,
+      96.15,
+      99.79,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "432",
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "433",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.45,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "435",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.13,
+      4.76,
+      14.29,
+      36.84,
+      49.09,
+      80.56,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "437",
+    "submissionMethod": "claims",
+    "deciles": [
+      2.94,
+      2.08,
+      1.85,
+      1.08,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "437",
+    "submissionMethod": "registry",
+    "deciles": [
+      7.36,
+      2.86,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "438",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      42.18,
+      57.14,
+      63.2,
+      66.85,
+      69.83,
+      72.96,
+      75.59,
+      78.57,
+      83.55
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "439",
+    "submissionMethod": "registry",
+    "deciles": [
+      36.84,
+      0.63,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "440",
+    "submissionMethod": "registry",
+    "deciles": [
+      91.93,
+      98.72,
+      99.62,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "441",
+    "submissionMethod": "registry",
+    "deciles": [
+      20.64,
+      36.95,
+      45.53,
+      52.78,
+      58.98,
+      63.64,
+      66.9,
+      71.83,
+      77.78
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "443",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.68,
+      2.74,
+      1.92,
+      1.72,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "444",
+    "submissionMethod": "registry",
+    "deciles": [
+      55.33,
+      73.71,
+      80.34,
+      91.3,
+      96.67,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "445",
+    "submissionMethod": "registry",
+    "deciles": [
+      5.56,
+      3.17,
+      2.81,
+      2.33,
+      1.87,
+      1.39,
+      1.02,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "449",
+    "submissionMethod": "registry",
+    "deciles": [
+      89.29,
+      93.48,
+      97.69,
+      98.87,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "453",
+    "submissionMethod": "registry",
+    "deciles": [
+      20,
+      17.28,
+      14.29,
+      12,
+      10,
+      8.82,
+      7,
+      5.45,
+      4.35
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "456",
+    "submissionMethod": "registry",
+    "deciles": [
+      93.22,
+      84,
+      77.27,
+      75.6,
+      68.33,
+      64.52,
+      60.68,
+      54.55,
+      29.03
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "457",
+    "submissionMethod": "registry",
+    "deciles": [
+      18.9,
+      15.82,
+      14.48,
+      12.31,
+      10,
+      8.55,
+      6.7,
+      4.77,
+      3.4
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "463",
+    "submissionMethod": "registry",
+    "deciles": [
+      91.18,
+      94.82,
+      96.32,
+      97.86,
+      98.57,
+      99.18,
+      99.74,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "464",
+    "submissionMethod": "registry",
+    "deciles": [
+      80,
+      86.73,
+      89.01,
+      92.01,
+      94.81,
+      96.05,
+      97.71,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "066",
+    "submissionMethod": "registry",
+    "deciles": [
+      56,
+      65.88,
+      72.85,
+      77.78,
+      81.98,
+      85.71,
+      89.29,
+      92.72,
+      96.02
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "MSPB_1",
+    "submissionMethod": "administrativeClaims",
+    "deciles": [
+      43284,
+      24418,
+      23155,
+      22358,
+      21726,
+      21180,
+      20670,
+      20136,
+      19511,
+      18657
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "TPCC_1",
+    "submissionMethod": "administrativeClaims",
+    "deciles": [
+      79929.9,
+      18838.8,
+      15754.4,
+      14355,
+      13447.8,
+      12712.2,
+      11998.9,
+      11197,
+      10082.4,
+      8065.99
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AAD1",
+    "submissionMethod": "registry",
+    "deciles": [
+      6.74,
+      13.46,
+      28.3,
+      45.18,
+      60.33,
+      72.77,
+      84.05,
+      90.12,
+      98.77
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AAD2",
+    "submissionMethod": "registry",
+    "deciles": [
+      6.64,
+      15.94,
+      36.18,
+      59.74,
+      78.2,
+      85.36,
+      91.86,
+      98.78,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AAD3",
+    "submissionMethod": "registry",
+    "deciles": [
+      6.15,
+      4,
+      1.8,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AAD4",
+    "submissionMethod": "registry",
+    "deciles": [
+      11.11,
+      3.16,
+      1.39,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AAD5",
+    "submissionMethod": "registry",
+    "deciles": [
+      82.93,
+      95.65,
+      98.31,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AAN1",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.35,
+      9.43,
+      11.11,
+      17.86,
+      20.51,
+      22.41,
+      35.29,
+      63.16,
+      84.09
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AAN10",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.01,
+      3.81,
+      6.58,
+      9.44,
+      15.26,
+      19.82,
+      33.99,
+      41.19,
+      64.96
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AAN9",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.13,
+      13.21,
+      35.48,
+      53.66,
+      78.67,
+      88,
+      92.59,
+      95.56,
+      98.9
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AAO11",
+    "submissionMethod": "registry",
+    "deciles": [
+      99.23,
+      99.7,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AAO15",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AAO17",
+    "submissionMethod": "registry",
+    "deciles": [
+      97.59,
+      98.51,
+      98.84,
+      99.38,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AAO22",
+    "submissionMethod": "registry",
+    "deciles": [
+      92.7,
+      95.12,
+      96.73,
+      97.7,
+      98.55,
+      99.7,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AAO23",
+    "submissionMethod": "registry",
+    "deciles": [
+      47.1,
+      62.79,
+      67.56,
+      70.5,
+      74.55,
+      75.65,
+      78.53,
+      83.2,
+      85.94
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AAO24",
+    "submissionMethod": "registry",
+    "deciles": [
+      87.66,
+      91.53,
+      93.14,
+      95.48,
+      96.57,
+      97.17,
+      98.14,
+      98.75,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AAO25",
+    "submissionMethod": "registry",
+    "deciles": [
+      99.94,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AAO26",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.76,
+      40.5,
+      49.57,
+      53.33,
+      65.64,
+      74.29,
+      79.13,
+      81.44,
+      87.5
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AAO28",
+    "submissionMethod": "registry",
+    "deciles": [
+      5,
+      10,
+      12.12,
+      15.91,
+      18.94,
+      21.81,
+      26.92,
+      38.71,
+      51.22
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AAO8",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ABG16",
+    "submissionMethod": "registry",
+    "deciles": [
+      29.49,
+      43.99,
+      63.33,
+      73.17,
+      80.23,
+      84.42,
+      90.7,
+      93.3,
+      97.62
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ABG21",
+    "submissionMethod": "registry",
+    "deciles": [
+      69.61,
+      85.55,
+      92.79,
+      96.73,
+      99.08,
+      99.92,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ABG28",
+    "submissionMethod": "registry",
+    "deciles": [
+      68.08,
+      82,
+      93.22,
+      97.6,
+      99.77,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ABG29",
+    "submissionMethod": "registry",
+    "deciles": [
+      33.65,
+      57.51,
+      73.57,
+      85.36,
+      93.76,
+      99.75,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ABG30",
+    "submissionMethod": "registry",
+    "deciles": [
+      10.49,
+      40.8,
+      73.12,
+      99.75,
+      99.95,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ABG31",
+    "submissionMethod": "registry",
+    "deciles": [
+      56.98,
+      72.58,
+      84.62,
+      93.02,
+      99.92,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ABG36",
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACEP19",
+    "submissionMethod": "registry",
+    "deciles": [
+      50.45,
+      53.87,
+      54.78,
+      57.77,
+      59.79,
+      62.89,
+      68.13,
+      74.08,
+      76.96
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACEP29",
+    "submissionMethod": "registry",
+    "deciles": [
+      63.27,
+      72.86,
+      78.26,
+      84.91,
+      87.23,
+      89.29,
+      90.63,
+      92.68,
+      95.6
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACEP30",
+    "submissionMethod": "registry",
+    "deciles": [
+      68.56,
+      70.32,
+      72.55,
+      73.68,
+      76.44,
+      77.57,
+      80.95,
+      82.22,
+      85.59
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACEP31",
+    "submissionMethod": "registry",
+    "deciles": [
+      63.27,
+      81.82,
+      84.06,
+      87.25,
+      91.02,
+      97.67,
+      99.68,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACEP32",
+    "submissionMethod": "registry",
+    "deciles": [
+      281,
+      212,
+      189,
+      177,
+      169,
+      158,
+      148,
+      140,
+      129
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACEP40",
+    "submissionMethod": "registry",
+    "deciles": [
+      196,
+      151,
+      135.5,
+      128,
+      118,
+      114,
+      108.5,
+      99,
+      90.5
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACEP48",
+    "submissionMethod": "registry",
+    "deciles": [
+      60,
+      68.37,
+      74.36,
+      77.27,
+      81.8,
+      84.85,
+      86.6,
+      88.71,
+      92.31
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACQR2",
+    "submissionMethod": "registry",
+    "deciles": [
+      91.3,
+      94.35,
+      94.92,
+      95.17,
+      95.85,
+      96.15,
+      96.83,
+      97.61,
+      98.58
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACQR3",
+    "submissionMethod": "registry",
+    "deciles": [
+      86.25,
+      88.14,
+      89.08,
+      90.97,
+      92.67,
+      93.66,
+      93.75,
+      95.4,
+      97.22
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACQR5",
+    "submissionMethod": "registry",
+    "deciles": [
+      67.28,
+      77.12,
+      80.65,
+      81.63,
+      83.71,
+      85.8,
+      87.15,
+      90.42,
+      95.45
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACQR8",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACR7",
+    "submissionMethod": "registry",
+    "deciles": [
+      24.19,
+      35.71,
+      45.31,
+      50,
+      55.44,
+      60,
+      63.33,
+      69.34,
+      73.08
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACRAD15",
+    "submissionMethod": "registry",
+    "deciles": [
+      53,
+      8,
+      4,
+      2,
+      2,
+      1,
+      1,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACRAD16",
+    "submissionMethod": "registry",
+    "deciles": [
+      82,
+      6,
+      4,
+      3,
+      2,
+      1,
+      1,
+      1,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACRAD17",
+    "submissionMethod": "registry",
+    "deciles": [
+      111,
+      15,
+      9,
+      7,
+      6,
+      5,
+      4,
+      3,
+      1
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACRAD18",
+    "submissionMethod": "registry",
+    "deciles": [
+      37,
+      6,
+      3,
+      2,
+      1,
+      1,
+      1,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACRAD19",
+    "submissionMethod": "registry",
+    "deciles": [
+      111,
+      43,
+      25,
+      19,
+      16,
+      8.5,
+      6,
+      4,
+      3
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACRAD23",
+    "submissionMethod": "registry",
+    "deciles": [
+      25.24,
+      21.44,
+      18.15,
+      17.13,
+      15.69,
+      14.14,
+      12.5,
+      11.42,
+      9.82
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACRAD25",
+    "submissionMethod": "registry",
+    "deciles": [
+      1573,
+      50,
+      33,
+      20,
+      15,
+      11,
+      8,
+      5,
+      2
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACRAD31",
+    "submissionMethod": "registry",
+    "deciles": [
+      59.36,
+      72.36,
+      80.97,
+      86.44,
+      87.15,
+      87.15,
+      92.57,
+      96.29,
+      96.29
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACRAD32",
+    "submissionMethod": "registry",
+    "deciles": [
+      70.52,
+      73.89,
+      75.83,
+      76.35,
+      84.81,
+      88.02,
+      95.38,
+      98.75,
+      99.74
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACRAD33",
+    "submissionMethod": "registry",
+    "deciles": [
+      30.73,
+      30.73,
+      61.21,
+      75.72,
+      80.4,
+      91.13,
+      93.63,
+      97.53,
+      99.62
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ACRAD5",
+    "submissionMethod": "registry",
+    "deciles": [
+      14.91,
+      12.95,
+      10.3,
+      8.96,
+      8.61,
+      7.66,
+      5.97,
+      4.23,
+      3.3
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AQI48",
+    "submissionMethod": "registry",
+    "deciles": [
+      91.07,
+      92.33,
+      93.22,
+      94.21,
+      94.95,
+      95.56,
+      95.95,
+      96.69,
+      97.65
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AQI50",
+    "submissionMethod": "registry",
+    "deciles": [
+      98.96,
+      99.5,
+      99.72,
+      99.86,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AQI51",
+    "submissionMethod": "registry",
+    "deciles": [
+      39.23,
+      79.15,
+      90.56,
+      95.9,
+      99.12,
+      99.79,
+      99.98,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AQI53",
+    "submissionMethod": "registry",
+    "deciles": [
+      56.25,
+      74.01,
+      76.87,
+      94.46,
+      98.08,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AQI54",
+    "submissionMethod": "registry",
+    "deciles": [
+      90.22,
+      97.44,
+      98.53,
+      99.37,
+      99.81,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AQI56",
+    "submissionMethod": "registry",
+    "deciles": [
+      72.61,
+      91.72,
+      94.75,
+      96.49,
+      98.16,
+      98.59,
+      99.85,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AQI59",
+    "submissionMethod": "registry",
+    "deciles": [
+      69.14,
+      80.47,
+      85.12,
+      89.45,
+      92.76,
+      95.88,
+      97.72,
+      99.69,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AQI60",
+    "submissionMethod": "registry",
+    "deciles": [
+      99.87,
+      99.94,
+      99.98,
+      99.99,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AQUA15",
+    "submissionMethod": "registry",
+    "deciles": [
+      34.55,
+      52.46,
+      65.57,
+      72.73,
+      76.86,
+      82.23,
+      85.97,
+      88.62,
+      92.77
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AQUA18",
+    "submissionMethod": "registry",
+    "deciles": [
+      78.05,
+      80.77,
+      88.14,
+      91.48,
+      93.94,
+      96.3,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "AQUA26",
+    "submissionMethod": "registry",
+    "deciles": [
+      16.45,
+      10.06,
+      8.73,
+      7.36,
+      6.82,
+      5.16,
+      3.47,
+      3.01,
+      1.88
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ASBS12",
+    "submissionMethod": "registry",
+    "deciles": [
+      96.12,
+      98.15,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "ECPR45",
+    "submissionMethod": "registry",
+    "deciles": [
+      77.89,
+      91.33,
+      96.95,
+      97.14,
+      98.17,
+      99.07,
+      99.33,
+      99.57,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "GIQIC17",
+    "submissionMethod": "registry",
+    "deciles": [
+      71.23,
+      80,
+      84.62,
+      86.36,
+      90.48,
+      93.75,
+      95.65,
+      97.5,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "GIQIC18",
+    "submissionMethod": "registry",
+    "deciles": [
+      83.13,
+      89.29,
+      92.31,
+      95,
+      97.1,
+      97.92,
+      99.24,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "GIQIC19",
+    "submissionMethod": "registry",
+    "deciles": [
+      26.88,
+      34.13,
+      41.86,
+      49.11,
+      60.1,
+      68.36,
+      83.57,
+      92.85,
+      96.95
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "GIQIC20",
+    "submissionMethod": "registry",
+    "deciles": [
+      25,
+      70.9,
+      80.54,
+      86.84,
+      91.3,
+      95.18,
+      96.97,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IQSS1",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.09,
+      1.59,
+      2.63,
+      3.03,
+      3.7,
+      5.41,
+      6.25,
+      8.33,
+      10.26
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IQSS2",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.21,
+      2.25,
+      3.06,
+      3.68,
+      4.76,
+      5,
+      8.52,
+      12.64,
+      22.26
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IQSS3",
+    "submissionMethod": "registry",
+    "deciles": [
+      56,
+      68.73,
+      75.9,
+      80.6,
+      84,
+      90.91,
+      93.26,
+      95.78,
+      99.19
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IQSS4",
+    "submissionMethod": "registry",
+    "deciles": [
+      25.76,
+      39.58,
+      52.38,
+      60,
+      64,
+      68,
+      72.73,
+      79.55,
+      83.33
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS1",
+    "submissionMethod": "registry",
+    "deciles": [
+      9.52,
+      22.73,
+      32.08,
+      37.04,
+      50.72,
+      53.97,
+      58,
+      75,
+      78.13
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS10",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS11",
+    "submissionMethod": "registry",
+    "deciles": [
+      80.13,
+      86.21,
+      88.8,
+      90.7,
+      92.55,
+      93.94,
+      95.3,
+      96.55,
+      98.01
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS13",
+    "submissionMethod": "registry",
+    "deciles": [
+      73.68,
+      79.35,
+      83.33,
+      86.94,
+      89.18,
+      90.48,
+      91.84,
+      93.75,
+      96.3
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS16",
+    "submissionMethod": "registry",
+    "deciles": [
+      86.67,
+      91.3,
+      93.83,
+      95.24,
+      95.98,
+      96.97,
+      98.5,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS17",
+    "submissionMethod": "registry",
+    "deciles": [
+      19.23,
+      32.14,
+      46.32,
+      55,
+      63.33,
+      69.57,
+      74.32,
+      81.82,
+      88.97
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS2",
+    "submissionMethod": "registry",
+    "deciles": [
+      51.59,
+      69.78,
+      78.79,
+      84.65,
+      88.89,
+      91.53,
+      93.59,
+      95.32,
+      96.99
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS23",
+    "submissionMethod": "registry",
+    "deciles": [
+      19.02,
+      45.9,
+      55,
+      65.22,
+      75.49,
+      81.58,
+      87.69,
+      94.87,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS25",
+    "submissionMethod": "registry",
+    "deciles": [
+      37.5,
+      16.67,
+      7.14,
+      2.78,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS26",
+    "submissionMethod": "registry",
+    "deciles": [
+      5.45,
+      3.03,
+      1.57,
+      0.6,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS27",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.57,
+      0.64,
+      0.21,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS28",
+    "submissionMethod": "registry",
+    "deciles": [
+      20.61,
+      31.07,
+      37.99,
+      44.65,
+      51.05,
+      56.72,
+      62.66,
+      69.78,
+      78.29
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS29",
+    "submissionMethod": "registry",
+    "deciles": [
+      15.38,
+      19.61,
+      20.83,
+      27.78,
+      31.58,
+      32.91,
+      34.38,
+      50,
+      95.15
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS3",
+    "submissionMethod": "registry",
+    "deciles": [
+      20.67,
+      17.14,
+      14.39,
+      12,
+      9.19,
+      7.14,
+      5.32,
+      4,
+      2.56
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS30",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.2,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS31",
+    "submissionMethod": "registry",
+    "deciles": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS33",
+    "submissionMethod": "registry",
+    "deciles": [
+      5.26,
+      2.02,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS34",
+    "submissionMethod": "registry",
+    "deciles": [
+      6.52,
+      4.29,
+      2.88,
+      1.85,
+      0.77,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS4",
+    "submissionMethod": "registry",
+    "deciles": [
+      13.48,
+      18.25,
+      23.81,
+      27.27,
+      30.99,
+      34.94,
+      39.02,
+      43.33,
+      53.85
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS7",
+    "submissionMethod": "registry",
+    "deciles": [
+      16.13,
+      20.83,
+      26.92,
+      29.8,
+      32.14,
+      33.33,
+      35.19,
+      37.2,
+      42.86
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "IRIS9",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "MA1",
+    "submissionMethod": "registry",
+    "deciles": [
+      12.16,
+      9.62,
+      6.77,
+      4.37,
+      3.17,
+      2.34,
+      1.11,
+      0.48,
+      0.03
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "MBSAQIP10",
+    "submissionMethod": "registry",
+    "deciles": [
+      8.45,
+      7.89,
+      6.9,
+      5,
+      3.93,
+      3.08,
+      2.17,
+      1.61,
+      0.94
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "MBSAQIP11",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.63,
+      1.9,
+      1.41,
+      1,
+      0.24,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "MBSAQIP12",
+    "submissionMethod": "registry",
+    "deciles": [
+      4,
+      3.33,
+      2.5,
+      2.27,
+      1.45,
+      1.09,
+      0.97,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "MEX1",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.26,
+      12,
+      23.9,
+      37.29,
+      46.81,
+      57.25,
+      66.1,
+      75,
+      82.86
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "MEX4",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.96,
+      4.03,
+      6.83,
+      12.46,
+      18.88,
+      23.47,
+      31.22,
+      41.8,
+      68.78
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "MEX5",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.69,
+      2.86,
+      7.89,
+      10.34,
+      15.38,
+      18.6,
+      27.27,
+      45.71,
+      69.01
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "MIRAMED17",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.41,
+      0.26,
+      0.16,
+      0.12,
+      0.1,
+      0.08,
+      0.06,
+      0.02,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "MIRAMED18",
+    "submissionMethod": "registry",
+    "deciles": [
+      96.78,
+      98.19,
+      98.37,
+      98.96,
+      99.3,
+      99.72,
+      99.83,
+      99.93,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "MIRAMED19",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.47,
+      0.3,
+      0.19,
+      0.14,
+      0.11,
+      0.09,
+      0.08,
+      0.04,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "MUSIC11",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.55,
+      5.13,
+      7.69,
+      9.52,
+      12.37,
+      16,
+      20.07,
+      26.09,
+      29.63
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "NHCR4",
+    "submissionMethod": "registry",
+    "deciles": [
+      7.69,
+      16,
+      20.89,
+      29.51,
+      39.29,
+      50,
+      63.41,
+      74.91,
+      88.89
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "NIPM8",
+    "submissionMethod": "registry",
+    "deciles": [
+      99.2,
+      99.61,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "NIPM9",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "NPAGSC9",
+    "submissionMethod": "registry",
+    "deciles": [
+      28.15,
+      19.31,
+      2.7,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "PIMSH1",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.65,
+      1.4,
+      2.8,
+      9.01,
+      20.96,
+      34.31,
+      43.44,
+      58.33,
+      82.42
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "PIMSH2",
+    "submissionMethod": "registry",
+    "deciles": [
+      57.14,
+      36.05,
+      30.43,
+      27.5,
+      24.14,
+      22,
+      16.9,
+      13.43,
+      7.69
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "QUANTUM31",
+    "submissionMethod": "registry",
+    "deciles": [
+      55.26,
+      78.55,
+      92.76,
+      95.36,
+      98.45,
+      99.31,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "RCOIR10",
+    "submissionMethod": "registry",
+    "deciles": [
+      36.62,
+      48.19,
+      52.27,
+      56.63,
+      60.93,
+      67.74,
+      73.08,
+      75,
+      78.95
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "RCOIR7",
+    "submissionMethod": "registry",
+    "deciles": [
+      48.28,
+      53.73,
+      62.67,
+      68.18,
+      73.46,
+      75.76,
+      83.19,
+      86.42,
+      90.63
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "RCOIR8",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.3,
+      0.24,
+      0.19,
+      0.11,
+      0.08,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "RPAQIR11",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.77,
+      0.47,
+      0.36,
+      0.23,
+      0.17,
+      0.12,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "RPAQIR12",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.81,
+      0.47,
+      0.37,
+      0.24,
+      0.16,
+      0.11,
+      0.06,
+      0,
+      0
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "RPAQIR13",
+    "submissionMethod": "registry",
+    "deciles": [
+      69.09,
+      75.37,
+      79.19,
+      82.22,
+      83.8,
+      85.07,
+      87.94,
+      89.03,
+      99.59
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "UREQA3",
+    "submissionMethod": "registry",
+    "deciles": [
+      45.1,
+      55.24,
+      57.94,
+      62.76,
+      65.22,
+      66.42,
+      67.86,
+      71.19,
+      76
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "UREQA4",
+    "submissionMethod": "registry",
+    "deciles": [
+      69.77,
+      78.1,
+      85.34,
+      90.58,
+      93.3,
+      94.31,
+      94.97,
+      96.83,
+      99.12
+    ],
+    "performanceYear": 2018
+  },
+  {
+    "measureId": "UREQA5",
+    "submissionMethod": "registry",
+    "deciles": [
+      6.17,
+      7.76,
+      10.34,
+      12.13,
+      15.15,
+      17.87,
+      24.36,
+      28.25,
+      40
+    ],
+    "performanceYear": 2018
+  }
+]


### PR DESCRIPTION
#### Motivation for change
Adds performance benchmarks to PY17 and PY18 benchmarks. This PR is a duplicate of #373 which was merged and then reverted.

#### What is being changed
Took performance benchmarks from the submissions api and applied them into the benchmarks stored in the repo. This should bring the repo and DB to parity for PY17 and PY18.

### Method used for generating these benchmarks

The existing build scripts would not run sucessfully against the existing files in the staging directories. Since this is just adding performance benchmarks in, we used the existing benchmarks file and the new performance benchmarks file the source files and removed all others. The series of steps is outlined below:

1. Retrieved performance benchmarks from prod using script in submission API
    * only pulled benchmarks with `status: current`
    * saved as `performance-benchmarks.json` in respective staging folders
2. sorted original benchmarks in place for easier comparison later
    * used command `jq 'sort_by(.measureId + .submissionMethod)'`
3. replaced existing staging json files with generated benchmark files
    * `mv benchmarks/2017.json staging/2017/benchmarks/json`
4. Built benchmarks for years
    * `npm run build:benchmarks 2017`
5. Commit updated 2017.json and 2018.json as well as performance-benchmarks.json files

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [ ] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [ ] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-4432