### PR TITLE
Update create-pull-request to v3.6.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,7 +77,7 @@ jobs:
             ref: master
         - name: Create Pull Request
           id: pr
-          uses: peter-evans/create-pull-request@172ec762f8ac8e050062398456fccd30444f8f30 #v2
+          uses: peter-evans/create-pull-request@45c510e1f68ba052e3cd911f661a799cfb9ba3a3 #v3.6.0
           with:
             token: ${{ secrets.GH_USER_TOKEN }}
             commit-message: Backfill develop with ${{ github.event.release.tag_name }}


### PR DESCRIPTION


#### Motivation for change

Github actions has deprecated `set-env` which the create-pull-request v2 version relied on, resulting in the github actions workflow failing to create a backfill pr once a release branch was merged into master and published.

#### What is being changed

Upgrading create-pull-request to v3, pinning it to the commit hash of the v3.6.0 release which should address the failing github action. None of the configuration changes between v2 and v3 should affect us. 


