### PR TITLE
QPPSF-8670: Update 2021 EMA Specialty Sets and Clinical Clusters

### DIFF
--- a/clinical-clusters/2021/clinical-clusters.json
+++ b/clinical-clusters/2021/clinical-clusters.json
@@ -1,42 +1,35 @@
 [
   {
-    "measureId": "001",
+    "measureId": "014",
     "submissionMethod": "claims",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
     "specialtySets": [
       {
-        "name": "nutritionDietician",
+        "name": "ophthalmology",
         "measureIds": [
-          "001",
-          "128",
+          "014",
+          "117",
           "130",
-          "181"
+          "141",
+          "226"
         ]
       }
     ]
   },
   {
-    "measureId": "128",
+    "measureId": "117",
     "submissionMethod": "claims",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
     "specialtySets": [
       {
-        "name": "nutritionDietician",
+        "name": "ophthalmology",
         "measureIds": [
-          "001",
-          "128",
+          "014",
+          "117",
           "130",
-          "181"
-        ]
-      },
-      {
-        "name": "podiatry",
-        "measureIds": [
-          "128",
-          "154",
-          "155",
+          "141",
           "226"
         ]
       }
@@ -49,12 +42,13 @@
     "lastPerformanceYear": null,
     "specialtySets": [
       {
-        "name": "nutritionDietician",
+        "name": "ophthalmology",
         "measureIds": [
-          "001",
-          "128",
+          "014",
+          "117",
           "130",
-          "181"
+          "141",
+          "226"
         ]
       },
       {
@@ -85,6 +79,16 @@
         ]
       },
       {
+        "name": "clinicalSocialWork",
+        "measureIds": [
+          "047",
+          "130",
+          "134",
+          "181",
+          "226"
+        ]
+      },
+      {
         "name": "urgentCare",
         "measureIds": [
           "093",
@@ -112,6 +116,14 @@
         ]
       },
       {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "128",
+          "130",
+          "181"
+        ]
+      },
+      {
         "name": "dermatology",
         "measureIds": [
           "130",
@@ -120,18 +132,10 @@
         ]
       },
       {
-        "name": "clinicalSocialWork",
-        "measureIds": [
-          "130",
-          "134",
-          "181",
-          "226"
-        ]
-      },
-      {
         "name": "speechLanguagePathology",
         "measureIds": [
           "130",
+          "134",
           "181",
           "182",
           "226"
@@ -140,23 +144,62 @@
     ]
   },
   {
-    "measureId": "181",
+    "measureId": "141",
     "submissionMethod": "claims",
     "firstPerformanceYear": 2017,
     "lastPerformanceYear": null,
     "specialtySets": [
       {
-        "name": "nutritionDietician",
+        "name": "ophthalmology",
         "measureIds": [
-          "001",
-          "128",
+          "014",
+          "117",
           "130",
-          "181"
+          "141",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "226",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "ophthalmology",
+        "measureIds": [
+          "014",
+          "117",
+          "130",
+          "141",
+          "226"
+        ]
+      },
+      {
+        "name": "plasticSurgery",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "neurosurgical",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226"
         ]
       },
       {
         "name": "clinicalSocialWork",
         "measureIds": [
+          "047",
           "130",
           "134",
           "181",
@@ -164,9 +207,46 @@
         ]
       },
       {
+        "name": "urgentCare",
+        "measureIds": [
+          "093",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "allergyImmunology",
+        "measureIds": [
+          "110",
+          "111",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "podiatry",
+        "measureIds": [
+          "128",
+          "154",
+          "155",
+          "226"
+        ]
+      },
+      {
+        "name": "dermatology",
+        "measureIds": [
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
         "name": "speechLanguagePathology",
         "measureIds": [
           "130",
+          "134",
           "181",
           "182",
           "226"
@@ -247,87 +327,6 @@
     ]
   },
   {
-    "measureId": "226",
-    "submissionMethod": "claims",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "specialtySets": [
-      {
-        "name": "plasticSurgery",
-        "measureIds": [
-          "021",
-          "023",
-          "130",
-          "226",
-          "317"
-        ]
-      },
-      {
-        "name": "neurosurgical",
-        "measureIds": [
-          "021",
-          "023",
-          "130",
-          "226"
-        ]
-      },
-      {
-        "name": "urgentCare",
-        "measureIds": [
-          "093",
-          "130",
-          "226",
-          "317"
-        ]
-      },
-      {
-        "name": "allergyImmunology",
-        "measureIds": [
-          "110",
-          "111",
-          "130",
-          "226",
-          "317"
-        ]
-      },
-      {
-        "name": "podiatry",
-        "measureIds": [
-          "128",
-          "154",
-          "155",
-          "226"
-        ]
-      },
-      {
-        "name": "dermatology",
-        "measureIds": [
-          "130",
-          "226",
-          "317"
-        ]
-      },
-      {
-        "name": "clinicalSocialWork",
-        "measureIds": [
-          "130",
-          "134",
-          "181",
-          "226"
-        ]
-      },
-      {
-        "name": "speechLanguagePathology",
-        "measureIds": [
-          "130",
-          "181",
-          "182",
-          "226"
-        ]
-      }
-    ]
-  },
-  {
     "measureId": "317",
     "submissionMethod": "claims",
     "firstPerformanceYear": 2017,
@@ -394,6 +393,16 @@
           "076",
           "130"
         ]
+      },
+      {
+        "name": "clinicalSocialWork",
+        "measureIds": [
+          "047",
+          "130",
+          "134",
+          "181",
+          "226"
+        ]
       }
     ]
   },
@@ -421,8 +430,79 @@
         "name": "interventionalRadiology",
         "measureIds": [
           "076",
-          "145",
-          "437"
+          "145"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "134",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "clinicalSocialWork",
+        "measureIds": [
+          "047",
+          "130",
+          "134",
+          "181",
+          "226"
+        ]
+      },
+      {
+        "name": "pediatrics",
+        "measureIds": [
+          "093",
+          "110",
+          "134"
+        ]
+      },
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "134",
+          "181",
+          "182",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "181",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "clinicalSocialWork",
+        "measureIds": [
+          "047",
+          "130",
+          "134",
+          "181",
+          "226"
+        ]
+      },
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "128",
+          "130",
+          "181"
+        ]
+      },
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "134",
+          "181",
+          "182",
+          "226"
         ]
       }
     ]
