### PR TITLE
Publish Release  v4.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Motivation for change
To delivery the latest benchmark for measure 478. Once this release is finalized and delivered, a release v4.5.2 will be generated.
