### PR TITLE
Feature/QPPBSR-8035: PY2021 Y5 WI benchmarks

### DIFF
--- a/benchmarks/2021.json
+++ b/benchmarks/2021.json
@@ -23,6 +23,25 @@
     "measureId": "001",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      100,
+      70,
+      60,
+      50,
+      40,
+      30,
+      20,
+      10
+    ]
+  },
+  {
+    "measureId": "001",
+    "benchmarkYear": 2019,
+    "performanceYear": 2021,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
     "isHighPriority": true,
@@ -217,6 +236,25 @@
       83.77,
       86.67,
       90.56
+    ]
+  },
+  {
+    "measureId": "110",
+    "benchmarkYear": 2019,
+    "performanceYear": 2021,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
     ]
   },
   {
@@ -963,6 +1001,25 @@
     "measureId": "112",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "112",
+    "benchmarkYear": 2019,
+    "performanceYear": 2021,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
     "isHighPriority": false,
@@ -997,6 +1054,25 @@
       78.11,
       85.85,
       97.36
+    ]
+  },
+  {
+    "measureId": "113",
+    "benchmarkYear": 2019,
+    "performanceYear": 2021,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
     ]
   },
   {
@@ -2020,6 +2096,25 @@
     ]
   },
   {
+    "measureId": "226",
+    "benchmarkYear": 2019,
+    "performanceYear": 2021,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
     "measureId": "236",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2030,6 +2125,25 @@
     "deciles": [
       0,
       20,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "236",
+    "benchmarkYear": 2019,
+    "performanceYear": 2021,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
       30,
       40,
       50,
@@ -2537,6 +2651,25 @@
       47.5,
       56.07,
       65.97
+    ]
+  },
+  {
+    "measureId": "318",
+    "benchmarkYear": 2019,
+    "performanceYear": 2021,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
     ]
   },
   {

--- a/staging/2021/benchmarks/json/wi-benchmarks.json
+++ b/staging/2021/benchmarks/json/wi-benchmarks.json
@@ -1,0 +1,135 @@
+[
+  {
+    "measureId": "110",
+    "benchmarkYear": 2021,
+    "performanceYear": 2021,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "112",
+    "benchmarkYear": 2021,
+    "performanceYear": 2021,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "113",
+    "benchmarkYear": 2021,
+    "performanceYear": 2021,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "226",
+    "benchmarkYear": 2021,
+    "performanceYear": 2021,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "236",
+    "benchmarkYear": 2021,
+    "performanceYear": 2021,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles":[
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "318",
+    "benchmarkYear": 2021,
+    "performanceYear": 2021,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "001",
+    "benchmarkYear": 2021,
+    "performanceYear": 2021,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      100,
+      70,
+      60,
+      50,
+      40,
+      30,
+      20,
+      10
+    ]
+  }
+]

--- a/staging/2021/benchmarks/json/wi-benchmarks.json
+++ b/staging/2021/benchmarks/json/wi-benchmarks.json
@@ -1,7 +1,7 @@
 [
   {
     "measureId": "110",
-    "benchmarkYear": 2021,
+    "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "cmsWebInterface",
     "isToppedOut": false,
@@ -20,7 +20,7 @@
   },
   {
     "measureId": "112",
-    "benchmarkYear": 2021,
+    "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "cmsWebInterface",
     "isToppedOut": false,
@@ -39,7 +39,7 @@
   },
   {
     "measureId": "113",
-    "benchmarkYear": 2021,
+    "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "cmsWebInterface",
     "isToppedOut": false,
@@ -58,7 +58,7 @@
   },
   {
     "measureId": "226",
-    "benchmarkYear": 2021,
+    "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "cmsWebInterface",
     "isToppedOut": false,
@@ -77,7 +77,7 @@
   },
   {
     "measureId": "236",
-    "benchmarkYear": 2021,
+    "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "cmsWebInterface",
     "isToppedOut": false,
@@ -96,7 +96,7 @@
   },
   {
     "measureId": "318",
-    "benchmarkYear": 2021,
+    "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "cmsWebInterface",
     "isToppedOut": false,
@@ -115,7 +115,7 @@
   },
   {
     "measureId": "001",
-    "benchmarkYear": 2021,
+    "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "cmsWebInterface",
     "isToppedOut": false,


### PR DESCRIPTION
#### Motivation for change

Y5 benchmark updates for WI

#### What is being changed

Add the measures required for WI in wi-benchmark.json and add measures to the 2021.json in the benchmark directory.

Reference: https://confluence.cms.gov/display/QPPBSR/Y5+WI+Benchmark+Updates

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [ ] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [x] Documentation updated
* [ ] Unit tests added/passing
* [ ] Verified working locally

##### Associated JIRA tickets:
https://jira.cms.gov/browse/QPPBSR-8035