@@ -437,8 +517,7 @@
         "name": "interventionalRadiology",
         "measureIds": [
           "076",
-          "145",
-          "437"
+          "145"
         ]
       }
     ],
@@ -447,7 +526,6 @@
         "name": "diagnosticImaging",
         "measureIds": [
           "145",
-          "146",
           "147",
           "195",
           "225"
@@ -456,33 +534,7 @@
       {
         "name": "interventionalRadiology",
         "measureIds": [
-          "145",
-          "437"
-        ]
-      }
-    ]
-  },
-  {
-    "measureId": "437",
-    "submissionMethod": "claims",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "specialtySets": [
-      {
-        "name": "interventionalRadiology",
-        "measureIds": [
-          "076",
-          "145",
-          "437"
-        ]
-      }
-    ],
-    "clinicalClusters": [
-      {
-        "name": "interventionalRadiology",
-        "measureIds": [
-          "145",
-          "437"
+          "145"
         ]
       }
     ]
@@ -590,31 +642,6 @@
     ]
   },
   {
-    "measureId": "134",
-    "submissionMethod": "claims",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "specialtySets": [
-      {
-        "name": "pediatrics",
-        "measureIds": [
-          "093",
-          "110",
-          "134"
-        ]
-      },
-      {
-        "name": "clinicalSocialWork",
-        "measureIds": [
-          "130",
-          "134",
-          "181",
-          "226"
-        ]
-      }
-    ]
-  },
-  {
     "measureId": "111",
     "submissionMethod": "claims",
     "firstPerformanceYear": 2017,
@@ -636,6 +663,31 @@
           "110",
           "111",
           "130"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "128",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "podiatry",
+        "measureIds": [
+          "128",
+          "154",
+          "155",
+          "226"
+        ]
+      },
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "128",
+          "130",
+          "181"
         ]
       }
     ]
