### PR TITLE
QPPA-4987: 2020-2021 CAHPS Measures

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,14 @@ const benchmarkJsonFileRegEx = /^[0-9]{4}\.json$/;
 const Constants = require('./constants.js');
 
 /**
+ * @return {Array<number>}
+ * An array of all the years that the library has data for
+ */
+exports.getValidPerformanceYears = function() {
+  return Constants.validPerformanceYears;
+};
+
+/**
  *
  * @return {{}} - benchmarks data -
  * An object keyed by performance year with array values
@@ -23,6 +31,23 @@ exports.getBenchmarksData = function() {
   });
 
   return benchmarksByYear;
+};
+
+/**
+ *
+ * @return {Array<number>}
+ * An array of years that the library has benchmarks for
+ */
+exports.getBenchmarksYears = function() {
+  const benchmarksYears = new Set();
+
+  fs.readdirSync(path.join(__dirname, 'benchmarks')).forEach(function(file) {
+    if (benchmarkJsonFileRegEx.test(file)) {
+      benchmarksYears.add(+file.match(yearRegEx)[0]);
+    }
+  });
+
+  return Array.from(benchmarksYears);
 };
 
 /**

--- a/measures/2020/measures-data.json
+++ b/measures/2020/measures-data.json
@@ -45626,6 +45626,526 @@
     }
   },
   {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Getting Timely Care, Appointments, and Information",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_1",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0005",
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for ACO SSM: Getting Timely Care, Appointments, and Information",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_ACO_1",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: How Well Providers Communicate",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_2",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0005",
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for ACO SSM: How Well Providers Communicate",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_ACO_2",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Patient’s Rating of Provider",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_3",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for ACO SSM: Patient’s Rating of Provider",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_ACO_3",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Access to Specialists",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_4",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for ACO SSM: Access to Specialists",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_ACO_4",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Health Promotion and Education",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_5",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for ACO SSM: Health Promotion and Education",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_ACO_5",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Shared Decision Making",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_6",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for ACO SSM: Shared Decision Making",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_ACO_6",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Health Status and Functional Status",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_7",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for ACO SSM: Health Status and Functional Status",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_ACO_7",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Care Coordination",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_8",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for ACO SSM: Care Coordination",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_ACO_46",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Courteous and Helpful Office Staff",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_9",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0005",
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for ACO SSM: Courteous and Helpful Office Staff",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_ACO_45",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Stewardship of Patient Resources",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_11",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for ACO SSM: Stewardship of Patient Resources",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_ACO_34",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
     "measureId": "AAAAI11",
     "title": "Asthma Assessment and Classification",
     "description": "Percentage of patients aged 5 years and older with asthma and documentation of an asthma assessment and classification. National Quality Strategy Domain: Effective Clinical Care Process Measure",

--- a/measures/2021/measures-data.json
+++ b/measures/2021/measures-data.json
@@ -9782,32 +9782,6 @@
   },
   {
     "category": "quality",
-    "firstPerformanceYear": 2018,
-    "lastPerformanceYear": null,
-    "metricType": "cahps",
-    "title": "CAHPS for ACO SSM: Getting Timely Care, Appointments, and Information",
-    "description": "",
-    "nationalQualityStrategyDomain": null,
-    "measureType": "patientEngagementExperience",
-    "measureId": "CAHPS_ACO_1",
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "nqfId": null,
-    "isInverse": false,
-    "strata": [],
-    "isHighPriority": true,
-    "isIcdImpacted": false,
-    "primarySteward": "Agency for Healthcare Research & Quality",
-    "submissionMethods": [
-      "certifiedSurveyVendor"
-    ],
-    "measureSets": [
-      "generalPracticeFamilyMedicine"
-    ],
-    "isRegistryMeasure": false
-  },
-  {
-    "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
     "metricType": "cahps",
@@ -9834,32 +9808,6 @@
   },
   {
     "category": "quality",
-    "firstPerformanceYear": 2018,
-    "lastPerformanceYear": null,
-    "metricType": "cahps",
-    "title": "CAHPS for ACO SSM: How Well Providers Communicate",
-    "description": "",
-    "nationalQualityStrategyDomain": null,
-    "measureType": "patientEngagementExperience",
-    "measureId": "CAHPS_ACO_2",
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "nqfId": null,
-    "isInverse": false,
-    "strata": [],
-    "isHighPriority": true,
-    "isIcdImpacted": false,
-    "primarySteward": "Agency for Healthcare Research & Quality",
-    "submissionMethods": [
-      "certifiedSurveyVendor"
-    ],
-    "measureSets": [
-      "generalPracticeFamilyMedicine"
-    ],
-    "isRegistryMeasure": false
-  },
-  {
-    "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
     "metricType": "cahps",
@@ -9868,32 +9816,6 @@
     "nationalQualityStrategyDomain": null,
     "measureType": "patientEngagementExperience",
     "measureId": "CAHPS_3",
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "nqfId": null,
-    "isInverse": false,
-    "strata": [],
-    "isHighPriority": true,
-    "isIcdImpacted": false,
-    "primarySteward": "Agency for Healthcare Research & Quality",
-    "submissionMethods": [
-      "certifiedSurveyVendor"
-    ],
-    "measureSets": [
-      "generalPracticeFamilyMedicine"
-    ],
-    "isRegistryMeasure": false
-  },
-  {
-    "category": "quality",
-    "firstPerformanceYear": 2018,
-    "lastPerformanceYear": null,
-    "metricType": "cahps",
-    "title": "CAHPS for ACO SSM: Patient’s Rating of Provider",
-    "description": "",
-    "nationalQualityStrategyDomain": null,
-    "measureType": "patientEngagementExperience",
-    "measureId": "CAHPS_ACO_3",
     "eMeasureId": null,
     "nqfEMeasureId": null,
     "nqfId": null,
@@ -9938,32 +9860,6 @@
   },
   {
     "category": "quality",
-    "firstPerformanceYear": 2018,
-    "lastPerformanceYear": null,
-    "metricType": "cahps",
-    "title": "CAHPS for ACO SSM: Access to Specialists",
-    "description": "",
-    "nationalQualityStrategyDomain": null,
-    "measureType": "patientEngagementExperience",
-    "measureId": "CAHPS_ACO_4",
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "nqfId": null,
-    "isInverse": false,
-    "strata": [],
-    "isHighPriority": true,
-    "isIcdImpacted": false,
-    "primarySteward": "Agency for Healthcare Research & Quality",
-    "submissionMethods": [
-      "certifiedSurveyVendor"
-    ],
-    "measureSets": [
-      "generalPracticeFamilyMedicine"
-    ],
-    "isRegistryMeasure": false
-  },
-  {
-    "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
     "metricType": "cahps",
@@ -9972,32 +9868,6 @@
     "nationalQualityStrategyDomain": null,
     "measureType": "patientEngagementExperience",
     "measureId": "CAHPS_5",
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "nqfId": null,
-    "isInverse": false,
-    "strata": [],
-    "isHighPriority": true,
-    "isIcdImpacted": false,
-    "primarySteward": "Agency for Healthcare Research & Quality",
-    "submissionMethods": [
-      "certifiedSurveyVendor"
-    ],
-    "measureSets": [
-      "generalPracticeFamilyMedicine"
-    ],
-    "isRegistryMeasure": false
-  },
-  {
-    "category": "quality",
-    "firstPerformanceYear": 2018,
-    "lastPerformanceYear": null,
-    "metricType": "cahps",
-    "title": "CAHPS for ACO SSM: Health Promotion and Education",
-    "description": "",
-    "nationalQualityStrategyDomain": null,
-    "measureType": "patientEngagementExperience",
-    "measureId": "CAHPS_ACO_5",
     "eMeasureId": null,
     "nqfEMeasureId": null,
     "nqfId": null,
@@ -10042,32 +9912,6 @@
   },
   {
     "category": "quality",
-    "firstPerformanceYear": 2018,
-    "lastPerformanceYear": null,
-    "metricType": "cahps",
-    "title": "CAHPS for ACO SSM: Shared Decision Making",
-    "description": "",
-    "nationalQualityStrategyDomain": null,
-    "measureType": "patientEngagementExperience",
-    "measureId": "CAHPS_ACO_6",
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "nqfId": null,
-    "isInverse": false,
-    "strata": [],
-    "isHighPriority": true,
-    "isIcdImpacted": false,
-    "primarySteward": "Agency for Healthcare Research & Quality",
-    "submissionMethods": [
-      "certifiedSurveyVendor"
-    ],
-    "measureSets": [
-      "generalPracticeFamilyMedicine"
-    ],
-    "isRegistryMeasure": false
-  },
-  {
-    "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
     "metricType": "cahps",
@@ -10076,32 +9920,6 @@
     "nationalQualityStrategyDomain": null,
     "measureType": "patientEngagementExperience",
     "measureId": "CAHPS_7",
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "nqfId": null,
-    "isInverse": false,
-    "strata": [],
-    "isHighPriority": true,
-    "isIcdImpacted": false,
-    "primarySteward": "Agency for Healthcare Research & Quality",
-    "submissionMethods": [
-      "certifiedSurveyVendor"
-    ],
-    "measureSets": [
-      "generalPracticeFamilyMedicine"
-    ],
-    "isRegistryMeasure": false
-  },
-  {
-    "category": "quality",
-    "firstPerformanceYear": 2018,
-    "lastPerformanceYear": null,
-    "metricType": "cahps",
-    "title": "CAHPS for ACO SSM: Health Status and Functional Status",
-    "description": "",
-    "nationalQualityStrategyDomain": null,
-    "measureType": "patientEngagementExperience",
-    "measureId": "CAHPS_ACO_7",
     "eMeasureId": null,
     "nqfEMeasureId": null,
     "nqfId": null,
@@ -10146,32 +9964,6 @@
   },
   {
     "category": "quality",
-    "firstPerformanceYear": 2018,
-    "lastPerformanceYear": null,
-    "metricType": "cahps",
-    "title": "CAHPS for ACO SSM: Care Coordination",
-    "description": "",
-    "nationalQualityStrategyDomain": null,
-    "measureType": "patientEngagementExperience",
-    "measureId": "CAHPS_ACO_46",
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "nqfId": null,
-    "isInverse": false,
-    "strata": [],
-    "isHighPriority": true,
-    "isIcdImpacted": false,
-    "primarySteward": "Agency for Healthcare Research & Quality",
-    "submissionMethods": [
-      "certifiedSurveyVendor"
-    ],
-    "measureSets": [
-      "generalPracticeFamilyMedicine"
-    ],
-    "isRegistryMeasure": false
-  },
-  {
-    "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
     "metricType": "cahps",
@@ -10198,32 +9990,6 @@
   },
   {
     "category": "quality",
-    "firstPerformanceYear": 2018,
-    "lastPerformanceYear": null,
-    "metricType": "cahps",
-    "title": "CAHPS for ACO SSM: Courteous and Helpful Office Staff",
-    "description": "",
-    "nationalQualityStrategyDomain": null,
-    "measureType": "patientEngagementExperience",
-    "measureId": "CAHPS_ACO_45",
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "nqfId": null,
-    "isInverse": false,
-    "strata": [],
-    "isHighPriority": true,
-    "isIcdImpacted": false,
-    "primarySteward": "Agency for Healthcare Research & Quality",
-    "submissionMethods": [
-      "certifiedSurveyVendor"
-    ],
-    "measureSets": [
-      "generalPracticeFamilyMedicine"
-    ],
-    "isRegistryMeasure": false
-  },
-  {
-    "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
     "metricType": "cahps",
@@ -10232,32 +9998,6 @@
     "nationalQualityStrategyDomain": null,
     "measureType": "patientEngagementExperience",
     "measureId": "CAHPS_11",
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "nqfId": null,
-    "isInverse": false,
-    "strata": [],
-    "isHighPriority": true,
-    "isIcdImpacted": false,
-    "primarySteward": "Agency for Healthcare Research & Quality",
-    "submissionMethods": [
-      "certifiedSurveyVendor"
-    ],
-    "measureSets": [
-      "generalPracticeFamilyMedicine"
-    ],
-    "isRegistryMeasure": false
-  },
-  {
-    "category": "quality",
-    "firstPerformanceYear": 2018,
-    "lastPerformanceYear": null,
-    "metricType": "cahps",
-    "title": "CAHPS for ACO SSM: Stewardship of Patient Resources",
-    "description": "",
-    "nationalQualityStrategyDomain": null,
-    "measureType": "patientEngagementExperience",
-    "measureId": "CAHPS_ACO_34",
     "eMeasureId": null,
     "nqfEMeasureId": null,
     "nqfId": null,

--- a/measures/2021/measures-data.json
+++ b/measures/2021/measures-data.json
@@ -9755,6 +9755,526 @@
     }
   },
   {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Getting Timely Care, Appointments, and Information",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_1",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0005",
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for ACO SSM: Getting Timely Care, Appointments, and Information",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_ACO_1",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: How Well Providers Communicate",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_2",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0005",
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for ACO SSM: How Well Providers Communicate",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_ACO_2",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Patient’s Rating of Provider",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_3",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for ACO SSM: Patient’s Rating of Provider",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_ACO_3",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Access to Specialists",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_4",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for ACO SSM: Access to Specialists",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_ACO_4",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Health Promotion and Education",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_5",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for ACO SSM: Health Promotion and Education",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_ACO_5",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Shared Decision Making",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_6",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for ACO SSM: Shared Decision Making",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_ACO_6",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Health Status and Functional Status",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_7",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for ACO SSM: Health Status and Functional Status",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_ACO_7",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Care Coordination",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_8",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for ACO SSM: Care Coordination",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_ACO_46",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Courteous and Helpful Office Staff",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_9",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0005",
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for ACO SSM: Courteous and Helpful Office Staff",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_ACO_45",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Stewardship of Patient Resources",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_11",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for ACO SSM: Stewardship of Patient Resources",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_ACO_34",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
     "measureId": "AAAAI17",
     "title": "Asthma Control: Minimal Important Difference Improvement",
     "description": "Percentage of patients aged 12 years and older whose asthma is not well-controlled as indicated by the Asthma Control Test, Asthma Control Questionnaire, or Asthma Therapy Assessment Questionnaire and who demonstrated a minimal important difference improvement upon a subsequent office visit during the 12-month reporting period. National Quality Strategy Domain: Person and Caregiver-Centered Experience and Outcomes Outcome Measure",

--- a/scripts/measures/2020/import-cahps-measures.js
+++ b/scripts/measures/2020/import-cahps-measures.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+/**
+ * Script to add cahps measures to cahps-measures.json from CSV
+ * To run: `node add-cahps-measures.js [DATA_CSV_FILE] [OUTPUT_FILE]`
+ * e.g. `node add-cahps-measures.js cahps_measures_origin.csv cahps-measures.json`
+ */
+
+// Libraries
+const fs = require('fs');
+const parse = require('csv-parse/lib/sync');
+const path = require('path');
+
+// Some measures have an NqfId (NQF: National Quality Forum) of '0005'
+const defaultNqfId = '0005';
+const nqfIdMap = {
+  'CAHPS for MIPS SSM: Getting Timely Care, Appointments, and Information': defaultNqfId,
+  'CAHPS for MIPS SSM: How Well Providers Communicate': defaultNqfId,
+  'CAHPS for MIPS SSM: Patient\'s Rating of Provider': defaultNqfId,
+  'CAHPS for MIPS SSM: Courteous and Helpful Office Staff': defaultNqfId
+};
+
+// Constants
+const CAHPS_CSV_COLUMNS = [
+  'Summary Survey Measure',
+  'MIPS Measure Description in the Repository',
+  'MIPS Measure ID for display in Measure Repository',
+  'ACO Measure Description in the Repository',
+  'ACO Measure ID for display in Measure Repository'
+];
+
+const cahpsMeasureTemplate = {
+  category: 'quality',
+  firstPerformanceYear: 2017,
+  lastPerformanceYear: null,
+  metricType: 'cahps',
+  title: null,
+  description: '',
+  nationalQualityStrategyDomain: null,
+  measureType: 'patientEngagementExperience',
+  measureId: null,
+  eMeasureId: null,
+  nqfEMeasureId: null,
+  nqfId: null,
+  isInverse: false,
+  strata: [],
+  isHighPriority: true,
+  isIcdImpacted: false,
+  primarySteward: 'Agency for Healthcare Research & Quality',
+  submissionMethods: [
+    'certifiedSurveyVendor'
+  ],
+  measureSets: [
+    'generalPracticeFamilyMedicine'
+  ]
+};
+
+function generateCahpsMeasure(record, idx) {
+  const measureTitle = record['MIPS Measure Description in the Repository'].trim();
+  const measureId = record['MIPS Measure ID for display in Measure Repository'].trim();
+
+  if (measureTitle === '') return false;
+
+  return {
+    ...cahpsMeasureTemplate,
+    title: measureTitle,
+    measureId: measureId,
+    nqfId: nqfIdMap[measureTitle] || null
+  };
+}
+
+function generateCahpsAcoMeasure(record, idx) {
+  const measureTitle = record['ACO Measure Description in the Repository'].trim();
+  const measureId = record['ACO Measure ID for display in Measure Repository'].trim();
+
+  if (measureTitle === '') return false;
+  if (measureTitle === 'Not part of ACO score in 2018 - will not include in 2018 repo') return false;
+
+  return {
+    ...cahpsMeasureTemplate,
+    title: measureTitle,
+    measureId: measureId,
+    nqfId: nqfIdMap[measureTitle] || null,
+    firstPerformanceYear: 2018
+  };
+}
+
+function importCahpsMeasures(cahpsMeasuresCsv, cahpsMeasuresFilepath) {
+  const cahpsMeasuresData = fs.readFileSync(path.join(__dirname, cahpsMeasuresCsv), {encoding: 'utf8'});
+  const records = parse(cahpsMeasuresData, {columns: CAHPS_CSV_COLUMNS, from: 2});
+  const cahpsMeasures = [];
+
+  records.forEach(function(record, idx) {
+    const cahpsMeasure = generateCahpsMeasure(record, idx);
+    if (cahpsMeasure) cahpsMeasures.push(cahpsMeasure);
+
+    const cahpsAcoMeasure = generateCahpsAcoMeasure(record, idx);
+    if (cahpsAcoMeasure) cahpsMeasures.push(cahpsAcoMeasure);
+  });
+
+  fs.writeFileSync(path.join(__dirname, cahpsMeasuresFilepath), JSON.stringify(cahpsMeasures, null, 2), {encoding: 'utf8', flag: 'w'});
+}
+
+const cahpsMeasuresCsv = process.argv[2];
+const outputFilepath = process.argv[3];
+
+importCahpsMeasures(cahpsMeasuresCsv, outputFilepath);

