### PR TITLE
QPPA-5660 Remove claims benchmarks for 001, 117 measures

### DIFF
--- a/benchmarks/2021.json
+++ b/benchmarks/2021.json
@@ -3,26 +3,6 @@
     "measureId": "001",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
-    "submissionMethod": "claims",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      79.99,
-      70,
-      60,
-      50,
-      40,
-      30,
-      20,
-      10
-    ]
-  },
-  {
-    "measureId": "001",
-    "benchmarkYear": 2019,
-    "performanceYear": 2021,
     "submissionMethod": "cmsWebInterface",
     "isToppedOut": false,
     "isToppedOutByProgram": false,
@@ -236,25 +216,6 @@
       83.77,
       86.67,
       90.56
-    ]
-  },
-  {
-    "measureId": "110",
-    "benchmarkYear": 2019,
-    "performanceYear": 2021,
-    "submissionMethod": "cmsWebInterface",
-    "isToppedOut": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      0,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
     ]
   },
   {
@@ -918,6 +879,25 @@
     ]
   },
   {
+    "measureId": "110",
+    "benchmarkYear": 2019,
+    "performanceYear": 2021,
+    "submissionMethod": "cmsWebInterface",
+    "isToppedOut": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
     "measureId": "111",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -1111,26 +1091,6 @@
       93.33,
       96.92,
       98.43,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "117",
-    "benchmarkYear": 2019,
-    "performanceYear": 2021,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      97.83,
-      100,
-      100,
-      100,
-      100,
-      100,
       100,
       100
     ]

--- a/staging/2021/benchmarks/benchmarks.csv
+++ b/staging/2021/benchmarks/benchmarks.csv
@@ -1,6 +1,5 @@
 Table 2: Historical MIPS Quality Measure Benchmark Results; created using PY2018 data and PY2020 Eligibility Rules,,,,,,,,,,,,,,,,,
 Measure_Name,Measure_ID,Collection_Type,Measure_Type,Benchmark,Standard_Deviation,Average,Decile_3,Decile_4,Decile_5,Decile_6,Decile_7,Decile_8,Decile_9,Decile_10,Topped_Out,Seven_Point_Cap,High_Priority
-Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,Medicare Part B Claims,Intermediate Outcome,Y,,15.6727392550143,79.99 - 70.01,70 - 60.01,60 - 50.01,50 - 40.01,40 - 30.01,30 - 20.01,20 - 10.01,<= 10,No,No,Y
 Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,eCQM,Intermediate Outcome,Y,,47.7050360962571,90.50 - 69.43,69.42 - 53.61,53.6 - 42.12,42.11 - 34.07,34.06 - 28.33,28.32 - 23.57,23.56 - 19.11,<=19.1,No,No,Y
 Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,MIPS CQM,Intermediate Outcome,Y,,46.7701042717793,90.69 - 72.52,72.51 - 55.18,55.17 - 41.99,41.98 - 32.57,32.56 - 25.49,25.48 - 19.16,19.15 - 12.88,<=12.87,No,No,Y
 Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) or Angiotensin Receptor-Neprilysin Inhibitor (ARNI) Therapy for Left Ventricular Systolic Dysfunction (LVSD),5,eCQM,Process,Y,,71.8131388329979,1.09 - 65.51,65.52 - 71.94,71.95 - 75.27,75.28 - 78.08,78.09 - 80.46,80.47 - 82.97,82.98 - 86.35,>= 86.36,No,No,N
@@ -58,7 +57,6 @@ Colorectal Cancer Screening,113,Medicare Part B Claims,Process,N,,--,--,--,--,--
 Colorectal Cancer Screening,113,eCQM,Process,Y,,47.2213975533785,15.15 - 27.51,27.52 - 38.73,38.74 - 49.04,49.05 - 58.3,58.31 - 67.54,67.55 - 76.05,76.06 - 85.05,>= 85.06,No,No,N
 Colorectal Cancer Screening,113,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
 Avoidance of Antibiotic Treatment for Acute Bronchitis/Bronchiolitis,116,MIPS CQM,Process,Y,,81.4741527001862,62.33 - 75.99,76.0 - 86.35,86.36 - 93.32,93.33 - 96.91,96.92 - 98.42,98.43 - 99.99,--,100,Yes,No,Y
-Diabetes: Eye Exam,117,Medicare Part B Claims,Process,Y,,92.3181820931638,97.83 - 99.99,--,--,--,--,--,--,100,Yes,Yes,N
 Diabetes: Eye Exam,117,eCQM,Process,Y,,40.5858287003907,12.0 - 20.54,20.55 - 30.68,30.69 - 44.81,44.82 - 69.39,69.4 - 94.16,94.17 - 98.42,98.43 - 99.92,>= 99.93,No,No,N
 Diabetes: Eye Exam,117,MIPS CQM,Process,Y,,83.6932025547445,89.93 - 96.67,96.68 - 98.85,98.86 - 99.69,99.7 - 99.99,--,--,--,100,Yes,Yes,N
 Coronary Artery Disease (CAD): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy - Diabetes or Left Ventricular Systolic Dysfunction (LVEF < 40%),118,MIPS CQM,Process,Y,,80.9126206896552,72.73 - 76.31,76.32 - 79.6,79.61 - 81.84,81.85 - 84.99,85.0 - 86.82,86.83 - 90.47,90.48 - 95.99,>= 96.0,No,No,N