@@ -684,6 +736,7 @@
         "name": "speechLanguagePathology",
         "measureIds": [
           "130",
+          "134",
           "181",
           "182",
           "226"
@@ -910,31 +963,6 @@
     ]
   },
   {
-    "measureId": "146",
-    "submissionMethod": "claims",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "clinicalClusters": [
-      {
-        "name": "diagnosticImaging",
-        "measureIds": [
-          "145",
-          "146",
-          "147",
-          "195",
-          "225"
-        ]
-      },
-      {
-        "name": "diagnosticMammography",
-        "measureIds": [
-          "146",
-          "225"
-        ]
-      }
-    ]
-  },
-  {
     "measureId": "147",
     "submissionMethod": "claims",
     "firstPerformanceYear": 2017,
@@ -944,7 +972,6 @@
         "name": "diagnosticImaging",
         "measureIds": [
           "145",
-          "146",
           "147",
           "195",
           "225"
@@ -962,7 +989,6 @@
         "name": "diagnosticImaging",
         "measureIds": [
           "145",
-          "146",
           "147",
           "195",
           "225"
@@ -980,165 +1006,9 @@
         "name": "diagnosticImaging",
         "measureIds": [
           "145",
-          "146",
           "147",
           "195",
           "225"
-        ]
-      },
-      {
-        "name": "diagnosticMammography",
-        "measureIds": [
-          "146",
-          "225"
-        ]
-      }
-    ]
-  },
-  {
-    "measureId": "012",
-    "submissionMethod": "claims",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "clinicalClusters": [
-      {
-        "name": "internalEyeCare",
-        "measureIds": [
-          "012",
-          "141"
-        ]
-      }
-    ]
-  },
-  {
-    "measureId": "141",
-    "submissionMethod": "claims",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "clinicalClusters": [
-      {
-        "name": "internalEyeCare",
-        "measureIds": [
-          "012",
-          "141"
-        ]
-      }
-    ]
-  },
-  {
-    "measureId": "001",
-    "submissionMethod": "registry",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "specialtySets": [
-      {
-        "name": "nutritionDietician",
-        "measureIds": [
-          "001",
-          "128",
-          "130",
-          "181",
-          "431"
-        ]
-      }
-    ]
-  },
-  {
-    "measureId": "128",
-    "submissionMethod": "registry",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "specialtySets": [
-      {
-        "name": "nutritionDietician",
-        "measureIds": [
-          "001",
-          "128",
-          "130",
-          "181",
-          "431"
-        ]
-      }
-    ]
-  },
-  {
-    "measureId": "130",
-    "submissionMethod": "registry",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "specialtySets": [
-      {
-        "name": "nutritionDietician",
-        "measureIds": [
-          "001",
-          "128",
-          "130",
-          "181",
-          "431"
-        ]
-      },
-      {
-        "name": "hospitalists",
-        "measureIds": [
-          "005",
-          "008",
-          "047",
-          "076",
-          "130"
-        ]
-      },
-      {
-        "name": "speechLanguagePathology",
-        "measureIds": [
-          "130",
-          "181",
-          "182",
-          "226"
-        ]
-      }
-    ]
-  },
-  {
-    "measureId": "181",
-    "submissionMethod": "registry",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "specialtySets": [
-      {
-        "name": "nutritionDietician",
-        "measureIds": [
-          "001",
-          "128",
-          "130",
-          "181",
-          "431"
-        ]
-      },
-      {
-        "name": "speechLanguagePathology",
-        "measureIds": [
-          "130",
-          "181",
-          "182",
-          "226"
-        ]
-      }
-    ]
-  },
-  {
-    "measureId": "431",
-    "submissionMethod": "registry",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "specialtySets": [
-      {
-        "name": "nutritionDietician",
-        "measureIds": [
-          "001",
-          "128",
-          "130",
-          "181",
-          "431"
         ]
       }
     ]
@@ -1216,6 +1086,43 @@
     ]
   },
   {
+    "measureId": "130",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "hospitalists",
+        "measureIds": [
+          "005",
+          "008",
+          "047",
+          "076",
+          "130"
+        ]
+      },
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "128",
+          "130",
+          "181",
+          "431"
+        ]
+      },
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "134",
+          "181",
+          "182",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
     "measureId": "102",
     "submissionMethod": "registry",
     "firstPerformanceYear": 2017,
@@ -1264,6 +1171,85 @@
     ]
   },
   {
+    "measureId": "128",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "128",
+          "130",
+          "181",
+          "431"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "181",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "128",
+          "130",
+          "181",
+          "431"
+        ]
+      },
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "134",
+          "181",
+          "182",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "431",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "128",
+          "130",
+          "181",
+          "431"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "134",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "134",
+          "181",
+          "182",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
     "measureId": "182",
     "submissionMethod": "registry",
     "firstPerformanceYear": 2017,
@@ -1273,6 +1259,7 @@
         "name": "speechLanguagePathology",
         "measureIds": [
           "130",
+          "134",
           "181",
           "182",
           "226"
@@ -1290,25 +1277,10 @@
         "name": "speechLanguagePathology",
         "measureIds": [
           "130",
+          "134",
           "181",
           "182",
           "226"
-        ]
-      }
-    ]
-  },
-  {
-    "measureId": "348",
-    "submissionMethod": "registry",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "specialtySets": [
-      {
-        "name": "electrophysiologyCardiacSpecialist",
-        "measureIds": [
-          "348",
-          "392",
-          "393"
         ]
       }
     ]
@@ -1322,7 +1294,6 @@
       {
         "name": "electrophysiologyCardiacSpecialist",
         "measureIds": [
-          "348",
           "392",
           "393"
         ]
@@ -1338,7 +1309,6 @@
       {
         "name": "electrophysiologyCardiacSpecialist",
         "measureIds": [
-          "348",
           "392",
           "393"
         ]
@@ -1473,8 +1443,7 @@
           "249",
           "250",
           "395",
-          "396",
-          "397"
+          "396"
         ]
       }
     ]
@@ -1491,8 +1460,7 @@
           "249",
           "250",
           "395",
-          "396",
-          "397"
+          "396"
         ]
       }
     ]
@@ -1509,8 +1477,7 @@
           "249",
           "250",
           "395",
-          "396",
-          "397"
+          "396"
         ]
       }
     ]
@@ -1527,8 +1494,7 @@
           "249",
           "250",
           "395",
-          "396",
-          "397"
+          "396"
         ]
       }
     ]
@@ -1540,13 +1506,25 @@
     "lastPerformanceYear": null,
     "clinicalClusters": [
       {
-        "name": "pathology",
+        "name": "pathologySkinCancer",
         "measureIds": [
-          "249",
-          "250",
-          "395",
-          "396",
-          "397"
+          "397",
+          "440"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "440",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "pathologySkinCancer",
+        "measureIds": [
+          "397",
+          "440"
         ]
       }
     ]
@@ -1563,7 +1541,8 @@
           "404",
           "424",
           "430",
-          "463"
+          "463",
+          "477"
         ]
       }
     ]