--- a/scripts/measures/2020/import-cahps-measures.js
+++ b/scripts/measures/2020/import-cahps-measures.js
@@ -85,8 +85,8 @@ function generateCahpsAcoMeasure(record, idx) {
   };
 }
 
-function importCahpsMeasures(cahpsMeasuresCsv, cahpsMeasuresFilepath) {
-  const cahpsMeasuresData = fs.readFileSync(path.join(__dirname, cahpsMeasuresCsv), {encoding: 'utf8'});
+function importCahpsMeasures(cahpsCsv, cahpsMeasuresFilepath) {
+  const cahpsMeasuresData = fs.readFileSync(path.join(__dirname, cahpsCsv), {encoding: 'utf8'});
   const records = parse(cahpsMeasuresData, {columns: CAHPS_CSV_COLUMNS, from: 2});
   const cahpsMeasures = [];
 

--- a/scripts/measures/2021/import-cahps-measures.js
+++ b/scripts/measures/2021/import-cahps-measures.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+/**
+ * Script to add cahps measures to cahps-measures.json from CSV
+ * To run: `node add-cahps-measures.js [DATA_CSV_FILE] [OUTPUT_FILE]`
+ * e.g. `node add-cahps-measures.js cahps_measures_origin.csv cahps-measures.json`
+ */
+
+// Libraries
+const fs = require('fs');
+const parse = require('csv-parse/lib/sync');
+const path = require('path');
+
+// Some measures have an NqfId (NQF: National Quality Forum) of '0005'
+const defaultNqfId = '0005';
+const nqfIdMap = {
+  'CAHPS for MIPS SSM: Getting Timely Care, Appointments, and Information': defaultNqfId,
+  'CAHPS for MIPS SSM: How Well Providers Communicate': defaultNqfId,
+  'CAHPS for MIPS SSM: Patient\'s Rating of Provider': defaultNqfId,
+  'CAHPS for MIPS SSM: Courteous and Helpful Office Staff': defaultNqfId
+};
+
+// Constants
+const CAHPS_CSV_COLUMNS = [
+  'Summary Survey Measure',
+  'MIPS Measure Description in the Repository',
+  'MIPS Measure ID for display in Measure Repository',
+  'ACO Measure Description in the Repository',
+  'ACO Measure ID for display in Measure Repository'
+];
+
+const cahpsMeasureTemplate = {
+  category: 'quality',
+  firstPerformanceYear: 2017,
+  lastPerformanceYear: null,
+  metricType: 'cahps',
+  title: null,
+  description: '',
+  nationalQualityStrategyDomain: null,
+  measureType: 'patientEngagementExperience',
+  measureId: null,
+  eMeasureId: null,
+  nqfEMeasureId: null,
+  nqfId: null,
+  isInverse: false,
+  strata: [],
+  isHighPriority: true,
+  isIcdImpacted: false,
+  primarySteward: 'Agency for Healthcare Research & Quality',
+  submissionMethods: [
+    'certifiedSurveyVendor'
+  ],
+  measureSets: [
+    'generalPracticeFamilyMedicine'
+  ]
+};
+
+function generateCahpsMeasure(record, idx) {
+  const measureTitle = record['MIPS Measure Description in the Repository'].trim();
+  const measureId = record['MIPS Measure ID for display in Measure Repository'].trim();
+
+  if (measureTitle === '') return false;
+
+  return {
+    ...cahpsMeasureTemplate,
+    title: measureTitle,
+    measureId: measureId,
+    nqfId: nqfIdMap[measureTitle] || null
+  };
+}
+
+function generateCahpsAcoMeasure(record, idx) {
+  const measureTitle = record['ACO Measure Description in the Repository'].trim();
+  const measureId = record['ACO Measure ID for display in Measure Repository'].trim();
+
+  if (measureTitle === '') return false;
+  if (measureTitle === 'Not part of ACO score in 2018 - will not include in 2018 repo') return false;
+
+  return {
+    ...cahpsMeasureTemplate,
+    title: measureTitle,
+    measureId: measureId,
+    nqfId: nqfIdMap[measureTitle] || null,
+    firstPerformanceYear: 2018
+  };
+}
+
+function importCahpsMeasures(cahpsMeasuresCsv, cahpsMeasuresFilepath) {
+  const cahpsMeasuresData = fs.readFileSync(path.join(__dirname, cahpsMeasuresCsv), {encoding: 'utf8'});
+  const records = parse(cahpsMeasuresData, {columns: CAHPS_CSV_COLUMNS, from: 2});
+  const cahpsMeasures = [];
+
+  records.forEach(function(record, idx) {
+    const cahpsMeasure = generateCahpsMeasure(record, idx);
+    if (cahpsMeasure) cahpsMeasures.push(cahpsMeasure);
+
+    const cahpsAcoMeasure = generateCahpsAcoMeasure(record, idx);
+    if (cahpsAcoMeasure) cahpsMeasures.push(cahpsAcoMeasure);
+  });
+
+  fs.writeFileSync(path.join(__dirname, cahpsMeasuresFilepath), JSON.stringify(cahpsMeasures, null, 2), {encoding: 'utf8', flag: 'w'});
+}
+
+const cahpsMeasuresCsv = process.argv[2];
+const outputFilepath = process.argv[3];
+
+importCahpsMeasures(cahpsMeasuresCsv, outputFilepath);

--- a/scripts/measures/2021/import-cahps-measures.js
+++ b/scripts/measures/2021/import-cahps-measures.js
@@ -85,8 +85,8 @@ function generateCahpsAcoMeasure(record, idx) {
   };
 }
 
-function importCahpsMeasures(cahpsMeasuresCsv, cahpsMeasuresFilepath) {
-  const cahpsMeasuresData = fs.readFileSync(path.join(__dirname, cahpsMeasuresCsv), {encoding: 'utf8'});
+function importCahpsMeasures(cahpsCsv, cahpsMeasuresFilepath) {
+  const cahpsMeasuresData = fs.readFileSync(path.join(__dirname, cahpsCsv), {encoding: 'utf8'});
   const records = parse(cahpsMeasuresData, {columns: CAHPS_CSV_COLUMNS, from: 2});
   const cahpsMeasures = [];
 

--- a/scripts/measures/build-2020-measures
+++ b/scripts/measures/build-2020-measures
@@ -52,9 +52,9 @@ node scripts/measures/$currentPerformanceYear/import-ia-measures.js \
 
 # Uncomment the below data set ingestion scripts as we receive the data for 2020
 
-# 3. Add CAHPS measures to the staging cahps-measures.json file:
-# node scripts/measures/$currentPerformanceYear/import-cahps-measures.js \
-#	$cahps_csv $cahps_measures
+3. Add CAHPS measures to the staging cahps-measures.json file:
+node scripts/measures/$currentPerformanceYear/import-cahps-measures.js \
+	$cahps_csv $cahps_measures
 
 # 4. Enrich `measures-data.json` file, run:
 node scripts/measures/$currentPerformanceYear/enrich-measures-data.js \
@@ -71,7 +71,7 @@ node scripts/measures/$currentPerformanceYear/import-cost-measures.js \
 
 # 7. Merge the array/jsonfile-per-measureType into a combined array of all measures
 node scripts/measures/$currentPerformanceYear/merge-measures-data.js \
-	 $ia_measures $enriched_pi_measures $enriched_quality_measures $cost_measures $final_measures # Note quality measures won't be in this list once enriched_quality_measures are created.
+	 $ia_measures $enriched_pi_measures $enriched_quality_measures $cost_measures $cahps_measures $final_measures # Note quality measures won't be in this list once enriched_quality_measures are created.
 # As these datasets are created, add these to the line above: $enriched_quality_measures  $cahps_measures $cost_measures
 
 # 8. Import and merge QCDR measures after previous measures have been built, as this has conflict-resolution logic

--- a/scripts/measures/build-2021-measures
+++ b/scripts/measures/build-2021-measures
@@ -52,9 +52,9 @@ node scripts/measures/$currentPerformanceYear/import-ia-measures.js \
 
 # Uncomment the below data set ingestion scripts as we receive the data for 2020
 
-# 3. Add CAHPS measures to the staging cahps-measures.json file:
-# node scripts/measures/$currentPerformanceYear/import-cahps-measures.js \
-#	$cahps_csv $cahps_measures
+3. Add CAHPS measures to the staging cahps-measures.json file:
+node scripts/measures/$currentPerformanceYear/import-cahps-measures.js \
+	$cahps_csv $cahps_measures
 
 # 4. Enrich `measures-data.json` file, run:
 node scripts/measures/$currentPerformanceYear/enrich-measures-data.js \
@@ -71,7 +71,7 @@ node scripts/measures/$currentPerformanceYear/import-cost-measures.js \
 
 # 7. Merge the array/jsonfile-per-measureType into a combined array of all measures
 node scripts/measures/$currentPerformanceYear/merge-measures-data.js \
-	 $ia_measures $enriched_pi_measures $enriched_quality_measures $cost_measures $final_measures # Note quality measures won't be in this list once enriched_quality_measures are created.
+	 $ia_measures $enriched_pi_measures $enriched_quality_measures $cost_measures $cahps_measures $final_measures # Note quality measures won't be in this list once enriched_quality_measures are created.
 # As these datasets are created, add these to the line above: $enriched_quality_measures  $cahps_measures $cost_measures
 
 # 8. Import and merge QCDR measures after previous measures have been built, as this has conflict-resolution logic

--- a/staging/2021/measures-data-cahps.json
+++ b/staging/2021/measures-data-cahps.json
@@ -26,31 +26,6 @@
   },
   {
     "category": "quality",
-    "firstPerformanceYear": 2018,
-    "lastPerformanceYear": null,
-    "metricType": "cahps",
-    "title": "CAHPS for ACO SSM: Getting Timely Care, Appointments, and Information",
-    "description": "",
-    "nationalQualityStrategyDomain": null,
-    "measureType": "patientEngagementExperience",
-    "measureId": "CAHPS_ACO_1",
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "nqfId": null,
-    "isInverse": false,
-    "strata": [],
-    "isHighPriority": true,
-    "isIcdImpacted": false,
-    "primarySteward": "Agency for Healthcare Research & Quality",
-    "submissionMethods": [
-      "certifiedSurveyVendor"
-    ],
-    "measureSets": [
-      "generalPracticeFamilyMedicine"
-    ]
-  },
-  {
-    "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
     "metricType": "cahps",
@@ -76,31 +51,6 @@
   },
   {
     "category": "quality",
-    "firstPerformanceYear": 2018,
-    "lastPerformanceYear": null,
-    "metricType": "cahps",
-    "title": "CAHPS for ACO SSM: How Well Providers Communicate",
-    "description": "",
-    "nationalQualityStrategyDomain": null,
-    "measureType": "patientEngagementExperience",
-    "measureId": "CAHPS_ACO_2",
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "nqfId": null,
-    "isInverse": false,
-    "strata": [],
-    "isHighPriority": true,
-    "isIcdImpacted": false,
-    "primarySteward": "Agency for Healthcare Research & Quality",
-    "submissionMethods": [
-      "certifiedSurveyVendor"
-    ],
-    "measureSets": [
-      "generalPracticeFamilyMedicine"
-    ]
-  },
-  {
-    "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
     "metricType": "cahps",
@@ -109,31 +59,6 @@
     "nationalQualityStrategyDomain": null,
     "measureType": "patientEngagementExperience",
     "measureId": "CAHPS_3",
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "nqfId": null,
-    "isInverse": false,
-    "strata": [],
-    "isHighPriority": true,
-    "isIcdImpacted": false,
-    "primarySteward": "Agency for Healthcare Research & Quality",
-    "submissionMethods": [
-      "certifiedSurveyVendor"
-    ],
-    "measureSets": [
-      "generalPracticeFamilyMedicine"
-    ]
-  },
-  {
-    "category": "quality",
-    "firstPerformanceYear": 2018,
-    "lastPerformanceYear": null,
-    "metricType": "cahps",
-    "title": "CAHPS for ACO SSM: Patient’s Rating of Provider",
-    "description": "",
-    "nationalQualityStrategyDomain": null,
-    "measureType": "patientEngagementExperience",
-    "measureId": "CAHPS_ACO_3",
     "eMeasureId": null,
     "nqfEMeasureId": null,
     "nqfId": null,
@@ -176,31 +101,6 @@
   },
   {
     "category": "quality",
-    "firstPerformanceYear": 2018,
-    "lastPerformanceYear": null,
-    "metricType": "cahps",
-    "title": "CAHPS for ACO SSM: Access to Specialists",
-    "description": "",
-    "nationalQualityStrategyDomain": null,
-    "measureType": "patientEngagementExperience",
-    "measureId": "CAHPS_ACO_4",
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "nqfId": null,
-    "isInverse": false,
-    "strata": [],
-    "isHighPriority": true,
-    "isIcdImpacted": false,
-    "primarySteward": "Agency for Healthcare Research & Quality",
-    "submissionMethods": [
-      "certifiedSurveyVendor"
-    ],
-    "measureSets": [
-      "generalPracticeFamilyMedicine"
-    ]
-  },
-  {
-    "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
     "metricType": "cahps",
@@ -209,31 +109,6 @@
     "nationalQualityStrategyDomain": null,
     "measureType": "patientEngagementExperience",
     "measureId": "CAHPS_5",
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "nqfId": null,
-    "isInverse": false,
-    "strata": [],
-    "isHighPriority": true,
-    "isIcdImpacted": false,
-    "primarySteward": "Agency for Healthcare Research & Quality",
-    "submissionMethods": [
-      "certifiedSurveyVendor"
-    ],
-    "measureSets": [
-      "generalPracticeFamilyMedicine"
-    ]
-  },
-  {
-    "category": "quality",
-    "firstPerformanceYear": 2018,
-    "lastPerformanceYear": null,
-    "metricType": "cahps",
-    "title": "CAHPS for ACO SSM: Health Promotion and Education",
-    "description": "",
-    "nationalQualityStrategyDomain": null,
-    "measureType": "patientEngagementExperience",
-    "measureId": "CAHPS_ACO_5",
     "eMeasureId": null,
     "nqfEMeasureId": null,
     "nqfId": null,
@@ -276,31 +151,6 @@
   },
   {
     "category": "quality",
-    "firstPerformanceYear": 2018,
-    "lastPerformanceYear": null,
-    "metricType": "cahps",
-    "title": "CAHPS for ACO SSM: Shared Decision Making",
-    "description": "",
-    "nationalQualityStrategyDomain": null,
-    "measureType": "patientEngagementExperience",
-    "measureId": "CAHPS_ACO_6",
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "nqfId": null,
-    "isInverse": false,
-    "strata": [],
-    "isHighPriority": true,
-    "isIcdImpacted": false,
-    "primarySteward": "Agency for Healthcare Research & Quality",
-    "submissionMethods": [
-      "certifiedSurveyVendor"
-    ],
-    "measureSets": [
-      "generalPracticeFamilyMedicine"
-    ]
-  },
-  {
-    "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
     "metricType": "cahps",
@@ -309,31 +159,6 @@
     "nationalQualityStrategyDomain": null,
     "measureType": "patientEngagementExperience",
     "measureId": "CAHPS_7",
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "nqfId": null,
-    "isInverse": false,
-    "strata": [],
-    "isHighPriority": true,
-    "isIcdImpacted": false,
-    "primarySteward": "Agency for Healthcare Research & Quality",
-    "submissionMethods": [
-      "certifiedSurveyVendor"
-    ],
-    "measureSets": [
-      "generalPracticeFamilyMedicine"
-    ]
-  },
-  {
-    "category": "quality",
-    "firstPerformanceYear": 2018,
-    "lastPerformanceYear": null,
-    "metricType": "cahps",
-    "title": "CAHPS for ACO SSM: Health Status and Functional Status",
-    "description": "",
-    "nationalQualityStrategyDomain": null,
-    "measureType": "patientEngagementExperience",
-    "measureId": "CAHPS_ACO_7",
     "eMeasureId": null,
     "nqfEMeasureId": null,
     "nqfId": null,
@@ -376,31 +201,6 @@
   },
   {
     "category": "quality",
-    "firstPerformanceYear": 2018,
-    "lastPerformanceYear": null,
-    "metricType": "cahps",
-    "title": "CAHPS for ACO SSM: Care Coordination",
-    "description": "",
-    "nationalQualityStrategyDomain": null,
-    "measureType": "patientEngagementExperience",
-    "measureId": "CAHPS_ACO_46",
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "nqfId": null,
-    "isInverse": false,
-    "strata": [],
-    "isHighPriority": true,
-    "isIcdImpacted": false,
-    "primarySteward": "Agency for Healthcare Research & Quality",
-    "submissionMethods": [
-      "certifiedSurveyVendor"
-    ],
-    "measureSets": [
-      "generalPracticeFamilyMedicine"
-    ]
-  },
-  {
-    "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
     "metricType": "cahps",
@@ -426,31 +226,6 @@
   },
   {
     "category": "quality",
-    "firstPerformanceYear": 2018,
-    "lastPerformanceYear": null,
-    "metricType": "cahps",
-    "title": "CAHPS for ACO SSM: Courteous and Helpful Office Staff",
-    "description": "",
-    "nationalQualityStrategyDomain": null,
-    "measureType": "patientEngagementExperience",
-    "measureId": "CAHPS_ACO_45",
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "nqfId": null,
-    "isInverse": false,
-    "strata": [],
-    "isHighPriority": true,
-    "isIcdImpacted": false,
-    "primarySteward": "Agency for Healthcare Research & Quality",
-    "submissionMethods": [
-      "certifiedSurveyVendor"
-    ],
-    "measureSets": [
-      "generalPracticeFamilyMedicine"
-    ]
-  },
-  {
-    "category": "quality",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
     "metricType": "cahps",
@@ -459,31 +234,6 @@
     "nationalQualityStrategyDomain": null,
     "measureType": "patientEngagementExperience",
     "measureId": "CAHPS_11",
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "nqfId": null,
-    "isInverse": false,
-    "strata": [],
-    "isHighPriority": true,
-    "isIcdImpacted": false,
-    "primarySteward": "Agency for Healthcare Research & Quality",
-    "submissionMethods": [
-      "certifiedSurveyVendor"
-    ],
-    "measureSets": [
-      "generalPracticeFamilyMedicine"
-    ]
-  },
-  {
-    "category": "quality",
-    "firstPerformanceYear": 2018,
-    "lastPerformanceYear": null,
-    "metricType": "cahps",
-    "title": "CAHPS for ACO SSM: Stewardship of Patient Resources",
-    "description": "",
-    "nationalQualityStrategyDomain": null,
-    "measureType": "patientEngagementExperience",
-    "measureId": "CAHPS_ACO_34",
     "eMeasureId": null,
     "nqfEMeasureId": null,
     "nqfId": null,

--- a/util/measures/2020/cahps-measures.csv
+++ b/util/measures/2020/cahps-measures.csv
@@ -1,0 +1,14 @@
+﻿Summary Survey Measure,MIPS Measure Description in the Repository,MIPS Measure ID for display in Measure Repository,ACO Measure Description in the Repository,ACO Measure ID for display in Measure Repository
+" Getting Timely Care, Appointments, and Information","CAHPS for MIPS SSM: Getting Timely Care, Appointments, and Information",CAHPS_1,"CAHPS for ACO SSM: Getting Timely Care, Appointments, and Information",CAHPS_ACO_1
+How Well Providers Communicate,CAHPS for MIPS SSM: How Well Providers Communicate,CAHPS_2,CAHPS for ACO SSM: How Well Providers Communicate,CAHPS_ACO_2
+Patient’s Rating of Provider,CAHPS for MIPS SSM: Patient’s Rating of Provider,CAHPS_3,CAHPS for ACO SSM: Patient’s Rating of Provider,CAHPS_ACO_3
+Access to Specialists,CAHPS for MIPS SSM: Access to Specialists,CAHPS_4,CAHPS for ACO SSM: Access to Specialists,CAHPS_ACO_4
+Health Promotion and Education,CAHPS for MIPS SSM: Health Promotion and Education,CAHPS_5,CAHPS for ACO SSM: Health Promotion and Education,CAHPS_ACO_5
+Shared Decision Making,CAHPS for MIPS SSM: Shared Decision Making,CAHPS_6,CAHPS for ACO SSM: Shared Decision Making,CAHPS_ACO_6
+Health Status and Functional Status,CAHPS for MIPS SSM: Health Status and Functional Status,CAHPS_7,CAHPS for ACO SSM: Health Status and Functional Status,CAHPS_ACO_7
+Care Coordination,CAHPS for MIPS SSM: Care Coordination,CAHPS_8,CAHPS for ACO SSM: Care Coordination,CAHPS_ACO_46
+Courteous and Helpful Office Staff,CAHPS for MIPS SSM: Courteous and Helpful Office Staff,CAHPS_9,CAHPS for ACO SSM: Courteous and Helpful Office Staff,CAHPS_ACO_45
+Stewardship of Patient Resources,CAHPS for MIPS SSM: Stewardship of Patient Resources,CAHPS_11,CAHPS for ACO SSM: Stewardship of Patient Resources,CAHPS_ACO_34
+,,,,
+,,,,
+,,,,

--- a/util/measures/2021/cahps-measures.csv
+++ b/util/measures/2021/cahps-measures.csv
@@ -1,0 +1,14 @@
+﻿Summary Survey Measure,MIPS Measure Description in the Repository,MIPS Measure ID for display in Measure Repository,ACO Measure Description in the Repository,ACO Measure ID for display in Measure Repository
+" Getting Timely Care, Appointments, and Information","CAHPS for MIPS SSM: Getting Timely Care, Appointments, and Information",CAHPS_1,"CAHPS for ACO SSM: Getting Timely Care, Appointments, and Information",CAHPS_ACO_1
+How Well Providers Communicate,CAHPS for MIPS SSM: How Well Providers Communicate,CAHPS_2,CAHPS for ACO SSM: How Well Providers Communicate,CAHPS_ACO_2
+Patient’s Rating of Provider,CAHPS for MIPS SSM: Patient’s Rating of Provider,CAHPS_3,CAHPS for ACO SSM: Patient’s Rating of Provider,CAHPS_ACO_3
+Access to Specialists,CAHPS for MIPS SSM: Access to Specialists,CAHPS_4,CAHPS for ACO SSM: Access to Specialists,CAHPS_ACO_4
+Health Promotion and Education,CAHPS for MIPS SSM: Health Promotion and Education,CAHPS_5,CAHPS for ACO SSM: Health Promotion and Education,CAHPS_ACO_5
+Shared Decision Making,CAHPS for MIPS SSM: Shared Decision Making,CAHPS_6,CAHPS for ACO SSM: Shared Decision Making,CAHPS_ACO_6
+Health Status and Functional Status,CAHPS for MIPS SSM: Health Status and Functional Status,CAHPS_7,CAHPS for ACO SSM: Health Status and Functional Status,CAHPS_ACO_7
+Care Coordination,CAHPS for MIPS SSM: Care Coordination,CAHPS_8,CAHPS for ACO SSM: Care Coordination,CAHPS_ACO_46
+Courteous and Helpful Office Staff,CAHPS for MIPS SSM: Courteous and Helpful Office Staff,CAHPS_9,CAHPS for ACO SSM: Courteous and Helpful Office Staff,CAHPS_ACO_45
+Stewardship of Patient Resources,CAHPS for MIPS SSM: Stewardship of Patient Resources,CAHPS_11,CAHPS for ACO SSM: Stewardship of Patient Resources,CAHPS_ACO_34
+,,,,
+,,,,
+,,,,

--- a/util/measures/2021/cahps-measures.csv
+++ b/util/measures/2021/cahps-measures.csv
@@ -1,14 +1,14 @@
 ﻿Summary Survey Measure,MIPS Measure Description in the Repository,MIPS Measure ID for display in Measure Repository,ACO Measure Description in the Repository,ACO Measure ID for display in Measure Repository
-" Getting Timely Care, Appointments, and Information","CAHPS for MIPS SSM: Getting Timely Care, Appointments, and Information",CAHPS_1,"CAHPS for ACO SSM: Getting Timely Care, Appointments, and Information",CAHPS_ACO_1
-How Well Providers Communicate,CAHPS for MIPS SSM: How Well Providers Communicate,CAHPS_2,CAHPS for ACO SSM: How Well Providers Communicate,CAHPS_ACO_2
-Patient’s Rating of Provider,CAHPS for MIPS SSM: Patient’s Rating of Provider,CAHPS_3,CAHPS for ACO SSM: Patient’s Rating of Provider,CAHPS_ACO_3
-Access to Specialists,CAHPS for MIPS SSM: Access to Specialists,CAHPS_4,CAHPS for ACO SSM: Access to Specialists,CAHPS_ACO_4
-Health Promotion and Education,CAHPS for MIPS SSM: Health Promotion and Education,CAHPS_5,CAHPS for ACO SSM: Health Promotion and Education,CAHPS_ACO_5
-Shared Decision Making,CAHPS for MIPS SSM: Shared Decision Making,CAHPS_6,CAHPS for ACO SSM: Shared Decision Making,CAHPS_ACO_6
-Health Status and Functional Status,CAHPS for MIPS SSM: Health Status and Functional Status,CAHPS_7,CAHPS for ACO SSM: Health Status and Functional Status,CAHPS_ACO_7
-Care Coordination,CAHPS for MIPS SSM: Care Coordination,CAHPS_8,CAHPS for ACO SSM: Care Coordination,CAHPS_ACO_46
-Courteous and Helpful Office Staff,CAHPS for MIPS SSM: Courteous and Helpful Office Staff,CAHPS_9,CAHPS for ACO SSM: Courteous and Helpful Office Staff,CAHPS_ACO_45
-Stewardship of Patient Resources,CAHPS for MIPS SSM: Stewardship of Patient Resources,CAHPS_11,CAHPS for ACO SSM: Stewardship of Patient Resources,CAHPS_ACO_34
+" Getting Timely Care, Appointments, and Information","CAHPS for MIPS SSM: Getting Timely Care, Appointments, and Information",CAHPS_1,,
+How Well Providers Communicate,CAHPS for MIPS SSM: How Well Providers Communicate,CAHPS_2,,
+Patient’s Rating of Provider,CAHPS for MIPS SSM: Patient’s Rating of Provider,CAHPS_3,,
+Access to Specialists,CAHPS for MIPS SSM: Access to Specialists,CAHPS_4,,
+Health Promotion and Education,CAHPS for MIPS SSM: Health Promotion and Education,CAHPS_5,,
+Shared Decision Making,CAHPS for MIPS SSM: Shared Decision Making,CAHPS_6,,
+Health Status and Functional Status,CAHPS for MIPS SSM: Health Status and Functional Status,CAHPS_7,,
+Care Coordination,CAHPS for MIPS SSM: Care Coordination,CAHPS_8,,
+Courteous and Helpful Office Staff,CAHPS for MIPS SSM: Courteous and Helpful Office Staff,CAHPS_9,,
+Stewardship of Patient Resources,CAHPS for MIPS SSM: Stewardship of Patient Resources,CAHPS_11,,
 ,,,,
 ,,,,
 ,,,,


### PR DESCRIPTION
Load PY 2020 and 2021 measures for CAHPS reporting. Measures are unchanged from 2019. ACO scores will not be loaded for these years, but measures are included for the sake of completeness.

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-4987
