### PR TITLE
Publish Release v4.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",


### PR DESCRIPTION
#### Motivation for change

Publish Release  Release/4.9.0

#### What is being changed

## Changes

- [QPPSF-8670](https://jira.cms.gov/browse/QPPSF-8670): Update 2021 EMA Specialty Sets and Clinical Clusters (#482)
- [QPPA-4742](https://jira.cms.gov/browse/QPPA-4742):  Remove nutritionDietician measureSet from 2021 measure 001 (#480)

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [ X ] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [ ] Unit tests added/passing
* [ ] Verified working locally