--- a/staging/2021/benchmarks/json/benchmarks.json
+++ b/staging/2021/benchmarks/json/benchmarks.json
@@ -3,26 +3,6 @@
     "measureId": "001",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
-    "submissionMethod": "claims",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      79.99,
-      70,
-      60,
-      50,
-      40,
-      30,
-      20,
-      10
-    ]
-  },
-  {
-    "measureId": "001",
-    "benchmarkYear": 2019,
-    "performanceYear": 2021,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
     "isHighPriority": true,
@@ -1035,26 +1015,6 @@
       93.33,
       96.92,
       98.43,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "117",
-    "benchmarkYear": 2019,
-    "performanceYear": 2021,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      97.83,
-      100,
-      100,
-      100,
-      100,
-      100,
       100,
       100
     ]

--- a/staging/2021/benchmarks/source.csv
+++ b/staging/2021/benchmarks/source.csv
@@ -1,5 +1,4 @@
 Measure Title,Measure ID,Collection Type,Measure Type,High Priority,Average Performance Rate,Measure has a Benchmark,Decile 3,Decile 4,Decile 5,Decile 6,Decile 7,Decile 8,Decile 9,Decile 10,Topped Out,Seven Point Cap
-Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,Medicare Part B Claims,Intermediate Outcome,Y,15.6727392550143,Y,79.99 - 70.01,70 - 60.01,60 - 50.01,50 - 40.01,40 - 30.01,30 - 20.01,20 - 10.01,<= 10,N,N
 Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,eCQM,Intermediate Outcome,Y,47.7050360962571,Y,90.50 - 69.43,69.42 - 53.61,53.6 - 42.12,42.11 - 34.07,34.06 - 28.33,28.32 - 23.57,23.56 - 19.11,<=19.1,N,N
 Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,MIPS CQM,Intermediate Outcome,Y,46.7701042717793,Y,90.69 - 72.52,72.51 - 55.18,55.17 - 41.99,41.98 - 32.57,32.56 - 25.49,25.48 - 19.16,19.15 - 12.88,<=12.87,N,N
 Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) or Angiotensin Receptor-Neprilysin Inhibitor (ARNI) Therapy for Left Ventricular Systolic Dysfunction (LVSD),5,eCQM,Process,N,71.8131388329979,Y,1.09 - 65.51,65.52 - 71.94,71.95 - 75.27,75.28 - 78.08,78.09 - 80.46,80.47 - 82.97,82.98 - 86.35,>= 86.36,N,N
@@ -57,7 +56,6 @@ Colorectal Cancer Screening,113,Medicare Part B Claims,Process,N,--,N,--,--,--,-
 Colorectal Cancer Screening,113,eCQM,Process,N,47.2213975533785,Y,15.15 - 27.51,27.52 - 38.73,38.74 - 49.04,49.05 - 58.3,58.31 - 67.54,67.55 - 76.05,76.06 - 85.05,>= 85.06,N,N
 Colorectal Cancer Screening,113,MIPS CQM,Process,N,--,N,--,--,--,--,--,--,--,--,N,N
 Avoidance of Antibiotic Treatment for Acute Bronchitis/Bronchiolitis,116,MIPS CQM,Process,Y,81.4741527001862,Y,62.33 - 75.99,76.0 - 86.35,86.36 - 93.32,93.33 - 96.91,96.92 - 98.42,98.43 - 99.99,--,100,Y,N
-Diabetes: Eye Exam,117,Medicare Part B Claims,Process,N,92.3181820931638,Y,97.83 - 99.99,--,--,--,--,--,--,100,Y,Y
 Diabetes: Eye Exam,117,eCQM,Process,N,40.5858287003907,Y,12.0 - 20.54,20.55 - 30.68,30.69 - 44.81,44.82 - 69.39,69.4 - 94.16,94.17 - 98.42,98.43 - 99.92,>= 99.93,N,N
 Diabetes: Eye Exam,117,MIPS CQM,Process,N,83.6932025547445,Y,89.93 - 96.67,96.68 - 98.85,98.86 - 99.69,99.7 - 99.99,--,--,--,100,Y,Y
 Coronary Artery Disease (CAD): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy - Diabetes or Left Ventricular Systolic Dysfunction (LVEF < 40%),118,MIPS CQM,Process,N,80.9126206896552,Y,72.73 - 76.31,76.32 - 79.6,79.61 - 81.84,81.85 - 84.99,85.0 - 86.82,86.83 - 90.47,90.48 - 95.99,>= 96.0,N,N


### PR DESCRIPTION
Remove 001, 117 benchmarks for claims
110 got moved, as it seems it was out of order in the json file but no change to data

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-5660
