### PR TITLE
QPPSF-8206: Fix benchmark year for 2020 WI

### DIFF
--- a/staging/2020/benchmarks/json/wi-benchmarks.json
+++ b/staging/2020/benchmarks/json/wi-benchmarks.json
@@ -1,7 +1,7 @@
 [
   {
     "measureId": "110",
-    "benchmarkYear": 2020,
+    "benchmarkYear": 2018,
     "performanceYear": 2020,
     "submissionMethod": "cmsWebInterface",
     "isToppedOut": false,
@@ -20,7 +20,7 @@
   },
   {
     "measureId": "112",
-    "benchmarkYear": 2020,
+    "benchmarkYear": 2018,
     "performanceYear": 2020,
     "submissionMethod": "cmsWebInterface",
     "isToppedOut": false,
@@ -39,7 +39,7 @@
   },
   {
     "measureId": "113",
-    "benchmarkYear": 2020,
+    "benchmarkYear": 2018,
     "performanceYear": 2020,
     "submissionMethod": "cmsWebInterface",
     "isToppedOut": false,
@@ -58,7 +58,7 @@
   },
   {
     "measureId": "226",
-    "benchmarkYear": 2020,
+    "benchmarkYear": 2018,
     "performanceYear": 2020,
     "submissionMethod": "cmsWebInterface",
     "isToppedOut": false,
@@ -77,7 +77,7 @@
   },
   {
     "measureId": "236",
-    "benchmarkYear": 2020,
+    "benchmarkYear": 2018,
     "performanceYear": 2020,
     "submissionMethod": "cmsWebInterface",
     "isToppedOut": false,
@@ -96,7 +96,7 @@
   },
   {
     "measureId": "318",
-    "benchmarkYear": 2020,
+    "benchmarkYear": 2018,
     "performanceYear": 2020,
     "submissionMethod": "cmsWebInterface",
     "isToppedOut": false,
@@ -115,7 +115,7 @@
   },
   {
     "measureId": "001",
-    "benchmarkYear": 2020,
+    "benchmarkYear": 2018,
     "performanceYear": 2020,
     "submissionMethod": "cmsWebInterface",
     "isToppedOut": false,


### PR DESCRIPTION
#### Motivation for change

Non-performance benchmarks should use a benchmark year two years prior to the performance year.

#### What is being changed

#387 fixed the output of the benchmark script, but not the WI input. If you re-run the script, the output has 2020 for the benchmark year for WI measures. So the input `staging/2021/benchmarks/json/wi-benchmarks.json` file needs to be changed.

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [ ] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [x] Unit tests added/passing
* [x] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-8206
