### PR TITLE
QPPSF-8240 - Adding Measures 478 Benchmark PY2020

### DIFF
--- a/benchmarks/2020.json
+++ b/benchmarks/2020.json
@@ -5015,6 +5015,25 @@
     "isToppedOutByProgram": false
   },
   {
+    "measureId": "478",
+    "performanceYear": 2020,
+    "benchmarkYear": 2020,
+    "submissionMethod": "registry",
+    "deciles": [
+      12.5,
+      38.9831,
+      42.8136,
+      47.619,
+      50,
+      56.5217,
+      66.6667,
+      71.4286,
+      89.0909
+    ],
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
+  },
+  {
     "measureId": "AAD12",
     "performanceYear": 2020,
     "benchmarkYear": 2020,

--- a/staging/2020/benchmarks/json/performance-benchmarks.json
+++ b/staging/2020/benchmarks/json/performance-benchmarks.json
@@ -3511,6 +3511,22 @@
     "performanceYear": 2020
   },
   {
+    "measureId": "478",
+    "submissionMethod": "registry",
+    "deciles": [
+      12.5,
+      38.9831,
+      42.8136,
+      47.619,
+      50,
+      56.5217,
+      66.6667,
+      71.4286,
+      89.0909
+    ],
+    "performanceYear": 2020
+  },
+  {
     "measureId": "047",
     "submissionMethod": "registry",
     "deciles": [


### PR DESCRIPTION
#### Motivation for change

Measure ID 478 was part of the PY2020 Final Scoring performance benchmarking delivery. This PR is to make sure the benchmark part of the pool of measures available for view on the Feedback and Measures UI. 

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [ ] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [ ] Unit tests added/passing
* [ ] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPSF-8240
