### PR TITLE
QPPC-3672:measure 254 eligibility options fix

### DIFF
--- a/claims-related/data/qpp-single-source-2021.json
+++ b/claims-related/data/qpp-single-source-2021.json
@@ -48029,6 +48029,36 @@
     "254": {
         "eligibilityOptions": [
             {
+                "additionalDiagnosisCodes": [
+                    "R10.0",
+                    "R10.10",
+                    "R10.13",
+                    "R10.2",
+                    "R10.30",
+                    "R10.31",
+                    "R10.32",
+                    "R10.33",
+                    "R10.813",
+                    "R10.814",
+                    "R10.815",
+                    "R10.816",
+                    "R10.817",
+                    "R10.819",
+                    "R10.823",
+                    "R10.824",
+                    "R10.825",
+                    "R10.826",
+                    "R10.827",
+                    "R10.829",
+                    "R10.84",
+                    "R10.9"
+                ],
+                "diagnosisCodes": [
+                    "O26.891",
+                    "O26.899",
+                    "O26.90",
+                    "O26.91"
+                ],
                 "maxAge": 50.0,
                 "minAge": 14.0,
                 "optionGroup": "00",
@@ -48074,42 +48104,6 @@
             },
             {
                 "additionalDiagnosisCodes": [
-                    "R10.0",
-                    "R10.10",
-                    "R10.13",
-                    "R10.2",
-                    "R10.30",
-                    "R10.31",
-                    "R10.32",
-                    "R10.33",
-                    "R10.813",
-                    "R10.814",
-                    "R10.815",
-                    "R10.816",
-                    "R10.817",
-                    "R10.819",
-                    "R10.823",
-                    "R10.824",
-                    "R10.825",
-                    "R10.826",
-                    "R10.827",
-                    "R10.829",
-                    "R10.84",
-                    "R10.9"
-                ],
-                "diagnosisCodes": [
-                    "O26.891",
-                    "O26.899",
-                    "O26.90",
-                    "O26.91"
-                ],
-                "maxAge": 50.0,
-                "minAge": 14.0,
-                "optionGroup": "00",
-                "sexCode": "F"
-            },
-            {
-                "additionalDiagnosisCodes": [
                     "O20.0",
                     "O20.8",
                     "O20.9",
@@ -48151,6 +48145,44 @@
                 "maxAge": 50.0,
                 "minAge": 14.0,
                 "optionGroup": "00",
+                "procedureCodes": [
+                    {
+                        "code": "99281",
+                        "placesOfService": [
+                            "23"
+                        ]
+                    },
+                    {
+                        "code": "99282",
+                        "placesOfService": [
+                            "23"
+                        ]
+                    },
+                    {
+                        "code": "99283",
+                        "placesOfService": [
+                            "23"
+                        ]
+                    },
+                    {
+                        "code": "99284",
+                        "placesOfService": [
+                            "23"
+                        ]
+                    },
+                    {
+                        "code": "99285",
+                        "placesOfService": [
+                            "23"
+                        ]
+                    },
+                    {
+                        "code": "99291",
+                        "placesOfService": [
+                            "23"
+                        ]
+                    }
+                ],
                 "sexCode": "F"
             }
         ],

--- a/claims-related/scripts/single_source_conversion_helpers.py
+++ b/claims-related/scripts/single_source_conversion_helpers.py
@@ -313,6 +313,18 @@ def extract_eligibility_options_from_measure_dataframe(measure_df):
 
     eligibility_options = []
     # Each distinct codeset creates a new eligibility option.
+
+    # This bit of code is to handle when common eligibility options are not explicitly part of a group
+    codeset_numbers = eligibility_df["codeset_number"].unique()
+    if -1 in codeset_numbers and 1 in codeset_numbers:
+        un_numbered = eligibility_df[eligibility_df["codeset_number"] == -1]
+        new_elig_out = eligibility_df[eligibility_df["codeset_number"] != -1]
+        for c in (set(codeset_numbers) - {-1}):
+            new_numbered = un_numbered.copy()
+            new_numbered["codeset_number"] = c
+            new_elig_out = new_elig_out.append(new_numbered)
+        eligibility_df = new_elig_out
+
     for codeset_number, codeset_df in eligibility_df.groupby('codeset_number'):
         procedure_codes = list(codeset_df[
             codeset_df['element_category'].isin(ENC_PROC_CODE_CATEGORY)

--- a/measures/2021/measures-data.json
+++ b/measures/2021/measures-data.json
@@ -53683,6 +53683,36 @@
     },
     "eligibilityOptions": [
       {
+        "additionalDiagnosisCodes": [
+          "R10.0",
+          "R10.10",
+          "R10.13",
+          "R10.2",
+          "R10.30",
+          "R10.31",
+          "R10.32",
+          "R10.33",
+          "R10.813",
+          "R10.814",
+          "R10.815",
+          "R10.816",
+          "R10.817",
+          "R10.819",
+          "R10.823",
+          "R10.824",
+          "R10.825",
+          "R10.826",
+          "R10.827",
+          "R10.829",
+          "R10.84",
+          "R10.9"
+        ],
+        "diagnosisCodes": [
+          "O26.891",
+          "O26.899",
+          "O26.90",
+          "O26.91"
+        ],
         "maxAge": 50,
         "minAge": 14,
         "optionGroup": "00",
@@ -53728,42 +53758,6 @@
       },
       {
         "additionalDiagnosisCodes": [
-          "R10.0",
-          "R10.10",
-          "R10.13",
-          "R10.2",
-          "R10.30",
-          "R10.31",
-          "R10.32",
-          "R10.33",
-          "R10.813",
-          "R10.814",
-          "R10.815",
-          "R10.816",
-          "R10.817",
-          "R10.819",
-          "R10.823",
-          "R10.824",
-          "R10.825",
-          "R10.826",
-          "R10.827",
-          "R10.829",
-          "R10.84",
-          "R10.9"
-        ],
-        "diagnosisCodes": [
-          "O26.891",
-          "O26.899",
-          "O26.90",
-          "O26.91"
-        ],
-        "maxAge": 50,
-        "minAge": 14,
-        "optionGroup": "00",
-        "sexCode": "F"
-      },
-      {
-        "additionalDiagnosisCodes": [
           "O20.0",
           "O20.8",
           "O20.9",
@@ -53805,6 +53799,44 @@
         "maxAge": 50,
         "minAge": 14,
         "optionGroup": "00",
+        "procedureCodes": [
+          {
+            "code": "99281",
+            "placesOfService": [
+              "23"
+            ]
+          },
+          {
+            "code": "99282",
+            "placesOfService": [
+              "23"
+            ]
+          },
+          {
+            "code": "99283",
+            "placesOfService": [
+              "23"
+            ]
+          },
+          {
+            "code": "99284",
+            "placesOfService": [
+              "23"
+            ]
+          },
+          {
+            "code": "99285",
+            "placesOfService": [
+              "23"
+            ]
+          },
+          {
+            "code": "99291",
+            "placesOfService": [
+              "23"
+            ]
+          }
+        ],
         "sexCode": "F"
       }
     ],

--- a/util/measures/2021/enriched-measures-data-quality.json
+++ b/util/measures/2021/enriched-measures-data-quality.json
@@ -51745,6 +51745,36 @@
     },
     "eligibilityOptions": [
       {
+        "additionalDiagnosisCodes": [
+          "R10.0",
+          "R10.10",
+          "R10.13",
+          "R10.2",
+          "R10.30",
+          "R10.31",
+          "R10.32",
+          "R10.33",
+          "R10.813",
+          "R10.814",
+          "R10.815",
+          "R10.816",
+          "R10.817",
+          "R10.819",
+          "R10.823",
+          "R10.824",
+          "R10.825",
+          "R10.826",
+          "R10.827",
+          "R10.829",
+          "R10.84",
+          "R10.9"
+        ],
+        "diagnosisCodes": [
+          "O26.891",
+          "O26.899",
+          "O26.90",
+          "O26.91"
+        ],
         "maxAge": 50,
         "minAge": 14,
         "optionGroup": "00",
@@ -51790,42 +51820,6 @@
       },
       {
         "additionalDiagnosisCodes": [
-          "R10.0",
-          "R10.10",
-          "R10.13",
-          "R10.2",
-          "R10.30",
-          "R10.31",
-          "R10.32",
-          "R10.33",
-          "R10.813",
-          "R10.814",
-          "R10.815",
-          "R10.816",
-          "R10.817",
-          "R10.819",
-          "R10.823",
-          "R10.824",
-          "R10.825",
-          "R10.826",
-          "R10.827",
-          "R10.829",
-          "R10.84",
-          "R10.9"
-        ],
-        "diagnosisCodes": [
-          "O26.891",
-          "O26.899",
-          "O26.90",
-          "O26.91"
-        ],
-        "maxAge": 50,
-        "minAge": 14,
-        "optionGroup": "00",
-        "sexCode": "F"
-      },
-      {
-        "additionalDiagnosisCodes": [
           "O20.0",
           "O20.8",
           "O20.9",
@@ -51867,6 +51861,44 @@
         "maxAge": 50,
         "minAge": 14,
         "optionGroup": "00",
+        "procedureCodes": [
+          {
+            "code": "99281",
+            "placesOfService": [
+              "23"
+            ]
+          },
+          {
+            "code": "99282",
+            "placesOfService": [
+              "23"
+            ]
+          },
+          {
+            "code": "99283",
+            "placesOfService": [
+              "23"
+            ]
+          },
+          {
+            "code": "99284",
+            "placesOfService": [
+              "23"
+            ]
+          },
+          {
+            "code": "99285",
+            "placesOfService": [
+              "23"
+            ]
+          },
+          {
+            "code": "99291",
+            "placesOfService": [
+              "23"
+            ]
+          }
+        ],
         "sexCode": "F"
       }
     ],


### PR DESCRIPTION
#### Motivation for change

The 2021 single source .csv file had inconsistent naming for measure 254's eligibility options. This caused the claims related single source converter to create three incomplete eligibility option objects instead of the two expected.

#### What is being changed

The claims related single source converter script was updated to account for this inconsistent tagging in the source .csv and correctly associates non numbered tags with all numbered tags, if numbered and unnumbered tags are combined, for a given measure


#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

No documentation to update. README says don't update package version for merging into develop. Unit tests pass and measure validation passes

* [ ] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [x] Unit tests added/passing
* [x] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPC-3672
