### PR TITLE
copied clinical cluster data for 2021 testing

### DIFF
--- a/clinical-clusters/2021/clinical-clusters-schema.yaml
+++ b/clinical-clusters/2021/clinical-clusters-schema.yaml
@@ -1,0 +1,36 @@
+id: https://github.com/CMSgov/qpp-measures-data/versions/0.0.1/clinical-clusters-schema.yaml
+$schema: http://json-schema.org/schema#
+type: array
+items: { $ref: #/definitions/ClusterType }
+definitions:
+  ClusterType:
+    type: object
+    properties:
+      measureId:
+        type: string
+        description: The measure identifier
+      firstPerformanceYear:
+        description: Year in which the measure was introduced.
+        type: integer
+        default: 2017
+      lastPerformanceYear:
+        description: Year in which the measure was deprecated.
+        type: [integer, 'null']
+        default: 'null'
+      clinicalClusters:
+        type: array
+        items: { $ref: #/definitions/ClinicalClusterType }
+      specialtySets:
+        type: array
+        items: { $ref: #/definitions/ClinicalClusterType }
+  ClinicalClusterType:
+    type: object
+    properties:
+      name:
+        type: string
+        description: Cluster or Specialty name
+      measureIds:
+        type: array
+        items:
+          type: string
+          description: Measure identifier

--- a/clinical-clusters/2021/clinical-clusters.json
+++ b/clinical-clusters/2021/clinical-clusters.json
@@ -1,0 +1,2172 @@
+[
+  {
+    "measureId": "001",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "001",
+          "128",
+          "130",
+          "181"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "128",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "001",
+          "128",
+          "130",
+          "181"
+        ]
+      },
+      {
+        "name": "podiatry",
+        "measureIds": [
+          "128",
+          "154",
+          "155",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "130",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "001",
+          "128",
+          "130",
+          "181"
+        ]
+      },
+      {
+        "name": "plasticSurgery",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "neurosurgical",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226"
+        ]
+      },
+      {
+        "name": "hospitalists",
+        "measureIds": [
+          "047",
+          "076",
+          "130"
+        ]
+      },
+      {
+        "name": "urgentCare",
+        "measureIds": [
+          "093",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "allergyImmunology",
+        "measureIds": [
+          "110",
+          "111",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "infectiousDisease",
+        "measureIds": [
+          "110",
+          "111",
+          "130"
+        ]
+      },
+      {
+        "name": "dermatology",
+        "measureIds": [
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "clinicalSocialWork",
+        "measureIds": [
+          "130",
+          "134",
+          "181",
+          "226"
+        ]
+      },
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "181",
+          "182",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "181",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "001",
+          "128",
+          "130",
+          "181"
+        ]
+      },
+      {
+        "name": "clinicalSocialWork",
+        "measureIds": [
+          "130",
+          "134",
+          "181",
+          "226"
+        ]
+      },
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "181",
+          "182",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "021",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "plasticSurgery",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "neurosurgical",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226"
+        ]
+      }
+    ],
+    "clinicalClusters": [
+      {
+        "name": "surgicalCare",
+        "measureIds": [
+          "021",
+          "023"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "023",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "plasticSurgery",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "neurosurgical",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226"
+        ]
+      }
+    ],
+    "clinicalClusters": [
+      {
+        "name": "surgicalCare",
+        "measureIds": [
+          "021",
+          "023"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "226",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "plasticSurgery",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "neurosurgical",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226"
+        ]
+      },
+      {
+        "name": "urgentCare",
+        "measureIds": [
+          "093",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "allergyImmunology",
+        "measureIds": [
+          "110",
+          "111",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "podiatry",
+        "measureIds": [
+          "128",
+          "154",
+          "155",
+          "226"
+        ]
+      },
+      {
+        "name": "dermatology",
+        "measureIds": [
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "clinicalSocialWork",
+        "measureIds": [
+          "130",
+          "134",
+          "181",
+          "226"
+        ]
+      },
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "181",
+          "182",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "317",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "plasticSurgery",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "emergencyMedicine",
+        "measureIds": [
+          "093",
+          "254",
+          "317",
+          "416"
+        ]
+      },
+      {
+        "name": "urgentCare",
+        "measureIds": [
+          "093",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "allergyImmunology",
+        "measureIds": [
+          "110",
+          "111",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "dermatology",
+        "measureIds": [
+          "130",
+          "226",
+          "317"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "047",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "hospitalists",
+        "measureIds": [
+          "047",
+          "076",
+          "130"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "076",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "hospitalists",
+        "measureIds": [
+          "047",
+          "076",
+          "130"
+        ]
+      },
+      {
+        "name": "anesthesiology",
+        "measureIds": [
+          "076"
+        ]
+      },
+      {
+        "name": "interventionalRadiology",
+        "measureIds": [
+          "076",
+          "145",
+          "437"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "145",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "interventionalRadiology",
+        "measureIds": [
+          "076",
+          "145",
+          "437"
+        ]
+      }
+    ],
+    "clinicalClusters": [
+      {
+        "name": "diagnosticImaging",
+        "measureIds": [
+          "145",
+          "146",
+          "147",
+          "195",
+          "225"
+        ]
+      },
+      {
+        "name": "interventionalRadiology",
+        "measureIds": [
+          "145",
+          "437"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "437",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "interventionalRadiology",
+        "measureIds": [
+          "076",
+          "145",
+          "437"
+        ]
+      }
+    ],
+    "clinicalClusters": [
+      {
+        "name": "interventionalRadiology",
+        "measureIds": [
+          "145",
+          "437"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "093",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "emergencyMedicine",
+        "measureIds": [
+          "093",
+          "254",
+          "317",
+          "416"
+        ]
+      },
+      {
+        "name": "pediatrics",
+        "measureIds": [
+          "093",
+          "110",
+          "134"
+        ]
+      },
+      {
+        "name": "urgentCare",
+        "measureIds": [
+          "093",
+          "130",
+          "226",
+          "317"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "254",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "emergencyMedicine",
+        "measureIds": [
+          "093",
+          "254",
+          "317",
+          "416"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "416",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "emergencyMedicine",
+        "measureIds": [
+          "093",
+          "254",
+          "317",
+          "416"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "110",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "pediatrics",
+        "measureIds": [
+          "093",
+          "110",
+          "134"
+        ]
+      },
+      {
+        "name": "allergyImmunology",
+        "measureIds": [
+          "110",
+          "111",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "infectiousDisease",
+        "measureIds": [
+          "110",
+          "111",
+          "130"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "134",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "pediatrics",
+        "measureIds": [
+          "093",
+          "110",
+          "134"
+        ]
+      },
+      {
+        "name": "clinicalSocialWork",
+        "measureIds": [
+          "130",
+          "134",
+          "181",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "111",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "allergyImmunology",
+        "measureIds": [
+          "110",
+          "111",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "infectiousDisease",
+        "measureIds": [
+          "110",
+          "111",
+          "130"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "154",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "podiatry",
+        "measureIds": [
+          "128",
+          "154",
+          "155",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "155",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "podiatry",
+        "measureIds": [
+          "128",
+          "154",
+          "155",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "182",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "181",
+          "182",
+          "226"
+        ]
+      },
+      {
+        "name": "chiropracticMedicine",
+        "measureIds": [
+          "182"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "249",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396",
+          "397"
+        ]
+      }
+    ],
+    "clinicalClusters": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "250",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396",
+          "397"
+        ]
+      }
+    ],
+    "clinicalClusters": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "395",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396",
+          "397"
+        ]
+      }
+    ],
+    "clinicalClusters": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "396",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396",
+          "397"
+        ]
+      }
+    ],
+    "clinicalClusters": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "397",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396",
+          "397"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "320",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "endoscopyAndPolypSurveillance",
+        "measureIds": [
+          "320",
+          "425"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "425",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "endoscopyAndPolypSurveillance",
+        "measureIds": [
+          "320",
+          "425"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "405",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "computedTomography",
+        "measureIds": [
+          "405",
+          "406",
+          "436"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "406",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "computedTomography",
+        "measureIds": [
+          "405",
+          "406",
+          "436"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "436",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "computedTomography",
+        "measureIds": [
+          "405",
+          "406",
+          "436"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "146",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "diagnosticImaging",
+        "measureIds": [
+          "145",
+          "146",
+          "147",
+          "195",
+          "225"
+        ]
+      },
+      {
+        "name": "diagnosticMammography",
+        "measureIds": [
+          "146",
+          "225"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "147",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "diagnosticImaging",
+        "measureIds": [
+          "145",
+          "146",
+          "147",
+          "195",
+          "225"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "195",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "diagnosticImaging",
+        "measureIds": [
+          "145",
+          "146",
+          "147",
+          "195",
+          "225"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "225",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "diagnosticImaging",
+        "measureIds": [
+          "145",
+          "146",
+          "147",
+          "195",
+          "225"
+        ]
+      },
+      {
+        "name": "diagnosticMammography",
+        "measureIds": [
+          "146",
+          "225"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "012",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "internalEyeCare",
+        "measureIds": [
+          "012",
+          "141"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "141",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "internalEyeCare",
+        "measureIds": [
+          "012",
+          "141"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "001",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "001",
+          "128",
+          "130",
+          "181",
+          "431"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "128",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "001",
+          "128",
+          "130",
+          "181",
+          "431"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "130",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "001",
+          "128",
+          "130",
+          "181",
+          "431"
+        ]
+      },
+      {
+        "name": "hospitalists",
+        "measureIds": [
+          "005",
+          "008",
+          "047",
+          "076",
+          "130"
+        ]
+      },
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "181",
+          "182",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "181",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "001",
+          "128",
+          "130",
+          "181",
+          "431"
+        ]
+      },
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "181",
+          "182",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "431",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "001",
+          "128",
+          "130",
+          "181",
+          "431"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "005",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "hospitalists",
+        "measureIds": [
+          "005",
+          "008",
+          "047",
+          "076",
+          "130"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "008",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "hospitalists",
+        "measureIds": [
+          "005",
+          "008",
+          "047",
+          "076",
+          "130"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "047",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "hospitalists",
+        "measureIds": [
+          "005",
+          "008",
+          "047",
+          "076",
+          "130"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "076",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "hospitalists",
+        "measureIds": [
+          "005",
+          "008",
+          "047",
+          "076",
+          "130"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "102",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "radiationOncology",
+        "measureIds": [
+          "102",
+          "143",
+          "144"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "143",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "radiationOncology",
+        "measureIds": [
+          "102",
+          "143",
+          "144"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "144",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "radiationOncology",
+        "measureIds": [
+          "102",
+          "143",
+          "144"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "182",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "181",
+          "182",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "226",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "181",
+          "182",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "348",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "electrophysiologyCardiacSpecialist",
+        "measureIds": [
+          "348",
+          "392",
+          "393"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "392",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "electrophysiologyCardiacSpecialist",
+        "measureIds": [
+          "348",
+          "392",
+          "393"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "393",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "electrophysiologyCardiacSpecialist",
+        "measureIds": [
+          "348",
+          "392",
+          "393"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "185",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "endoscopyAndPolypSurveillance",
+        "measureIds": [
+          "185",
+          "320",
+          "425",
+          "439"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "320",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "endoscopyAndPolypSurveillance",
+        "measureIds": [
+          "185",
+          "320",
+          "425",
+          "439"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "425",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "endoscopyAndPolypSurveillance",
+        "measureIds": [
+          "185",
+          "320",
+          "425",
+          "439"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "439",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "endoscopyAndPolypSurveillance",
+        "measureIds": [
+          "185",
+          "320",
+          "425",
+          "439"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "322",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "cardiacStressImaging",
+        "measureIds": [
+          "322",
+          "323",
+          "324"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "323",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "cardiacStressImaging",
+        "measureIds": [
+          "322",
+          "323",
+          "324"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "324",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "cardiacStressImaging",
+        "measureIds": [
+          "322",
+          "323",
+          "324"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "249",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396",
+          "397"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "250",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396",
+          "397"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "395",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396",
+          "397"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "396",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396",
+          "397"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "397",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396",
+          "397"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "404",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "anesthesiologyCare",
+        "measureIds": [
+          "404",
+          "424",
+          "430",
+          "463"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "424",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "anesthesiologyCare",
+        "measureIds": [
+          "404",
+          "424",
+          "430",
+          "463"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "430",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "anesthesiologyCare",
+        "measureIds": [
+          "404",
+          "424",
+          "430",
+          "463"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "463",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "anesthesiologyCare",
+        "measureIds": [
+          "404",
+          "424",
+          "430",
+          "463"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "167",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "cabgCare",
+        "measureIds": [
+          "167",
+          "168",
+          "445"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "168",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "cabgCare",
+        "measureIds": [
+          "167",
+          "168",
+          "445"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "445",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "cabgCare",
+        "measureIds": [
+          "167",
+          "168",
+          "445"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "191",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "cataractCare",
+        "measureIds": [
+          "191",
+          "303",
+          "304",
+          "389"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "303",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "cataractCare",
+        "measureIds": [
+          "191",
+          "303",
+          "304",
+          "389"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "304",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "cataractCare",
+        "measureIds": [
+          "191",
+          "303",
+          "304",
+          "389"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "389",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "cataractCare",
+        "measureIds": [
+          "191",
+          "303",
+          "304",
+          "389"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "145",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "diagnosticImaging",
+        "measureIds": [
+          "145",
+          "146",
+          "147",
+          "195",
+          "225"
+        ]
+      },
+      {
+        "name": "interventionalRadiology",
+        "measureIds": [
+          "145",
+          "409",
+          "413",
+          "437",
+          "465"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "146",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "diagnosticImaging",
+        "measureIds": [
+          "145",
+          "146",
+          "147",
+          "195",
+          "225"
+        ]
+      },
+      {
+        "name": "diagnosticMammography",
+        "measureIds": [
+          "146",
+          "225"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "147",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "diagnosticImaging",
+        "measureIds": [
+          "145",
+          "146",
+          "147",
+          "195",
+          "225"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "195",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "diagnosticImaging",
+        "measureIds": [
+          "145",
+          "146",
+          "147",
+          "195",
+          "225"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "225",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "diagnosticImaging",
+        "measureIds": [
+          "145",
+          "146",
+          "147",
+          "195",
+          "225"
+        ]
+      },
+      {
+        "name": "diagnosticMammography",
+        "measureIds": [
+          "146",
+          "225"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "360",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "computedTomography",
+        "measureIds": [
+          "360",
+          "364",
+          "405",
+          "406",
+          "436"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "364",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "computedTomography",
+        "measureIds": [
+          "360",
+          "364",
+          "405",
+          "406",
+          "436"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "405",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "computedTomography",
+        "measureIds": [
+          "360",
+          "364",
+          "405",
+          "406",
+          "436"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "406",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "computedTomography",
+        "measureIds": [
+          "360",
+          "364",
+          "405",
+          "406",
+          "436"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "436",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "computedTomography",
+        "measureIds": [
+          "360",
+          "364",
+          "405",
+          "406",
+          "436"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "021",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "surgicalCare",
+        "measureIds": [
+          "021",
+          "023",
+          "355",
+          "357",
+          "358"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "023",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "surgicalCare",
+        "measureIds": [
+          "021",
+          "023",
+          "355",
+          "357",
+          "358"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "355",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "surgicalCare",
+        "measureIds": [
+          "021",
+          "023",
+          "355",
+          "357",
+          "358"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "357",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "surgicalCare",
+        "measureIds": [
+          "021",
+          "023",
+          "355",
+          "357",
+          "358"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "358",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "surgicalCare",
+        "measureIds": [
+          "021",
+          "023",
+          "355",
+          "357",
+          "358"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "012",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "internalEyeCare",
+        "measureIds": [
+          "012",
+          "141",
+          "384",
+          "385"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "141",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "internalEyeCare",
+        "measureIds": [
+          "012",
+          "141",
+          "384",
+          "385"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "384",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "internalEyeCare",
+        "measureIds": [
+          "012",
+          "141",
+          "384",
+          "385"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "385",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "internalEyeCare",
+        "measureIds": [
+          "012",
+          "141",
+          "384",
+          "385"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "409",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "interventionalRadiology",
+        "measureIds": [
+          "145",
+          "409",
+          "413",
+          "437",
+          "465"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "413",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "interventionalRadiology",
+        "measureIds": [
+          "145",
+          "409",
+          "413",
+          "437",
+          "465"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "437",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "interventionalRadiology",
+        "measureIds": [
+          "145",
+          "409",
+          "413",
+          "437",
+          "465"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "465",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "interventionalRadiology",
+        "measureIds": [
+          "145",
+          "409",
+          "413",
+          "437",
+          "465"
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
#### Motivation for change

Copying 2020 clinical clusters data for 2021 in order to unblock testing of the Quality pipeline in Scoring Engine for Y5.

#### What is being changed

Detailed information about what is being changed and rationale for interesting decisions made

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [ ] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [ ] Unit tests added/passing
* [ ] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-XXXX