@@ -1580,7 +1559,8 @@
           "404",
           "424",
           "430",
-          "463"
+          "463",
+          "477"
         ]
       }
     ]
@@ -1597,7 +1577,8 @@
           "404",
           "424",
           "430",
-          "463"
+          "463",
+          "477"
         ]
       }
     ]
@@ -1614,7 +1595,26 @@
           "404",
           "424",
           "430",
-          "463"
+          "463",
+          "477"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "477",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2020,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "anesthesiologyCare",
+        "measureIds": [
+          "404",
+          "424",
+          "430",
+          "463",
+          "477"
         ]
       }
     ]
@@ -1745,7 +1745,6 @@
         "name": "diagnosticImaging",
         "measureIds": [
           "145",
-          "146",
           "147",
           "195",
           "225"
@@ -1757,33 +1756,7 @@
           "145",
           "409",
           "413",
-          "437",
           "465"
-        ]
-      }
-    ]
-  },
-  {
-    "measureId": "146",
-    "submissionMethod": "registry",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "clinicalClusters": [
-      {
-        "name": "diagnosticImaging",
-        "measureIds": [
-          "145",
-          "146",
-          "147",
-          "195",
-          "225"
-        ]
-      },
-      {
-        "name": "diagnosticMammography",
-        "measureIds": [
-          "146",
-          "225"
         ]
       }
     ]
@@ -1798,7 +1771,6 @@
         "name": "diagnosticImaging",
         "measureIds": [
           "145",
-          "146",
           "147",
           "195",
           "225"
@@ -1816,7 +1788,6 @@
         "name": "diagnosticImaging",
         "measureIds": [
           "145",
-          "146",
           "147",
           "195",
           "225"
@@ -1834,16 +1805,8 @@
         "name": "diagnosticImaging",
         "measureIds": [
           "145",
-          "146",
           "147",
           "195",
-          "225"
-        ]
-      },
-      {
-        "name": "diagnosticMammography",
-        "measureIds": [
-          "146",
           "225"
         ]
       }
@@ -2030,23 +1993,6 @@
     ]
   },
   {
-    "measureId": "012",
-    "submissionMethod": "registry",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "clinicalClusters": [
-      {
-        "name": "internalEyeCare",
-        "measureIds": [
-          "012",
-          "141",
-          "384",
-          "385"
-        ]
-      }
-    ]
-  },
-  {
     "measureId": "141",
     "submissionMethod": "registry",
     "firstPerformanceYear": 2017,
@@ -2055,7 +2001,6 @@
       {
         "name": "internalEyeCare",
         "measureIds": [
-          "012",
           "141",
           "384",
           "385"
@@ -2072,7 +2017,6 @@
       {
         "name": "internalEyeCare",
         "measureIds": [
-          "012",
           "141",
           "384",
           "385"
@@ -2089,7 +2033,6 @@
       {
         "name": "internalEyeCare",
         "measureIds": [
-          "012",
           "141",
           "384",
           "385"
@@ -2109,7 +2052,6 @@
           "145",
           "409",
           "413",
-          "437",
           "465"
         ]
       }
@@ -2127,25 +2069,6 @@
           "145",
           "409",
           "413",
-          "437",
-          "465"
-        ]
-      }
-    ]
-  },
-  {
-    "measureId": "437",
-    "submissionMethod": "registry",
-    "firstPerformanceYear": 2017,
-    "lastPerformanceYear": null,
-    "clinicalClusters": [
-      {
-        "name": "interventionalRadiology",
-        "measureIds": [
-          "145",
-          "409",
-          "413",
-          "437",
           "465"
         ]
       }
@@ -2163,7 +2086,6 @@
           "145",
           "409",
           "413",
-          "437",
           "465"
         ]
       }

--- a/clinical-clusters/2022/clinical-clusters-schema.yaml
+++ b/clinical-clusters/2022/clinical-clusters-schema.yaml
@@ -1,0 +1,36 @@
+id: https://github.com/CMSgov/qpp-measures-data/versions/0.0.1/clinical-clusters-schema.yaml
+$schema: http://json-schema.org/schema#
+type: array
+items: { $ref: #/definitions/ClusterType }
+definitions:
+  ClusterType:
+    type: object
+    properties:
+      measureId:
+        type: string
+        description: The measure identifier
+      firstPerformanceYear:
+        description: Year in which the measure was introduced.
+        type: integer
+        default: 2017
+      lastPerformanceYear:
+        description: Year in which the measure was deprecated.
+        type: [integer, 'null']
+        default: 'null'
+      clinicalClusters:
+        type: array
+        items: { $ref: #/definitions/ClinicalClusterType }
+      specialtySets:
+        type: array
+        items: { $ref: #/definitions/ClinicalClusterType }
+  ClinicalClusterType:
+    type: object
+    properties:
+      name:
+        type: string
+        description: Cluster or Specialty name
+      measureIds:
+        type: array
+        items:
+          type: string
+          description: Measure identifier

--- a/clinical-clusters/2022/clinical-clusters.json
+++ b/clinical-clusters/2022/clinical-clusters.json
@@ -1,0 +1,2094 @@
+[
+  {
+    "measureId": "014",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "ophthalmology",
+        "measureIds": [
+          "014",
+          "117",
+          "130",
+          "141",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "117",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "ophthalmology",
+        "measureIds": [
+          "014",
+          "117",
+          "130",
+          "141",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "130",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "ophthalmology",
+        "measureIds": [
+          "014",
+          "117",
+          "130",
+          "141",
+          "226"
+        ]
+      },
+      {
+        "name": "plasticSurgery",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "neurosurgical",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226"
+        ]
+      },
+      {
+        "name": "hospitalists",
+        "measureIds": [
+          "047",
+          "076",
+          "130"
+        ]
+      },
+      {
+        "name": "clinicalSocialWork",
+        "measureIds": [
+          "047",
+          "130",
+          "134",
+          "181",
+          "226"
+        ]
+      },
+      {
+        "name": "urgentCare",
+        "measureIds": [
+          "093",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "allergyImmunology",
+        "measureIds": [
+          "110",
+          "111",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "infectiousDisease",
+        "measureIds": [
+          "110",
+          "111",
+          "130"
+        ]
+      },
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "128",
+          "130",
+          "181"
+        ]
+      },
+      {
+        "name": "dermatology",
+        "measureIds": [
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "134",
+          "181",
+          "182",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "141",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "ophthalmology",
+        "measureIds": [
+          "014",
+          "117",
+          "130",
+          "141",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "226",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "ophthalmology",
+        "measureIds": [
+          "014",
+          "117",
+          "130",
+          "141",
+          "226"
+        ]
+      },
+      {
+        "name": "plasticSurgery",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "neurosurgical",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226"
+        ]
+      },
+      {
+        "name": "clinicalSocialWork",
+        "measureIds": [
+          "047",
+          "130",
+          "134",
+          "181",
+          "226"
+        ]
+      },
+      {
+        "name": "urgentCare",
+        "measureIds": [
+          "093",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "allergyImmunology",
+        "measureIds": [
+          "110",
+          "111",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "podiatry",
+        "measureIds": [
+          "128",
+          "154",
+          "155",
+          "226"
+        ]
+      },
+      {
+        "name": "dermatology",
+        "measureIds": [
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "134",
+          "181",
+          "182",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "021",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "plasticSurgery",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "neurosurgical",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226"
+        ]
+      }
+    ],
+    "clinicalClusters": [
+      {
+        "name": "surgicalCare",
+        "measureIds": [
+          "021",
+          "023"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "023",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "plasticSurgery",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "neurosurgical",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226"
+        ]
+      }
+    ],
+    "clinicalClusters": [
+      {
+        "name": "surgicalCare",
+        "measureIds": [
+          "021",
+          "023"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "317",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "plasticSurgery",
+        "measureIds": [
+          "021",
+          "023",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "emergencyMedicine",
+        "measureIds": [
+          "093",
+          "254",
+          "317",
+          "416"
+        ]
+      },
+      {
+        "name": "urgentCare",
+        "measureIds": [
+          "093",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "allergyImmunology",
+        "measureIds": [
+          "110",
+          "111",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "dermatology",
+        "measureIds": [
+          "130",
+          "226",
+          "317"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "047",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "hospitalists",
+        "measureIds": [
+          "047",
+          "076",
+          "130"
+        ]
+      },
+      {
+        "name": "clinicalSocialWork",
+        "measureIds": [
+          "047",
+          "130",
+          "134",
+          "181",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "076",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "hospitalists",
+        "measureIds": [
+          "047",
+          "076",
+          "130"
+        ]
+      },
+      {
+        "name": "anesthesiology",
+        "measureIds": [
+          "076"
+        ]
+      },
+      {
+        "name": "interventionalRadiology",
+        "measureIds": [
+          "076",
+          "145"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "134",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "clinicalSocialWork",
+        "measureIds": [
+          "047",
+          "130",
+          "134",
+          "181",
+          "226"
+        ]
+      },
+      {
+        "name": "pediatrics",
+        "measureIds": [
+          "093",
+          "110",
+          "134"
+        ]
+      },
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "134",
+          "181",
+          "182",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "181",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "clinicalSocialWork",
+        "measureIds": [
+          "047",
+          "130",
+          "134",
+          "181",
+          "226"
+        ]
+      },
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "128",
+          "130",
+          "181"
+        ]
+      },
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "134",
+          "181",
+          "182",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "145",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "interventionalRadiology",
+        "measureIds": [
+          "076",
+          "145"
+        ]
+      }
+    ],
+    "clinicalClusters": [
+      {
+        "name": "diagnosticImaging",
+        "measureIds": [
+          "145",
+          "147",
+          "195",
+          "225"
+        ]
+      },
+      {
+        "name": "interventionalRadiology",
+        "measureIds": [
+          "145"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "093",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "emergencyMedicine",
+        "measureIds": [
+          "093",
+          "254",
+          "317",
+          "416"
+        ]
+      },
+      {
+        "name": "pediatrics",
+        "measureIds": [
+          "093",
+          "110",
+          "134"
+        ]
+      },
+      {
+        "name": "urgentCare",
+        "measureIds": [
+          "093",
+          "130",
+          "226",
+          "317"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "254",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "emergencyMedicine",
+        "measureIds": [
+          "093",
+          "254",
+          "317",
+          "416"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "416",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "emergencyMedicine",
+        "measureIds": [
+          "093",
+          "254",
+          "317",
+          "416"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "110",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "pediatrics",
+        "measureIds": [
+          "093",
+          "110",
+          "134"
+        ]
+      },
+      {
+        "name": "allergyImmunology",
+        "measureIds": [
+          "110",
+          "111",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "infectiousDisease",
+        "measureIds": [
+          "110",
+          "111",
+          "130"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "111",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "allergyImmunology",
+        "measureIds": [
+          "110",
+          "111",
+          "130",
+          "226",
+          "317"
+        ]
+      },
+      {
+        "name": "infectiousDisease",
+        "measureIds": [
+          "110",
+          "111",
+          "130"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "128",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "podiatry",
+        "measureIds": [
+          "128",
+          "154",
+          "155",
+          "226"
+        ]
+      },
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "128",
+          "130",
+          "181"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "154",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "podiatry",
+        "measureIds": [
+          "128",
+          "154",
+          "155",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "155",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "podiatry",
+        "measureIds": [
+          "128",
+          "154",
+          "155",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "182",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "134",
+          "181",
+          "182",
+          "226"
+        ]
+      },
+      {
+        "name": "chiropracticMedicine",
+        "measureIds": [
+          "182"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "249",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396",
+          "397"
+        ]
+      }
+    ],
+    "clinicalClusters": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "250",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396",
+          "397"
+        ]
+      }
+    ],
+    "clinicalClusters": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "395",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396",
+          "397"
+        ]
+      }
+    ],
+    "clinicalClusters": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "396",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396",
+          "397"
+        ]
+      }
+    ],
+    "clinicalClusters": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "397",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396",
+          "397"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "320",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "endoscopyAndPolypSurveillance",
+        "measureIds": [
+          "320",
+          "425"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "425",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "endoscopyAndPolypSurveillance",
+        "measureIds": [
+          "320",
+          "425"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "405",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "computedTomography",
+        "measureIds": [
+          "405",
+          "406",
+          "436"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "406",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "computedTomography",
+        "measureIds": [
+          "405",
+          "406",
+          "436"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "436",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "computedTomography",
+        "measureIds": [
+          "405",
+          "406",
+          "436"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "147",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "diagnosticImaging",
+        "measureIds": [
+          "145",
+          "147",
+          "195",
+          "225"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "195",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "diagnosticImaging",
+        "measureIds": [
+          "145",
+          "147",
+          "195",
+          "225"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "225",
+    "submissionMethod": "claims",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "diagnosticImaging",
+        "measureIds": [
+          "145",
+          "147",
+          "195",
+          "225"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "005",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "hospitalists",
+        "measureIds": [
+          "005",
+          "008",
+          "047",
+          "076",
+          "130"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "008",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "hospitalists",
+        "measureIds": [
+          "005",
+          "008",
+          "047",
+          "076",
+          "130"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "047",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "hospitalists",
+        "measureIds": [
+          "005",
+          "008",
+          "047",
+          "076",
+          "130"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "076",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "hospitalists",
+        "measureIds": [
+          "005",
+          "008",
+          "047",
+          "076",
+          "130"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "130",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "hospitalists",
+        "measureIds": [
+          "005",
+          "008",
+          "047",
+          "076",
+          "130"
+        ]
+      },
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "128",
+          "130",
+          "181",
+          "431"
+        ]
+      },
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "134",
+          "181",
+          "182",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "102",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "radiationOncology",
+        "measureIds": [
+          "102",
+          "143",
+          "144"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "143",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "radiationOncology",
+        "measureIds": [
+          "102",
+          "143",
+          "144"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "144",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "radiationOncology",
+        "measureIds": [
+          "102",
+          "143",
+          "144"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "128",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "128",
+          "130",
+          "181",
+          "431"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "181",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "128",
+          "130",
+          "181",
+          "431"
+        ]
+      },
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "134",
+          "181",
+          "182",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "431",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "nutritionDietician",
+        "measureIds": [
+          "128",
+          "130",
+          "181",
+          "431"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "134",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "134",
+          "181",
+          "182",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "182",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "134",
+          "181",
+          "182",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "226",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "speechLanguagePathology",
+        "measureIds": [
+          "130",
+          "134",
+          "181",
+          "182",
+          "226"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "392",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "electrophysiologyCardiacSpecialist",
+        "measureIds": [
+          "392",
+          "393"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "393",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "specialtySets": [
+      {
+        "name": "electrophysiologyCardiacSpecialist",
+        "measureIds": [
+          "392",
+          "393"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "185",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "endoscopyAndPolypSurveillance",
+        "measureIds": [
+          "185",
+          "320",
+          "425",
+          "439"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "320",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "endoscopyAndPolypSurveillance",
+        "measureIds": [
+          "185",
+          "320",
+          "425",
+          "439"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "425",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "endoscopyAndPolypSurveillance",
+        "measureIds": [
+          "185",
+          "320",
+          "425",
+          "439"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "439",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "endoscopyAndPolypSurveillance",
+        "measureIds": [
+          "185",
+          "320",
+          "425",
+          "439"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "322",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "cardiacStressImaging",
+        "measureIds": [
+          "322",
+          "323",
+          "324"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "323",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "cardiacStressImaging",
+        "measureIds": [
+          "322",
+          "323",
+          "324"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "324",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "cardiacStressImaging",
+        "measureIds": [
+          "322",
+          "323",
+          "324"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "249",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "250",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "395",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "396",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "pathology",
+        "measureIds": [
+          "249",
+          "250",
+          "395",
+          "396"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "397",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "pathologySkinCancer",
+        "measureIds": [
+          "397",
+          "440"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "440",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "pathologySkinCancer",
+        "measureIds": [
+          "397",
+          "440"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "404",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "anesthesiologyCare",
+        "measureIds": [
+          "404",
+          "424",
+          "430",
+          "463",
+          "477"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "424",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "anesthesiologyCare",
+        "measureIds": [
+          "404",
+          "424",
+          "430",
+          "463",
+          "477"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "430",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "anesthesiologyCare",
+        "measureIds": [
+          "404",
+          "424",
+          "430",
+          "463",
+          "477"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "463",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "anesthesiologyCare",
+        "measureIds": [
+          "404",
+          "424",
+          "430",
+          "463",
+          "477"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "477",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2020,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "anesthesiologyCare",
+        "measureIds": [
+          "404",
+          "424",
+          "430",
+          "463",
+          "477"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "167",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "cabgCare",
+        "measureIds": [
+          "167",
+          "168",
+          "445"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "168",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "cabgCare",
+        "measureIds": [
+          "167",
+          "168",
+          "445"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "445",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "cabgCare",
+        "measureIds": [
+          "167",
+          "168",
+          "445"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "191",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "cataractCare",
+        "measureIds": [
+          "191",
+          "303",
+          "304",
+          "389"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "303",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "cataractCare",
+        "measureIds": [
+          "191",
+          "303",
+          "304",
+          "389"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "304",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "cataractCare",
+        "measureIds": [
+          "191",
+          "303",
+          "304",
+          "389"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "389",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "cataractCare",
+        "measureIds": [
+          "191",
+          "303",
+          "304",
+          "389"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "145",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "diagnosticImaging",
+        "measureIds": [
+          "145",
+          "147",
+          "195",
+          "225"
+        ]
+      },
+      {
+        "name": "interventionalRadiology",
+        "measureIds": [
+          "145",
+          "409",
+          "413",
+          "465"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "147",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "diagnosticImaging",
+        "measureIds": [
+          "145",
+          "147",
+          "195",
+          "225"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "195",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "diagnosticImaging",
+        "measureIds": [
+          "145",
+          "147",
+          "195",
+          "225"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "225",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "diagnosticImaging",
+        "measureIds": [
+          "145",
+          "147",
+          "195",
+          "225"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "360",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "computedTomography",
+        "measureIds": [
+          "360",
+          "364",
+          "405",
+          "406",
+          "436"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "364",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "computedTomography",
+        "measureIds": [
+          "360",
+          "364",
+          "405",
+          "406",
+          "436"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "405",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "computedTomography",
+        "measureIds": [
+          "360",
+          "364",
+          "405",
+          "406",
+          "436"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "406",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "computedTomography",
+        "measureIds": [
+          "360",
+          "364",
+          "405",
+          "406",
+          "436"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "436",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "computedTomography",
+        "measureIds": [
+          "360",
+          "364",
+          "405",
+          "406",
+          "436"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "021",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "surgicalCare",
+        "measureIds": [
+          "021",
+          "023",
+          "355",
+          "357",
+          "358"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "023",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "surgicalCare",
+        "measureIds": [
+          "021",
+          "023",
+          "355",
+          "357",
+          "358"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "355",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "surgicalCare",
+        "measureIds": [
+          "021",
+          "023",
+          "355",
+          "357",
+          "358"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "357",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "surgicalCare",
+        "measureIds": [
+          "021",
+          "023",
+          "355",
+          "357",
+          "358"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "358",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "surgicalCare",
+        "measureIds": [
+          "021",
+          "023",
+          "355",
+          "357",
+          "358"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "141",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "internalEyeCare",
+        "measureIds": [
+          "141",
+          "384",
+          "385"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "384",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "internalEyeCare",
+        "measureIds": [
+          "141",
+          "384",
+          "385"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "385",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "internalEyeCare",
+        "measureIds": [
+          "141",
+          "384",
+          "385"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "409",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "interventionalRadiology",
+        "measureIds": [
+          "145",
+          "409",
+          "413",
+          "465"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "413",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "interventionalRadiology",
+        "measureIds": [
+          "145",
+          "409",
+          "413",
+          "465"
+        ]
+      }
+    ]
+  },
+  {
+    "measureId": "465",
+    "submissionMethod": "registry",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "clinicalClusters": [
+      {
+        "name": "interventionalRadiology",
+        "measureIds": [
+          "145",
+          "409",
+          "413",
+          "465"
+        ]
+      }
+    ]
+  }
+]

--- a/scripts/clinical-clusters/build-clinical-clusters
+++ b/scripts/clinical-clusters/build-clinical-clusters
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-currentPerformanceYear=2020
+currentPerformanceYear=2021
 
 # generate EMA cluster data
 echo "Generating clinical cluster :"

--- a/scripts/clinical-clusters/ema-clinical-cluster-builder.js
+++ b/scripts/clinical-clusters/ema-clinical-cluster-builder.js
@@ -22,7 +22,7 @@ const _ = require('lodash');
 const parse = require('csv-parse/lib/sync');
 
 const MAX_SPECIALITY_SET_SIZE = 6;
-const SUPPORTED_PERFORMANCE_YEARS = [2017, 2018, 2019, 2020];
+const SUPPORTED_PERFORMANCE_YEARS = [2017, 2018, 2019, 2020, 2021];
 
 let measuresJson = '';
 const performanceYear = parseInt(process.argv[2], 10);
@@ -50,6 +50,10 @@ const specialSpecialtySetRelations = {
     registry: []
   },
   2020: {
+    claims: [],
+    registry: []
+  },
+  2021: {
     claims: [],
     registry: []
   }
@@ -137,6 +141,10 @@ const specialClusterRelations = {
     ]
   },
   2020: {
+    claims: [],
+    registry: []
+  },
+  2021: {
     claims: [],
     registry: []
   }

--- a/util/clinical-clusters/2021/ClaimsClinical_Cluster.csv
+++ b/util/clinical-clusters/2021/ClaimsClinical_Cluster.csv
@@ -1,0 +1,17 @@
+Title,Quality ID
+Pathology,249
+Pathology,250
+Pathology,395
+Pathology,396
+SurgicalCare,21
+SurgicalCare,23
+endoscopyAndPolypSurveillance,320
+endoscopyAndPolypSurveillance,425
+computedTomography,405
+computedTomography,406
+computedTomography,436
+diagnosticImaging,145
+diagnosticImaging,147
+diagnosticImaging,195
+diagnosticImaging,225
+interventionalRadiology,145

--- a/util/clinical-clusters/2021/RegistryClinicalCluster.csv
+++ b/util/clinical-clusters/2021/RegistryClinicalCluster.csv
@@ -1,0 +1,47 @@
+Title,Quality ID
+Endoscopy and Polyp Surveillance,185
+Endoscopy and Polyp Surveillance,320
+Endoscopy and Polyp Surveillance,425
+Endoscopy and Polyp Surveillance,439
+Cardiac Stress Imaging,322
+Cardiac Stress Imaging,323
+Cardiac Stress Imaging,324
+Pathology,249
+Pathology,250
+Pathology,395
+Pathology,396
+Pathology Skin Cancer,397
+Pathology Skin Cancer,440
+Anesthesiology Care,404
+Anesthesiology Care,424
+Anesthesiology Care,430
+Anesthesiology Care,463
+Anesthesiology Care,477
+CABG Care,167
+CABG Care,168
+CABG Care,445
+Cataract Care,191
+Cataract Care,303
+Cataract Care,304
+Cataract Care,389
+Diagnostic Imaging,145
+Diagnostic Imaging,147
+Diagnostic Imaging,195
+Diagnostic Imaging,225
+Computed Tomography,360
+Computed Tomography,364
+Computed Tomography,405
+Computed Tomography,406
+Computed Tomography,436
+Surgical Care,021
+Surgical Care,023
+Surgical Care,355
+Surgical Care,357
+Surgical Care,358
+Internal Eye Care,141
+Internal Eye Care,384
+Internal Eye Care,385
+Interventional Radiology,145
+Interventional Radiology,409
+Interventional Radiology,413
+Interventional Radiology,465


### PR DESCRIPTION
#### Motivation for change

Y5 update for EMA Specialty Sets and Clinical Clusters

Edit: 
- Manually entered the 2022 EMA Clinical Clusters and Specialty sets as a copy of Y5 EMA SS's and CC's.
  - This is for ScoringEngines ability to fail gracefully on Y6 EMA. CC: @shadford 

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [ ] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [ ] Unit tests added/passing
* [ ] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPSF-8670
