### PR TITLE
QPPSF-8478 - Initial 2022 Benchmarks

### DIFF
--- a/benchmarks/2022.json
+++ b/benchmarks/2022.json
@@ -3,20 +3,40 @@
     "measureId": "001",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      79.99,
+      70,
+      60,
+      50,
+      40,
+      30,
+      20,
+      10
+    ]
+  },
+  {
+    "measureId": "001",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      90.5,
-      69.42,
-      53.6,
-      42.11,
-      34.06,
-      28.32,
-      23.56,
-      19.1
+      79.99,
+      70,
+      60,
+      50,
+      40,
+      30,
+      20,
+      10
     ]
   },
   {
@@ -29,14 +49,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      90.69,
-      72.51,
-      55.17,
-      41.98,
-      32.56,
-      25.48,
-      19.15,
-      12.87
+      79.99,
+      70,
+      60,
+      50,
+      40,
+      30,
+      20,
+      10
     ]
   },
   {
@@ -49,14 +69,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      1.09,
-      65.52,
-      71.95,
-      75.28,
-      78.09,
-      80.47,
-      82.98,
-      86.36
+      70.26,
+      75.76,
+      78.65,
+      81.82,
+      85.47,
+      88.89,
+      92.31,
+      95.4
     ]
   },
   {
@@ -66,13 +86,13 @@
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": false,
-    "isToppedOutByProgram": false,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      90,
-      95.71,
-      98.02,
-      99.27,
+      92.31,
+      96.3,
+      98.31,
+      100,
       100,
       100,
       100,
@@ -89,13 +109,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      77.58,
-      82.98,
-      86.98,
-      90.35,
-      93.27,
-      95.87,
-      98.94,
+      77.91,
+      83.12,
+      86.51,
+      89.43,
+      92.63,
+      95.91,
+      99.67,
       100
     ]
   },
@@ -109,14 +129,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      45.83,
-      71.57,
-      83.88,
-      88.75,
-      91.79,
-      94.11,
-      95.79,
-      97.75
+      82.14,
+      84.66,
+      86.56,
+      88.33,
+      90,
+      91.67,
+      93.52,
+      96
     ]
   },
   {
@@ -129,12 +149,12 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      49.07,
-      74.04,
-      84.79,
-      91.93,
-      94.72,
-      97.73,
+      80.65,
+      86.81,
+      90,
+      91.86,
+      96.92,
+      100,
       100,
       100
     ]
@@ -144,19 +164,19 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": true,
+    "isToppedOut": false,
     "isHighPriority": false,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      86.69,
-      90.14,
-      92.31,
-      94.05,
-      95.24,
-      96.37,
-      97.44,
-      100
+      84.96,
+      87.76,
+      90.11,
+      91.29,
+      92.58,
+      94.26,
+      95.62,
+      97.34
     ]
   },
   {
@@ -170,8 +190,8 @@
     "deciles": [
       0,
       95,
-      97.5,
-      99.14,
+      97.56,
+      99.1,
       100,
       100,
       100,
@@ -189,14 +209,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      65.38,
-      70.69,
-      74.34,
-      78.04,
-      80.95,
-      83.77,
-      86.67,
-      90.56
+      66.3,
+      74.23,
+      78.18,
+      80.43,
+      82.5,
+      84.65,
+      86.73,
+      90.91
     ]
   },
   {
@@ -209,34 +229,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      83.62,
-      88.72,
-      92.31,
-      95.06,
-      96.97,
-      98.33,
-      99.29,
-      100
-    ]
-  },
-  {
-    "measureId": "014",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
+      79.71,
+      86.74,
+      91.39,
+      94.85,
+      96.84,
+      98.26,
+      99.17,
+      99.89
     ]
   },
   {
@@ -249,12 +249,12 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      86.18,
-      91.75,
-      95.02,
-      96.93,
-      98.52,
-      99.59,
+      88.05,
+      92.59,
+      95.85,
+      97.87,
+      99.34,
+      100,
       100,
       100
     ]
@@ -269,14 +269,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      54.33,
-      66.67,
-      75.34,
-      81.6,
-      87.18,
-      91.37,
-      95.08,
-      97.88
+      62.5,
+      72.41,
+      80.37,
+      85.83,
+      90.32,
+      93.71,
+      96.87,
+      99.03
     ]
   },
   {
@@ -289,233 +289,113 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      83.62,
+      79.11,
+      90.91,
+      96.92,
+      99.65,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "024",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      12.07,
+      45,
+      61.65,
+      77.97,
+      87.36,
+      97.06,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "039",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      35.96,
+      47,
+      60,
+      70.68,
+      78.46,
+      88.6,
+      97.58,
+      100
+    ]
+  },
+  {
+    "measureId": "039",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      17.3,
+      31.01,
+      45.23,
+      56.71,
+      66.27,
+      75.3,
+      83.33,
+      95.6
+    ]
+  },
+  {
+    "measureId": "047",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      83.21,
+      98.46,
+      99.77,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "047",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      27.11,
+      51.83,
+      71.89,
+      85.05,
       93.53,
-      97.83,
-      99.93,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "021",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "021",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      78.79,
-      97.51,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "023",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "023",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      95.45,
-      99.91,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "024",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      79.31,
-      94.24,
-      96.08,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "024",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      14.13,
-      36.36,
-      78.07,
-      82.88,
-      87.88,
-      93.75,
-      99.8,
-      100
-    ]
-  },
-  {
-    "measureId": "039",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      37.13,
-      49.57,
-      59.31,
-      66.38,
-      76.03,
-      87.21,
-      96.34,
-      100
-    ]
-  },
-  {
-    "measureId": "039",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      13.41,
-      28.59,
-      39.8,
-      51.49,
-      61.47,
-      70.35,
-      79.68,
-      90.85
-    ]
-  },
-  {
-    "measureId": "044",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      94.29,
-      96.51,
-      98.57,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "047",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      84.39,
-      97.46,
-      99.7,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "047",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      20.33,
-      43.84,
-      64.44,
-      79.02,
-      89.24,
-      95.6,
-      98.95,
+      98.27,
+      99.77,
       100
     ]
   },
@@ -529,33 +409,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      23.56,
-      40.07,
-      57.38,
-      73.75,
-      82.39,
-      93.05,
-      98.54,
-      100
-    ]
-  },
-  {
-    "measureId": "050",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      97.56,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
+      17.86,
+      37.82,
+      57.45,
+      71.43,
+      85.6,
+      95.62,
+      99.67,
       100
     ]
   },
@@ -569,12 +429,12 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      57.62,
-      74.66,
-      84.46,
-      90.28,
-      95.86,
-      99.85,
+      53.01,
+      72.18,
+      84.29,
+      91.38,
+      96.6,
+      100,
       100,
       100
     ]
@@ -589,11 +449,11 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      84.62,
-      95,
-      98.29,
-      99.67,
-      100,
+      70.09,
+      81.32,
+      90.9,
+      97.95,
+      99.82,
       100,
       100,
       100
@@ -609,112 +469,52 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      76.15,
-      80.79,
+      81.7,
+      85.42,
+      88.33,
+      90.91,
+      92.95,
+      95.43,
+      97.73,
+      100
+    ]
+  },
+  {
+    "measureId": "066",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      57.92,
+      68.75,
+      75.45,
+      80.91,
+      85.17,
+      88.17,
+      92.04,
+      95.83
+    ]
+  },
+  {
+    "measureId": "066",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
       84.39,
-      87.1,
-      90.11,
-      92.86,
-      95.58,
-      100
-    ]
-  },
-  {
-    "measureId": "065",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      93.33,
-      95.45,
-      97.14,
-      98.44,
-      99.41,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "066",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      52.34,
-      67.16,
-      76.08,
-      81.75,
-      85.53,
-      87.84,
-      90.69,
-      94.46
-    ]
-  },
-  {
-    "measureId": "066",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      80.85,
-      88.09,
-      93.1,
-      97.11,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "067",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      96.41,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "070",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      64.44,
-      98.46,
-      100,
-      100,
-      100,
-      100,
+      88.73,
+      91.84,
+      93.9,
+      95.65,
+      97.3,
       100,
       100
     ]
@@ -729,7 +529,7 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      99.7,
+      100,
       100,
       100,
       100,
@@ -749,29 +549,9 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      97.2,
-      99.43,
+      95.92,
+      99.31,
       100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "093",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      93.55,
-      96.3,
-      98.11,
       100,
       100,
       100,
@@ -789,32 +569,12 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      83.89,
-      89.46,
-      92.86,
-      95.52,
-      97.26,
-      98.84,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "102",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      90.61,
-      97.12,
-      100,
-      100,
-      100,
-      100,
+      86.36,
+      91.3,
+      94.03,
+      96.18,
+      97.5,
+      99.23,
       100,
       100
     ]
@@ -829,8 +589,8 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      95.85,
-      99.61,
+      83.62,
+      94.25,
       100,
       100,
       100,
@@ -849,14 +609,74 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      2.04,
-      4.76,
-      10.48,
-      22.13,
-      37.61,
-      57.23,
-      72.49,
-      92.62
+      1.15,
+      2.7,
+      7.37,
+      14.62,
+      28.77,
+      46.53,
+      71.6,
+      90.8
+    ]
+  },
+  {
+    "measureId": "110",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      63.2,
+      78.85,
+      87.24,
+      93.68,
+      98.71,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "110",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      18.75,
+      28.57,
+      36.95,
+      44.21,
+      51.26,
+      58.63,
+      67.61,
+      80.4
+    ]
+  },
+  {
+    "measureId": "110",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      35.39,
+      50.61,
+      62.47,
+      74.26,
+      84.63,
+      92.76,
+      98.47,
+      100
     ]
   },
   {
@@ -869,12 +689,12 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      68.68,
-      76.32,
-      82.47,
-      87.57,
-      93.09,
-      97.9,
+      67.34,
+      75.93,
+      81.11,
+      86.88,
+      92.79,
+      97.7,
       100,
       100
     ]
@@ -889,14 +709,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      20.44,
-      33.72,
-      44.7,
-      54.86,
-      63.22,
-      71.1,
-      78.8,
-      87.93
+      20.82,
+      35.06,
+      46.56,
+      56.48,
+      64.72,
+      72.56,
+      79.89,
+      88.32
     ]
   },
   {
@@ -909,14 +729,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      35.11,
-      51.29,
-      61.9,
-      69.16,
+      42.58,
+      55.58,
+      64.5,
+      70.3,
       75,
-      79.9,
-      85.83,
-      95
+      79.63,
+      85.88,
+      96.3
     ]
   },
   {
@@ -929,13 +749,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      66.67,
-      77.08,
-      84.88,
-      89.63,
-      93.48,
-      97.36,
-      99.03,
+      64.66,
+      75,
+      81.66,
+      86.45,
+      91.04,
+      95.83,
+      98.85,
       100
     ]
   },
@@ -949,14 +769,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      24.44,
-      37.14,
-      46.32,
-      54.41,
-      61.11,
-      67.23,
-      73.95,
-      82.02
+      24.92,
+      36.04,
+      45.5,
+      52.87,
+      59.4,
+      65.41,
+      72.12,
+      80.69
     ]
   },
   {
@@ -969,14 +789,34 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      22.37,
-      40,
-      50.98,
-      60.27,
-      70.21,
-      78.11,
-      85.85,
-      97.36
+      24.55,
+      41.5,
+      51.25,
+      60.65,
+      68.28,
+      74.87,
+      84.78,
+      97.67
+    ]
+  },
+  {
+    "measureId": "113",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      57.94,
+      70.47,
+      82.01,
+      89.67,
+      95.57,
+      99.32,
+      100,
+      100
     ]
   },
   {
@@ -989,32 +829,52 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      15.15,
-      27.52,
-      38.74,
-      49.05,
-      58.31,
-      67.55,
-      76.06,
-      85.06
+      16.32,
+      28.66,
+      40,
+      49.25,
+      57.83,
+      66.74,
+      74.99,
+      84.37
     ]
   },
   {
-    "measureId": "116",
+    "measureId": "113",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
+    "isToppedOut": false,
+    "isHighPriority": false,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      62.33,
-      76,
-      86.36,
-      93.33,
-      96.92,
-      98.43,
+      17.93,
+      34.8,
+      51.81,
+      61.06,
+      74.19,
+      82.04,
+      92.41,
+      99.43
+    ]
+  },
+  {
+    "measureId": "117",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
       100,
       100
     ]
@@ -1029,14 +889,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      12,
-      20.55,
-      30.69,
-      44.82,
-      69.4,
-      94.17,
-      98.43,
-      99.93
+      13.19,
+      22.03,
+      31.86,
+      44.62,
+      65.97,
+      95.94,
+      99.14,
+      100
     ]
   },
   {
@@ -1049,10 +909,10 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      89.93,
-      96.68,
-      98.86,
-      99.7,
+      94.31,
+      97.86,
+      99.33,
+      99.86,
       100,
       100,
       100,
@@ -1069,14 +929,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      72.73,
-      76.32,
-      79.61,
-      81.85,
-      85,
-      86.83,
-      90.48,
-      96
+      71.43,
+      75.61,
+      78.25,
+      81.39,
+      84.21,
+      86.99,
+      92,
+      100
     ]
   },
   {
@@ -1089,14 +949,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      70.31,
-      76.92,
-      81.55,
-      85.23,
-      88.24,
-      91.41,
-      94.78,
-      98.55
+      72.45,
+      77.78,
+      81.71,
+      84.67,
+      87.35,
+      90.43,
+      93.98,
+      98.87
     ]
   },
   {
@@ -1109,12 +969,12 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      71.17,
-      79.48,
-      86.67,
-      91.81,
-      96.23,
-      98.68,
+      70.74,
+      79.51,
+      85.06,
+      89.74,
+      94.03,
+      98.1,
       100,
       100
     ]
@@ -1124,16 +984,16 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": false,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      59.55,
-      74.76,
-      86.49,
-      94.87,
-      99.32,
+      73.01,
+      84.97,
+      93.58,
+      98.56,
+      100,
       100,
       100,
       100
@@ -1144,16 +1004,16 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": false,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      58.76,
-      74.03,
-      85.06,
-      94.65,
-      99.18,
+      66.3,
+      80.12,
+      92.71,
+      98.7,
+      100,
       100,
       100,
       100
@@ -1169,9 +1029,9 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      91.47,
+      92.37,
       98.58,
-      99.73,
+      99.72,
       100,
       100,
       100,
@@ -1189,14 +1049,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      23.26,
-      27.42,
-      32.65,
-      40.91,
-      53.43,
-      69.27,
-      83.8,
-      95.12
+      23.35,
+      28.14,
+      34.68,
+      43.57,
+      56.81,
+      73.6,
+      86.18,
+      95.39
     ]
   },
   {
@@ -1209,13 +1069,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      32.73,
-      51.06,
-      70.17,
-      84.69,
-      93.28,
-      98.06,
-      99.76,
+      35.17,
+      55.72,
+      76.04,
+      88.51,
+      95.81,
+      99.08,
+      100,
       100
     ]
   },
@@ -1230,7 +1090,7 @@
     "deciles": [
       0,
       99.67,
-      99.94,
+      99.97,
       100,
       100,
       100,
@@ -1249,14 +1109,14 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      83.73,
-      91.28,
-      94.91,
-      97,
-      98.31,
-      99.18,
-      99.7,
-      99.95
+      80.38,
+      88.24,
+      92.36,
+      95.26,
+      97.17,
+      98.42,
+      99.33,
+      99.9
     ]
   },
   {
@@ -1269,11 +1129,11 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      86.71,
-      96.32,
-      98.95,
-      99.68,
-      99.91,
+      77.92,
+      90.47,
+      95.6,
+      98.15,
+      99.69,
       100,
       100,
       100
@@ -1289,7 +1149,7 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      95.94,
+      95.29,
       99.51,
       100,
       100,
@@ -1303,19 +1163,39 @@
     "measureId": "134",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      6.33,
+      12.67,
+      20.8,
+      30.77,
+      42.72,
+      55.96,
+      70.44,
+      87.36
+    ]
+  },
+  {
+    "measureId": "134",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
     "submissionMethod": "registry",
     "isToppedOut": false,
     "isHighPriority": false,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      14.76,
-      37.44,
-      55.93,
-      71.74,
-      84.69,
-      95.56,
-      99.22,
+      34.63,
+      60.11,
+      79.7,
+      89.61,
+      97.14,
+      99.42,
+      100,
       100
     ]
   },
@@ -1329,8 +1209,8 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      95,
-      98.84,
+      98.18,
+      100,
       100,
       100,
       100,
@@ -1349,9 +1229,9 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      75.51,
-      92.59,
-      98.81,
+      81.28,
+      96,
+      100,
       100,
       100,
       100,
@@ -1389,12 +1269,12 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      32.62,
-      60.32,
-      82.14,
-      93.48,
-      98.55,
-      100,
+      46.38,
+      69.03,
+      81.82,
+      90.44,
+      95.42,
+      98.28,
       100,
       100
     ]
@@ -1404,19 +1284,19 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      67.56,
-      85.32,
-      91.89,
-      95.34,
-      97.07,
-      97.96,
-      98.8,
-      99.81
+      75.43,
+      87.06,
+      92.86,
+      95.99,
+      97.44,
+      98.32,
+      98.99,
+      99.83
     ]
   },
   {
@@ -1429,10 +1309,10 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      93.65,
-      97.66,
-      99.21,
-      99.84,
+      90.07,
+      95.87,
+      98.6,
+      99.56,
       100,
       100,
       100,
@@ -1440,158 +1320,138 @@
     ]
   },
   {
-    "measureId": "145",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      85.71,
-      94.44,
-      97.62,
-      99.19,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "145",
+    "measureId": "144",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      86.61,
-      95.48,
-      98.41,
-      99.73,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "147",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      71.43,
-      85.71,
-      95.45,
-      98.46,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "147",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      93.66,
-      98.92,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "154",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      99.07,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "154",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      87.86,
-      96.13,
-      98.82,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "155",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      87.5,
-      98.08,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "155",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
+    "isToppedOut": false,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      85.88,
-      93.88,
-      97.84,
+      66.67,
+      78.72,
+      87.39,
+      93.22,
+      96.8,
+      98.97,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "145",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      76.12,
+      89.83,
+      96,
+      99.7,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "145",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      93.69,
+      99,
+      99.92,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "147",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      60.77,
+      82.22,
+      95.24,
+      98.33,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "147",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      97.16,
+      99.78,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "155",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      95.74,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "155",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      93.1,
+      97.9,
+      100,
       100,
       100,
       100,
@@ -1609,13 +1469,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      8.8,
-      7.69,
-      5.87,
-      5,
-      3.52,
-      2.63,
-      1.59,
+      9.52,
+      7.89,
+      5.66,
+      5.17,
+      3.85,
+      3.45,
+      2.7,
       0
     ]
   },
@@ -1629,12 +1489,12 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      3.6,
-      2.44,
-      2.04,
-      1.47,
-      1.22,
-      0.55,
+      3.96,
+      3.51,
+      2.55,
+      1.96,
+      1.51,
+      0.95,
       0,
       0
     ]
@@ -1649,13 +1509,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      3.04,
-      2.48,
-      2.14,
-      1.55,
-      1.21,
-      0.48,
-      0,
+      4.2,
+      3.46,
+      2.67,
+      2.3,
+      1.7,
+      1.6,
+      0.58,
       0
     ]
   },
@@ -1664,16 +1524,16 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": false,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      51.61,
-      77.63,
-      89.71,
-      93.2,
-      97.37,
+      60,
+      81.97,
+      90.91,
+      97.95,
+      100,
       100,
       100,
       100
@@ -1689,13 +1549,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      65.49,
-      75.2,
-      85.38,
-      91.04,
-      95.22,
-      98.23,
-      99.67,
+      47.31,
+      69.95,
+      78.04,
+      87.6,
+      92.81,
+      98.92,
+      100,
       100
     ]
   },
@@ -1709,11 +1569,11 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      76.28,
-      89.4,
-      94.26,
-      97.72,
-      99.03,
+      87.85,
+      92.45,
+      96.71,
+      99.07,
+      100,
       100,
       100,
       100
@@ -1726,11 +1586,11 @@
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": false,
-    "isToppedOutByProgram": false,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      98.26,
-      99.69,
+      100,
+      100,
       100,
       100,
       100,
@@ -1749,69 +1609,49 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      98.88,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "181",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      58.52,
-      78.66,
-      89.13,
-      95.66,
-      98.92,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "182",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      99.56,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "182",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      98.57,
-      99.59,
+      99.1,
       99.84,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "181",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      92.48,
+      97.81,
+      99.6,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "182",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      98.52,
+      99.66,
+      99.87,
       100,
       100,
       100,
@@ -1824,17 +1664,17 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      44.62,
       81.25,
-      90.59,
-      95.74,
-      98.05,
-      99.55,
+      89.37,
+      97.87,
+      99.49,
+      100,
+      100,
       100,
       100
     ]
@@ -1849,12 +1689,12 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      82.74,
-      88.32,
-      91.67,
-      93.55,
-      95.45,
-      97.22,
+      86.46,
+      93.42,
+      96.15,
+      100,
+      100,
+      100,
       100,
       100
     ]
@@ -1869,13 +1709,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      88.04,
-      93.46,
-      95.71,
-      97.13,
-      98.23,
-      98.86,
-      99.5,
+      88.67,
+      93.02,
+      95.35,
+      96.83,
+      97.97,
+      98.81,
+      99.64,
       100
     ]
   },
@@ -1889,30 +1729,10 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      94.17,
-      96.3,
-      97.44,
-      98.45,
-      99.45,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "195",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      97.77,
-      99.4,
-      100,
-      100,
+      92.83,
+      95.52,
+      97.33,
+      98.55,
       100,
       100,
       100,
@@ -1920,47 +1740,7 @@
     ]
   },
   {
-    "measureId": "195",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      99.28,
-      99.84,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "225",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "225",
+    "measureId": "217",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
@@ -1969,12 +1749,172 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
+      42.22,
+      44.9,
+      48.28,
+      50.79,
+      54.21,
+      60.23,
+      68,
+      81.82
+    ]
+  },
+  {
+    "measureId": "218",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      36.73,
+      42.63,
+      45.71,
+      50,
+      54.39,
+      58.36,
+      62.86,
+      72.22
+    ]
+  },
+  {
+    "measureId": "219",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      35.48,
+      44,
+      48,
+      51.13,
+      53.85,
+      57.76,
+      63.33,
+      68.75
+    ]
+  },
+  {
+    "measureId": "220",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      39.68,
+      45.79,
+      48.26,
+      54.9,
+      60,
+      65.66,
+      72.06,
+      87.18
+    ]
+  },
+  {
+    "measureId": "221",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      35.44,
+      40.18,
+      43.87,
+      47.05,
+      52.81,
+      59.47,
+      71.23,
+      81.43
+    ]
+  },
+  {
+    "measureId": "222",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      41.41,
+      44.36,
+      49.48,
+      51.92,
+      58.33,
+      61.9,
+      71.93,
+      80
+    ]
+  },
+  {
+    "measureId": "226",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      87.18,
+      95.38,
       100,
       100,
       100,
       100,
       100,
-      100,
+      100
+    ]
+  },
+  {
+    "measureId": "226",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      18.92,
+      25.81,
+      34.17,
+      44.44,
+      56.63,
+      70.37,
+      84.11,
+      95.42
+    ]
+  },
+  {
+    "measureId": "226",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      30.91,
+      49.09,
+      66.67,
+      80.88,
+      90.78,
+      96.46,
       100,
       100
     ]
@@ -2009,14 +1949,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      51.69,
-      57.08,
-      61.33,
-      64.8,
-      68.45,
-      72.04,
-      76.36,
-      82.38
+      51.06,
+      56.31,
+      60.14,
+      63.64,
+      67.05,
+      70.65,
+      74.95,
+      80.84
     ]
   },
   {
@@ -2037,6 +1977,46 @@
       70,
       80,
       90
+    ]
+  },
+  {
+    "measureId": "238",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      12.98,
+      7.56,
+      3.87,
+      1.64,
+      0.63,
+      0.18,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "238",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      3.4,
+      1.33,
+      0.63,
+      0.32,
+      0.16,
+      0.03,
+      0,
+      0
     ]
   },
   {
@@ -2049,14 +2029,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      27.47,
-      30.49,
-      32.13,
-      33.33,
-      34.48,
-      38.54,
-      47.93,
-      63.65
+      25.64,
+      29.13,
+      31.21,
+      32.86,
+      34.67,
+      39.77,
+      49.69,
+      63.88
     ]
   },
   {
@@ -2069,14 +2049,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      17.93,
-      25.54,
-      32.4,
-      36.75,
-      40.19,
-      44.74,
-      49.57,
-      56.86
+      23.44,
+      31.82,
+      37.27,
+      41.63,
+      45.94,
+      50.05,
+      53.23,
+      59.69
     ]
   },
   {
@@ -2089,14 +2069,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      19.02,
-      25.64,
-      31.43,
-      37.14,
-      42.86,
-      48.98,
-      63.71,
-      90.58
+      12.75,
+      17.03,
+      23.76,
+      29.87,
+      36.33,
+      45.84,
+      59.49,
+      90.91
     ]
   },
   {
@@ -2189,12 +2169,12 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      88.64,
-      92.25,
-      95.26,
-      96.77,
-      98.25,
-      99.18,
+      91.09,
+      93.42,
+      95.38,
+      96.7,
+      98.01,
+      99.53,
       100,
       100
     ]
@@ -2209,9 +2189,9 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      78.39,
-      95.41,
-      99.08,
+      85.06,
+      97.2,
+      100,
       100,
       100,
       100,
@@ -2229,13 +2209,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      14.49,
-      24,
-      39.22,
-      50,
-      65.48,
-      89.5,
-      95,
+      12.88,
+      21.24,
+      29.85,
+      53.7,
+      67.57,
+      75.47,
+      100,
       100
     ]
   },
@@ -2249,12 +2229,12 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      24,
-      42.8,
-      58.23,
-      71.65,
-      93.1,
-      99.87,
+      24.14,
+      40.34,
+      58.92,
+      78.79,
+      94.16,
+      100,
       100,
       100
     ]
@@ -2269,10 +2249,10 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      88.15,
-      95.65,
-      98.69,
-      100,
+      78.32,
+      90.91,
+      96.56,
+      99.43,
       100,
       100,
       100,
@@ -2289,14 +2269,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      8.33,
-      13.64,
-      21.74,
-      31.58,
-      44.83,
-      59.74,
-      73.91,
-      91.89
+      7.19,
+      13.04,
+      21.31,
+      30,
+      41.84,
+      56,
+      71.53,
+      88.89
     ]
   },
   {
@@ -2304,15 +2284,15 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": false,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      43.54,
-      68.18,
-      91.04,
-      98.24,
+      83.13,
+      97.2,
+      100,
+      100,
       100,
       100,
       100,
@@ -2329,10 +2309,10 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      75,
-      92.45,
-      96.37,
-      98.68,
+      90.91,
+      99.55,
+      100,
+      100,
       100,
       100,
       100,
@@ -2349,9 +2329,9 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      86.36,
-      93.38,
-      97.67,
+      93.37,
+      99.73,
+      100,
       100,
       100,
       100,
@@ -2364,16 +2344,16 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      43.28,
-      66.67,
-      83.33,
-      95.39,
-      98.33,
+      63.85,
+      92.55,
+      99.19,
+      100,
+      100,
       100,
       100,
       100
@@ -2386,14 +2366,14 @@
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": false,
-    "isToppedOutByProgram": false,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      34.39,
-      57.47,
-      81.08,
-      92.06,
-      98.06,
+      64.07,
+      86.36,
+      94.44,
+      100,
+      100,
       100,
       100,
       100
@@ -2409,10 +2389,10 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      25.57,
-      59.89,
-      89.28,
-      98.94,
+      32.76,
+      73.39,
+      92.06,
+      100,
       100,
       100,
       100,
@@ -2424,16 +2404,16 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": true,
+    "isToppedOut": false,
     "isHighPriority": true,
-    "isToppedOutByProgram": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      48.35,
-      65.71,
-      85.71,
-      93.73,
-      100,
+      15.58,
+      40.2,
+      77.62,
+      84.53,
+      95.28,
       100,
       100,
       100
@@ -2449,14 +2429,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      0.27,
-      0.43,
-      0.64,
-      0.92,
-      1.25,
-      1.85,
-      2.91,
-      7.65
+      0.76,
+      1.06,
+      1.32,
+      1.61,
+      1.94,
+      2.56,
+      3.96,
+      7.05
     ]
   },
   {
@@ -2469,14 +2449,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      11.36,
-      18.37,
-      25,
-      32.29,
-      39.57,
-      46.81,
-      55.56,
-      68.17
+      11.25,
+      17.65,
+      24.56,
+      31.63,
+      38.8,
+      45.89,
+      53.5,
+      65.79
     ]
   },
   {
@@ -2489,14 +2469,74 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      19.88,
-      26.67,
-      32.2,
-      37.66,
-      42.47,
-      47.5,
-      56.07,
-      65.97
+      19.12,
+      26.13,
+      30.74,
+      35.72,
+      40.37,
+      45.83,
+      52.17,
+      63.4
+    ]
+  },
+  {
+    "measureId": "317",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      88.31,
+      97.87,
+      99.47,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "317",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      15.66,
+      20.02,
+      23.68,
+      27.31,
+      30.97,
+      34.83,
+      40.07,
+      49.06
+    ]
+  },
+  {
+    "measureId": "317",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      23.48,
+      30.85,
+      38.37,
+      50,
+      65.12,
+      83.28,
+      96.5,
+      100
     ]
   },
   {
@@ -2509,14 +2549,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      18.81,
-      36.28,
-      52.34,
-      66.65,
-      78.72,
-      87.5,
-      94.19,
-      98.27
+      14.21,
+      30.16,
+      46.37,
+      61.46,
+      74.34,
+      85.18,
+      93.44,
+      98.1
     ]
   },
   {
@@ -2529,8 +2569,8 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      92.68,
-      99.07,
+      81.08,
+      97.44,
       100,
       100,
       100,
@@ -2549,12 +2589,12 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      81.69,
-      89.02,
-      93.3,
-      95.81,
-      97.47,
-      98.61,
+      87.65,
+      93.15,
+      95.35,
+      97.07,
+      98.36,
+      99.62,
       100,
       100
     ]
@@ -2569,8 +2609,8 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      0.33,
-      0,
+      1.22,
+      0.19,
       0,
       0,
       0,
@@ -2589,7 +2629,7 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      0,
+      0.05,
       0,
       0,
       0,
@@ -2609,8 +2649,8 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      2.51,
-      0.71,
+      3.5,
+      0.42,
       0,
       0,
       0,
@@ -2623,37 +2663,17 @@
     "measureId": "326",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      98.63,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "326",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": false,
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      79.1,
-      83.68,
-      88.46,
-      94.51,
-      98.71,
+      82.65,
+      96,
+      99.08,
+      100,
+      100,
       100,
       100,
       100
@@ -2669,13 +2689,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      75.95,
-      62.5,
-      50.12,
-      37.57,
-      25.12,
-      14.81,
-      5.28,
+      65.71,
+      51.85,
+      41.75,
+      30,
+      20.38,
+      10.71,
+      4,
       0
     ]
   },
@@ -2689,33 +2709,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      52.44,
-      61.37,
-      72.64,
-      85.76,
-      89.94,
-      96.13,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "337",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      68,
-      80.77,
-      88.89,
-      94.42,
-      97.54,
-      100,
-      100,
+      69.39,
+      73.58,
+      76.88,
+      81.45,
+      85.71,
+      90.06,
+      98,
       100
     ]
   },
@@ -2729,12 +2729,12 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      76.89,
-      84.21,
-      87.33,
-      91.55,
-      95.37,
-      96.97,
+      77.17,
+      86.34,
+      88.11,
+      92.78,
+      95.56,
+      98.25,
       100,
       100
     ]
@@ -2749,73 +2749,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      54.8,
-      60.09,
-      70,
-      75,
-      84.51,
-      98.48,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "342",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "350",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      99.6,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "351",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      99.36,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
+      50.57,
+      58.06,
+      61.48,
+      68.71,
+      72.22,
+      88.36,
+      96.92,
       100
     ]
   },
@@ -2829,11 +2769,11 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      3.23,
-      1.79,
-      0,
-      0,
-      0,
+      7.8,
+      4.5,
+      3.85,
+      1.89,
+      0.83,
       0,
       0,
       0
@@ -2849,10 +2789,10 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      2.45,
-      1.33,
-      0.79,
-      0.18,
+      3.55,
+      2.02,
+      1.2,
+      0.64,
       0,
       0,
       0,
@@ -2869,11 +2809,11 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      5.76,
-      3.95,
+      6.19,
+      4,
       2.78,
-      1.09,
-      0,
+      2.14,
+      1.06,
       0,
       0,
       0
@@ -2889,9 +2829,9 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      3.33,
-      1.82,
-      0.77,
+      2.71,
+      1.05,
+      0.39,
       0,
       0,
       0,
@@ -2904,15 +2844,15 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      34.62,
-      72.43,
-      91.23,
-      98.51,
+      71.08,
+      88.59,
+      96.85,
+      99.62,
       100,
       100,
       100,
@@ -2929,9 +2869,9 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      85.51,
-      98.77,
-      99.94,
+      67.86,
+      96.48,
+      99.72,
       100,
       100,
       100,
@@ -2946,37 +2886,17 @@
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": true,
-    "isToppedOutByProgram": false,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      95.83,
-      98.11,
-      100,
+      61.97,
+      79.07,
+      96.37,
       100,
       100,
       100,
       100,
       100
-    ]
-  },
-  {
-    "measureId": "366",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      20.31,
-      24.14,
-      29.55,
-      35.95,
-      39.53,
-      45.49,
-      50.59,
-      65.64
     ]
   },
   {
@@ -2989,14 +2909,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      3.65,
-      4.92,
-      6.34,
-      7.61,
-      9.63,
-      12,
-      15,
-      22.03
+      3.67,
+      4.87,
+      6.97,
+      8.33,
+      10.79,
+      13.94,
+      17.65,
+      25.42
     ]
   },
   {
@@ -3009,14 +2929,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      9.72,
-      16.98,
-      25.51,
-      34.93,
-      46.43,
-      60,
-      74.6,
-      89.66
+      7.71,
+      12.5,
+      18.73,
+      26.32,
+      37.1,
+      51.19,
+      66.67,
+      87.32
     ]
   },
   {
@@ -3024,15 +2944,15 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      60,
-      77.55,
-      92.31,
-      97.55,
+      62.79,
+      85.64,
+      94.76,
+      98.62,
       100,
       100,
       100,
@@ -3049,14 +2969,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      8.19,
-      10.32,
-      14.84,
-      21.1,
-      29.09,
-      37.5,
-      51.35,
-      61.03
+      2.65,
+      4.63,
+      6.62,
+      8.89,
+      10.91,
+      13.79,
+      20.73,
+      28.31
     ]
   },
   {
@@ -3069,14 +2989,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      4.73,
-      8.33,
-      11.54,
-      15.83,
-      19.75,
-      33.33,
-      53.57,
-      100
+      4.07,
+      5.34,
+      5.77,
+      9.66,
+      12.68,
+      16.87,
+      20,
+      28.23
     ]
   },
   {
@@ -3089,8 +3009,8 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      0.87,
-      0.38,
+      0.88,
+      0.41,
       0,
       0,
       0,
@@ -3109,14 +3029,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      0.26,
-      0.54,
-      1.1,
-      2.19,
-      3.85,
+      0.18,
+      0.43,
+      0.95,
+      2.14,
+      3.4,
       5.23,
-      7.31,
-      13.67
+      8.58,
+      11.32
     ]
   },
   {
@@ -3129,14 +3049,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      7.45,
-      12.5,
-      19.12,
-      29.8,
-      39.09,
-      47.11,
-      58.71,
-      87.47
+      5.79,
+      12,
+      17.48,
+      28.47,
+      35.85,
+      51.75,
+      59.74,
+      84.15
     ]
   },
   {
@@ -3149,10 +3069,10 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      51.52,
-      80.85,
-      96.52,
-      100,
+      81.08,
+      93.02,
+      95.56,
+      99.32,
       100,
       100,
       100,
@@ -3164,14 +3084,14 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      96,
-      100,
-      100,
+      93.33,
+      96.43,
+      97.92,
       100,
       100,
       100,
@@ -3189,13 +3109,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      30.48,
-      38.54,
-      51.95,
-      71.08,
-      94.46,
-      98.19,
-      100,
+      21.48,
+      29.54,
+      39.35,
+      69.94,
+      92.86,
+      97.14,
+      99.87,
       100
     ]
   },
@@ -3209,14 +3129,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      3.28,
+      5.88,
       7.69,
-      18.59,
-      22.73,
-      23.97,
-      30.43,
-      38.73,
-      46.67
+      12,
+      17.5,
+      21.69,
+      25.56,
+      31.58,
+      40
     ]
   },
   {
@@ -3309,7 +3229,7 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      100,
+      99.26,
       100,
       100,
       100,
@@ -3349,34 +3269,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      33.33,
-      49.29,
-      58.05,
-      80.14,
-      100,
+      33.17,
+      41.12,
+      48.05,
+      69.55,
+      91.28,
       100,
       100,
       100
-    ]
-  },
-  {
-    "measureId": "400",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      1.39,
-      2.03,
-      3.94,
-      9.29,
-      18.03,
-      28.78,
-      43.82,
-      75.53
     ]
   },
   {
@@ -3389,11 +3289,11 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      88.14,
-      93.55,
-      96.55,
-      98.46,
-      99.56,
+      89.41,
+      94.12,
+      96.88,
+      98.64,
+      99.74,
       100,
       100,
       100
@@ -3409,34 +3309,34 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      53.27,
-      62.2,
-      68.18,
-      73.18,
-      79.19,
-      84.43,
-      91.76,
-      98.21
+      59.9,
+      66.67,
+      73.1,
+      78.82,
+      84.72,
+      89.19,
+      92.87,
+      99.89
     ]
   },
   {
-    "measureId": "406",
+    "measureId": "405",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
-    "submissionMethod": "claims",
+    "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": true,
-    "isToppedOutByProgram": true,
+    "isToppedOutByProgram": false,
     "deciles": [
+      0,
+      75.47,
+      88.46,
+      96.36,
+      98.61,
       100,
-      0.4,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
+      100,
+      100,
+      100
     ]
   },
   {
@@ -3449,8 +3349,8 @@
     "isToppedOutByProgram": true,
     "deciles": [
       100,
-      2.27,
-      0,
+      6.67,
+      3.17,
       0,
       0,
       0,
@@ -3469,12 +3369,12 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      56.12,
-      70.59,
-      80,
-      87.88,
-      93.33,
-      97.44,
+      58.22,
+      73.08,
+      84.68,
+      91.76,
+      96.59,
+      100,
       100,
       100
     ]
@@ -3489,13 +3389,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      83.73,
-      90.91,
-      94.44,
-      96.4,
-      97.56,
-      98.55,
-      99.42,
+      82.24,
+      86.73,
+      90.48,
+      94.55,
+      96.62,
+      98.17,
+      99.33,
       100
     ]
   },
@@ -3509,14 +3409,34 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      27.21,
-      20,
-      12.12,
-      5.88,
-      3.45,
-      2.04,
+      25.15,
+      17.92,
+      12.6,
+      9.31,
+      5.56,
+      2.07,
       0,
       0
+    ]
+  },
+  {
+    "measureId": "418",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      3.33,
+      4,
+      5.07,
+      8.09,
+      10.71,
+      15.12,
+      21.62,
+      54.55
     ]
   },
   {
@@ -3526,16 +3446,16 @@
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": true,
-    "isToppedOutByProgram": false,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
-      28.52,
-      16.35,
-      10.43,
-      5.35,
-      3.23,
-      1.62,
-      0.2,
+      23.08,
+      14.41,
+      9.23,
+      5.06,
+      4.35,
+      2.94,
+      1.53,
       0
     ]
   },
@@ -3544,15 +3464,15 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      98.22,
-      99.27,
-      99.69,
-      99.86,
+      98.08,
+      99.28,
+      99.75,
+      99.91,
       99.97,
       100,
       100,
@@ -3563,40 +3483,20 @@
     "measureId": "425",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      98.8,
-      99.44,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "425",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": false,
-    "isToppedOutByProgram": false,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      89.1,
-      94.78,
-      96.73,
-      97.96,
-      98.56,
-      99.13,
-      99.48,
-      99.95
+      92.57,
+      95.25,
+      97.18,
+      98.27,
+      99.02,
+      99.53,
+      99.96,
+      100
     ]
   },
   {
@@ -3609,12 +3509,12 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      96.68,
-      98.18,
-      98.94,
-      99.5,
-      99.78,
-      99.95,
+      98.21,
+      99.2,
+      99.61,
+      99.79,
+      99.91,
+      99.99,
       100,
       100
     ]
@@ -3629,10 +3529,10 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      96.5,
-      98.68,
-      99.57,
-      99.88,
+      96.37,
+      98.67,
+      99.54,
+      99.93,
       100,
       100,
       100,
@@ -3649,9 +3549,9 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      98.96,
-      99.77,
-      99.97,
+      99.54,
+      99.91,
+      99.99,
       100,
       100,
       100,
@@ -3669,14 +3569,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      62.47,
-      66.22,
-      68.97,
-      71.37,
-      73.75,
-      76.08,
-      79.57,
-      83.33
+      65.52,
+      68.69,
+      71,
+      73.12,
+      75.22,
+      77.49,
+      80.2,
+      83.63
     ]
   },
   {
@@ -3689,14 +3589,34 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      67.31,
-      73.03,
-      76.5,
-      82.4,
-      87.44,
-      93.1,
+      69.7,
+      75.54,
+      80.95,
+      85,
+      90.91,
+      99.81,
       100,
       100
+    ]
+  },
+  {
+    "measureId": "439",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
     ]
   },
   {
@@ -3709,8 +3629,8 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      98.36,
-      99.72,
+      99.55,
+      100,
       100,
       100,
       100,
@@ -3729,14 +3649,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      12.76,
-      22.33,
-      27.56,
-      36.45,
-      42.55,
-      48.48,
-      55.56,
-      63.97
+      30.23,
+      39.99,
+      51.49,
+      61.9,
+      67.59,
+      72.55,
+      76.4,
+      80.61
     ]
   },
   {
@@ -3749,12 +3669,12 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      4,
-      2.97,
-      2.4,
-      1.94,
-      1.04,
-      0.67,
+      3.36,
+      2.86,
+      2.54,
+      2.27,
+      1.72,
+      1.23,
       0,
       0
     ]
@@ -3769,13 +3689,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      18.18,
-      15.56,
-      13.95,
-      11.27,
-      10,
-      8.57,
-      6.06,
+      17.86,
+      15.22,
+      13.68,
+      11.3,
+      9.38,
+      6.31,
+      4.76,
       0
     ]
   },
@@ -3789,13 +3709,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      11.32,
-      10,
-      8.16,
-      6.98,
-      4.26,
-      3.03,
-      2.22,
+      14.81,
+      11.26,
+      8.77,
+      5.38,
+      4.15,
+      2.53,
+      1.35,
       0
     ]
   },
@@ -3809,11 +3729,11 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      94.59,
       97.3,
-      98.25,
-      99.08,
-      99.67,
+      98.93,
+      99.74,
+      100,
+      100,
       100,
       100,
       100
@@ -3824,18 +3744,18 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      84.47,
-      87.53,
-      90,
-      92.75,
-      94.54,
-      96.15,
-      97.6,
+      86.79,
+      91.23,
+      93.04,
+      95.59,
+      96.4,
+      97.62,
+      98.47,
       100
     ]
   },
@@ -3846,7 +3766,7 @@
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": true,
     "isHighPriority": true,
-    "isToppedOutByProgram": false,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       0,
@@ -3869,18 +3789,18 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      1.46,
-      2.45,
-      5.32,
-      9.49,
-      25.51,
-      100,
-      100,
-      100
+      3.56,
+      6.42,
+      9.16,
+      12.32,
+      15.84,
+      19.07,
+      23.62,
+      33.18
     ]
   },
   {
-    "measureId": "AAAAI6",
+    "measureId": "477",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
@@ -3889,18 +3809,18 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
+      80.46,
+      85.95,
+      91.92,
+      96.16,
+      98.71,
+      99.6,
+      99.93,
       100
     ]
   },
   {
-    "measureId": "AAAAI8",
+    "measureId": "478",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
@@ -3909,10 +3829,70 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      99.72,
-      99.73,
-      99.77,
+      38.72,
+      43.28,
+      47.62,
+      49.29,
+      55.22,
+      66.08,
+      70.37,
+      78.07
+    ]
+  },
+  {
+    "measureId": "AAD12",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      91.8,
+      96.43,
+      98.55,
       100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "AAD6",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      96.99,
+      98.81,
+      99.8,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "AAD7",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      82.68,
+      95.26,
+      97.7,
+      99.37,
       100,
       100,
       100,
@@ -3929,14 +3909,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      49.63,
-      54.49,
-      57.88,
-      62.61,
-      67.05,
-      73.18,
-      79.67,
-      84.91
+      47.33,
+      53.7,
+      57.16,
+      62.86,
+      67.37,
+      71.43,
+      76.35,
+      80.73
     ]
   },
   {
@@ -3949,14 +3929,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      58.33,
-      70,
-      74,
-      80.45,
-      88.89,
-      92.5,
-      96.15,
-      97.92
+      56.67,
+      67.8,
+      74.17,
+      80.03,
+      86.6,
+      91.53,
+      94.52,
+      98.98
     ]
   },
   {
@@ -3969,54 +3949,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      53.7,
-      64.73,
-      81.22,
-      86.8,
-      90.2,
-      92.67,
-      96.3,
-      97.68
-    ]
-  },
-  {
-    "measureId": "AAO20",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      96.03,
-      97.5,
-      98.08,
-      98.42,
-      98.81,
-      98.98,
-      99.4,
+      38.82,
+      60,
+      70.2,
+      87.11,
+      91.69,
+      96.26,
+      97.34,
       100
-    ]
-  },
-  {
-    "measureId": "AAO21",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      21.29,
-      25.7,
-      36.08,
-      42.08,
-      43.17,
-      44.51,
-      46.45,
-      52.11
     ]
   },
   {
@@ -4029,14 +3969,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      61.71,
-      67.55,
-      70.42,
-      72.82,
-      75.72,
-      77.36,
-      80.09,
-      84.44
+      49.92,
+      58.78,
+      64.47,
+      68,
+      72.08,
+      75.97,
+      86.18,
+      89.52
     ]
   },
   {
@@ -4044,59 +3984,19 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      82.68,
-      85.53,
-      87.62,
-      90.85,
-      93.37,
-      96.02,
-      96.97,
-      98.62
-    ]
-  },
-  {
-    "measureId": "ACCPIN7",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      71.74,
-      76.09,
-      80.41,
-      82.81,
-      83.99,
-      87.5,
-      89.6,
-      93.42
-    ]
-  },
-  {
-    "measureId": "ACCPIN8",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      19.73,
-      22.75,
-      25.18,
-      27.58,
-      29.2,
-      30.72,
-      34.29,
-      38.56
+      91.19,
+      94.68,
+      97.28,
+      98.93,
+      99.39,
+      100,
+      100,
+      100
     ]
   },
   {
@@ -4109,14 +4009,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      53.1,
-      54.86,
-      58.04,
-      60.14,
-      63.29,
-      64.97,
-      68.42,
-      72.76
+      59.44,
+      62.24,
+      65.52,
+      66.87,
+      69.88,
+      71.93,
+      77.27,
+      82.1
     ]
   },
   {
@@ -4129,13 +4029,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      14.87,
-      10.99,
-      9.22,
-      6.55,
-      4.81,
-      3.69,
-      2.77,
+      12.85,
+      9.39,
+      7.48,
+      5.94,
+      4.73,
+      3.57,
+      2.67,
       0
     ]
   },
@@ -4149,14 +4049,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      21.55,
-      24.48,
-      27.67,
-      32.8,
-      37.75,
-      41.46,
-      44.7,
-      51.48
+      22.92,
+      25.44,
+      28.79,
+      30.64,
+      37.8,
+      40.62,
+      46.14,
+      52.36
     ]
   },
   {
@@ -4169,14 +4069,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      59.36,
-      67.83,
-      70.74,
-      72.7,
-      76.06,
-      77.27,
-      79.04,
-      88.22
+      56.31,
+      60.2,
+      68.02,
+      70.98,
+      74.15,
+      77.86,
+      83.66,
+      90.32
     ]
   },
   {
@@ -4189,14 +4089,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      73.81,
-      76.52,
-      77.64,
-      80.48,
-      82.92,
-      84.79,
-      87.03,
-      90.59
+      73.73,
+      75,
+      77.22,
+      78.72,
+      80,
+      82.61,
+      86.42,
+      88.89
     ]
   },
   {
@@ -4209,14 +4109,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      48.44,
-      54.36,
-      57.21,
-      73.91,
-      75.25,
-      77.78,
-      85.26,
-      89.21
+      64.41,
+      66.18,
+      77.83,
+      78.71,
+      85.88,
+      89.52,
+      92.07,
+      93.48
     ]
   },
   {
@@ -4229,38 +4129,58 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      83.63,
-      85.96,
-      87.5,
-      89.58,
-      90.91,
-      92.16,
-      94.25,
-      96.61
+      75,
+      79.17,
+      84.44,
+      88.94,
+      92.13,
+      93.88,
+      94.69,
+      96.5
     ]
   },
   {
-    "measureId": "ACMS2",
+    "measureId": "ACEP50",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": true,
+    "isToppedOut": false,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
-      0,
-      82.14,
-      92.03,
-      96.21,
-      97.48,
-      98.33,
-      99.51,
-      99.89,
-      100
+      100,
+      0.11,
+      0.02,
+      0.06,
+      0.13,
+      0.19,
+      0.29,
+      0.38,
+      0.5
     ]
   },
   {
-    "measureId": "ACMS3",
+    "measureId": "ACEP51",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      0.13,
+      0,
+      0.07,
+      0.11,
+      0.17,
+      0.21,
+      0.3,
+      0.44
+    ]
+  },
+  {
+    "measureId": "ACEP52",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
@@ -4269,13 +4189,33 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      80.95,
-      86.09,
-      86.67,
-      89.94,
-      94.34,
-      95.89,
-      98.31,
+      46.33,
+      55.26,
+      57.76,
+      62.26,
+      67.74,
+      69.79,
+      72.18,
+      75.89
+    ]
+  },
+  {
+    "measureId": "ACEP53",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      63.64,
+      80,
+      84.72,
+      91.06,
+      94.64,
+      97.06,
+      98.85,
       100
     ]
   },
@@ -4289,34 +4229,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      1.27,
-      1.08,
-      0.91,
-      0.75,
-      0.36,
-      0.15,
-      0.08,
-      0
-    ]
-  },
-  {
-    "measureId": "ACQR16",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      66.41,
-      70,
-      73.08,
-      75.7,
-      80.04,
-      83.93,
-      87.59,
-      92.86
+      100,
+      10,
+      1.97,
+      1.17,
+      0.9,
+      0.61,
+      0.38,
+      0.17
     ]
   },
   {
@@ -4329,14 +4249,74 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      90.91,
-      92.59,
-      94.44,
-      95.72,
-      96.78,
-      97.37,
-      98.39,
-      99.02
+      92.21,
+      95.08,
+      95.92,
+      96.36,
+      97.35,
+      98.48,
+      99.02,
+      100
+    ]
+  },
+  {
+    "measureId": "ACR10",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      13,
+      21.14,
+      30.77,
+      38.09,
+      44.02,
+      51.35,
+      55.42,
+      62.03
+    ]
+  },
+  {
+    "measureId": "ACR12",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      9.33,
+      12.05,
+      19.44,
+      33.44,
+      41.23,
+      48.48,
+      68.87,
+      85.03
+    ]
+  },
+  {
+    "measureId": "ACR14",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      31.94,
+      35.71,
+      40.91,
+      43.24,
+      50,
+      54.55,
+      61.54,
+      66.67
     ]
   },
   {
@@ -4349,14 +4329,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      6.38,
-      4.92,
-      3.85,
-      2.77,
-      2.02,
-      1.5,
-      1.16,
-      0.79
+      6.65,
+      5.28,
+      4.1,
+      3.42,
+      2.78,
+      1.92,
+      1.37,
+      0.81
     ]
   },
   {
@@ -4369,14 +4349,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      8.2,
-      6.44,
-      5.15,
-      4.14,
-      3.29,
-      2.41,
-      1.82,
-      1.07
+      7.79,
+      6.33,
+      5.02,
+      4.22,
+      3.18,
+      2.45,
+      1.7,
+      0.96
     ]
   },
   {
@@ -4389,14 +4369,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      16.2,
-      11.59,
-      9.48,
-      7.91,
-      6.04,
-      4.8,
-      3.61,
-      2.33
+      16.66,
+      12.75,
+      10.16,
+      8.59,
+      6.82,
+      5.3,
+      4.05,
+      2.61
     ]
   },
   {
@@ -4409,14 +4389,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      6.51,
-      4.9,
-      4.03,
-      3.22,
-      2.62,
-      2.11,
-      1.63,
-      1.17
+      6.98,
+      5.3,
+      4.42,
+      3.94,
+      3.1,
+      2.46,
+      1.68,
+      1.15
     ]
   },
   {
@@ -4429,14 +4409,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      42.76,
-      26.2,
-      14.75,
-      10.5,
-      8.38,
-      6.9,
-      5.08,
-      3.88
+      29.79,
+      24.9,
+      16.13,
+      11.61,
+      9.72,
+      6.95,
+      4.03,
+      2.75
     ]
   },
   {
@@ -4449,14 +4429,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      34.33,
-      25.23,
-      22.26,
-      16.38,
-      11.31,
-      6.78,
-      3.97,
-      0.83
+      37.52,
+      26.51,
+      19.63,
+      14.58,
+      10.12,
+      5.32,
+      2.13,
+      0.58
     ]
   },
   {
@@ -4469,14 +4449,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      60.43,
-      73.29,
-      82.25,
-      87.26,
-      89.16,
-      94.28,
-      95.14,
-      95.65
+      76.09,
+      84.86,
+      85.5,
+      89.23,
+      92.08,
+      95.12,
+      95.12,
+      96.22
     ]
   },
   {
@@ -4489,14 +4469,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      89.93,
-      91.01,
-      91.91,
-      92.58,
-      93.09,
-      94.53,
-      95.59,
-      96.38
+      90.28,
+      90.8,
+      91.73,
+      92.3,
+      92.95,
+      94.04,
+      95.31,
+      96.36
     ]
   },
   {
@@ -4505,16 +4485,16 @@
     "performanceYear": 2022,
     "submissionMethod": "registry",
     "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      85.5,
-      91.46,
-      95.45,
-      97.14,
-      98.82,
-      99.49,
+      96.74,
+      98.76,
+      99.25,
+      99.78,
+      100,
+      100,
       100,
       100
     ]
@@ -4526,16 +4506,56 @@
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      95.66,
+      98.33,
+      99.4,
+      99.68,
+      99.88,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "AQI65",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      81,
-      92.29,
-      97.16,
-      99.56,
-      99.91,
+      66.67,
+      87.24,
+      92.59,
+      95.59,
+      97.02,
+      99.68,
       100,
-      100,
+      100
+    ]
+  },
+  {
+    "measureId": "AQI68",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      89.99,
+      95.66,
+      97.47,
+      98.38,
+      99.34,
+      99.68,
+      99.96,
       100
     ]
   },
@@ -4549,14 +4569,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      41.28,
-      38.71,
-      34.48,
-      31.47,
-      28.41,
-      21.36,
-      13.79,
-      2.27
+      34.27,
+      31.24,
+      19.89,
+      13,
+      7.46,
+      4.6,
+      1.74,
+      0
     ]
   },
   {
@@ -4569,34 +4589,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      47.84,
-      53.19,
-      63.15,
-      69.67,
-      74.66,
-      76.98,
-      84.1,
-      92.25
-    ]
-  },
-  {
-    "measureId": "AQUA18",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      26.39,
-      28.13,
-      28.38,
-      29.37,
-      33.33,
-      45.32,
-      58.54,
-      66.67
+      41.04,
+      44.88,
+      49.39,
+      60.25,
+      73.53,
+      78.37,
+      80.03,
+      84.5
     ]
   },
   {
@@ -4609,14 +4609,74 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      14.58,
-      12.16,
-      9.33,
-      6.48,
-      5,
-      3.08,
-      1.03,
+      17.11,
+      14.79,
+      12.5,
+      8.01,
+      5.63,
+      3.18,
+      1.78,
       0
+    ]
+  },
+  {
+    "measureId": "CAP28",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      81.41,
+      85.56,
+      88.75,
+      90.89,
+      91.88,
+      93.61,
+      97.46,
+      97.92
+    ]
+  },
+  {
+    "measureId": "ECPR39",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      86.9,
+      88.21,
+      90.55,
+      92.59,
+      94.49,
+      97.1,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "ECPR46",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      92.58,
+      96.68,
+      98.17,
+      98.79,
+      99.07,
+      99.39,
+      100,
+      100
     ]
   },
   {
@@ -4629,14 +4689,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      87.68,
-      89.67,
-      90.72,
-      91.38,
-      92.87,
-      93.96,
-      95.52,
-      96.53
+      82.86,
+      86.58,
+      86.96,
+      87.95,
+      88.65,
+      90.32,
+      92.78,
+      94.03
     ]
   },
   {
@@ -4644,39 +4704,19 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      47.96,
-      60.71,
-      79.83,
-      86.71,
-      91.67,
-      96.07,
+      82.05,
+      94.34,
+      96.08,
+      98.37,
+      100,
+      100,
       100,
       100
-    ]
-  },
-  {
-    "measureId": "IRIS1",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      38.75,
-      46.15,
-      48.72,
-      55.88,
-      56.4,
-      66.99,
-      71.79,
-      80
     ]
   },
   {
@@ -4689,14 +4729,54 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      70.84,
-      82.48,
-      87.44,
-      88.75,
-      89.87,
-      92.25,
-      93.88,
-      98.08
+      80.35,
+      83.12,
+      85.54,
+      87.01,
+      88.19,
+      89.22,
+      91.16,
+      93.94
+    ]
+  },
+  {
+    "measureId": "IRIS17",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      47.83,
+      54.4,
+      57.14,
+      59.09,
+      64.52,
+      69.23,
+      75,
+      81.65
+    ]
+  },
+  {
+    "measureId": "IRIS2",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      23.67,
+      29.08,
+      32.96,
+      38.21,
+      41.36,
+      45.55,
+      53.73,
+      76.81
     ]
   },
   {
@@ -4709,14 +4789,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      68.75,
-      75.34,
-      79.92,
-      83.02,
-      87.8,
-      89.19,
-      94.12,
-      95.81
+      57.5,
+      80.95,
+      82.86,
+      84,
+      87.04,
+      90.28,
+      92.31,
+      95.09
     ]
   },
   {
@@ -4729,38 +4809,98 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      21.43,
-      27.5,
-      30.53,
+      11,
+      13.64,
+      15.73,
+      20.83,
+      26.39,
+      54.97,
+      75,
+      90.32
+    ]
+  },
+  {
+    "measureId": "IRIS46",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      15.79,
+      51.92,
+      61.22,
+      68.22,
+      72,
+      73.33,
+      88.1,
+      97.56
+    ]
+  },
+  {
+    "measureId": "IRIS53",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      86.96,
+      88,
+      89.45,
+      90.79,
+      91.18,
+      94.44,
+      94.52,
+      96.67
+    ]
+  },
+  {
+    "measureId": "IRIS54",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      2.41,
+      2,
+      1.64,
+      1.21,
+      0.82,
+      0.56,
+      0.18,
+      0
+    ]
+  },
+  {
+    "measureId": "IRIS55",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      27.85,
+      28.89,
+      31.37,
       33.33,
-      38.98,
-      62.86,
-      70.97,
-      85.71
+      36.07,
+      43.49,
+      45.1,
+      49.31
     ]
   },
   {
-    "measureId": "IRIS44",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      15.65,
-      14.01,
-      13.12,
-      11.83,
-      10.84,
-      9.52,
-      8.83,
-      2.33
-    ]
-  },
-  {
-    "measureId": "IRIS48",
+    "measureId": "IRIS59",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
@@ -4769,18 +4909,18 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      2.86,
-      4.42,
-      6.01,
-      7.7,
-      15.61,
-      22.62,
-      31.25,
-      37.33
+      1.85,
+      3.18,
+      4.96,
+      8.14,
+      12.31,
+      18.07,
+      26.43,
+      31.23
     ]
   },
   {
-    "measureId": "IRIS50",
+    "measureId": "MSN15",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
@@ -4789,254 +4929,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      42.86,
-      47.62,
-      53.33,
-      56.52,
-      57.89,
-      67.57,
-      68.18,
-      68.97
-    ]
-  },
-  {
-    "measureId": "IRIS6",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      91.74,
-      93.86,
-      95.7,
-      98.28,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "IROMS11",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      42.45,
-      32.59,
-      30,
-      27.04,
-      25,
-      22.61,
-      21.62,
-      15.58
-    ]
-  },
-  {
-    "measureId": "IROMS12",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      46.15,
-      44.07,
-      43.01,
-      40.31,
-      39.58,
-      38.1,
-      35.95,
-      24
-    ]
-  },
-  {
-    "measureId": "IROMS13",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      39.66,
-      38.26,
-      36.93,
-      35,
-      33.64,
-      32.82,
-      31.58,
-      20.97
-    ]
-  },
-  {
-    "measureId": "IROMS14",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      52.31,
-      50.56,
-      49.25,
-      47.94,
-      46.67,
-      45.53,
-      43.53,
-      18.79
-    ]
-  },
-  {
-    "measureId": "IROMS15",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      46.15,
-      43.85,
-      43.08,
-      42.01,
-      40.91,
-      39.44,
-      35.71,
-      3.17
-    ]
-  },
-  {
-    "measureId": "IROMS16",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      46.05,
-      43.98,
-      42.76,
-      41.59,
-      40.08,
-      38.92,
-      37.04,
-      5.83
-    ]
-  },
-  {
-    "measureId": "IROMS17",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      37.8,
-      36.36,
-      35.16,
-      34.34,
-      33.33,
-      32.29,
-      30.49,
-      18.52
-    ]
-  },
-  {
-    "measureId": "IROMS18",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      47.06,
-      45.43,
-      44.15,
-      43.48,
-      42.86,
-      41.6,
-      40.81,
-      25
-    ]
-  },
-  {
-    "measureId": "IROMS19",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      28.57,
-      27.56,
-      25.76,
-      24.41,
-      23.42,
-      22.22,
-      20.65,
-      6.73
-    ]
-  },
-  {
-    "measureId": "IROMS20",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      46.81,
-      45.29,
-      44.85,
-      43.75,
-      41.79,
-      40.7,
-      39.29,
-      15.6
-    ]
-  },
-  {
-    "measureId": "MEDNAX54",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      22.11,
-      12.74,
-      8.66,
-      5.59,
-      4.12,
-      3.16,
-      2.39,
-      0.7
+      78,
+      89,
+      92,
+      94.5,
+      96,
+      97,
+      99,
+      99
     ]
   },
   {
@@ -5049,14 +4949,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      17.65,
-      25,
-      37.93,
-      52,
-      60.78,
-      72.14,
-      86.44,
-      90.48
+      31.25,
+      48.39,
+      64.33,
+      69.51,
+      76.92,
+      85.56,
+      94.12,
+      95.24
     ]
   },
   {
@@ -5069,14 +4969,34 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      2.22,
-      3.7,
-      6.17,
-      18.18,
-      29.79,
-      40,
-      48.72,
-      64.81
+      3.41,
+      4.71,
+      11.11,
+      30.84,
+      38.3,
+      46.43,
+      57.3,
+      64.46
+    ]
+  },
+  {
+    "measureId": "PIMSH10",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      17.65,
+      38.71,
+      40.4,
+      47.92,
+      57.69,
+      64.24,
+      73.33,
+      80
     ]
   },
   {
@@ -5089,14 +5009,34 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      29.61,
-      35.06,
-      38.17,
-      40.81,
-      43.91,
-      47.37,
-      51.05,
-      58.26
+      33.33,
+      37.13,
+      39.71,
+      43.55,
+      46.83,
+      50,
+      52.88,
+      58.85
+    ]
+  },
+  {
+    "measureId": "PIMSH9",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      10.03,
+      8,
+      6.25,
+      4.46,
+      3.57,
+      2.94,
+      1.37,
+      0
     ]
   },
   {
@@ -5106,13 +5046,13 @@
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": true,
-    "isToppedOutByProgram": false,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      89.46,
-      95.74,
-      98.15,
-      99.17,
+      94.55,
+      98.44,
+      99.46,
+      100,
       100,
       100,
       100,
@@ -5129,14 +5069,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      67.09,
-      70.45,
-      74.09,
-      75.9,
-      76.97,
-      78.57,
-      84.13,
-      89.52
+      70.05,
+      72.97,
+      77.62,
+      80.41,
+      81.83,
+      83.59,
+      88.93,
+      93.26
     ]
   },
   {
@@ -5149,14 +5089,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      60.98,
-      66.99,
-      70.17,
-      76.05,
-      78.31,
-      81.68,
-      84.66,
-      87.02
+      67.57,
+      69.69,
+      72.72,
+      78.05,
+      82.91,
+      85.92,
+      87.85,
+      89.87
     ]
   },
   {
@@ -5169,14 +5109,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      74.6,
-      82.95,
-      84.01,
-      86.01,
-      90.05,
-      92.06,
-      93.62,
-      96.08
+      80.4,
+      85.45,
+      87.67,
+      92.15,
+      92.96,
+      94.19,
+      94.95,
+      95.75
     ]
   },
   {
@@ -5186,17 +5126,17 @@
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": true,
-    "isToppedOutByProgram": false,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      91.72,
-      92.19,
-      95.19,
-      96.71,
-      96.94,
-      97.49,
-      97.82,
-      99.82
+      95.86,
+      97.24,
+      98.08,
+      98.67,
+      99.23,
+      99.4,
+      99.58,
+      99.93
     ]
   },
   {
@@ -5209,14 +5149,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      79.43,
-      82.14,
-      85.56,
-      86.98,
-      89.04,
-      91.86,
-      93.84,
-      95.79
+      76.16,
+      81.25,
+      86.41,
+      88.72,
+      90.96,
+      93.1,
+      93.75,
+      95.24
     ]
   },
   {
@@ -5229,74 +5169,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      78.35,
-      81.65,
-      82.68,
-      84.2,
-      86.07,
-      91,
-      91.69,
-      93.15
-    ]
-  },
-  {
-    "measureId": "STS1",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      5.63,
-      5.26,
-      4.94,
-      4.07,
-      3.7,
-      2.67,
-      2.28,
-      0
-    ]
-  },
-  {
-    "measureId": "STS7",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      2.08,
-      20,
-      42.86,
-      55.56,
-      73.33,
-      87.27,
-      95.2,
-      99.26
-    ]
-  },
-  {
-    "measureId": "UREQA4",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      90.21,
-      92.91,
-      94.22,
-      94.98,
-      97.3,
-      97.96,
-      98.71,
-      99.51
+      78.05,
+      80.95,
+      83.08,
+      87.3,
+      89.66,
+      92.31,
+      94.05,
+      95.74
     ]
   }
 ]

--- a/benchmarks/2022.json
+++ b/benchmarks/2022.json
@@ -1860,66 +1860,6 @@
     ]
   },
   {
-    "measureId": "226",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      87.18,
-      95.38,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "226",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      18.92,
-      25.81,
-      34.17,
-      44.44,
-      56.63,
-      70.37,
-      84.11,
-      95.42
-    ]
-  },
-  {
-    "measureId": "226",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      30.91,
-      49.09,
-      66.67,
-      80.88,
-      90.78,
-      96.46,
-      100,
-      100
-    ]
-  },
-  {
     "measureId": "236",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
@@ -1977,46 +1917,6 @@
       70,
       80,
       90
-    ]
-  },
-  {
-    "measureId": "238",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      12.98,
-      7.56,
-      3.87,
-      1.64,
-      0.63,
-      0.18,
-      0,
-      0
-    ]
-  },
-  {
-    "measureId": "238",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      3.4,
-      1.33,
-      0.63,
-      0.32,
-      0.16,
-      0.03,
-      0,
-      0
     ]
   },
   {
@@ -2477,66 +2377,6 @@
       45.83,
       52.17,
       63.4
-    ]
-  },
-  {
-    "measureId": "317",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      88.31,
-      97.87,
-      99.47,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "317",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      15.66,
-      20.02,
-      23.68,
-      27.31,
-      30.97,
-      34.83,
-      40.07,
-      49.06
-    ]
-  },
-  {
-    "measureId": "317",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      23.48,
-      30.85,
-      38.37,
-      50,
-      65.12,
-      83.28,
-      96.5,
-      100
     ]
   },
   {
@@ -3600,26 +3440,6 @@
     ]
   },
   {
-    "measureId": "439",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
     "measureId": "440",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
@@ -3817,26 +3637,6 @@
       99.6,
       99.93,
       100
-    ]
-  },
-  {
-    "measureId": "478",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      38.72,
-      43.28,
-      47.62,
-      49.29,
-      55.22,
-      66.08,
-      70.37,
-      78.07
     ]
   },
   {
@@ -4137,46 +3937,6 @@
       93.88,
       94.69,
       96.5
-    ]
-  },
-  {
-    "measureId": "ACEP50",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      0.11,
-      0.02,
-      0.06,
-      0.13,
-      0.19,
-      0.29,
-      0.38,
-      0.5
-    ]
-  },
-  {
-    "measureId": "ACEP51",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      0.13,
-      0,
-      0.07,
-      0.11,
-      0.17,
-      0.21,
-      0.3,
-      0.44
     ]
   },
   {

--- a/benchmarks/2022.json
+++ b/benchmarks/2022.json
@@ -1,0 +1,5302 @@
+[
+  {
+    "measureId": "001",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      90.5,
+      69.42,
+      53.6,
+      42.11,
+      34.06,
+      28.32,
+      23.56,
+      19.1
+    ]
+  },
+  {
+    "measureId": "001",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      90.69,
+      72.51,
+      55.17,
+      41.98,
+      32.56,
+      25.48,
+      19.15,
+      12.87
+    ]
+  },
+  {
+    "measureId": "005",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      1.09,
+      65.52,
+      71.95,
+      75.28,
+      78.09,
+      80.47,
+      82.98,
+      86.36
+    ]
+  },
+  {
+    "measureId": "005",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      90,
+      95.71,
+      98.02,
+      99.27,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "006",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      77.58,
+      82.98,
+      86.98,
+      90.35,
+      93.27,
+      95.87,
+      98.94,
+      100
+    ]
+  },
+  {
+    "measureId": "007",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      45.83,
+      71.57,
+      83.88,
+      88.75,
+      91.79,
+      94.11,
+      95.79,
+      97.75
+    ]
+  },
+  {
+    "measureId": "007",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      49.07,
+      74.04,
+      84.79,
+      91.93,
+      94.72,
+      97.73,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "008",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      86.69,
+      90.14,
+      92.31,
+      94.05,
+      95.24,
+      96.37,
+      97.44,
+      100
+    ]
+  },
+  {
+    "measureId": "008",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      95,
+      97.5,
+      99.14,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "009",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      65.38,
+      70.69,
+      74.34,
+      78.04,
+      80.95,
+      83.77,
+      86.67,
+      90.56
+    ]
+  },
+  {
+    "measureId": "012",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      83.62,
+      88.72,
+      92.31,
+      95.06,
+      96.97,
+      98.33,
+      99.29,
+      100
+    ]
+  },
+  {
+    "measureId": "014",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "014",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      86.18,
+      91.75,
+      95.02,
+      96.93,
+      98.52,
+      99.59,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "019",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      54.33,
+      66.67,
+      75.34,
+      81.6,
+      87.18,
+      91.37,
+      95.08,
+      97.88
+    ]
+  },
+  {
+    "measureId": "019",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      83.62,
+      93.53,
+      97.83,
+      99.93,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "021",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "021",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      78.79,
+      97.51,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "023",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "023",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      95.45,
+      99.91,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "024",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      79.31,
+      94.24,
+      96.08,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "024",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      14.13,
+      36.36,
+      78.07,
+      82.88,
+      87.88,
+      93.75,
+      99.8,
+      100
+    ]
+  },
+  {
+    "measureId": "039",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      37.13,
+      49.57,
+      59.31,
+      66.38,
+      76.03,
+      87.21,
+      96.34,
+      100
+    ]
+  },
+  {
+    "measureId": "039",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      13.41,
+      28.59,
+      39.8,
+      51.49,
+      61.47,
+      70.35,
+      79.68,
+      90.85
+    ]
+  },
+  {
+    "measureId": "044",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      94.29,
+      96.51,
+      98.57,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "047",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      84.39,
+      97.46,
+      99.7,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "047",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      20.33,
+      43.84,
+      64.44,
+      79.02,
+      89.24,
+      95.6,
+      98.95,
+      100
+    ]
+  },
+  {
+    "measureId": "048",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      23.56,
+      40.07,
+      57.38,
+      73.75,
+      82.39,
+      93.05,
+      98.54,
+      100
+    ]
+  },
+  {
+    "measureId": "050",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      97.56,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "050",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      57.62,
+      74.66,
+      84.46,
+      90.28,
+      95.86,
+      99.85,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "052",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      84.62,
+      95,
+      98.29,
+      99.67,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "065",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      76.15,
+      80.79,
+      84.39,
+      87.1,
+      90.11,
+      92.86,
+      95.58,
+      100
+    ]
+  },
+  {
+    "measureId": "065",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      93.33,
+      95.45,
+      97.14,
+      98.44,
+      99.41,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "066",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      52.34,
+      67.16,
+      76.08,
+      81.75,
+      85.53,
+      87.84,
+      90.69,
+      94.46
+    ]
+  },
+  {
+    "measureId": "066",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      80.85,
+      88.09,
+      93.1,
+      97.11,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "067",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      96.41,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "070",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      64.44,
+      98.46,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "076",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      99.7,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "076",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      97.2,
+      99.43,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "093",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      93.55,
+      96.3,
+      98.11,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "093",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      83.89,
+      89.46,
+      92.86,
+      95.52,
+      97.26,
+      98.84,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "102",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      90.61,
+      97.12,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "104",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      95.85,
+      99.61,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "107",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      2.04,
+      4.76,
+      10.48,
+      22.13,
+      37.61,
+      57.23,
+      72.49,
+      92.62
+    ]
+  },
+  {
+    "measureId": "111",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      68.68,
+      76.32,
+      82.47,
+      87.57,
+      93.09,
+      97.9,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "111",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      20.44,
+      33.72,
+      44.7,
+      54.86,
+      63.22,
+      71.1,
+      78.8,
+      87.93
+    ]
+  },
+  {
+    "measureId": "111",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      35.11,
+      51.29,
+      61.9,
+      69.16,
+      75,
+      79.9,
+      85.83,
+      95
+    ]
+  },
+  {
+    "measureId": "112",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      66.67,
+      77.08,
+      84.88,
+      89.63,
+      93.48,
+      97.36,
+      99.03,
+      100
+    ]
+  },
+  {
+    "measureId": "112",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      24.44,
+      37.14,
+      46.32,
+      54.41,
+      61.11,
+      67.23,
+      73.95,
+      82.02
+    ]
+  },
+  {
+    "measureId": "112",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      22.37,
+      40,
+      50.98,
+      60.27,
+      70.21,
+      78.11,
+      85.85,
+      97.36
+    ]
+  },
+  {
+    "measureId": "113",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      15.15,
+      27.52,
+      38.74,
+      49.05,
+      58.31,
+      67.55,
+      76.06,
+      85.06
+    ]
+  },
+  {
+    "measureId": "116",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      62.33,
+      76,
+      86.36,
+      93.33,
+      96.92,
+      98.43,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "117",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      12,
+      20.55,
+      30.69,
+      44.82,
+      69.4,
+      94.17,
+      98.43,
+      99.93
+    ]
+  },
+  {
+    "measureId": "117",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      89.93,
+      96.68,
+      98.86,
+      99.7,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "118",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      72.73,
+      76.32,
+      79.61,
+      81.85,
+      85,
+      86.83,
+      90.48,
+      96
+    ]
+  },
+  {
+    "measureId": "119",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      70.31,
+      76.92,
+      81.55,
+      85.23,
+      88.24,
+      91.41,
+      94.78,
+      98.55
+    ]
+  },
+  {
+    "measureId": "119",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      71.17,
+      79.48,
+      86.67,
+      91.81,
+      96.23,
+      98.68,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "126",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      59.55,
+      74.76,
+      86.49,
+      94.87,
+      99.32,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "127",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      58.76,
+      74.03,
+      85.06,
+      94.65,
+      99.18,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "128",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      91.47,
+      98.58,
+      99.73,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "128",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      23.26,
+      27.42,
+      32.65,
+      40.91,
+      53.43,
+      69.27,
+      83.8,
+      95.12
+    ]
+  },
+  {
+    "measureId": "128",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      32.73,
+      51.06,
+      70.17,
+      84.69,
+      93.28,
+      98.06,
+      99.76,
+      100
+    ]
+  },
+  {
+    "measureId": "130",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      99.67,
+      99.94,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "130",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      83.73,
+      91.28,
+      94.91,
+      97,
+      98.31,
+      99.18,
+      99.7,
+      99.95
+    ]
+  },
+  {
+    "measureId": "130",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      86.71,
+      96.32,
+      98.95,
+      99.68,
+      99.91,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "134",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      95.94,
+      99.51,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "134",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      14.76,
+      37.44,
+      55.93,
+      71.74,
+      84.69,
+      95.56,
+      99.22,
+      100
+    ]
+  },
+  {
+    "measureId": "137",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      95,
+      98.84,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "138",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      75.51,
+      92.59,
+      98.81,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "141",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "141",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      32.62,
+      60.32,
+      82.14,
+      93.48,
+      98.55,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "143",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      67.56,
+      85.32,
+      91.89,
+      95.34,
+      97.07,
+      97.96,
+      98.8,
+      99.81
+    ]
+  },
+  {
+    "measureId": "143",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      93.65,
+      97.66,
+      99.21,
+      99.84,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "145",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      85.71,
+      94.44,
+      97.62,
+      99.19,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "145",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      86.61,
+      95.48,
+      98.41,
+      99.73,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "147",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      71.43,
+      85.71,
+      95.45,
+      98.46,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "147",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      93.66,
+      98.92,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "154",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      99.07,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "154",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      87.86,
+      96.13,
+      98.82,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "155",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      87.5,
+      98.08,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "155",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      85.88,
+      93.88,
+      97.84,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "164",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      8.8,
+      7.69,
+      5.87,
+      5,
+      3.52,
+      2.63,
+      1.59,
+      0
+    ]
+  },
+  {
+    "measureId": "167",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      3.6,
+      2.44,
+      2.04,
+      1.47,
+      1.22,
+      0.55,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "168",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      3.04,
+      2.48,
+      2.14,
+      1.55,
+      1.21,
+      0.48,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "176",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      51.61,
+      77.63,
+      89.71,
+      93.2,
+      97.37,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "177",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      65.49,
+      75.2,
+      85.38,
+      91.04,
+      95.22,
+      98.23,
+      99.67,
+      100
+    ]
+  },
+  {
+    "measureId": "178",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      76.28,
+      89.4,
+      94.26,
+      97.72,
+      99.03,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "180",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      98.26,
+      99.69,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "181",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      98.88,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "181",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      58.52,
+      78.66,
+      89.13,
+      95.66,
+      98.92,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "182",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      99.56,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "182",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      98.57,
+      99.59,
+      99.84,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "185",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      44.62,
+      81.25,
+      90.59,
+      95.74,
+      98.05,
+      99.55,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "187",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      82.74,
+      88.32,
+      91.67,
+      93.55,
+      95.45,
+      97.22,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "191",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      88.04,
+      93.46,
+      95.71,
+      97.13,
+      98.23,
+      98.86,
+      99.5,
+      100
+    ]
+  },
+  {
+    "measureId": "191",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      94.17,
+      96.3,
+      97.44,
+      98.45,
+      99.45,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "195",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      97.77,
+      99.4,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "195",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      99.28,
+      99.84,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "225",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "225",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "236",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      20,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "236",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      51.69,
+      57.08,
+      61.33,
+      64.8,
+      68.45,
+      72.04,
+      76.36,
+      82.38
+    ]
+  },
+  {
+    "measureId": "236",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      20,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "239",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      27.47,
+      30.49,
+      32.13,
+      33.33,
+      34.48,
+      38.54,
+      47.93,
+      63.65
+    ]
+  },
+  {
+    "measureId": "240",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      17.93,
+      25.54,
+      32.4,
+      36.75,
+      40.19,
+      44.74,
+      49.57,
+      56.86
+    ]
+  },
+  {
+    "measureId": "243",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      19.02,
+      25.64,
+      31.43,
+      37.14,
+      42.86,
+      48.98,
+      63.71,
+      90.58
+    ]
+  },
+  {
+    "measureId": "249",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "249",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "250",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "250",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "254",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      88.64,
+      92.25,
+      95.26,
+      96.77,
+      98.25,
+      99.18,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "265",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      78.39,
+      95.41,
+      99.08,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "268",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      14.49,
+      24,
+      39.22,
+      50,
+      65.48,
+      89.5,
+      95,
+      100
+    ]
+  },
+  {
+    "measureId": "277",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      24,
+      42.8,
+      58.23,
+      71.65,
+      93.1,
+      99.87,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "279",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      88.15,
+      95.65,
+      98.69,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "281",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      8.33,
+      13.64,
+      21.74,
+      31.58,
+      44.83,
+      59.74,
+      73.91,
+      91.89
+    ]
+  },
+  {
+    "measureId": "282",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      43.54,
+      68.18,
+      91.04,
+      98.24,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "283",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      75,
+      92.45,
+      96.37,
+      98.68,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "286",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      86.36,
+      93.38,
+      97.67,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "288",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      43.28,
+      66.67,
+      83.33,
+      95.39,
+      98.33,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "290",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      34.39,
+      57.47,
+      81.08,
+      92.06,
+      98.06,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "291",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      25.57,
+      59.89,
+      89.28,
+      98.94,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "293",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      48.35,
+      65.71,
+      85.71,
+      93.73,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "305",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0.27,
+      0.43,
+      0.64,
+      0.92,
+      1.25,
+      1.85,
+      2.91,
+      7.65
+    ]
+  },
+  {
+    "measureId": "309",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      11.36,
+      18.37,
+      25,
+      32.29,
+      39.57,
+      46.81,
+      55.56,
+      68.17
+    ]
+  },
+  {
+    "measureId": "310",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      19.88,
+      26.67,
+      32.2,
+      37.66,
+      42.47,
+      47.5,
+      56.07,
+      65.97
+    ]
+  },
+  {
+    "measureId": "318",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      18.81,
+      36.28,
+      52.34,
+      66.65,
+      78.72,
+      87.5,
+      94.19,
+      98.27
+    ]
+  },
+  {
+    "measureId": "320",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      92.68,
+      99.07,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "320",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      81.69,
+      89.02,
+      93.3,
+      95.81,
+      97.47,
+      98.61,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "322",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      0.33,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "323",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "324",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      2.51,
+      0.71,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "326",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      98.63,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "326",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      79.1,
+      83.68,
+      88.46,
+      94.51,
+      98.71,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "331",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      75.95,
+      62.5,
+      50.12,
+      37.57,
+      25.12,
+      14.81,
+      5.28,
+      0
+    ]
+  },
+  {
+    "measureId": "332",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      52.44,
+      61.37,
+      72.64,
+      85.76,
+      89.94,
+      96.13,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "337",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      68,
+      80.77,
+      88.89,
+      94.42,
+      97.54,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "338",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      76.89,
+      84.21,
+      87.33,
+      91.55,
+      95.37,
+      96.97,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "340",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      54.8,
+      60.09,
+      70,
+      75,
+      84.51,
+      98.48,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "342",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "350",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      99.6,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "351",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      99.36,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "354",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      3.23,
+      1.79,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "355",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      2.45,
+      1.33,
+      0.79,
+      0.18,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "356",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      5.76,
+      3.95,
+      2.78,
+      1.09,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "357",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      3.33,
+      1.82,
+      0.77,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "358",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      34.62,
+      72.43,
+      91.23,
+      98.51,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "360",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      85.51,
+      98.77,
+      99.94,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "364",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      95.83,
+      98.11,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "366",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      20.31,
+      24.14,
+      29.55,
+      35.95,
+      39.53,
+      45.49,
+      50.59,
+      65.64
+    ]
+  },
+  {
+    "measureId": "370",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      3.65,
+      4.92,
+      6.34,
+      7.61,
+      9.63,
+      12,
+      15,
+      22.03
+    ]
+  },
+  {
+    "measureId": "374",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      9.72,
+      16.98,
+      25.51,
+      34.93,
+      46.43,
+      60,
+      74.6,
+      89.66
+    ]
+  },
+  {
+    "measureId": "374",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      60,
+      77.55,
+      92.31,
+      97.55,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "375",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      8.19,
+      10.32,
+      14.84,
+      21.1,
+      29.09,
+      37.5,
+      51.35,
+      61.03
+    ]
+  },
+  {
+    "measureId": "376",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      4.73,
+      8.33,
+      11.54,
+      15.83,
+      19.75,
+      33.33,
+      53.57,
+      100
+    ]
+  },
+  {
+    "measureId": "378",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      0.87,
+      0.38,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "379",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0.26,
+      0.54,
+      1.1,
+      2.19,
+      3.85,
+      5.23,
+      7.31,
+      13.67
+    ]
+  },
+  {
+    "measureId": "382",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      7.45,
+      12.5,
+      19.12,
+      29.8,
+      39.09,
+      47.11,
+      58.71,
+      87.47
+    ]
+  },
+  {
+    "measureId": "383",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      51.52,
+      80.85,
+      96.52,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "384",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      96,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "389",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      30.48,
+      38.54,
+      51.95,
+      71.08,
+      94.46,
+      98.19,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "394",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      3.28,
+      7.69,
+      18.59,
+      22.73,
+      23.97,
+      30.43,
+      38.73,
+      46.67
+    ]
+  },
+  {
+    "measureId": "395",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "395",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "396",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "396",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "397",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "397",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "398",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      33.33,
+      49.29,
+      58.05,
+      80.14,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "400",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      1.39,
+      2.03,
+      3.94,
+      9.29,
+      18.03,
+      28.78,
+      43.82,
+      75.53
+    ]
+  },
+  {
+    "measureId": "402",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      88.14,
+      93.55,
+      96.55,
+      98.46,
+      99.56,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "404",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      53.27,
+      62.2,
+      68.18,
+      73.18,
+      79.19,
+      84.43,
+      91.76,
+      98.21
+    ]
+  },
+  {
+    "measureId": "406",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      100,
+      0.4,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "406",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      100,
+      2.27,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "410",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      56.12,
+      70.59,
+      80,
+      87.88,
+      93.33,
+      97.44,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "415",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      83.73,
+      90.91,
+      94.44,
+      96.4,
+      97.56,
+      98.55,
+      99.42,
+      100
+    ]
+  },
+  {
+    "measureId": "416",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      27.21,
+      20,
+      12.12,
+      5.88,
+      3.45,
+      2.04,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "419",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      28.52,
+      16.35,
+      10.43,
+      5.35,
+      3.23,
+      1.62,
+      0.2,
+      0
+    ]
+  },
+  {
+    "measureId": "424",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      98.22,
+      99.27,
+      99.69,
+      99.86,
+      99.97,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "425",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      98.8,
+      99.44,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "425",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      89.1,
+      94.78,
+      96.73,
+      97.96,
+      98.56,
+      99.13,
+      99.48,
+      99.95
+    ]
+  },
+  {
+    "measureId": "430",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      96.68,
+      98.18,
+      98.94,
+      99.5,
+      99.78,
+      99.95,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "436",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      96.5,
+      98.68,
+      99.57,
+      99.88,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "436",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      98.96,
+      99.77,
+      99.97,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "438",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      62.47,
+      66.22,
+      68.97,
+      71.37,
+      73.75,
+      76.08,
+      79.57,
+      83.33
+    ]
+  },
+  {
+    "measureId": "438",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      67.31,
+      73.03,
+      76.5,
+      82.4,
+      87.44,
+      93.1,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "440",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      98.36,
+      99.72,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "441",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      12.76,
+      22.33,
+      27.56,
+      36.45,
+      42.55,
+      48.48,
+      55.56,
+      63.97
+    ]
+  },
+  {
+    "measureId": "445",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      4,
+      2.97,
+      2.4,
+      1.94,
+      1.04,
+      0.67,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "453",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      18.18,
+      15.56,
+      13.95,
+      11.27,
+      10,
+      8.57,
+      6.06,
+      0
+    ]
+  },
+  {
+    "measureId": "457",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      11.32,
+      10,
+      8.16,
+      6.98,
+      4.26,
+      3.03,
+      2.22,
+      0
+    ]
+  },
+  {
+    "measureId": "463",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      94.59,
+      97.3,
+      98.25,
+      99.08,
+      99.67,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "464",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      84.47,
+      87.53,
+      90,
+      92.75,
+      94.54,
+      96.15,
+      97.6,
+      100
+    ]
+  },
+  {
+    "measureId": "472",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "475",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      1.46,
+      2.45,
+      5.32,
+      9.49,
+      25.51,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "AAAAI6",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "AAAAI8",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      99.72,
+      99.73,
+      99.77,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "AAN5",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      49.63,
+      54.49,
+      57.88,
+      62.61,
+      67.05,
+      73.18,
+      79.67,
+      84.91
+    ]
+  },
+  {
+    "measureId": "AAN8",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      58.33,
+      70,
+      74,
+      80.45,
+      88.89,
+      92.5,
+      96.15,
+      97.92
+    ]
+  },
+  {
+    "measureId": "AAN9",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      53.7,
+      64.73,
+      81.22,
+      86.8,
+      90.2,
+      92.67,
+      96.3,
+      97.68
+    ]
+  },
+  {
+    "measureId": "AAO20",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      96.03,
+      97.5,
+      98.08,
+      98.42,
+      98.81,
+      98.98,
+      99.4,
+      100
+    ]
+  },
+  {
+    "measureId": "AAO21",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      21.29,
+      25.7,
+      36.08,
+      42.08,
+      43.17,
+      44.51,
+      46.45,
+      52.11
+    ]
+  },
+  {
+    "measureId": "AAO23",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      61.71,
+      67.55,
+      70.42,
+      72.82,
+      75.72,
+      77.36,
+      80.09,
+      84.44
+    ]
+  },
+  {
+    "measureId": "AAO24",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      82.68,
+      85.53,
+      87.62,
+      90.85,
+      93.37,
+      96.02,
+      96.97,
+      98.62
+    ]
+  },
+  {
+    "measureId": "ACCPIN7",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      71.74,
+      76.09,
+      80.41,
+      82.81,
+      83.99,
+      87.5,
+      89.6,
+      93.42
+    ]
+  },
+  {
+    "measureId": "ACCPIN8",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      19.73,
+      22.75,
+      25.18,
+      27.58,
+      29.2,
+      30.72,
+      34.29,
+      38.56
+    ]
+  },
+  {
+    "measureId": "ACEP19",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      53.1,
+      54.86,
+      58.04,
+      60.14,
+      63.29,
+      64.97,
+      68.42,
+      72.76
+    ]
+  },
+  {
+    "measureId": "ACEP21",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      14.87,
+      10.99,
+      9.22,
+      6.55,
+      4.81,
+      3.69,
+      2.77,
+      0
+    ]
+  },
+  {
+    "measureId": "ACEP22",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      21.55,
+      24.48,
+      27.67,
+      32.8,
+      37.75,
+      41.46,
+      44.7,
+      51.48
+    ]
+  },
+  {
+    "measureId": "ACEP25",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      59.36,
+      67.83,
+      70.74,
+      72.7,
+      76.06,
+      77.27,
+      79.04,
+      88.22
+    ]
+  },
+  {
+    "measureId": "ACEP30",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      73.81,
+      76.52,
+      77.64,
+      80.48,
+      82.92,
+      84.79,
+      87.03,
+      90.59
+    ]
+  },
+  {
+    "measureId": "ACEP31",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      48.44,
+      54.36,
+      57.21,
+      73.91,
+      75.25,
+      77.78,
+      85.26,
+      89.21
+    ]
+  },
+  {
+    "measureId": "ACEP48",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      83.63,
+      85.96,
+      87.5,
+      89.58,
+      90.91,
+      92.16,
+      94.25,
+      96.61
+    ]
+  },
+  {
+    "measureId": "ACMS2",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      82.14,
+      92.03,
+      96.21,
+      97.48,
+      98.33,
+      99.51,
+      99.89,
+      100
+    ]
+  },
+  {
+    "measureId": "ACMS3",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      80.95,
+      86.09,
+      86.67,
+      89.94,
+      94.34,
+      95.89,
+      98.31,
+      100
+    ]
+  },
+  {
+    "measureId": "ACMS4",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      1.27,
+      1.08,
+      0.91,
+      0.75,
+      0.36,
+      0.15,
+      0.08,
+      0
+    ]
+  },
+  {
+    "measureId": "ACQR16",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      66.41,
+      70,
+      73.08,
+      75.7,
+      80.04,
+      83.93,
+      87.59,
+      92.86
+    ]
+  },
+  {
+    "measureId": "ACQR3",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      90.91,
+      92.59,
+      94.44,
+      95.72,
+      96.78,
+      97.37,
+      98.39,
+      99.02
+    ]
+  },
+  {
+    "measureId": "ACRAD15",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      6.38,
+      4.92,
+      3.85,
+      2.77,
+      2.02,
+      1.5,
+      1.16,
+      0.79
+    ]
+  },
+  {
+    "measureId": "ACRAD16",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      8.2,
+      6.44,
+      5.15,
+      4.14,
+      3.29,
+      2.41,
+      1.82,
+      1.07
+    ]
+  },
+  {
+    "measureId": "ACRAD17",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      16.2,
+      11.59,
+      9.48,
+      7.91,
+      6.04,
+      4.8,
+      3.61,
+      2.33
+    ]
+  },
+  {
+    "measureId": "ACRAD18",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      6.51,
+      4.9,
+      4.03,
+      3.22,
+      2.62,
+      2.11,
+      1.63,
+      1.17
+    ]
+  },
+  {
+    "measureId": "ACRAD19",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      42.76,
+      26.2,
+      14.75,
+      10.5,
+      8.38,
+      6.9,
+      5.08,
+      3.88
+    ]
+  },
+  {
+    "measureId": "ACRAD25",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      34.33,
+      25.23,
+      22.26,
+      16.38,
+      11.31,
+      6.78,
+      3.97,
+      0.83
+    ]
+  },
+  {
+    "measureId": "ACRAD34",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      60.43,
+      73.29,
+      82.25,
+      87.26,
+      89.16,
+      94.28,
+      95.14,
+      95.65
+    ]
+  },
+  {
+    "measureId": "AQI48",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      89.93,
+      91.01,
+      91.91,
+      92.58,
+      93.09,
+      94.53,
+      95.59,
+      96.38
+    ]
+  },
+  {
+    "measureId": "AQI56",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      85.5,
+      91.46,
+      95.45,
+      97.14,
+      98.82,
+      99.49,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "AQI62",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      81,
+      92.29,
+      97.16,
+      99.56,
+      99.91,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "AQUA14",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      41.28,
+      38.71,
+      34.48,
+      31.47,
+      28.41,
+      21.36,
+      13.79,
+      2.27
+    ]
+  },
+  {
+    "measureId": "AQUA15",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      47.84,
+      53.19,
+      63.15,
+      69.67,
+      74.66,
+      76.98,
+      84.1,
+      92.25
+    ]
+  },
+  {
+    "measureId": "AQUA18",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      26.39,
+      28.13,
+      28.38,
+      29.37,
+      33.33,
+      45.32,
+      58.54,
+      66.67
+    ]
+  },
+  {
+    "measureId": "AQUA26",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      14.58,
+      12.16,
+      9.33,
+      6.48,
+      5,
+      3.08,
+      1.03,
+      0
+    ]
+  },
+  {
+    "measureId": "EPREOP30",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      87.68,
+      89.67,
+      90.72,
+      91.38,
+      92.87,
+      93.96,
+      95.52,
+      96.53
+    ]
+  },
+  {
+    "measureId": "GIQIC10",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      47.96,
+      60.71,
+      79.83,
+      86.71,
+      91.67,
+      96.07,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "IRIS1",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      38.75,
+      46.15,
+      48.72,
+      55.88,
+      56.4,
+      66.99,
+      71.79,
+      80
+    ]
+  },
+  {
+    "measureId": "IRIS13",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      70.84,
+      82.48,
+      87.44,
+      88.75,
+      89.87,
+      92.25,
+      93.88,
+      98.08
+    ]
+  },
+  {
+    "measureId": "IRIS23",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      68.75,
+      75.34,
+      79.92,
+      83.02,
+      87.8,
+      89.19,
+      94.12,
+      95.81
+    ]
+  },
+  {
+    "measureId": "IRIS43",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      21.43,
+      27.5,
+      30.53,
+      33.33,
+      38.98,
+      62.86,
+      70.97,
+      85.71
+    ]
+  },
+  {
+    "measureId": "IRIS44",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      15.65,
+      14.01,
+      13.12,
+      11.83,
+      10.84,
+      9.52,
+      8.83,
+      2.33
+    ]
+  },
+  {
+    "measureId": "IRIS48",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      2.86,
+      4.42,
+      6.01,
+      7.7,
+      15.61,
+      22.62,
+      31.25,
+      37.33
+    ]
+  },
+  {
+    "measureId": "IRIS50",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      42.86,
+      47.62,
+      53.33,
+      56.52,
+      57.89,
+      67.57,
+      68.18,
+      68.97
+    ]
+  },
+  {
+    "measureId": "IRIS6",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      91.74,
+      93.86,
+      95.7,
+      98.28,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "IROMS11",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      42.45,
+      32.59,
+      30,
+      27.04,
+      25,
+      22.61,
+      21.62,
+      15.58
+    ]
+  },
+  {
+    "measureId": "IROMS12",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      46.15,
+      44.07,
+      43.01,
+      40.31,
+      39.58,
+      38.1,
+      35.95,
+      24
+    ]
+  },
+  {
+    "measureId": "IROMS13",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      39.66,
+      38.26,
+      36.93,
+      35,
+      33.64,
+      32.82,
+      31.58,
+      20.97
+    ]
+  },
+  {
+    "measureId": "IROMS14",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      52.31,
+      50.56,
+      49.25,
+      47.94,
+      46.67,
+      45.53,
+      43.53,
+      18.79
+    ]
+  },
+  {
+    "measureId": "IROMS15",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      46.15,
+      43.85,
+      43.08,
+      42.01,
+      40.91,
+      39.44,
+      35.71,
+      3.17
+    ]
+  },
+  {
+    "measureId": "IROMS16",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      46.05,
+      43.98,
+      42.76,
+      41.59,
+      40.08,
+      38.92,
+      37.04,
+      5.83
+    ]
+  },
+  {
+    "measureId": "IROMS17",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      37.8,
+      36.36,
+      35.16,
+      34.34,
+      33.33,
+      32.29,
+      30.49,
+      18.52
+    ]
+  },
+  {
+    "measureId": "IROMS18",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      47.06,
+      45.43,
+      44.15,
+      43.48,
+      42.86,
+      41.6,
+      40.81,
+      25
+    ]
+  },
+  {
+    "measureId": "IROMS19",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      28.57,
+      27.56,
+      25.76,
+      24.41,
+      23.42,
+      22.22,
+      20.65,
+      6.73
+    ]
+  },
+  {
+    "measureId": "IROMS20",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      46.81,
+      45.29,
+      44.85,
+      43.75,
+      41.79,
+      40.7,
+      39.29,
+      15.6
+    ]
+  },
+  {
+    "measureId": "MEDNAX54",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      22.11,
+      12.74,
+      8.66,
+      5.59,
+      4.12,
+      3.16,
+      2.39,
+      0.7
+    ]
+  },
+  {
+    "measureId": "NHCR4",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      17.65,
+      25,
+      37.93,
+      52,
+      60.78,
+      72.14,
+      86.44,
+      90.48
+    ]
+  },
+  {
+    "measureId": "PIMSH1",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      2.22,
+      3.7,
+      6.17,
+      18.18,
+      29.79,
+      40,
+      48.72,
+      64.81
+    ]
+  },
+  {
+    "measureId": "PIMSH4",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      29.61,
+      35.06,
+      38.17,
+      40.81,
+      43.91,
+      47.37,
+      51.05,
+      58.26
+    ]
+  },
+  {
+    "measureId": "QUANTUM31",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      89.46,
+      95.74,
+      98.15,
+      99.17,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "RCOIR10",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      67.09,
+      70.45,
+      74.09,
+      75.9,
+      76.97,
+      78.57,
+      84.13,
+      89.52
+    ]
+  },
+  {
+    "measureId": "RCOIR12",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      60.98,
+      66.99,
+      70.17,
+      76.05,
+      78.31,
+      81.68,
+      84.66,
+      87.02
+    ]
+  },
+  {
+    "measureId": "RCOIR7",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      74.6,
+      82.95,
+      84.01,
+      86.01,
+      90.05,
+      92.06,
+      93.62,
+      96.08
+    ]
+  },
+  {
+    "measureId": "RPAQIR13",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      91.72,
+      92.19,
+      95.19,
+      96.71,
+      96.94,
+      97.49,
+      97.82,
+      99.82
+    ]
+  },
+  {
+    "measureId": "RPAQIR14",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      79.43,
+      82.14,
+      85.56,
+      86.98,
+      89.04,
+      91.86,
+      93.84,
+      95.79
+    ]
+  },
+  {
+    "measureId": "RPAQIR15",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      78.35,
+      81.65,
+      82.68,
+      84.2,
+      86.07,
+      91,
+      91.69,
+      93.15
+    ]
+  },
+  {
+    "measureId": "STS1",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      5.63,
+      5.26,
+      4.94,
+      4.07,
+      3.7,
+      2.67,
+      2.28,
+      0
+    ]
+  },
+  {
+    "measureId": "STS7",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      2.08,
+      20,
+      42.86,
+      55.56,
+      73.33,
+      87.27,
+      95.2,
+      99.26
+    ]
+  },
+  {
+    "measureId": "UREQA4",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      90.21,
+      92.91,
+      94.22,
+      94.98,
+      97.3,
+      97.96,
+      98.71,
+      99.51
+    ]
+  }
+]

--- a/benchmarks/2022/benchmarks-schema.yaml
+++ b/benchmarks/2022/benchmarks-schema.yaml
@@ -1,0 +1,31 @@
+id: https://github.com/CMSgov/qpp-measures-data/versions/0.0.1/benchmarks-schema.yaml
+$schema: http://json-schema.org/schema#
+type: array
+items: { $ref: #/definitions/benchmark }
+
+definitions:
+  benchmark:
+    type: object
+    properties:
+      measureId:
+        description: measureId corresponds to a measure object's measureId.
+        type: string
+      performanceYear:
+        description: The performanceYear four digit integer corresponds to the time period of the performance data that was submitted for scoring.
+        type: number
+      isToppedOut:
+        description: isToppedOut is a boolean value that describes whether a benchmark's latter deciles repeat a value of 100 or, in the case of inverse measures, a value of 0.
+        type: boolean
+      benchmarkYear:
+        description: The benchmarkYear four digit integer corresponds to the time period of the performance data that was used to generate this benchmark. The submitted performance data will be compared against the benchmarkYear's results.
+        type: number
+      deciles:
+        description: The deciles list object is a list of 9 numbers representing deciles of measurement values for a given measure, performance year and submission method. The 9 numbers represent the inclusive lower bounds of deciles 2 through 10. The upper and lower bounds of the measurement value range are implied to be 100 and 0 respectively for direct measures and 0 and 100 respectively for inverse measures. The range of any given decile begins at its lower bound and continues up to but does not include the subsequent decile's lower bound. If the subsequent decile's lower bound is equal to the current decile's lower bound, then that decile is undefined or, in other words, empty. In the case of NonProp and Cost measures there will be 10 deciles.
+        type: array
+        items:
+          type: [number]
+        minItems: 9
+        maxItems: 10
+      submissionMethod:
+        enum: [claims, registry, cmsWebInterface, administrativeClaims, electronicHealthRecord, certifiedSurveyVendor]
+    required: [measureId, performanceYear, benchmarkYear, submissionMethod, deciles]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "5.1.0-beta.0",
+  "version": "3.1.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "5.0.0",
+  "version": "5.1.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "5.1.0-beta.0",
+  "version": "3.1.0-beta.1",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qpp-measures-data",
-  "version": "5.0.0",
+  "version": "5.1.0-beta.0",
   "description": "Quality Payment Program Measures Data Repository",
   "repository": {
     "type": "git",

--- a/staging/2022/benchmarks/benchmarks.csv
+++ b/staging/2022/benchmarks/benchmarks.csv
@@ -1,0 +1,646 @@
+Table 2: Historical MIPS Quality Measure Benchmark Results; created using PY2018 data and PY2020 Eligibility Rules,,,,,,,,,,,,,,,,,
+Measure_Name,Measure_ID,Collection_Type,Measure_Type,Benchmark,Standard_Deviation,Average,Decile_3,Decile_4,Decile_5,Decile_6,Decile_7,Decile_8,Decile_9,Decile_10,Topped_Out,Seven_Point_Cap,High_Priority
+Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,Medicare Part B Claims,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,eCQM,Intermediate Outcome,Y,,47.7050360962571,90.50 - 69.43,69.42 - 53.61,53.6 - 42.12,42.11 - 34.07,34.06 - 28.33,28.32 - 23.57,23.56 - 19.11,<=19.1,No,No,Y
+Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,MIPS CQM,Intermediate Outcome,Y,,46.7701042717793,90.69 - 72.52,72.51 - 55.18,55.17 - 41.99,41.98 - 32.57,32.56 - 25.49,25.48 - 19.16,19.15 - 12.88,<=12.87,No,No,Y
+Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) or Angiotensin Receptor-Neprilysin Inhibitor (ARNI) Therapy for Left Ventricular Systolic Dysfunction (LVSD),5,eCQM,Process,Y,,71.8131388329979,1.09 - 65.51,65.52 - 71.94,71.95 - 75.27,75.28 - 78.08,78.09 - 80.46,80.47 - 82.97,82.98 - 86.35,>= 86.36,No,No,N
+Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) or Angiotensin Receptor-Neprilysin Inhibitor (ARNI) Therapy for Left Ventricular Systolic Dysfunction (LVSD),5,MIPS CQM,Process,Y,,93.5209962406015,90.0 - 95.7,95.71 - 98.01,98.02 - 99.26,99.27 - 99.99,--,--,--,100,Yes,No,N
+Coronary Artery Disease (CAD): Antiplatelet Therapy,6,MIPS CQM,Process,Y,,85.6797691894793,77.58 - 82.97,82.98 - 86.97,86.98 - 90.34,90.35 - 93.26,93.27 - 95.86,95.87 - 98.93,98.94 - 99.99,100,No,No,N
+Coronary Artery Disease (CAD): Beta-Blocker Therapy -Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF < 40%),7,eCQM,Process,Y,,87.5259194395799,45.83 - 71.56,71.57 - 83.87,83.88 - 88.74,88.75 - 91.78,91.79 - 94.1,94.11 - 95.78,95.79 - 97.74,>= 97.75,No,No,N
+Coronary Artery Disease (CAD): Beta-Blocker Therapy -Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF < 40%),7,MIPS CQM,Process,Y,,89.090403587444,49.07 - 74.03,74.04 - 84.78,84.79 - 91.92,91.93 - 94.71,94.72 - 97.72,97.73 - 99.99,--,100,No,No,N
+Heart Failure (HF): Beta-Blocker Therapy for Left Ventricular Systolic Dysfunction (LVSD),8,eCQM,Process,Y,,91.11909375,86.69 - 90.13,90.14 - 92.3,92.31 - 94.04,94.05 - 95.23,95.24 - 96.36,96.37 - 97.43,97.44 - 99.99,100,Yes,No,N
+Heart Failure (HF): Beta-Blocker Therapy for Left Ventricular Systolic Dysfunction (LVSD),8,MIPS CQM,Process,Y,,95.5429702970297,95.0 - 97.49,97.5 - 99.13,99.14 - 99.99,--,--,--,--,100,Yes,Yes,N
+Anti-Depressant Medication Management,9,eCQM,Process,Y,,72.8213304721029,65.38 - 70.68,70.69 - 74.33,74.34 - 78.03,78.04 - 80.94,80.95 - 83.76,83.77 - 86.66,86.67 - 90.55,>= 90.56,No,No,N
+Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation,12,eCQM,Process,Y,,86.2467270992363,83.62 - 88.71,88.72 - 92.3,92.31 - 95.05,95.06 - 96.96,96.97 - 98.32,98.33 - 99.28,99.29 - 99.99,100,No,No,N
+Age-Related Macular Degeneration (AMD): Dilated Macular Examination,14,Medicare Part B Claims,Process,Y,,96.4909847434118,--,--,--,--,--,--,--,100,Yes,Yes,N
+Age-Related Macular Degeneration (AMD): Dilated Macular Examination,14,MIPS CQM,Process,Y,,89.4193408309903,86.18 - 91.74,91.75 - 95.01,95.02 - 96.92,96.93 - 98.51,98.52 - 99.58,99.59 - 99.99,--,100,Yes,Yes,N
+Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care,19,eCQM,Process,Y,,69.2460049321823,54.33 - 66.66,66.67 - 75.33,75.34 - 81.59,81.6 - 87.17,87.18 - 91.36,91.37 - 95.07,95.08 - 97.87,>= 97.88,No,No,Y
+Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care,19,MIPS CQM,Process,Y,,88.5375747508305,83.62 - 93.52,93.53 - 97.82,97.83 - 99.92,99.93 - 99.99,--,--,--,100,Yes,Yes,Y
+Perioperative Care: Selection of Prophylactic Antibiotic -First OR Second-Generation Cephalosporin,21,Medicare Part B Claims,Process,Y,,89.4589567430025,--,--,--,--,--,--,--,100,Yes,Yes,Y
+Perioperative Care: Selection of Prophylactic Antibiotic -First OR Second-Generation Cephalosporin,21,MIPS CQM,Process,Y,,81.8085294117647,78.79 - 97.5,97.51 - 99.99,--,--,--,--,--,100,Yes,Yes,Y
+Perioperative Care: Venous Thromboembolism (VTE) Prophylaxis (When Indicated in ALL Patients),23,Medicare Part B Claims,Process,Y,,89.7840935672514,--,--,--,--,--,--,--,100,Yes,Yes,Y
+Perioperative Care: Venous Thromboembolism (VTE) Prophylaxis (When Indicated in ALL Patients),23,MIPS CQM,Process,Y,,87.9667318435754,95.45 - 99.9,99.91 - 99.99,--,--,--,--,--,100,Yes,Yes,Y
+Communication with the Physician or Other Clinician Managing On-Going Care Post-Fracture for Men and Women Aged 50 Years and Older,24,Medicare Part B Claims,Process,Y,,87.07,79.31 - 94.23,94.24 - 96.07,96.08 - 99.99,--,--,--,--,100,Yes,Yes,Y
+Communication with the Physician or Other Clinician Managing On-Going Care Post-Fracture for Men and Women Aged 50 Years and Older,24,MIPS CQM,Process,Y,,43.7145384615384,14.13 - 36.35,36.36 - 78.06,78.07 - 82.87,82.88 - 87.87,87.88 - 93.74,93.75 - 99.79,99.8 - 99.99,100,No,No,Y
+Screening for Osteoporosis for Women Aged 65-85 Years of Age,39,Medicare Part B Claims,Process,Y,,64.328880597015,37.13 - 49.56,49.57 - 59.3,59.31 - 66.37,66.38 - 76.02,76.03 - 87.2,87.21 - 96.33,96.34 - 99.99,100,No,No,N
+Screening for Osteoporosis for Women Aged 65-85 Years of Age,39,MIPS CQM,Process,Y,,45.7150154035736,13.41 - 28.58,28.59 - 39.79,39.8 - 51.48,51.49 - 61.46,61.47 - 70.34,70.35 - 79.67,79.68 - 90.84,>= 90.85,No,No,N
+Coronary Artery Bypass Graft (CABG): Preoperative Beta-Blocker in Patients with Isolated CABG Surgery,44,MIPS CQM,Process,Y,,96.5059322033898,94.29 - 96.5,96.51 - 98.56,98.57 - 99.99,--,--,--,--,100,Yes,Yes,N
+Advance Care Plan,47,Medicare Part B Claims,Process,Y,,82.0406559308719,84.39 - 97.45,97.46 - 99.69,99.7 - 99.99,--,--,--,--,100,Yes,Yes,Y
+Advance Care Plan,47,MIPS CQM,Process,Y,,59.7357802746567,20.33 - 43.83,43.84 - 64.43,64.44 - 79.01,79.02 - 89.23,89.24 - 95.59,95.6 - 98.94,98.95 - 99.99,100,No,No,Y
+Urinary Incontinence: Assessment of Presence or Absence of Urinary Incontinence in Women Aged 65 Years and Older,48,MIPS CQM,Process,Y,,59.2931132075471,23.56 - 40.06,40.07 - 57.37,57.38 - 73.74,73.75 - 82.38,82.39 - 93.04,93.05 - 98.53,98.54 - 99.99,100,No,No,N
+Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Years and Older,50,Medicare Part B Claims,Process,Y,,94.7019251336898,97.56 - 99.99,--,--,--,--,--,--,100,Yes,Yes,Y
+Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Years and Older,50,MIPS CQM,Process,Y,,75.47984,57.62 - 74.65,74.66 - 84.45,84.46 - 90.27,90.28 - 95.85,95.86 - 99.84,99.85 - 99.99,--,100,No,No,Y
+Chronic Obstructive Pulmonary Disease (COPD): Long-Acting Inhaled Bronchodilator Therapy,52,MIPS CQM,Process,Y,,92.141,84.62 - 94.99,95.0 - 98.28,98.29 - 99.66,99.67 - 99.99,--,--,--,100,Yes,Yes,N
+Appropriate Treatment for Upper Respiratory Infection (URI),65,eCQM,Process,Y,,84.7032034220532,76.15 - 80.78,80.79 - 84.38,84.39 - 87.09,87.1 - 90.1,90.11 - 92.85,92.86 - 95.57,95.58 - 99.99,100,No,No,Y
+Appropriate Treatment for Upper Respiratory Infection (URI),65,MIPS CQM,Process,Y,,95.4215851272015,93.33 - 95.44,95.45 - 97.13,97.14 - 98.43,98.44 - 99.4,99.41 - 99.99,--,--,100,Yes,Yes,Y
+Appropriate Testing for Pharyngitis,66,eCQM,Process,Y,,62.5310832025117,52.34 - 67.15,67.16 - 76.07,76.08 - 81.74,81.75 - 85.52,85.53 - 87.83,87.84 - 90.68,90.69 - 94.45,>= 94.46,No,No,Y
+Appropriate Testing for Pharyngitis,66,MIPS CQM,Process,Y,,88.5485748218527,80.85 - 88.08,88.09 - 93.09,93.1 - 97.1,97.11 - 99.99,--,--,--,100,Yes,No,Y
+Hematology: Myelodysplastic Syndrome (MDS) and Acute Leukemias: Baseline Cytogenetic Testing Performed on Bone Marrow,67,MIPS CQM,Process,Y,,86.4245945945946,96.41 - 99.99,--,--,--,--,--,--,100,Yes,No,N
+Hematology: Chronic Lymphocytic Leukemia (CLL): Baseline Flow Cytometry,70,MIPS CQM,Process,Y,,83.5231666666666,64.44 - 98.45,98.46 - 99.99,--,--,--,--,--,100,Yes,No,N
+Prevention of Central Venous Catheter (CVC) - Related Bloodstream Infections,76,Medicare Part B Claims,Process,Y,,95.2457598039215,99.7 - 99.99,--,--,--,--,--,--,100,Yes,Yes,Y
+Prevention of Central Venous Catheter (CVC) - Related Bloodstream Infections,76,MIPS CQM,Process,Y,,94.7033246301131,97.2 - 99.42,99.43 - 99.99,--,--,--,--,--,100,Yes,Yes,Y
+Acute Otitis Externa (AOE): Systemic Antimicrobial Therapy -Avoidance of Inappropriate Use,93,Medicare Part B Claims,Process,Y,,92.7283870967741,93.55 - 96.29,96.3 - 98.1,98.11 - 99.99,--,--,--,--,100,Yes,Yes,Y
+Acute Otitis Externa (AOE): Systemic Antimicrobial Therapy -Avoidance of Inappropriate Use,93,MIPS CQM,Process,Y,,90.0238735177865,83.89 - 89.45,89.46 - 92.85,92.86 - 95.51,95.52 - 97.25,97.26 - 98.83,98.84 - 99.99,--,100,Yes,Yes,Y
+Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients,102,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients,102,MIPS CQM,Process,Y,,93.6969047619047,90.61 - 97.11,97.12 - 99.99,--,--,--,--,--,100,Yes,Yes,Y
+Prostate Cancer: Combination Androgen Deprivation Therapy for High Risk or Very High Risk Prostate Cancer,104,MIPS CQM,Process,Y,,89.6194,95.85 - 99.6,99.61 - 99.99,--,--,--,--,--,100,Yes,Yes,N
+Adult Major Depressive Disorder (MDD): Suicide Risk Assessment,107,eCQM,Process,Y,,12.4506392694064,2.04 - 4.75,4.76 - 10.47,10.48 - 22.12,22.13 - 37.6,37.61 - 57.22,57.23 - 72.48,72.49 - 92.61,>= 92.62,No,No,N
+Preventive Care and Screening: Influenza Immunization,110,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Preventive Care and Screening: Influenza Immunization,110,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Preventive Care and Screening: Influenza Immunization,110,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Pneumococcal Vaccination Status for Older Adults,111,Medicare Part B Claims,Process,Y,,80.2478802992518,68.68 - 76.31,76.32 - 82.46,82.47 - 87.56,87.57 - 93.08,93.09 - 97.89,97.9 - 99.99,--,100,No,No,N
+Pneumococcal Vaccination Status for Older Adults,111,eCQM,Process,Y,,49.1972718720601,20.44 - 33.71,33.72 - 44.69,44.7 - 54.85,54.86 - 63.21,63.22 - 71.09,71.1 - 78.79,78.8 - 87.92,>= 87.93,No,No,N
+Pneumococcal Vaccination Status for Older Adults,111,MIPS CQM,Process,Y,,59.872691591947,35.11 - 51.28,51.29 - 61.89,61.9 - 69.15,69.16 - 74.99,75.0 - 79.89,79.9 - 85.82,85.83 - 94.99,>= 95.0,No,No,N
+Breast Cancer Screening,112,Medicare Part B Claims,Process,Y,,79.7034440559441,66.67 - 77.07,77.08 - 84.87,84.88 - 89.62,89.63 - 93.47,93.48 - 97.35,97.36 - 99.02,99.03 - 99.99,100,No,No,N
+Breast Cancer Screening,112,eCQM,Process,Y,,49.6088767463519,24.44 - 37.13,37.14 - 46.31,46.32 - 54.4,54.41 - 61.1,61.11 - 67.22,67.23 - 73.94,73.95 - 82.01,>= 82.02,No,No,N
+Breast Cancer Screening,112,MIPS CQM,Process,Y,,52.0179231692677,22.37 - 39.99,40.0 - 50.97,50.98 - 60.26,60.27 - 70.2,70.21 - 78.1,78.11 - 85.84,85.85 - 97.35,>= 97.36,No,No,N
+Colorectal Cancer Screening,113,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Colorectal Cancer Screening,113,eCQM,Process,Y,,47.2213975533785,15.15 - 27.51,27.52 - 38.73,38.74 - 49.04,49.05 - 58.3,58.31 - 67.54,67.55 - 76.05,76.06 - 85.05,>= 85.06,No,No,N
+Colorectal Cancer Screening,113,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Avoidance of Antibiotic Treatment for Acute Bronchitis/Bronchiolitis,116,MIPS CQM,Process,Y,,81.4741527001862,62.33 - 75.99,76.0 - 86.35,86.36 - 93.32,93.33 - 96.91,96.92 - 98.42,98.43 - 99.99,--,100,Yes,No,Y
+Diabetes: Eye Exam,117,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,Yes,Yes,N
+Diabetes: Eye Exam,117,eCQM,Process,Y,,40.5858287003907,12.0 - 20.54,20.55 - 30.68,30.69 - 44.81,44.82 - 69.39,69.4 - 94.16,94.17 - 98.42,98.43 - 99.92,>= 99.93,No,No,N
+Diabetes: Eye Exam,117,MIPS CQM,Process,Y,,83.6932025547445,89.93 - 96.67,96.68 - 98.85,98.86 - 99.69,99.7 - 99.99,--,--,--,100,Yes,Yes,N
+Coronary Artery Disease (CAD): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy - Diabetes or Left Ventricular Systolic Dysfunction (LVEF < 40%),118,MIPS CQM,Process,Y,,80.9126206896552,72.73 - 76.31,76.32 - 79.6,79.61 - 81.84,81.85 - 84.99,85.0 - 86.82,86.83 - 90.47,90.48 - 95.99,>= 96.0,No,No,N
+Diabetes: Medical Attention for Nephropathy,119,eCQM,Process,Y,,80.890559681217,70.31 - 76.91,76.92 - 81.54,81.55 - 85.22,85.23 - 88.23,88.24 - 91.4,91.41 - 94.77,94.78 - 98.54,>= 98.55,No,No,N
+Diabetes: Medical Attention for Nephropathy,119,MIPS CQM,Process,Y,,83.2002131979694,71.17 - 79.47,79.48 - 86.66,86.67 - 91.8,91.81 - 96.22,96.23 - 98.67,98.68 - 99.99,--,100,No,No,N
+"Diabetes Mellitus: Diabetic Foot and Ankle Care, Peripheral Neuropathy -Neurological Evaluation",126,MIPS CQM,Process,Y,,74.470623640319,59.55 - 74.75,74.76 - 86.48,86.49 - 94.86,94.87 - 99.31,99.32 - 99.99,--,--,100,No,No,N
+"Diabetes Mellitus: Diabetic Foot and Ankle Care, Ulcer Prevention -Evaluation of Footwear",127,MIPS CQM,Process,Y,,73.6955837563451,58.76 - 74.02,74.03 - 85.05,85.06 - 94.64,94.65 - 99.17,99.18 - 99.99,--,--,100,No,No,N
+Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,Medicare Part B Claims,Process,Y,,90.3953081264107,91.47 - 98.57,98.58 - 99.72,99.73 - 99.99,--,--,--,--,100,Yes,Yes,N
+Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,eCQM,Process,Y,,50.2093711591613,23.26 - 27.41,27.42 - 32.64,32.65 - 40.9,40.91 - 53.42,53.43 - 69.26,69.27 - 83.79,83.8 - 95.11,>= 95.12,No,No,N
+Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,MIPS CQM,Process,Y,,69.6454257185264,32.73 - 51.05,51.06 - 70.16,70.17 - 84.68,84.69 - 93.27,93.28 - 98.05,98.06 - 99.75,99.76 - 99.99,100,No,No,N
+Documentation of Current Medications in the Medical Record,130,Medicare Part B Claims,Process,Y,,96.6693510392611,99.67 - 99.93,99.94 - 99.99,--,--,--,--,--,100,Yes,Yes,Y
+Documentation of Current Medications in the Medical Record,130,eCQM,Process,Y,,87.7832238995999,83.73 - 91.27,91.28 - 94.9,94.91 - 96.99,97.0 - 98.3,98.31 - 99.17,99.18 - 99.69,99.7 - 99.94,>= 99.95,Yes,Yes,Y
+Documentation of Current Medications in the Medical Record,130,MIPS CQM,Process,Y,,86.7688172423549,86.71 - 96.31,96.32 - 98.94,98.95 - 99.67,99.68 - 99.9,99.91 - 99.99,--,--,100,Yes,Yes,Y
+Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,Medicare Part B Claims,Process,Y,,85.7614463705308,95.94 - 99.5,99.51 - 99.99,--,--,--,--,--,100,Yes,Yes,N
+Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,MIPS CQM,Process,Y,,48.8621452420701,14.76 - 37.43,37.44 - 55.92,55.93 - 71.73,71.74 - 84.68,84.69 - 95.55,95.56 - 99.21,99.22 - 99.99,100,No,No,N
+Melanoma: Continuity of Care -Recall System,137,MIPS CQM,Structure,Y,,90.6854179285281,95.0 - 98.83,98.84 - 99.99,--,--,--,--,--,100,No,No,Y
+Melanoma: Coordination of Care,138,MIPS CQM,Process,Y,,83.5092088091354,75.51 - 92.58,92.59 - 98.8,98.81 - 99.99,--,--,--,--,100,Yes,Yes,Y
+Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care,141,Medicare Part B Claims,Outcome,Y,,96.2794287184766,--,--,--,--,--,--,--,100,No,No,Y
+Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care,141,MIPS CQM,Outcome,Y,,72.8744573991031,32.62 - 60.31,60.32 - 82.13,82.14 - 93.47,93.48 - 98.54,98.55 - 99.99,--,--,100,No,No,Y
+Oncology: Medical and Radiation - Pain Intensity Quantified,143,eCQM,Process,Y,,72.9170072992699,67.56 - 85.31,85.32 - 91.88,91.89 - 95.33,95.34 - 97.06,97.07 - 97.95,97.96 - 98.79,98.8 - 99.8,>= 99.81,No,No,Y
+Oncology: Medical and Radiation - Pain Intensity Quantified,143,MIPS CQM,Process,Y,,88.3933073929961,93.65 - 97.65,97.66 - 99.2,99.21 - 99.83,99.84 - 99.99,--,--,--,100,Yes,Yes,Y
+Oncology: Medical and Radiation - Plan of Care for Pain,144,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Radiology: Exposure Dose Indices or Exposure Time and Number of Images Reported for Procedures Using Fluoroscopy,145,Medicare Part B Claims,Process,Y,,86.6393830334189,85.71 - 94.43,94.44 - 97.61,97.62 - 99.18,99.19 - 99.99,--,--,--,100,Yes,Yes,Y
+Radiology: Exposure Dose Indices or Exposure Time and Number of Images Reported for Procedures Using Fluoroscopy,145,MIPS CQM,Process,Y,,88.1613309352517,86.61 - 95.47,95.48 - 98.4,98.41 - 99.72,99.73 - 99.99,--,--,--,100,Yes,Yes,Y
+Nuclear Medicine: Correlation with Existing Imaging Studies for All Patients Undergoing Bone Scintigraphy,147,Medicare Part B Claims,Process,Y,,84.9635816618911,71.43 - 85.7,85.71 - 95.44,95.45 - 98.45,98.46 - 99.99,--,--,--,100,Yes,Yes,Y
+Nuclear Medicine: Correlation with Existing Imaging Studies for All Patients Undergoing Bone Scintigraphy,147,MIPS CQM,Process,Y,,94.1728539823008,93.66 - 98.91,98.92 - 99.99,--,--,--,--,--,100,Yes,Yes,Y
+Falls: Risk Assessment,154,Medicare Part B Claims,Process,Y,,93.97617076326,99.07 - 99.99,--,--,--,--,--,--,100,Yes,Yes,Y
+Falls: Risk Assessment,154,MIPS CQM,Process,Y,,89.8856579648375,87.86 - 96.12,96.13 - 98.81,98.82 - 99.99,--,--,--,--,100,Yes,Yes,Y
+Falls: Plan of Care,155,Medicare Part B Claims,Process,Y,,84.1366297322251,87.5 - 98.07,98.08 - 99.99,--,--,--,--,--,100,Yes,Yes,Y
+Falls: Plan of Care,155,MIPS CQM,Process,Y,,88.6247621809744,85.88 - 93.87,93.88 - 97.83,97.84 - 99.99,--,--,--,--,100,Yes,No,Y
+Coronary Artery Bypass Graft (CABG): Prolonged Intubation,164,MIPS CQM,Outcome,Y,,6.07689440993789,8.8 - 7.7,7.69 - 5.88,5.87 - 5.01,5.0 - 3.53,3.52 - 2.64,2.63 - 1.6,1.59 - 0.01,0,No,No,Y
+Coronary Artery Bypass Graft (CABG): Postoperative Renal Failure,167,MIPS CQM,Outcome,Y,,1.7751282051282,3.6 - 2.45,2.44 - 2.05,2.04 - 1.48,1.47 - 1.23,1.22 - 0.56,0.55 - 0.01,--,0,No,No,Y
+Coronary Artery Bypass Graft (CABG): Surgical Re-Exploration,168,MIPS CQM,Outcome,Y,,2.30433121019108,3.04 - 2.49,2.48 - 2.15,2.14 - 1.56,1.55 - 1.22,1.21 - 0.49,0.48 - 0.01,--,0,No,No,Y
+Tuberculosis Screening Prior to First Course Biologic Therapy,176,MIPS CQM,Process,Y,,80.827037037037,51.61 - 77.62,77.63 - 89.7,89.71 - 93.19,93.2 - 97.36,97.37 - 99.99,--,--,100,No,No,N
+Rheumatoid Arthritis (RA): Periodic Assessment of Disease Activity,177,MIPS CQM,Process,Y,,78.3961924686192,65.49 - 75.19,75.2 - 85.37,85.38 - 91.03,91.04 - 95.21,95.22 - 98.22,98.23 - 99.66,99.67 - 99.99,100,No,No,N
+Rheumatoid Arthritis (RA): Functional Status Assessment,178,MIPS CQM,Process,Y,,84.3917518248175,76.28 - 89.39,89.4 - 94.25,94.26 - 97.71,97.72 - 99.02,99.03 - 99.99,--,--,100,Yes,Yes,N
+Rheumatoid Arthritis (RA): Glucocorticoid Management,180,MIPS CQM,Process,Y,,93.0318518518518,98.26 - 99.68,99.69 - 99.99,--,--,--,--,--,100,Yes,No,N
+Elder Maltreatment Screen and Follow-Up Plan,181,Medicare Part B Claims,Process,Y,,71.4839729729729,98.88 - 99.99,--,--,--,--,--,--,100,Yes,Yes,Y
+Elder Maltreatment Screen and Follow-Up Plan,181,MIPS CQM,Process,Y,,59.839012345679,58.52 - 78.65,78.66 - 89.12,89.13 - 95.65,95.66 - 98.91,98.92 - 99.99,--,--,100,No,No,Y
+Functional Outcome Assessment,182,Medicare Part B Claims,Process,Y,,91.3948139797068,99.56 - 99.99,--,--,--,--,--,--,100,Yes,Yes,Y
+Functional Outcome Assessment,182,MIPS CQM,Process,Y,,88.4535928809789,98.57 - 99.58,99.59 - 99.83,99.84 - 99.99,--,--,--,--,100,Yes,No,Y
+Colonoscopy Interval for Patients with a History of Adenomatous Polyps -Avoidance of Inappropriate Use,185,MIPS CQM,Process,Y,,73.8619565217391,44.62 - 81.24,81.25 - 90.58,90.59 - 95.73,95.74 - 98.04,98.05 - 99.54,99.55 - 99.99,--,100,No,No,Y
+Stroke and Stroke Rehabilitation: Thrombolytic Therapy,187,MIPS CQM,Process,Y,,86.4108312958435,82.74 - 88.31,88.32 - 91.66,91.67 - 93.54,93.55 - 95.44,95.45 - 97.21,97.22 - 99.99,--,100,Yes,Yes,N
+Cataracts: 20/40 or Better Visual Acuity within 90 Days Following Cataract Surgery,191,eCQM,Outcome,Y,,89.6666764995084,88.04 - 93.45,93.46 - 95.7,95.71 - 97.12,97.13 - 98.22,98.23 - 98.85,98.86 - 99.49,99.5 - 99.99,100,No,No,Y
+Cataracts: 20/40 or Better Visual Acuity within 90 Days Following Cataract Surgery,191,MIPS CQM,Outcome,Y,,94.9035181236673,94.17 - 96.29,96.3 - 97.43,97.44 - 98.44,98.45 - 99.44,99.45 - 99.99,--,--,100,No,No,Y
+Radiology: Stenosis Measurement in Carotid Imaging Reports,195,Medicare Part B Claims,Process,Y,,95.4921433267587,97.77 - 99.39,99.4 - 99.99,--,--,--,--,--,100,Yes,Yes,N
+Radiology: Stenosis Measurement in Carotid Imaging Reports,195,MIPS CQM,Process,Y,,97.4846540880503,99.28 - 99.83,99.84 - 99.99,--,--,--,--,--,100,Yes,Yes,N
+"HIV/AIDS: Sexually Transmitted Disease Screening for Chlamydia, Gonorrhea, and Syphilis",205,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Functional Status Change for Patients with Knee Impairments,217,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Functional Status Change for Patients with Hip Impairments,218,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+"Functional Status Change for Patients with Lower Leg, Foot or Ankle Impairments",219,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Functional Status Change for Patients with Low Back Impairments,220,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Functional Status Change for Patients with Shoulder Impairments,221,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+"Functional Status Change for Patients with Elbow, Wrist or Hand Impairments",222,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Radiology: Reminder System for Screening Mammograms,225,Medicare Part B Claims,Structure,Y,,95.3990882134915,--,--,--,--,--,--,--,100,No,No,Y
+Radiology: Reminder System for Screening Mammograms,225,MIPS CQM,Structure,Y,,98.3717478510028,--,--,--,--,--,--,--,100,No,No,Y
+Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Controlling High Blood Pressure,236,Medicare Part B Claims,Intermediate Outcome,Y,,75.5984821811936,20 - 29.99,30 - 39.99,40 - 49.99,50 - 59.99,60 - 69.99,70 - 79.99,80 - 89.99,>= 90,No,No,Y
+Controlling High Blood Pressure,236,eCQM,Intermediate Outcome,Y,,62.8862114689167,51.69 - 57.07,57.08 - 61.32,61.33 - 64.79,64.8 - 68.44,68.45 - 72.03,72.04 - 76.35,76.36 - 82.37,>= 82.38,No,No,Y
+Controlling High Blood Pressure,236,MIPS CQM,Intermediate Outcome,Y,,65.1931454367984,20 - 29.99,30 - 39.99,40 - 49.99,50 - 59.99,60 - 69.99,70 - 79.99,80 - 89.99,>= 90,No,No,Y
+Use of High-Risk Medications in Older Adults,238,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Use of High-Risk Medications in Older Adults,238,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Weight Assessment and Counseling for Nutrition and Physical Activity for Children and Adolescents,239,eCQM,Process,Y,,35.2767064901519,27.47 - 30.48,30.49 - 32.12,32.13 - 33.32,33.33 - 34.47,34.48 - 38.53,38.54 - 47.92,47.93 - 63.64,>= 63.65,No,No,N
+Childhood Immunization Status,240,eCQM,Process,Y,,27.4728189910979,17.93 - 25.53,25.54 - 32.39,32.4 - 36.74,36.75 - 40.18,40.19 - 44.73,44.74 - 49.56,49.57 - 56.85,>= 56.86,No,No,N
+Cardiac Rehabilitation Patient Referral from an Outpatient Setting,243,MIPS CQM,Process,Y,,41.1488546255506,19.02 - 25.63,25.64 - 31.42,31.43 - 37.13,37.14 - 42.85,42.86 - 48.97,48.98 - 63.7,63.71 - 90.57,>= 90.58,No,No,Y
+Barrett's Esophagus,249,Medicare Part B Claims,Process,Y,,99.8581877022653,--,--,--,--,--,--,--,100,Yes,Yes,N
+Barrett's Esophagus,249,MIPS CQM,Process,Y,,99.2971287128712,--,--,--,--,--,--,--,100,Yes,Yes,N
+Radical Prostatectomy Pathology Reporting,250,Medicare Part B Claims,Process,Y,,98.2015714285714,--,--,--,--,--,--,--,100,Yes,Yes,N
+Radical Prostatectomy Pathology Reporting,250,MIPS CQM,Process,Y,,99.8214173228346,--,--,--,--,--,--,--,100,Yes,Yes,N
+Ultrasound Determination of Pregnancy Location for Pregnant Patients with Abdominal Pain,254,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Ultrasound Determination of Pregnancy Location for Pregnant Patients with Abdominal Pain,254,MIPS CQM,Process,Y,,93.0846037735849,88.64 - 92.24,92.25 - 95.25,95.26 - 96.76,96.77 - 98.24,98.25 - 99.17,99.18 - 99.99,--,100,Yes,Yes,N
+Rate of Open Repair of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post-Operative Day #7),258,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post-Operative Day #2),259,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+"Rate of Carotid Endarterectomy (CEA) for Asymptomatic Patients, without Major Complications (Discharged to Home by Post-Operative Day #2)",260,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Referral for Otologic Evaluation for Patients with Acute or Chronic Dizziness,261,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Referral for Otologic Evaluation for Patients with Acute or Chronic Dizziness,261,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Sentinel Lymph Node Biopsy for Invasive Breast Cancer,264,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Biopsy Follow-Up,265,MIPS CQM,Process,Y,,79.1830451936872,78.39 - 95.4,95.41 - 99.07,99.08 - 99.99,--,--,--,--,100,Yes,Yes,Y
+Epilepsy: Counseling for Women of Childbearing Potential with Epilepsy,268,MIPS CQM,Process,Y,,43.6021428571428,14.49 - 23.99,24.0 - 39.21,39.22 - 49.99,50.0 - 65.47,65.48 - 89.49,89.5 - 94.99,95.0 - 99.99,100,No,No,N
+Inflammatory Bowel Disease (IBD): Assessment of Hepatitis B Virus (HBV) Status Before Initiating Anti-TNF (Tumor Necrosis Factor) Therapy,275,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Sleep Apnea: Severity Assessment at Initial Diagnosis,277,MIPS CQM,Process,Y,,54.9790849673202,24.0 - 42.79,42.8 - 58.22,58.23 - 71.64,71.65 - 93.09,93.1 - 99.86,99.87 - 99.99,--,100,No,No,N
+Sleep Apnea: Assessment of Adherence to Positive Airway Pressure Therapy,279,MIPS CQM,Process,Y,,85.6362499999999,88.15 - 95.64,95.65 - 98.68,98.69 - 99.99,--,--,--,--,100,Yes,Yes,N
+Dementia: Cognitive Assessment,281,eCQM,Process,Y,,27.06210652304,8.33 - 13.63,13.64 - 21.73,21.74 - 31.57,31.58 - 44.82,44.83 - 59.73,59.74 - 73.9,73.91 - 91.88,>= 91.89,No,No,N
+Dementia: Functional Status Assessment,282,MIPS CQM,Process,Y,,64.8544918032786,43.54 - 68.17,68.18 - 91.03,91.04 - 98.23,98.24 - 99.99,--,--,--,100,No,No,N
+Dementia Associated Behavioral and Psychiatric Symptoms Screening and Management,283,MIPS CQM,Process,Y,,79.4561,75.0 - 92.44,92.45 - 96.36,96.37 - 98.67,98.68 - 99.99,--,--,--,100,Yes,Yes,N
+Dementia: Safety Concern Screening and Follow-Up for Patients with Dementia,286,MIPS CQM,Process,Y,,77.5369607843137,86.36 - 93.37,93.38 - 97.66,97.67 - 99.99,--,--,--,--,100,Yes,Yes,Y
+Dementia: Education and Support of Caregivers for Patients with Dementia,288,MIPS CQM,Process,Y,,68.2778155339805,43.28 - 66.66,66.67 - 83.32,83.33 - 95.38,95.39 - 98.32,98.33 - 99.99,--,--,100,No,No,Y
+Parkinson's Disease: Psychiatric Symptoms Assessment for Patients with Parkinson's Disease,290,MIPS CQM,Process,Y,,70.9461607142857,34.39 - 57.46,57.47 - 81.07,81.08 - 92.05,92.06 - 98.05,98.06 - 99.99,--,--,100,Yes,No,N
+Parkinson's Disease: Cognitive Impairment or Dysfunction Assessment for Patients with Parkinson's Disease,291,MIPS CQM,Process,Y,,69.3419791666666,25.57 - 59.88,59.89 - 89.27,89.28 - 98.93,98.94 - 99.99,--,--,--,100,Yes,Yes,N
+Parkinson's Disease: Rehabilitative Therapy Options,293,MIPS CQM,Process,Y,,65.6724489795918,48.35 - 65.7,65.71 - 85.7,85.71 - 93.72,93.73 - 99.99,--,--,--,100,Yes,Yes,Y
+Cataracts: Improvement in Patient's Visual Function within 90 Days Following Cataract Surgery,303,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Cataracts: Patient Satisfaction within 90 Days Following Cataract Surgery,304,MIPS CQM,Patient Engagement/Experience,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Initiation and Engagement of Alcohol and Other Drug Dependence Treatment,305,eCQM,Process,Y,,1.43877573131094,0.27 - 0.42,0.43 - 0.63,0.64 - 0.91,0.92 - 1.24,1.25 - 1.84,1.85 - 2.9,2.91 - 7.64,>= 7.65,No,No,Y
+Cervical Cancer Screening,309,eCQM,Process,Y,,30.8815560066873,11.36 - 18.36,18.37 - 24.99,25.0 - 32.28,32.29 - 39.56,39.57 - 46.8,46.81 - 55.55,55.56 - 68.16,>= 68.17,No,No,N
+Chlamydia Screening for Women,310,eCQM,Process,Y,,34.5808434712085,19.88 - 26.66,26.67 - 32.19,32.2 - 37.65,37.66 - 42.46,42.47 - 47.49,47.5 - 56.06,56.07 - 65.96,>= 65.97,No,No,N
+Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Falls: Screening for Future Fall Risk,318,eCQM,Process,Y,,48.7824093991916,18.81 - 36.27,36.28 - 52.33,52.34 - 66.64,66.65 - 78.71,78.72 - 87.49,87.5 - 94.18,94.19 - 98.26,>= 98.27,No,No,Y
+Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients,320,Medicare Part B Claims,Process,Y,,92.9267768595041,92.68 - 99.06,99.07 - 99.99,--,--,--,--,--,100,Yes,Yes,Y
+Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients,320,MIPS CQM,Process,Y,,82.7260753880266,81.69 - 89.01,89.02 - 93.29,93.3 - 95.8,95.81 - 97.46,97.47 - 98.6,98.61 - 99.99,--,100,Yes,Yes,Y
+Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low-Risk Surgery Patients,322,MIPS CQM,Efficiency,Y,,29.2517142857142,0.33 - 0.01,--,--,--,--,--,--,0,No,No,Y
+Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Routine Testing After Percutaneous Coronary Intervention (PCI),323,MIPS CQM,Efficiency,Y,,2.88305555555555,--,--,--,--,--,--,--,0,No,No,Y
+"Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Testing in Asymptomatic, Low-Risk Patients",324,MIPS CQM,Efficiency,Y,,8.14732558139534,2.51 - 0.72,0.71 - 0.01,--,--,--,--,--,0,No,No,Y
+Atrial Fibrillation and Atrial Flutter: Chronic Anticoagulation Therapy,326,Medicare Part B Claims,Process,Y,,96.9824736842105,98.63 - 99.99,--,--,--,--,--,--,100,Yes,Yes,N
+Atrial Fibrillation and Atrial Flutter: Chronic Anticoagulation Therapy,326,MIPS CQM,Process,Y,,88.3319076923077,79.1 - 83.67,83.68 - 88.45,88.46 - 94.5,94.51 - 98.7,98.71 - 99.99,--,--,100,Yes,Yes,N
+Adult Sinusitis: Antibiotic Prescribed for Acute Viral Sinusitis (Overuse),331,MIPS CQM,Process,Y,,45.6709751709246,75.95 - 62.51,62.5 - 50.13,50.12 - 37.58,37.57 - 25.13,25.12 - 14.82,14.81 - 5.29,5.28 - 0.01,0,No,No,Y
+Adult Sinusitis: Appropriate Choice of Antibiotic: Amoxicillin With or Without Clavulanate Prescribed for Patients with Acute Bacterial Sinusitis (Appropriate Use),332,MIPS CQM,Process,Y,,77.6143801652892,52.44 - 61.36,61.37 - 72.63,72.64 - 85.75,85.76 - 89.93,89.94 - 96.12,96.13 - 99.99,--,100,No,No,Y
+Maternity Care: Elective Delivery or Early Induction Without Medical Indication at < 39 Weeks (Overuse),335,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Maternity Care: Postpartum Follow-up and Care Coordination,336,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+"Psoriasis: Tuberculosis (TB) Prevention for Patients with Psoriasis, Psoriatic Arthritis and Rheumatoid Arthritis on a Biological Immune Response Modifier",337,MIPS CQM,Process,Y,,81.1451323654995,68.0 - 80.76,80.77 - 88.88,88.89 - 94.41,94.42 - 97.53,97.54 - 99.99,--,--,100,No,No,N
+HIV Viral Load Suppression,338,MIPS CQM,Outcome,Y,,78.5221311475409,76.89 - 84.2,84.21 - 87.32,87.33 - 91.54,91.55 - 95.36,95.37 - 96.96,96.97 - 99.99,--,100,No,No,Y
+HIV Medical Visit Frequency,340,MIPS CQM,Process,Y,,75.4488095238095,54.8 - 60.08,60.09 - 69.99,70.0 - 74.99,75.0 - 84.5,84.51 - 98.47,98.48 - 99.99,--,100,No,No,Y
+Pain Brought Under Control Within 48 Hours,342,MIPS CQM,Outcome,Y,,97.9841860465116,--,--,--,--,--,--,--,100,No,No,Y
+"Rate of Carotid Artery Stenting (CAS) for Asymptomatic Patients, Without Major Complications (Discharged to Home by Post-Operative Day #2)",344,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Total Knee Replacement: Shared Decision-Making: Trial of Conservative (Non-surgical) Therapy,350,MIPS CQM,Process,Y,,93.6550920245398,99.6 - 99.99,--,--,--,--,--,--,100,Yes,Yes,Y
+Total Knee Replacement: Venous Thromboembolic and Cardiovascular Risk Evaluation,351,MIPS CQM,Process,Y,,93.8951199999999,99.36 - 99.99,--,--,--,--,--,--,100,Yes,Yes,Y
+Anastomotic Leak Intervention,354,MIPS CQM,Outcome,Y,,4.2053488372093,3.23 - 1.8,1.79 - 0.01,--,--,--,--,--,0,No,No,Y
+Unplanned Reoperation within the 30 Day Postoperative Period,355,MIPS CQM,Outcome,Y,,7.14739010989011,2.45 - 1.34,1.33 - 0.8,0.79 - 0.19,0.18 - 0.01,--,--,--,0,No,No,Y
+Unplanned Hospital Readmission within 30 Days of Principal Procedure,356,MIPS CQM,Outcome,Y,,6.89044052863436,5.76 - 3.96,3.95 - 2.79,2.78 - 1.1,1.09 - 0.01,--,--,--,0,No,No,Y
+Surgical Site Infection (SSI),357,MIPS CQM,Outcome,Y,,11.8914114832535,3.33 - 1.83,1.82 - 0.78,0.77 - 0.01,--,--,--,--,0,No,No,Y
+Patient-Centered Surgical Risk Assessment and Communication,358,MIPS CQM,Process,Y,,54.0293280632411,34.62 - 72.42,72.43 - 91.22,91.23 - 98.5,98.51 - 99.99,--,--,--,100,No,No,Y
+Optimizing Patient Exposure to Ionizing Radiation: Count of Potential High Dose Radiation Imaging Studies: Computed Tomography (CT) and Cardiac Nuclear Medicine Studies,360,MIPS CQM,Process,Y,,81.1845744680851,85.51 - 98.76,98.77 - 99.93,99.94 - 99.99,--,--,--,--,100,Yes,Yes,Y
+Optimizing Patient Exposure to Ionizing Radiation: Appropriateness: Follow-up CT Imaging for Incidentally Detected Pulmonary Nodules According to Recommended Guidelines,364,MIPS CQM,Process,Y,,95.3193198992443,95.83 - 98.1,98.11 - 99.99,--,--,--,--,--,100,Yes,No,Y
+Follow-Up Care for Children Prescribed ADHD Medication (ADD),366,eCQM,Process,Y,,37.4164563106796,20.31 - 24.13,24.14 - 29.54,29.55 - 35.94,35.95 - 39.52,39.53 - 45.48,45.49 - 50.58,50.59 - 65.63,>= 65.64,No,No,N
+Depression Remission at Twelve Months,370,eCQM,Outcome,Y,,9.05646517739817,3.65 - 4.91,4.92 - 6.33,6.34 - 7.6,7.61 - 9.62,9.63 - 11.99,12.0 - 14.99,15.0 - 22.02,>= 22.03,No,No,Y
+Depression Remission at Twelve Months,370,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Closing the Referral Loop: Receipt of Specialist Report,374,eCQM,Process,Y,,36.6991446958688,9.72 - 16.97,16.98 - 25.5,25.51 - 34.92,34.93 - 46.42,46.43 - 59.99,60.0 - 74.59,74.6 - 89.65,>= 89.66,No,No,Y
+Closing the Referral Loop: Receipt of Specialist Report,374,MIPS CQM,Process,Y,,72.9680888290713,60.0 - 77.54,77.55 - 92.3,92.31 - 97.54,97.55 - 99.99,--,--,--,100,No,No,Y
+Functional Status Assessment for Total Knee Replacement,375,eCQM,Process,Y,,1.29369778869778,8.19 - 10.31,10.32 - 14.83,14.84 - 21.09,21.1 - 29.08,29.09 - 37.49,37.5 - 51.34,51.35 - 61.02,>= 61.03,No,No,Y
+Functional Status Assessment for Total Hip Replacement,376,eCQM,Process,Y,,1.73537280701754,4.73 - 8.32,8.33 - 11.53,11.54 - 15.82,15.83 - 19.74,19.75 - 33.32,33.33 - 53.56,53.57 - 99.99,100,No,No,Y
+Functional Status Assessments for Congestive Heart Failure,377,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Children Who Have Dental Decay or Cavities,378,eCQM,Outcome,Y,,.529196956889264,0.87 - 0.39,0.38 - 0.01,--,--,--,--,--,0,No,No,Y
+"Primary Caries Prevention Intervention as Offered by Primary Care Providers, including Dentists",379,eCQM,Process,Y,,1.06873433583959,0.26 - 0.53,0.54 - 1.09,1.1 - 2.18,2.19 - 3.84,3.85 - 5.22,5.23 - 7.3,7.31 - 13.66,>= 13.67,No,No,N
+Child and Adolescent Major Depressive Disorder (MDD): Suicide Risk Assessment,382,eCQM,Process,Y,,23.9799293286219,7.45 - 12.49,12.5 - 19.11,19.12 - 29.79,29.8 - 39.08,39.09 - 47.1,47.11 - 58.7,58.71 - 87.46,>= 87.47,No,No,Y
+Adherence to Antipsychotic Medications For Individuals with Schizophrenia,383,MIPS CQM,Intermediate Outcome,Y,,81.008125,51.52 - 80.84,80.85 - 96.51,96.52 - 99.99,--,--,--,--,100,No,No,Y
+Adult Primary Rhegmatogenous Retinal Detachment Surgery: No Return to the Operating Room Within 90 Days of Surgery,384,MIPS CQM,Outcome,Y,,96.0267647058823,96.0 - 99.99,--,--,--,--,--,--,100,No,No,Y
+Adult Primary Rhegmatogenous Retinal Detachment Surgery: Visual Acuity Improvement Within 90 Days of Surgery,385,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Amyotrophic Lateral Sclerosis (ALS) Patient Care Preferences,386,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Annual Hepatitis C Virus (HCV) Screening for Patients who are Active Injection Drug Users,387,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Cataract Surgery: Difference Between Planned and Final Refraction,389,MIPS CQM,Outcome,Y,,63.7319245283018,30.48 - 38.53,38.54 - 51.94,51.95 - 71.07,71.08 - 94.45,94.46 - 98.18,98.19 - 99.99,--,100,No,No,Y
+Follow-Up After Hospitalization for Mental Illness (FUH),391,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Cardiac Tamponade and/or Pericardiocentesis Following Atrial Fibrillation Ablation,392,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+"Infection within 180 Days of Cardiac Implantable Electronic Device (CIED) Implantation, Replacement, or Revision",393,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Immunizations for Adolescents,394,MIPS CQM,Process,Y,,14.0085937499999,3.28 - 7.68,7.69 - 18.58,18.59 - 22.72,22.73 - 23.96,23.97 - 30.42,30.43 - 38.72,38.73 - 46.66,>= 46.67,No,No,N
+Lung Cancer Reporting (Biopsy/Cytology Specimens),395,Medicare Part B Claims,Process,Y,,99.1657928802588,--,--,--,--,--,--,--,100,Yes,Yes,Y
+Lung Cancer Reporting (Biopsy/Cytology Specimens),395,MIPS CQM,Process,Y,,98.7408146067415,--,--,--,--,--,--,--,100,Yes,Yes,Y
+Lung Cancer Reporting (Resection Specimens),396,Medicare Part B Claims,Process,Y,,99.7918918918919,--,--,--,--,--,--,--,100,Yes,Yes,Y
+Lung Cancer Reporting (Resection Specimens),396,MIPS CQM,Process,Y,,99.7160732984293,--,--,--,--,--,--,--,100,Yes,Yes,Y
+Melanoma Reporting,397,Medicare Part B Claims,Process,Y,,96.4929761904761,--,--,--,--,--,--,--,100,Yes,Yes,Y
+Melanoma Reporting,397,MIPS CQM,Process,Y,,97.2853082191781,--,--,--,--,--,--,--,100,Yes,Yes,Y
+Optimal Asthma Control,398,MIPS CQM,Outcome,Y,,31.7328888888888,33.33 - 49.28,49.29 - 58.04,58.05 - 80.13,80.14 - 99.99,--,--,--,100,No,No,Y
+One-Time Screening for Hepatitis C Virus (HCV) for Patients at Risk,400,MIPS CQM,Process,Y,,19.6015012106537,1.39 - 2.02,2.03 - 3.93,3.94 - 9.28,9.29 - 18.02,18.03 - 28.77,28.78 - 43.81,43.82 - 75.52,>= 75.53,No,No,N
+Hepatitis C: Screening for Hepatocellular Carcinoma (HCC) in Patients with Cirrhosis,401,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Tobacco Use and Help with Quitting Among Adolescents,402,MIPS CQM,Process,Y,,91.4053365129835,88.14 - 93.54,93.55 - 96.54,96.55 - 98.45,98.46 - 99.55,99.56 - 99.99,--,--,100,Yes,Yes,N
+Anesthesiology Smoking Abstinence,404,MIPS CQM,Intermediate Outcome,Y,,69.0437335285505,53.27 - 62.19,62.2 - 68.17,68.18 - 73.17,73.18 - 79.18,79.19 - 84.42,84.43 - 91.75,91.76 - 98.2,>= 98.21,No,No,Y
+Appropriate Follow-up Imaging for Incidental Abdominal Lesions,405,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Appropriate Follow-up Imaging for Incidental Abdominal Lesions,405,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Appropriate Follow-up Imaging for Incidental Thyroid Nodules in Patients,406,Medicare Part B Claims,Process,Y,,11.3532647058823,0.4 - 0.01,--,--,--,--,--,--,0,Yes,Yes,Y
+Appropriate Follow-up Imaging for Incidental Thyroid Nodules in Patients,406,MIPS CQM,Process,Y,,4.60948012232415,2.27 - 0.01,--,--,--,--,--,--,0,Yes,Yes,Y
+Clinical Outcome Post Endovascular Stroke Treatment,409,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Psoriasis: Clinical Response to Systemic Medications,410,MIPS CQM,Outcome,Y,,74.3226846220677,56.12 - 70.58,70.59 - 79.99,80.0 - 87.87,87.88 - 93.32,93.33 - 97.43,97.44 - 99.99,--,100,No,No,Y
+Door to Puncture Time for Endovascular Stroke Treatment,413,MIPS CQM,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older,415,MIPS CQM,Efficiency,Y,,91.8041241496598,83.73 - 90.9,90.91 - 94.43,94.44 - 96.39,96.4 - 97.55,97.56 - 98.54,98.55 - 99.41,99.42 - 99.99,100,No,No,Y
+Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,416,Medicare Part B Claims,Efficiency,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,416,MIPS CQM,Efficiency,Y,,15.8907389937106,27.21 - 20.01,20.0 - 12.13,12.12 - 5.89,5.88 - 3.46,3.45 - 2.05,2.04 - 0.01,--,0,No,No,Y
+Osteoporosis Management in Women Who Had a Fracture,418,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Osteoporosis Management in Women Who Had a Fracture,418,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Overuse of Imaging for the Evaluation of Primary Headache,419,MIPS CQM,Process,Y,,16.7383809523809,28.52 - 16.36,16.35 - 10.44,10.43 - 5.36,5.35 - 3.24,3.23 - 1.63,1.62 - 0.21,0.2 - 0.01,0,Yes,No,Y
+Varicose Vein Treatment with Saphenous Ablation: Outcome Survey,420,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Appropriate Assessment of Retrievable Inferior Vena Cava (IVC) Filters for Removal,421,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Performing Cystoscopy at the Time of Hysterectomy for Pelvic Organ Prolapse to Detect Lower Urinary Tract Injury,422,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Performing Cystoscopy at the Time of Hysterectomy for Pelvic Organ Prolapse to Detect Lower Urinary Tract Injury,422,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Perioperative Temperature Management,424,MIPS CQM,Outcome,Y,,97.9629433272395,98.22 - 99.26,99.27 - 99.68,99.69 - 99.85,99.86 - 99.96,99.97 - 99.99,--,--,100,No,No,Y
+Photodocumentation of Cecal Intubation,425,Medicare Part B Claims,Process,Y,,99.0177987421383,98.8 - 99.43,99.44 - 99.99,--,--,--,--,--,100,Yes,No,N
+Photodocumentation of Cecal Intubation,425,MIPS CQM,Process,Y,,92.0179439252336,89.1 - 94.77,94.78 - 96.72,96.73 - 97.95,97.96 - 98.55,98.56 - 99.12,99.13 - 99.47,99.48 - 99.94,>= 99.95,Yes,No,N
+Pelvic Organ Prolapse: Preoperative Screening for Uterine Malignancy,429,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Pelvic Organ Prolapse: Preoperative Screening for Uterine Malignancy,429,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Prevention of Post-Operative Nausea and Vomiting (PONV) -Combination Therapy,430,MIPS CQM,Process,Y,,96.8483870967742,96.68 - 98.17,98.18 - 98.93,98.94 - 99.49,99.5 - 99.77,99.78 - 99.94,99.95 - 99.99,--,100,Yes,Yes,Y
+Preventive Care and Screening: Unhealthy Alcohol Use: Screening & Brief Counseling,431,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Proportion of Patients Sustaining a Bladder Injury at the Time of any Pelvic Organ Prolapse Repair,432,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Proportion of Patients Sustaining a Bowel Injury at the time of any Pelvic Organ Prolapse Repair,433,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Proportion of Patients Sustaining a Ureter Injury at the Time of Pelvic Organ Prolapse Repair,434,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Radiation Consideration for Adult CT: Utilization of Dose Lowering Techniques,436,Medicare Part B Claims,Process,Y,,93.1926809815949,96.5 - 98.67,98.68 - 99.56,99.57 - 99.87,99.88 - 99.99,--,--,--,100,Yes,Yes,N
+Radiation Consideration for Adult CT: Utilization of Dose Lowering Techniques,436,MIPS CQM,Process,Y,,96.2689352989353,98.96 - 99.76,99.77 - 99.96,99.97 - 99.99,--,--,--,--,100,Yes,Yes,N
+Statin Therapy for the Prevention and Treatment of Cardiovascular Disease,438,eCQM,Process,Y,,68.5675027685493,62.47 - 66.21,66.22 - 68.96,68.97 - 71.36,71.37 - 73.74,73.75 - 76.07,76.08 - 79.56,79.57 - 83.32,>= 83.33,No,No,N
+Statin Therapy for the Prevention and Treatment of Cardiovascular Disease,438,MIPS CQM,Process,Y,,80.7900487804878,67.31 - 73.02,73.03 - 76.49,76.5 - 82.39,82.4 - 87.43,87.44 - 93.09,93.1 - 99.99,--,100,No,No,N
+Age Appropriate Screening Colonoscopy,439,MIPS CQM,Efficiency,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Skin Cancer: Biopsy Reporting Time -Pathologist to Clinician,440,MIPS CQM,Process,Y,,97.465600814664,98.36 - 99.71,99.72 - 99.99,--,--,--,--,--,100,Yes,Yes,Y
+Ischemic Vascular Disease (IVD) All or None Outcome Measure (Optimal Control),441,MIPS CQM,Intermediate Outcome,Y,,33.282197309417,12.76 - 22.32,22.33 - 27.55,27.56 - 36.44,36.45 - 42.54,42.55 - 48.47,48.48 - 55.55,55.56 - 63.96,>= 63.97,No,No,Y
+Non-Recommended Cervical Cancer Screening in Adolescent Females,443,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Medication Management for People with Asthma,444,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Risk-Adjusted Operative Mortality for Coronary Artery Bypass Graft (CABG),445,MIPS CQM,Outcome,Y,,2.22376623376623,4.0 - 2.98,2.97 - 2.41,2.4 - 1.95,1.94 - 1.05,1.04 - 0.68,0.67 - 0.01,--,0,No,No,Y
+Appropriate Workup Prior to Endometrial Ablation,448,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Appropriate Treatment for Patients with Stage I (T1c) - III HER2 Positive Breast Cancer,450,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+RAS (KRAS and NRAS) Gene Mutation Testing Performed for Patients with Metastatic Colorectal Cancer who receive Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibody Therapy,451,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Patients with Metastatic Colorectal Cancer and RAS (KRAS or NRAS) Gene Mutation Spared Treatment with Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibodies,452,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Percentage of Patients Who Died from Cancer Receiving Chemotherapy in the Last 14 Days of Life (lower score -better),453,MIPS CQM,Process,Y,,12.8828187919463,18.18 - 15.57,15.56 - 13.96,13.95 - 11.28,11.27 - 10.01,10.0 - 8.58,8.57 - 6.07,6.06 - 0.01,0,No,No,Y
+Percentage of Patients Who Died from Cancer Admitted to the Intensive Care Unit (ICU) in the Last 30 Days of Life (lower score -better),455,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Percentage of Patients Who Died from Cancer Admitted to Hospice for Less than 3 days (lower score -better),457,MIPS CQM,Outcome,Y,,8.48145161290322,11.32 - 10.01,10.0 - 8.17,8.16 - 6.99,6.98 - 4.27,4.26 - 3.04,3.03 - 2.23,2.22 - 0.01,0,No,No,Y
+Back Pain After Lumbar Discectomy/Laminectomy,459,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Back Pain After Lumbar Fusion,460,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Leg Pain After Lumbar Discectomy/Laminectomy,461,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Bone Density Evaluation for Patients with Prostate Cancer and Receiving Androgen Deprivation Therapy,462,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Prevention of Post-Operative Vomiting (POV) -Combination Therapy (Pediatrics),463,MIPS CQM,Process,Y,,96.1175274725274,94.59 - 97.29,97.3 - 98.24,98.25 - 99.07,99.08 - 99.66,99.67 - 99.99,--,--,100,Yes,Yes,Y
+Otitis Media with Effusion: Systemic Antimicrobials - Avoidance of Inappropriate Use,464,MIPS CQM,Process,Y,,89.8478527607361,84.47 - 87.52,87.53 - 89.99,90.0 - 92.74,92.75 - 94.53,94.54 - 96.14,96.15 - 97.59,97.6 - 99.99,100,No,No,Y
+Uterine Artery Embolization Technique: Documentation of Angiographic Endpoints and Interrogation of Ovarian Arteries,465,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Continuity of Pharmacotherapy for Opioid Use Disorder (OUD),468,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Functional Status After Lumbar Fusion,469,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Functional Status After Primary Total Knee Replacement,470,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Functional Status After Lumbar Discectomy/Laminectomy,471,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Appropriate Use of DXA Scans in Women Under 65 Years Who Do Not Meet the Risk Factor Profile for Osteoporotic Fracture,472,eCQM,Process,Y,,1.22275193798449,--,--,--,--,--,--,--,0,Yes,No,Y
+Leg Pain After Lumbar Fusion,473,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+HIV Screening,475,eCQM,Process,Y,,7.33773333333333,1.46 - 2.44,2.45 - 5.31,5.32 - 9.48,9.49 - 25.5,25.51 - 99.99,--,--,100,No,No,N
+Urinary Symptom Score Change 6-12 Months After Diagnosis of Benign Prostatic Hyperplasia,476,eCQM,patientReportedOutcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Multimodal Pain Management,477,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Functional Status Change for Patients with Neck Impairments,478,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Asthma Control: Minimal Important Difference Improvement,AAAAI17,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Penicillin Allergy: Appropriate Removal or Confirmation,AAAAI18,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Asthma: Assessment of Asthma Control -Ambulatory Care Setting,AAAAI2,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Documentation of Clinical Response to Allergen Immunotherapy within One Year,AAAAI6,QCDR Measure,Process,Y,,100.,--,--,--,--,--,--,--,100,Yes,No,Y
+Achievement of Projected Effective Dose of Standardized Allergens for Patient Treated With Allergen Immunotherapy for at Least One Year,AAAAI8,QCDR Measure,Outcome,Y,,99.4083333333333,99.72 - 99.72,99.73 - 99.76,99.77 - 99.99,--,--,--,--,100,No,No,Y
+Dermatitis -Improvement in Patient-Reported Itch Severity,AAD10,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Skin Cancer Surgery: Post-Operative Complications,AAD11,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Melanoma: -Appropriate Surgical Margins,AAD12,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Skin Cancer: Biopsy Reporting Time - Clinician to Patient,AAD6,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Psoriasis: Screening for Psoriatic Arthritis,AAD7,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Chronic Skin Conditions: Patient Reported Quality-of-Life,AAD8,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Psoriasis -Improvement in Patient-Reported Itch Severity,AAD9,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Quality of Life Outcome for Patients with Neurologic Conditions,AAN22,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Pediatric Medication reconciliation,AAN25,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Activity counseling for back pain,AAN26,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Diabetes/Pre-Diabetes Screening for Patients with DSP,AAN28,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Comprehensive Epilepsy Care Center Referral or Discussion for Patients with Epilepsy,AAN29,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Migraine Preventive Therapy Management,AAN30,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Acute Treatment Prescribed for Cluster Headache,AAN31,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Preventive Treatment Prescribed for Cluster Headache,AAN32,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Fatigue Screening and Follow-Up for Patients with MS,AAN33,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Patient reported falls and plan of care,AAN34,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Medication Prescribed For Acute Migraine Attack,AAN5,QCDR Measure,Process,Y,,62.8229629629629,49.63 - 54.48,54.49 - 57.87,57.88 - 62.6,62.61 - 67.04,67.05 - 73.17,73.18 - 79.66,79.67 - 84.9,>= 84.91,No,No,N
+Exercise and Appropriate Physical Activity Counseling for Patients with MS,AAN8,QCDR Measure,Process,Y,,73.2660273972602,58.33 - 69.99,70.0 - 73.99,74.0 - 80.44,80.45 - 88.88,88.89 - 92.49,92.5 - 96.14,96.15 - 97.91,>= 97.92,No,No,N
+Querying About Symptoms of Autonomic Dysfunction for Patients with Parkinson's Disease,AAN9,QCDR Measure,Process,Y,,72.3732142857143,53.7 - 64.72,64.73 - 81.21,81.22 - 86.79,86.8 - 90.19,90.2 - 92.66,92.67 - 96.29,96.3 - 97.67,>= 97.68,No,No,N
+Tympanostomy Tubes: Topical Ear Drop Monotherapy Acute Otorrhea,AAO12,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Bell's Palsy: Inappropriate Use of Magnetic Resonance Imaging or Computed Tomography Scan (Inverse Measure),AAO13,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Age-related Hearing Loss: Audiometric Evaluation,AAO16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Tympanostomy Tubes: Hearing Test,AAO20,QCDR Measure,Process,Y,,96.3380769230769,96.03 - 97.49,97.5 - 98.07,98.08 - 98.41,98.42 - 98.8,98.81 - 98.97,98.98 - 99.39,99.4 - 99.99,100,Yes,No,N
+Otitis Media with Effusion: Hearing Test for Chronic OME > 3 months,AAO21,QCDR Measure,Process,Y,,37.2285714285714,21.29 - 25.69,25.7 - 36.07,36.08 - 42.07,42.08 - 43.16,43.17 - 44.5,44.51 - 46.44,46.45 - 52.1,>= 52.11,No,No,N
+Allergic Rhinitis: Intranasal Corticosteroids or Oral Antihistamines,AAO23,QCDR Measure,Process,Y,,69.6216129032258,61.71 - 67.54,67.55 - 70.41,70.42 - 72.81,72.82 - 75.71,75.72 - 77.35,77.36 - 80.08,80.09 - 84.43,>= 84.44,No,No,N
+Allergic Rhinitis: Avoidance of Leukotriene Inhibitors,AAO24,QCDR Measure,Process,Y,,89.47635,82.68 - 85.52,85.53 - 87.61,87.62 - 90.84,90.85 - 93.36,93.37 - 96.01,96.02 - 96.96,96.97 - 98.61,>= 98.62,No,No,Y
+Quality of Life for Patients with Neurotology Disorders,AAO29,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Otitis Media with Effusion (OME): Avoidance of Inappropriate Use of Medications,AAO31,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Standard BPPV Management,AAO32,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Dysphonia: Postoperative Laryngeal Examination,AAO34,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Benign Positional Paroxysmal Vertigo (BPPV): Dix-Hallpike and Canalith Repositioning,AAO35,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Tympanostomy Tubes: Resolution of Otitis Media with Effusion in Adults and Children,AAO36,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Pediatric OSA: Objective Assessment of Positive Airway Pressure Therapy Adherence,AASM1,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Pediatric OSA: Objective Assessment of OSA Signs and Symptoms in Children with Complex Medical Conditions,AASM2,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Adult OSA: Screening for Adult OSA by Primary Care Physicians,AASM3,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Person-Centered Primary Care Measure Performance Measure (PCPCM PRO-PM),ABFM11,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Measuring the Value-Functions of Primary Care: Provider Level Continuity Measure,ABFM9,QCDR Measure,Efficiency and Cost/Resource Use,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Hypotension Prevention After Spinal Placement for Elective Cesarean Section,ABG40,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Upper Extremity Nerve Blockade in Shoulder Surgery,ABG41,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Known or Suspected Difficult Airway Mitigation Strategies,ABG42,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Heart Failure: Patient Self Care Education,ACCPIN11,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Peripheral Artery Disease: Treatment of Blood Cholesterol to Reduce Atherosclerotic Cardiovascular Risk,ACCPIN7,QCDR Measure,Process,Y,,77.8094318181818,71.74 - 76.08,76.09 - 80.4,80.41 - 82.8,82.81 - 83.98,83.99 - 87.49,87.5 - 89.59,89.6 - 93.41,>= 93.42,No,No,N
+Hypertension Control (Stage 1 or 2),ACCPIN8,QCDR Measure,Intermediate Outcome,Y,,26.5656153846153,19.73 - 22.74,22.75 - 25.17,25.18 - 27.57,27.58 - 29.19,29.2 - 30.71,30.72 - 34.28,34.29 - 38.55,>= 38.56,No,No,Y
+Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older,ACEP19,QCDR Measure,Process,Y,,60.3532075471698,53.1 - 54.85,54.86 - 58.03,58.04 - 60.13,60.14 - 63.28,63.29 - 64.96,64.97 - 68.41,68.42 - 72.75,>= 72.76,No,No,Y
+Coagulation Studies in Patients Presenting with Chest Pain with No Coagulopathy or Bleeding,ACEP21,QCDR Measure,Process,Y,,9.90906040268455,14.87 - 11.0,10.99 - 9.23,9.22 - 6.56,6.55 - 4.82,4.81 - 3.7,3.69 - 2.78,2.77 - 0.01,0,No,No,Y
+Appropriate Emergency Department Utilization of CT for Pulmonary Embolism,ACEP22,QCDR Measure,Process,Y,,33.6521538461538,21.55 - 24.47,24.48 - 27.66,27.67 - 32.79,32.8 - 37.74,37.75 - 41.45,41.46 - 44.69,44.7 - 51.47,>= 51.48,No,No,Y
+Tobacco Use: Screening and Cessation Intervention for Patients with Asthma and COPD,ACEP25,QCDR Measure,Process,Y,,70.4149122807017,59.36 - 67.82,67.83 - 70.73,70.74 - 72.69,72.7 - 76.05,76.06 - 77.26,77.27 - 79.03,79.04 - 88.21,>= 88.22,No,No,N
+Sepsis Management: Septic Shock: Lactate Clearance Rate of >= 10%,ACEP30,QCDR Measure,Outcome,Y,,80.1643333333333,73.81 - 76.51,76.52 - 77.63,77.64 - 80.47,80.48 - 82.91,82.92 - 84.78,84.79 - 87.02,87.03 - 90.58,>= 90.59,No,No,Y
+Appropriate Foley catheter use in the emergency department,ACEP31,QCDR Measure,Process,Y,,67.1533333333333,48.44 - 54.35,54.36 - 57.2,57.21 - 73.9,73.91 - 75.24,75.25 - 77.77,77.78 - 85.25,85.26 - 89.2,>= 89.21,No,No,Y
+"Sepsis Management: Septic Shock: Lactate Level Measurement, Antibiotics Ordered, and Fluid Resuscitation",ACEP48,QCDR Measure,Process,Y,,87.5795652173913,83.63 - 85.95,85.96 - 87.49,87.5 - 89.57,89.58 - 90.9,90.91 - 92.15,92.16 - 94.24,94.25 - 96.6,>= 96.61,No,No,N
+ED Median Time from ED arrival to ED departure for all Adult Patients,ACEP50,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,N
+ED Median Time from ED arrival to ED departure for all Pediatric Patients,ACEP51,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Appropriate Emergency Department Utilization of Lumbar Spine Imaging for Atraumatic Low Back Pain,ACEP52,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Appropriate Use of Imaging for Recurrent Renal Colic,ACEP53,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Appropriate Utilization of FAST Exam in the Emergency Department,ACEP54,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,ACEP55,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Follow-Up Care Coordination Documented in Discharge Summary,ACEP56,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+"Avoidance of Opioid therapy for migraine, low back pain, dental pain",ACEP57,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Appropriate Treatment for Adults with Upper Respiratory Infection (URI),ACEP58,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Closing the Mohs Surgery Referral Loop: Transmission of Surgical Report,ACMS2,QCDR Measure,Process,Y,,85.335303030303,82.14 - 92.02,92.03 - 96.2,96.21 - 97.47,97.48 - 98.32,98.33 - 99.5,99.51 - 99.88,99.89 - 99.99,100,Yes,No,Y
+Antibiotic Prophylaxis for High Risk Cardiac / Orthopedic Cases prior to Mohs micrographic surgery - Prevention of Overuse,ACMS3,QCDR Measure,Process,Y,,80.111724137931,80.95 - 86.08,86.09 - 86.66,86.67 - 89.93,89.94 - 94.33,94.34 - 95.88,95.89 - 98.3,98.31 - 99.99,100,No,No,Y
+Surgical Site Infection Rate - Mohs Micrographic Surgery,ACMS4,QCDR Measure,Outcome,Y,,.868026315789473,1.27 - 1.09,1.08 - 0.92,0.91 - 0.76,0.75 - 0.37,0.36 - 0.16,0.15 - 0.09,0.08 - 0.01,0,No,No,Y
+Documentation of High-Risk Squamous Cell Carcinoma Stage in Mohs Micrographic Surgery Record,ACMS5,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Limit quantity of opioids prescribed for pain management in patients following Mohs micrographic surgery,ACMS8,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+ABCDEF Bundle - Early mobility for ICU patients,ACQR12,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Sepsis: Hour One bundle,ACQR13,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Use of a risk stratification tool in patients with CAP,ACQR15,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+COPD Exacerbation or CHF Exacerbation requiring Hospital Admission: Palliative Care Evaluation,ACQR16,QCDR Measure,Efficiency and Cost/Resource Use,Y,,75.5976923076923,66.41 - 69.99,70.0 - 73.07,73.08 - 75.69,75.7 - 80.03,80.04 - 83.92,83.93 - 87.58,87.59 - 92.85,>= 92.86,No,No,Y
+COPD: Steroids for no more than 5 days in COPD Exacerbation,ACQR3,QCDR Measure,Efficiency and Cost/Resource Use,Y,,94.0229333333333,90.91 - 92.58,92.59 - 94.43,94.44 - 95.71,95.72 - 96.77,96.78 - 97.36,97.37 - 98.38,98.39 - 99.01,>= 99.02,No,No,Y
+Use of ACE-I or ARB and beta blockade in CHF,ACQR9,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Hepatitis B Safety Screening,ACR10,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Disease Activity Measurement for Patients with PsA,ACR12,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Gout: Serum Urate Target,ACR14,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Safe Hydroxychloroquine Dosing,ACR15,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Rheumatoid Arthritis Patients with Low Disease Activity or Remission,ACR16,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Report Turnaround Time: Radiography,ACRAD15,QCDR Measure,Outcome,Y,,4.57878238341969,6.38 - 4.93,4.92 - 3.86,3.85 - 2.78,2.77 - 2.03,2.02 - 1.51,1.5 - 1.17,1.16 - 0.8,<= 0.79,No,No,Y
+Report Turnaround Time: Ultrasound (Excluding Breast US),ACRAD16,QCDR Measure,Outcome,Y,,6.42633587786259,8.2 - 6.45,6.44 - 5.16,5.15 - 4.15,4.14 - 3.3,3.29 - 2.42,2.41 - 1.83,1.82 - 1.08,<= 1.07,No,No,Y
+Report Turnaround Time: MRI,ACRAD17,QCDR Measure,Outcome,Y,,10.7413483146067,16.2 - 11.6,11.59 - 9.49,9.48 - 7.92,7.91 - 6.05,6.04 - 4.81,4.8 - 3.62,3.61 - 2.34,<= 2.33,No,No,Y
+Report Turnaround Time: CT,ACRAD18,QCDR Measure,Outcome,Y,,6.81127226463104,6.51 - 4.91,4.9 - 4.04,4.03 - 3.23,3.22 - 2.63,2.62 - 2.12,2.11 - 1.64,1.63 - 1.18,<= 1.17,No,No,Y
+Report Turnaround Time: PET,ACRAD19,QCDR Measure,Outcome,Y,,24.5643617021276,42.76 - 26.21,26.2 - 14.76,14.75 - 10.51,10.5 - 8.39,8.38 - 6.91,6.9 - 5.09,5.08 - 3.89,<= 3.88,No,No,Y
+Report Turnaround Time: Mammography,ACRAD25,QCDR Measure,Outcome,Y,,22.8680104712041,34.33 - 25.24,25.23 - 22.27,22.26 - 16.39,16.38 - 11.32,11.31 - 6.79,6.78 - 3.98,3.97 - 0.84,<= 0.83,No,No,Y
+"Multi-strata weighted average for 3 CT Exam Types: Overall Percent of CT exams for which Dose Length Product is at or below the size-specific diagnostic reference level (for CT Abdomen-pelvis with contrast/single phase scan, CT Chest without contrast/single phase scan and CT Head/Brain without contrast/single phase scan)",ACRAD34,QCDR Measure,Outcome,Y,,78.9054237288135,60.43 - 73.28,73.29 - 82.24,82.25 - 87.25,87.26 - 89.15,89.16 - 94.27,94.28 - 95.13,95.14 - 95.64,>= 95.65,No,No,Y
+Incidental Coronary Artery Calcification Reported on Chest CT,ACRAD36,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Interpretation of CT Pulmonary Angiography (CTPA) for Pulmonary Embolism,ACRAD37,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Use of Low Dose Cranial CT or MRI Examinations for Patients with Ventricular Shunts,ACRAD38,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Use of Low Dose CT Studies for Adults with Suspicion of Urolithiasis or Nephrolithiasis,ACRAD39,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Use of Structured Reporting in Prostate MRI,ACRAD40,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Use of Quantitative Criteria for Oncologic FDG PET Imaging,ACRAD41,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Surveillance Imaging for Liver Nodules <10mm in Patients at Risk for Hepatocellular Carcinoma (HCC),ACRAD42,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Ventral Hernia Repair: Pain and Functional Status Assessment,AHSQC10,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Abdominal Wall Reconstruction Surgical Site Occurrence Requiring Procedural Intervention within the 30 Day Postoperative Period,AHSQC6,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Hip Arthroplasty: Shared Decision-Making: Trial of Conservative (Non-surgical) Therapy,AJRR3,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Hip Arthroplasty: Venous Thromboembolic and Cardiovascular Risk Evaluation,AJRR4,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Hip/Knee Arthroplasty: Unplanned Readmission within 90 Days Following the Primary Procedure,AJRR6,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Hip/Knee Replacement: Postoperative Ambulation,AJRR7,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Coronary Artery Bypass Graft (CABG): Prolonged Intubation -Inverse Measure,AQI18,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Patient-Reported Experience with Anesthesia,AQI48,QCDR Measure,Patient Reported Outcome,Y,,92.2841780821917,89.93 - 91.0,91.01 - 91.9,91.91 - 92.57,92.58 - 93.08,93.09 - 94.52,94.53 - 95.58,95.59 - 96.37,>= 96.38,No,No,Y
+Adherence to Blood Conservation Guidelines for Cardiac Operations using Cardiopulmonary Bypass (CPB) -Composite,AQI49,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Team-Based Implementation of a Care-and-Communication Bundle for ICU Patients,AQI55,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Use of Neuraxial Techniques and/or Peripheral Nerve Blocks for Total Knee Arthroplasty (TKA),AQI56,QCDR Measure,Process,Y,,89.4729801324503,85.5 - 91.45,91.46 - 95.44,95.45 - 97.13,97.14 - 98.81,98.82 - 99.48,99.49 - 99.99,--,100,Yes,No,N
+Safe Opioid Prescribing Practices,AQI57,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Obstructive Sleep Apnea: Patient Education,AQI62,QCDR Measure,Process,Y,,87.0532608695652,81.0 - 92.28,92.29 - 97.15,97.16 - 99.55,99.56 - 99.9,99.91 - 99.99,--,--,100,Yes,No,N
+Avoidance of Cerebral Hyperthermia for Procedures Involving Cardiopulmonary Bypass,AQI65,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Consultation for Frail Patients,AQI67,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Obstructive Sleep Apnea: Mitigation Strategies,AQI68,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Intraoperative Antibiotic Redosing,AQI69,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Prevention of Arterial Line-Related Bloodstream Infections,AQI70,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Ambulatory Glucose Management,AQI71,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Perioperative Anemia Management,AQI72,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Stones: Inappropriate Repeat Shock Wave Lithotripsy (SWL) Within 6 Months of Initial Treatment,AQUA14,QCDR Measure,Outcome,Y,,31.06625,41.28 - 38.72,38.71 - 34.49,34.48 - 31.48,31.47 - 28.42,28.41 - 21.37,21.36 - 13.8,13.79 - 2.28,<= 2.27,No,No,Y
+Stones: Urinalysis Performed Before Surgical Stone Procedures,AQUA15,QCDR Measure,Process,Y,,65.0795454545454,47.84 - 53.18,53.19 - 63.14,63.15 - 69.66,69.67 - 74.65,74.66 - 76.97,76.98 - 84.09,84.1 - 92.24,>= 92.25,No,No,Y
+Non-Muscle Invasive Bladder Cancer: Repeat Transurethral Resection of Bladder Tumor (TURBT) for T1 disease,AQUA16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Non-Muscle Invasive Bladder Cancer: Early Surveillance Cystoscopy for Non-Muscle Invasive Bladder Cancer,AQUA18,QCDR Measure,Process,Y,,37.746923076923,26.39 - 28.12,28.13 - 28.37,28.38 - 29.36,29.37 - 33.32,33.33 - 45.31,45.32 - 58.53,58.54 - 66.66,>= 66.67,No,No,N
+Benign Prostate Hyperplasia (BPH): Inappropriate Lab & Imaging Services for Patients with BPH,AQUA26,QCDR Measure,Process,Y,,11.1280487804878,14.58 - 12.17,12.16 - 9.34,9.33 - 6.49,6.48 - 5.01,5.0 - 3.09,3.08 - 1.04,1.03 - 0.01,0,No,No,Y
+Hospital admissions/complications within 30 days of TRUS Biopsy,AQUA8,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Patient Satisfaction with Information Provided during Breast Reconstruction,ASPS10,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Airway Assessment for patients undergoing Rhinoplasty,ASPS16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Patient Satisfaction with Rhinoplasty Procedure,ASPS17,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Shared-decision making for post-operative management of discomfort following Rhinoplasty,ASPS18,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Coordination of Care for Anticoagulated Patients Undergoing Reconstruction After Skin Cancer Resection,ASPS22,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Visits to the ER or Urgent Care Following Reconstruction After Skin Cancer Resection,ASPS24,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Patient Satisfaction with Information Prior to Facial Reconstruction After Skin Cancer Resection Procedures,ASPS26,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Avoidance of Post-operative Systemic Antibiotics for Office-based Closures and Reconstruction After Skin Cancer Procedures,ASPS27,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Continuation of Anticoagulation Therapy in the Office-based Setting for Closure and Reconstruction After Skin Cancer Resection Procedures,ASPS28,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Avoidance of Opioid Prescriptions for Closure and Reconstruction After Skin Cancer Resection,ASPS29,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Breast Reconstruction: Return to OR,ASPS5,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Turnaround Time (TAT) - Biopsies,CAP22,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Helicobacter pylori Status and Turnaround Time,CAP28,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Urinary Bladder Biopsy Diagnostic Requirements For Appropriate Patient Management,CAP30,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+"Prostate Cancer Gleason Pattern, Score, and Grade Group",CAP32,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+"Mismatch Repair (MMR) or Microsatellite Instability (MSI) Biomarker Testing Status in Colorectal Carcinoma, Endometrial, Gastroesophageal, or Small Bowel Carcinoma",CAP33,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Biomarker Status to Inform Clinical Management and Treatment Decisions in Patients with Non-small Cell Lung Cancer,CAP34,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+"Cancer Protocol and Turnaround Time for Gastrointestinal Carcinomas: Gastric, Esophageal, Colorectal and Hepatocellular Carcinomas",CAP35,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+p16 Immunohistochemistry Reporting for Human Papillomavirus in Patients with Oropharyngeal Squamous Cell Carcinoma (OPSCC),CAP36,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+"Cancer Protocol and Turnaround Time for Gynecologic and Genitourinary Carcinomas: Carcinoma of the Endometrium, Prostate, and Renal Tubular Origin",CAP37,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Patient-Reported Pain and/or Function Improvement after Total Knee Arthroplasty,CCOME1,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Patient-Reported Pain and/or Function Improvement after ACLR Surgery,CCOME4,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Extent of Osteoarthritis Observed in Arthroscopic Partial Meniscectomy,CCOME5,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Patient-Reported Pain and/or Function Improvement after APM Surgery,CCOME6,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Patient-Reported Pain and/or Function Improvement after Total Hip Arthroplasty,CCOME7,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Patient-Reported Pain and/or Function Improvement after Total Shoulder Arthroplasty,CCOME8,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Adequate Off-loading of Diabetic Foot Ulcer at each visit,CDR1,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Diabetic Foot Ulcer (DFU) Healing or Closure,CDR2,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Adequate Compression at each visit for Patients with VLUs,CDR5,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Venous Leg Ulcer (VLU) outcome measure: Healing or Closure,CDR6,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Appropriate Use of hyperbaric oxygen therapy for patients with diabetic foot ulcers,CDR8,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Post operative hypocalcemia after thyroidectomy surgery,CESQIP1,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Pre operative ultrasound exam of patients with thyroid cancer,CESQIP3,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Related readmission for adrenal related problems,CESQIP5,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+qPTH >50% Reduction at End of Procedure,CESQIP9,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Avoid Head CT for Patients with Uncomplicated Syncope,ECPR39,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Initiation of the Initial Sepsis Bundle,ECPR40,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Rh Status Evaluation and Treatment of Pregnant Women at Risk of Fetal Blood Exposure,ECPR41,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Avoidance of Opiates for Low Back Pain or Migraines,ECPR46,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Door to Diagnostic Evaluation by a Provider Within 30 Minutes -Urgent Care Patients,ECPR50,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Discharge Prescription of Naloxone after Opioid Poisoning or Overdose,ECPR51,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Appropriate Treatment of Psychosis and Agitation in the Emergency Department,ECPR52,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Clinician Reporting of Loss of Consciousness to State Department of Public Health or Department of Motor Vehicles,ECPR53,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Avoidance of Co-Prescribing of Opioid Analgesic and Benzodiazepine,ECPR54,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Avoidance of Long-Acting (LA) or Extended-Release (ER) Opiate Prescriptions and Opiate Prescriptions for Greater Than 3 Days Duration for Acute Pain,ECPR55,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Opioid Withdrawal: Initiation of Medication-Assisted Treatment (MAT) and Referral to Outpatient Opioid Treatment,ECPR56,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Ultrasound Guidance for Peripheral Nerve Block with Patient Experience,EPREOP30,QCDR Measure,Outcome,Y,,91.3126666666666,87.68 - 89.66,89.67 - 90.71,90.72 - 91.37,91.38 - 92.86,92.87 - 93.95,93.96 - 95.51,95.52 - 96.52,>= 96.53,No,No,Y
+Intraoperative Hypotension among Non-Emergent Noncardiac Surgical Cases,EPREOP31,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Review of Pain Status Assessment for Patients with Osteoarthritis,FORCE21,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Functional Status Change for Patients Post Stroke: Lower Body,FOTO2,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Functional Status Change for Patients Post Stroke: Upper Body,FOTO3,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Functional Status Changes for Patients with Upper or Lower Extremity Regional Swelling,FOTO4,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Appropriate management of anticoagulation in the peri-procedural period rate -EGD,GIQIC10,QCDR Measure,Process,Y,,69.2643617021276,47.96 - 60.7,60.71 - 79.82,79.83 - 86.7,86.71 - 91.66,91.67 - 96.06,96.07 - 99.99,--,100,No,No,Y
+Screening Colonoscopy Adenoma Detection Rate,GIQIC22,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Appropriate follow-up interval based on pathology findings in screening colonoscopy,GIQIC23,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Venous Thromboembolism (VTE) Prophylaxis,HCPR14,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Physician's Orders for Life-Sustaining Treatment (POLST) Form,HCPR16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Pressure Ulcers -Risk Assessment and Plan of Care,HCPR17,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Unintentional Weight Loss -Risk Assessment and Plan of Care,HCPR18,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Clostridium Difficile -Risk Assessment and Plan of Care,HCPR20,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Critical Care Transfer of Care -Use of Verbal Checklist or Protocol,HCPR22,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Avoidance of Echocardiogram and Carotid Ultrasound for Syncope,HCPR23,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Outcomes of Hearing Loss Treatment,HM10,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Outcomes of Treatment of Subjective Tinnitus,HM11,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Outcomes of Treatment of Benign Paroxysmal Positional Vertigo,HM12,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Functional Status Change for Patients With Upper-limb Functional Status Deficit,HM4,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Functional Status Change for Patients With Neck Functional Status Deficit,HM5,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Functional Status Change for Patients With Low Back Functional Status Deficit,HM6,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Functional Status Change for Patients with Vestibular Dysfunction,HM7,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Functional Status Change for Patients With Lower Extremity Functional Status Deficit,HM8,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Functional Benefit of a Cochlear Implant,HM9,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Comprehensive TTE studies reporting a measured value of LVEF AND wall motion findings with LVEF < 50%,IGR1,QCDR Measure,Efficiency and Cost/Resource Use,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Transthoracic Echo (TTE) performance per ASE guidelines,IGR10,QCDR Measure,Efficiency and Cost/Resource Use,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Appropriate diagnosis verification and severity grading for valve disease through transthoracic echocardiography (TTE) quantitative parameters.,IGR12,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Appropriate Evaluation of Left Ventricular Structure and Systolic Function with Transthoracic Echocardiography (TTE) to Guide Heart Failure and Cardiomyopathy Management,IGR14,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Myocardial Perfusion Imaging (MPI) or Stress Echocardiography Imaging Studies - Adequate Exercise Protocol,IGR15,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+"Myocardial Perfusion Imaging (MPI) Studies, Transthoracic Echo (TTE), or Stress Echocardiography Imaging Studies - Adequate Reporting for Appropriate Interventions",IGR16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Myocardial Perfusion Imaging (MPI) studies - Radiation Reduction Strategies,IGR17,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Myocardial Perfusion Imaging (MPI) or Stress Echocardiography imaging studies - Improving Image Quality,IGR18,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+"Parameters in stress echocardiography dobutamine testing for low flow, low gradient aortic stenosis",IGR2,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Stress echo performance for shortness of breath per ASE guidelines,IGR9,QCDR Measure,Efficiency and Cost/Resource Use,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Endothelial Keratoplasty - Post-operative improvement in best corrected visual acuity to 20/40 or better,IRIS1,QCDR Measure,Outcome,Y,,55.1739130434782,38.75 - 46.14,46.15 - 48.71,48.72 - 55.87,55.88 - 56.39,56.4 - 66.98,66.99 - 71.78,71.79 - 79.99,>= 80.0,No,No,Y
+Glaucoma – Intraocular Pressure Reduction,IRIS2,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Diabetic Macular Edema - Loss of Visual Acuity,IRIS13,QCDR Measure,Outcome,Y,,86.0751923076923,70.84 - 82.47,82.48 - 87.43,87.44 - 88.74,88.75 - 89.86,89.87 - 92.24,92.25 - 93.87,93.88 - 98.07,>= 98.08,No,No,Y
+Acute Anterior Uveitis: Post-treatment Grade 0 anterior chamber cells,IRIS17,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Refractive Surgery: Patients with a postoperative uncorrected visual acuity (UCVA) of 20/20 or better within 30 days,IRIS23,QCDR Measure,Outcome,Y,,80.3240909090909,68.75 - 75.33,75.34 - 79.91,79.92 - 83.01,83.02 - 87.79,87.8 - 89.18,89.19 - 94.11,94.12 - 95.8,>= 95.81,No,No,Y
+Refractive Surgery: Patients with a postoperative correction within + or - 0.5 Diopter (D) of the intended correction,IRIS24,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Avoidance of Routine Antibiotic Use in Patients Before or After Intravitreal Injections,IRIS26,QCDR Measure,Efficiency and Cost/Resource Use,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Improvement of Macular Edema in Patients with Uveitis,IRIS35,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Endothelial Keratoplasty -Dislocation Requiring Surgical Intervention,IRIS38,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Intraocular Pressure Reduction Following Trabeculectomy or an Aqueous Shunt Procedure,IRIS39,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Improved visual acuity after epiretinal membrane treatment within 120 days,IRIS41,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Intraocular Pressure Reduction Following Laser Trabeculoplasty,IRIS43,QCDR Measure,Outcome,Y,,45.9873333333333,21.43 - 27.49,27.5 - 30.52,30.53 - 33.32,33.33 - 38.97,38.98 - 62.85,62.86 - 70.96,70.97 - 85.7,>= 85.71,No,No,Y
+Visual Field Progression in Glaucoma,IRIS44,QCDR Measure,Outcome,Y,,12.2051351351351,15.65 - 14.02,14.01 - 13.13,13.12 - 11.84,11.83 - 10.85,10.84 - 9.53,9.52 - 8.84,8.83 - 2.34,<= 2.33,No,No,Y
+Exudative Age-Related Macular Degeneration: Loss of Visual Acuity,IRIS45,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Evidence of anatomic closure of macular hole within 90 days after surgery as documented by OCT,IRIS46,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Adult Surgical Esotropia: Postoperative alignment,IRIS48,QCDR Measure,Outcome,Y,,17.9125,2.86 - 4.41,4.42 - 6.0,6.01 - 7.69,7.7 - 15.6,15.61 - 22.61,22.62 - 31.24,31.25 - 37.32,>= 37.33,No,No,Y
+Surgical Pediatric Esotropia: Postoperative alignment,IRIS49,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Surgery for Acquired Involutional Ptosis: Patients with an improvement of marginal reflex distance (MRD),IRIS5,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Amblyopia: Interocular visual acuity,IRIS50,QCDR Measure,Outcome,Y,,54.3538095238095,42.86 - 47.61,47.62 - 53.32,53.33 - 56.51,56.52 - 57.88,57.89 - 67.56,67.57 - 68.17,68.18 - 68.96,>= 68.97,No,No,Y
+Acute Anterior Uveitis: Post-treatment visual acuity,IRIS51,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Post-operative opioid management following ocular surgery,IRIS52,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Chronic Anterior Uveitis - Post-treatment visual acuity,IRIS53,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Complications After Cataract Surgery,IRIS54,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Visual Acuity Improvement Following Cataract Surgery and Minimally Invasive Glaucoma Surgery,IRIS55,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Adult Diplopia: Improvement of ocular deviation or absence of diplopia or functional improvement,IRIS56,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Idiopathic Intracranial Hypertension: Improvement of mean deviation or stability of mean deviation,IRIS57,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Improved Visual Acuity after Vitrectomy for Complications of Diabetic Retinopathy within 120 Days,IRIS58,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Regaining Vision After Cataract Surgery,IRIS59,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Acquired Involutional Entropion: Normalized lid position after surgical repair,IRIS6,QCDR Measure,Outcome,Y,,91.297619047619,91.74 - 93.85,93.86 - 95.69,95.7 - 98.27,98.28 - 99.99,--,--,--,100,No,No,Y
+Visual Acuity Improvement Following Cataract Surgery Combined with a Trabeculectomy or an Aqueous Shunt Procedure,IRIS60,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) to indicate functional improvement in knee rehabilitation of patients with knee injury measured via their validated Knee Outcome Survey (KOS) score, or equivalent instrument which has undergone peer reviewed published validation and demonstrates a peer reviewed published MCID.",IROMS11,QCDR Measure,Patient Reported Outcome,Y,,26.800022172949,42.45 - 32.6,32.59 - 30.01,30.0 - 27.05,27.04 - 25.01,25.0 - 22.62,22.61 - 21.63,21.62 - 15.59,<= 15.58,No,No,Y
+"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with knee injury pain.",IROMS12,QCDR Measure,Patient Reported Outcome,Y,,40.707676056338,46.15 - 44.08,44.07 - 43.02,43.01 - 40.32,40.31 - 39.59,39.58 - 38.11,38.1 - 35.96,35.95 - 24.01,<= 24.0,No,No,Y
+"Failure to Progress (FTP): Proportion of patients not achieving a Minimal Clinically Important Difference (MCID) to indicate functional improvement in rehabilitation of patients with hip, leg or ankle injuries using the validated Lower Extremity Function Scale (LEFS) score, or equivalent instrument which has undergone peer reviewed published validation and demonstrates a peer reviewed published MCID.",IROMS13,QCDR Measure,Patient Reported Outcome,Y,,35.2059594095941,39.66 - 38.27,38.26 - 36.94,36.93 - 35.01,35.0 - 33.65,33.64 - 32.83,32.82 - 31.59,31.58 - 20.98,<= 20.97,No,No,Y
+"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with hip, leg or ankle (lower extremity except knee) injury.",IROMS14,QCDR Measure,Patient Reported Outcome,Y,,45.2645303867403,52.31 - 50.57,50.56 - 49.26,49.25 - 47.95,47.94 - 46.68,46.67 - 45.54,45.53 - 43.54,43.53 - 18.8,<= 18.79,No,No,Y
+Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) to indicate functional improvement in rehabilitation of patients with neck pain/injury measured via the validated Neck Disability Index (NDI).,IROMS15,QCDR Measure,Patient Reported Outcome,Y,,40.2512468193384,46.15 - 43.86,43.85 - 43.09,43.08 - 42.02,42.01 - 40.92,40.91 - 39.45,39.44 - 35.72,35.71 - 3.18,<= 3.17,No,No,Y
+"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with neck pain/injury.",IROMS16,QCDR Measure,Patient Reported Outcome,Y,,39.3922102425876,46.05 - 43.99,43.98 - 42.77,42.76 - 41.6,41.59 - 40.09,40.08 - 38.93,38.92 - 37.05,37.04 - 5.84,<= 5.83,No,No,Y
+Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) to indicate functional improvement in rehabilitation patients with low back pain measured via the validated Modified Low Back Pain Disability Questionnaire (MDQ) score.,IROMS17,QCDR Measure,Patient Reported Outcome,Y,,32.4685519591141,37.8 - 36.37,36.36 - 35.17,35.16 - 34.35,34.34 - 33.34,33.33 - 32.3,32.29 - 30.5,30.49 - 18.53,<= 18.52,No,No,Y
+"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with low back pain.",IROMS18,QCDR Measure,Patient Reported Outcome,Y,,42.2747957371225,47.06 - 45.44,45.43 - 44.16,44.15 - 43.49,43.48 - 42.87,42.86 - 41.61,41.6 - 40.82,40.81 - 25.01,<= 25.0,No,No,Y
+"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) to indicate functional improvement in rehabilitation of patients with arm, shoulder, and hand injury measured via the validated Disability of Arm Shoulder and Hand (DASH) score, Quick Disability of Arm Shoulder and Hand (QDASH) score, or equivalent instrument which has undergone peer reviewed published validation and demonstrates a peer reviewed published MCID.",IROMS19,QCDR Measure,Patient Reported Outcome,Y,,24.8214691151919,28.57 - 27.57,27.56 - 25.77,25.76 - 24.42,24.41 - 23.43,23.42 - 22.23,22.22 - 20.66,20.65 - 6.74,<= 6.73,No,No,Y
+"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with arm, shoulder, or hand injury.",IROMS20,QCDR Measure,Patient Reported Outcome,Y,,40.6319512195122,46.81 - 45.3,45.29 - 44.86,44.85 - 43.76,43.75 - 41.8,41.79 - 40.71,40.7 - 39.3,39.29 - 15.61,<= 15.6,No,No,Y
+Use of Anxiety Severity Measure,MBHR1,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Symptom Improvement in adults with ADHD,MBHR10,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Cognitive Assessment with Counseling on Safety and Potential Risk,MBHR11,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Patient Feedback of Test Results Following Cognitive or Mental Status Assessment,MBHR12,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Anxiety Response at 6-months,MBHR2,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Pain Interference Response utilizing PROMIS,MBHR3,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Social Role Functioning Outcome utilizing PROMIS,MBHR4,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Screening and monitoring for psychosocial problems among children and youth,MBHR5,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Sleep Quality Assessment and Sleep Response at 3-months,MBHR6,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Posttraumatic Stress Disorder (PTSD) Outcome Assessment for Adults and Children,MBHR7,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Alcohol Use Disorder Outcome Response,MBHR8,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Outcome monitoring of ADHD functional impairment in children and youth,MBHR9,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Use of Capnography for Non-Operating Room Anesthesia,MEDNAX53,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Labor Epidural Failure when Converting from Labor Analgesia to Cesarean Section Anesthesia,MEDNAX54,QCDR Measure,Outcome,Y,,10.7765,22.11 - 12.75,12.74 - 8.67,8.66 - 5.6,5.59 - 4.13,4.12 - 3.17,3.16 - 2.4,2.39 - 0.71,<= 0.7,No,No,Y
+Use of ASPECTS (Alberta Stroke Program Early CT Score) for non-contrast CT Head performed for suspected acute stroke.,MEDNAX55,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Use of a “PEG Test” to Manage Patients Receiving Opioids,MEDNAX56,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Hammer Toe Outcome,MEX5,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Screening Coronary Calcium Scoring for Cardiovascular Risk Assessment Including Coronary Artery Calcification Regional Distribution Scoring,MSN13,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Use of Thyroid Imaging Reporting & Data System (TI-RADS) in Final Report to Stratify Thyroid Nodule Risk,MSN15,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Screening Abdominal Aortic Aneurysm Reporting with Recommendations,MSN16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Prostate Cancer: Confirmation Testing in low risk AS eligible patients,MUSIC10,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Prostate Cancer: Follow-Up Testing for patients on active surveillance for at least 30 months,MUSIC11,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Kidney Stones: ED visit within 30 days of ureteroscopy,MUSIC12,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Kidney Stones: SWL in patients with largest renal stone > 2 cm or lower pole stone > 1 cm,MUSIC15,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Kidney Stones: Opioid utilization after ureteroscopy and shockwave lithotripsy,MUSIC17,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Kidney Stones: Alpha-blockers at discharge for patients undergoing ureteroscopy or shockwave lithotripsy,MUSIC18,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Kidney Stones: Readmission within 30 days of ureteroscopy,MUSIC19,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Prostate Cancer: Complications within 30 days of radical prostatectomy,MUSIC20,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Prostate Cancer: Opioid utilization after radical prostatectomy,MUSIC21,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Prostate Cancer: Urinary continence at 12 months post-radical prostatectomy,MUSIC22,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Renal Mass: Documentation of the RENAL score for patients with small renal mass diagnoses,MUSIC23,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Kidney Stones: Post-ureteroscopy and shockwave lithotripsy imaging for any stones,MUSIC24,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Renal Mass: ED visit or Readmission within 30 days of radical nephrectomy,MUSIC25,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Renal Mass: ED Visit or Readmission within 30 days of partial nephrectomy,MUSIC26,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Prostate Cancer: Active Surveillance/Watchful Waiting for Low Risk Prostate Cancer Patients,MUSIC4,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Prostate Cancer: Radical Prostatectomy Cases LOS,MUSIC5,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Repeat screening or surveillance colonoscopy recommended within one year due to inadequate/poor bowel preparation,NHCR4,QCDR Measure,Process,Y,,49.8047368421052,17.65 - 24.99,25.0 - 37.92,37.93 - 51.99,52.0 - 60.77,60.78 - 72.13,72.14 - 86.43,86.44 - 90.47,>= 90.48,No,No,Y
+CHANGE IN PATIENT REPORTED QUALITY OF LIFE FOLLOWING EPIDURAL LYSIS OF ADHESIONS,NIPM18,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+CHANGE IN PATIENT REPORTED QUALITY OF LIFE AND FUNCTIONAL STATUS FOLLOWING MEDIAL BRANCH RADIOFREQUENCY ABLATION,NIPM19,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+CHANGE IN PATIENT REPORTED PAIN AND FUNCTIONAL STATUS FOLLOWING SPINAL CORD STIMULATOR IMPLANTATION,NIPM20,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+CHANGE IN PATIENT REPORTED QUALITY OF LIFE FOLLOWING EPIDURAL CORTICOSTEROID INJECTION,NIPM22,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+CHANGE IN PATIENT REPORTED QUALITY OF LIFE FOLLOWING MAJOR JOINT CORTICOSTEROID INJECTION,NIPM23,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+CHANGE IN PATIENT REPORTED QUALITY OF LIFE FOLLOWING INTRATHECAL PUMP IMPLANTATION,NIPM24,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+CHANGE IN PATIENT REPORTED QUALITY OF LIFE FOLLOWING INTERSPINOUS INDIRECT DECOMPRESSION (SPACER),NIPM25,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Notification to the ordering provider requesting myoglobin or CK-MB in the diagnosis of suspected acute myocardial infarction (AMI),NPQR1,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Rate of communicating results of an amended report with a major discrepancy to the responsible provider,NPQR11,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Rate of notification to clinical provider of a new diagnosis of malignancy,NPQR13,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Non-small cell lung carcinoma (NSCLC) ancillary biomarker testing status and turnaround time (TAT) from point of specimen accession date to ancillary biomarker testing completion and reporting date should be ≤ 10 days,NPQR15,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Notification to the provider ordering repeat blood chemistry panels in clinically stable patients within four days.,NPQR16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Notification to the provider ordering repeat C. difficile stool toxin testing within seven days,NPQR17,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Notification to the provider ordering repeat CBCs in clinically stable patients within four days,NPQR18,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Notification to the provider ordering repeat Hepatitis C serology testing on a patient with previously positive results,NPQR19,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Notification to the ordering provider requesting thyroid screening tests other than only a Thyroid Stimulating Hormone (TSH) test in the initial screening of a patient with a suspected thyroid disorder,NPQR2,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Notification to the ordering provider requesting amylase testing in the diagnosis of suspected acute pancreatitis,NPQR3,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Time interval: critical value reporting for chemistry,NPQR4,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Time interval: critical value reporting for cerebrospinal fluid - white blood cell (CSF - WBC),NPQR5,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Time interval: critical value reporting for toxicology,NPQR6,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Time interval: critical value reporting for troponin,NPQR7,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Quality of Life - Physical Health Outcomes,OBERD32,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Appropriate non-invasive arterial testing for patients with intermittent claudication who are undergoing a LE peripheral vascular intervention,OEIS6,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Structured Walking Program Prior to Intervention for Claudication,OEIS7,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Use of ultrasound guidance for vascular access,OEIS8,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Patient Reported Health-Related Quality of Life (HRQoL) during Treatment for Advanced Cancer,ONSQIR21,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+PCR Test with MR2 or greater result (BCR-ABL1 transcript level <= 1% [IS]) for patients receiving TKI for at least 6 months for Chronic Myelogenous Leukemia,ONSQIR22,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Assessment for and management of immune-related adverse events during cancer treatment with checkpoint inhibitors (ICPi),ONSQIR23,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Oncology: Advance Care Planning in metastatic cancer patients,PIMSH1,QCDR Measure,Patient Engagement/Experience,Y,,18.9278468899521,2.22 - 3.69,3.7 - 6.16,6.17 - 18.17,18.18 - 29.78,29.79 - 39.99,40.0 - 48.71,48.72 - 64.8,>= 64.81,No,No,Y
+Oncology: Hepatitis B serology testing and prophylactic treatment prior to receiving anti-CD20 targeting drugs,PIMSH10,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+"Oncology: Utilization of PET, PET/CT, or CT scans for breast cancer stage 0, I, or II at any time during the course of evaluation and treatment",PIMSH11,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Oncology: Utilization of GCSF in metastatic colorectal cancer,PIMSH2,QCDR Measure,Efficiency and Cost/Resource Use,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Oncology: Combination chemotherapy recommended or received within 4 months of diagnosis by women under 70 with AJCC stage T1cN0M0 to Stage 1B-III ER/PR negative breast cancer,PIMSH3,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Oncology: Patient-reported pain improvement,PIMSH4,QCDR Measure,Patient Reported Outcome,Y,,40.7223076923076,29.61 - 35.05,35.06 - 38.16,38.17 - 40.8,40.81 - 43.9,43.91 - 47.36,47.37 - 51.04,51.05 - 58.25,>= 58.26,No,No,Y
+Oncology: Mutation testing for lung cancer completed prior to start of targeted therapy,PIMSH8,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Oncology: Supportive care drug utilization in last 14 days of life,PIMSH9,QCDR Measure,Efficiency and Cost/Resource Use,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Appropriate Documentation of a Malnutrition Diagnosis,PINC55,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Assessment of Nutritionally At-Risk Patients for Malnutrition and Development of Nutrition Recommendations/Interventions by a Registered Dietitian Nutritionist,PINC56,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+"Measurement-based Care Processes: Baseline Assessment, Monitoring and Treatment Adjustment",PP8,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Improvement or Maintenance of Functioning for Individuals with a Mental Health and/or Substance Use Disorder,PP9,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+IVC Filter Management Confirmation,QMM16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Appropriate Follow-up Recommendations for Ovarian-Adnexal Lesions using the Ovarian-Adnexal Reporting and Data System (O-RADS),QMM17,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Use of Breast Cancer Risk Score on Mammography,QMM18,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+DEXA/DXA and Fracture Risk Assessment for Patients with Osteopenia,QMM19,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Opening Pressure in Lumbar Puncture,QMM20,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Concurrent Chemo radiation for Patients with a Diagnosis of Stage IIIB NSCLC,QOPI23,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Sentinel Lymph Node (SLN) Biopsies for Patients AJCC T1b-T4 Melanoma,QOPI26,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Appropriate Antiemetic Therapy for High- and Moderate Emetic Risk Antineoplastic Agents,QOPI27,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Central Line Ultrasound Guidance,QUANTUM31,QCDR Measure,Process,Y,,91.7532599118942,89.46 - 95.73,95.74 - 98.14,98.15 - 99.16,99.17 - 99.99,--,--,--,100,Yes,No,Y
+Upper Extremity Edema Improvement,RCOIR10,QCDR Measure,Patient Reported Outcome,Y,,74.628125,67.09 - 70.44,70.45 - 74.08,74.09 - 75.89,75.9 - 76.96,76.97 - 78.56,78.57 - 84.12,84.13 - 89.51,>= 89.52,No,No,Y
+Tunneled Hemodialysis Catheter Success,RCOIR12,QCDR Measure,Outcome,Y,,71.3988235294117,60.98 - 66.98,66.99 - 70.16,70.17 - 76.04,76.05 - 78.3,78.31 - 81.67,81.68 - 84.65,84.66 - 87.01,>= 87.02,No,No,Y
+Percutaneous Arteriovenous Fistula for Dialysis - Clinical Success Rate,RCOIR13,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+End Stage Renal Disease (ESRD) Initiation of Home Dialysis or Self-Care,RCOIR5,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Improved Access Site Bleeding,RCOIR7,QCDR Measure,Outcome,Y,,84.2947058823529,74.6 - 82.94,82.95 - 84.0,84.01 - 86.0,86.01 - 90.04,90.05 - 92.05,92.06 - 93.61,93.62 - 96.07,>= 96.08,No,No,Y
+Heel Pain Treatment Outcomes for Adults,REGCLR1,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Tendinitis/ Enthesopathy- Injection Treatment Outcomes for Adults,REGCLR2,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Bunion Outcome - Adult and Adolescent,REGCLR3,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Heel Pain Treatment Outcomes for Pediatric Patients,REGCLR4,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Offloading with Remote Monitoring,REGCLR5,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Use of Digital Imaging to Monitor and Improve Treatment Outcomes in Chronic Wound Healing,REGCLR6,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Use of Ankle Foot Orthotics to improve patient function,REGCLR7,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Rate of Timely Documentation Transmission to Dialysis Unit/Referring Physician,RPAQIR13,QCDR Measure,Process,Y,,82.4648780487804,91.72 - 92.18,92.19 - 95.18,95.19 - 96.7,96.71 - 96.93,96.94 - 97.48,97.49 - 97.81,97.82 - 99.81,>= 99.82,Yes,No,Y
+Arteriovenous Graft Thrombectomy Success Rate,RPAQIR14,QCDR Measure,Outcome,Y,,76.5662857142857,79.43 - 82.13,82.14 - 85.55,85.56 - 86.97,86.98 - 89.03,89.04 - 91.85,91.86 - 93.83,93.84 - 95.78,>= 95.79,No,No,Y
+Arteriovenous Fistulae Thrombectomy Success Rate,RPAQIR15,QCDR Measure,Outcome,Y,,77.2086666666666,78.35 - 81.64,81.65 - 82.67,82.68 - 84.19,84.2 - 86.06,86.07 - 90.99,91.0 - 91.68,91.69 - 93.14,>= 93.15,No,No,Y
+Peritoneal Dialysis Catheter Success Rate,RPAQIR16,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Advance Directives Completed,RPAQIR18,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Transplant Referral,RPAQIR5,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Percent of patients meeting SCB thresholds for back or neck pain,SPINETRACK4,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Percent of patients meeting SCB thresholds for leg or arm pain,SPINETRACK5,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Percent of patients meeting SCB thresholds for pain-related disability (ODI/NDI),SPINETRACK6,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Patient satisfaction following spinal fusion surgery,SPINETRACK8,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Unplanned hospital readmission following spinal fusion surgery.,SPINETRACK9,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Prolonged Length of Stay Following Coronary Artery Bypass Grafting,STS1,QCDR Measure,Outcome,Y,,2.6012925170068,5.63 - 5.27,5.26 - 4.95,4.94 - 4.08,4.07 - 3.71,3.7 - 2.68,2.67 - 2.29,2.28 - 0.01,0,No,No,Y
+Patient Centered Surgical Risk Assessment and Communication for Cardiac Surgery,STS7,QCDR Measure,Process,Y,,56.4682876712329,2.08 - 19.99,20.0 - 42.85,42.86 - 55.55,55.56 - 73.32,73.33 - 87.26,87.27 - 95.19,95.2 - 99.25,>= 99.26,No,No,Y
+Ankylosing Spondylitis: Controlled Disease,UREQA1,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Ankylosing Spondylitis: Appropriate Pharmacologic Therapy,UREQA2,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Folic or Folinic Acid Therapy for Patients Treated with Methotrexate,UREQA4,QCDR Measure,Process,Y,,92.049511447327,90.21 - 92.9,92.91 - 94.21,94.22 - 94.97,94.98 - 97.29,97.3 - 97.95,97.96 - 98.7,98.71 - 99.5,>= 99.51,No,No,N
+Patient Reported Nutritional Assessment in Patients with Wounds and Ulcers,USWR22,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Non Invasive Arterial Assessment of patients with lower extremity wounds or ulcers for determination of healing potential,USWR23,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Patient Reported Experience of Care: Wound Outcome,USWR24,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Pressure Ulcer* (PU) Healing or Closure for ulcers on the torso (body),USWR25,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Patient Reported Outcome of late effects of radiation symptoms following treatment with Hyperbaric Oxygen Therapy (HBOT),USWR26,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Assessment of Nutritionally At-Risk Patients for Malnutrition and Development of Nutrition Recommendations/Interventions by a Registered Dietitian Nutritionist,USWR27,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Obtaining Preoperative Nutritional Recommendations from a Registered Dietitian Nutritionist (RDN) in Nutritionally At-Risk Surgical Patients,USWR28,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Diabetes Care All or None Outcome Measure: Optimal Control,WCHQ10,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
+Diabetes Care All or None Process Measure: Optimal Testing,WCHQ9,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N

--- a/staging/2022/benchmarks/benchmarks.csv
+++ b/staging/2022/benchmarks/benchmarks.csv
@@ -1,646 +1,564 @@
 Table 2: Historical MIPS Quality Measure Benchmark Results; created using PY2018 data and PY2020 Eligibility Rules,,,,,,,,,,,,,,,,,
 Measure_Name,Measure_ID,Collection_Type,Measure_Type,Benchmark,Standard_Deviation,Average,Decile_3,Decile_4,Decile_5,Decile_6,Decile_7,Decile_8,Decile_9,Decile_10,Topped_Out,Seven_Point_Cap,High_Priority
-Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,Medicare Part B Claims,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,eCQM,Intermediate Outcome,Y,,47.7050360962571,90.50 - 69.43,69.42 - 53.61,53.6 - 42.12,42.11 - 34.07,34.06 - 28.33,28.32 - 23.57,23.56 - 19.11,<=19.1,No,No,Y
-Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),1,MIPS CQM,Intermediate Outcome,Y,,46.7701042717793,90.69 - 72.52,72.51 - 55.18,55.17 - 41.99,41.98 - 32.57,32.56 - 25.49,25.48 - 19.16,19.15 - 12.88,<=12.87,No,No,Y
-Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) or Angiotensin Receptor-Neprilysin Inhibitor (ARNI) Therapy for Left Ventricular Systolic Dysfunction (LVSD),5,eCQM,Process,Y,,71.8131388329979,1.09 - 65.51,65.52 - 71.94,71.95 - 75.27,75.28 - 78.08,78.09 - 80.46,80.47 - 82.97,82.98 - 86.35,>= 86.36,No,No,N
-Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) or Angiotensin Receptor-Neprilysin Inhibitor (ARNI) Therapy for Left Ventricular Systolic Dysfunction (LVSD),5,MIPS CQM,Process,Y,,93.5209962406015,90.0 - 95.7,95.71 - 98.01,98.02 - 99.26,99.27 - 99.99,--,--,--,100,Yes,No,N
-Coronary Artery Disease (CAD): Antiplatelet Therapy,6,MIPS CQM,Process,Y,,85.6797691894793,77.58 - 82.97,82.98 - 86.97,86.98 - 90.34,90.35 - 93.26,93.27 - 95.86,95.87 - 98.93,98.94 - 99.99,100,No,No,N
-Coronary Artery Disease (CAD): Beta-Blocker Therapy -Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF < 40%),7,eCQM,Process,Y,,87.5259194395799,45.83 - 71.56,71.57 - 83.87,83.88 - 88.74,88.75 - 91.78,91.79 - 94.1,94.11 - 95.78,95.79 - 97.74,>= 97.75,No,No,N
-Coronary Artery Disease (CAD): Beta-Blocker Therapy -Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF < 40%),7,MIPS CQM,Process,Y,,89.090403587444,49.07 - 74.03,74.04 - 84.78,84.79 - 91.92,91.93 - 94.71,94.72 - 97.72,97.73 - 99.99,--,100,No,No,N
-Heart Failure (HF): Beta-Blocker Therapy for Left Ventricular Systolic Dysfunction (LVSD),8,eCQM,Process,Y,,91.11909375,86.69 - 90.13,90.14 - 92.3,92.31 - 94.04,94.05 - 95.23,95.24 - 96.36,96.37 - 97.43,97.44 - 99.99,100,Yes,No,N
-Heart Failure (HF): Beta-Blocker Therapy for Left Ventricular Systolic Dysfunction (LVSD),8,MIPS CQM,Process,Y,,95.5429702970297,95.0 - 97.49,97.5 - 99.13,99.14 - 99.99,--,--,--,--,100,Yes,Yes,N
-Anti-Depressant Medication Management,9,eCQM,Process,Y,,72.8213304721029,65.38 - 70.68,70.69 - 74.33,74.34 - 78.03,78.04 - 80.94,80.95 - 83.76,83.77 - 86.66,86.67 - 90.55,>= 90.56,No,No,N
-Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation,12,eCQM,Process,Y,,86.2467270992363,83.62 - 88.71,88.72 - 92.3,92.31 - 95.05,95.06 - 96.96,96.97 - 98.32,98.33 - 99.28,99.29 - 99.99,100,No,No,N
-Age-Related Macular Degeneration (AMD): Dilated Macular Examination,14,Medicare Part B Claims,Process,Y,,96.4909847434118,--,--,--,--,--,--,--,100,Yes,Yes,N
-Age-Related Macular Degeneration (AMD): Dilated Macular Examination,14,MIPS CQM,Process,Y,,89.4193408309903,86.18 - 91.74,91.75 - 95.01,95.02 - 96.92,96.93 - 98.51,98.52 - 99.58,99.59 - 99.99,--,100,Yes,Yes,N
-Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care,19,eCQM,Process,Y,,69.2460049321823,54.33 - 66.66,66.67 - 75.33,75.34 - 81.59,81.6 - 87.17,87.18 - 91.36,91.37 - 95.07,95.08 - 97.87,>= 97.88,No,No,Y
-Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care,19,MIPS CQM,Process,Y,,88.5375747508305,83.62 - 93.52,93.53 - 97.82,97.83 - 99.92,99.93 - 99.99,--,--,--,100,Yes,Yes,Y
-Perioperative Care: Selection of Prophylactic Antibiotic -First OR Second-Generation Cephalosporin,21,Medicare Part B Claims,Process,Y,,89.4589567430025,--,--,--,--,--,--,--,100,Yes,Yes,Y
-Perioperative Care: Selection of Prophylactic Antibiotic -First OR Second-Generation Cephalosporin,21,MIPS CQM,Process,Y,,81.8085294117647,78.79 - 97.5,97.51 - 99.99,--,--,--,--,--,100,Yes,Yes,Y
-Perioperative Care: Venous Thromboembolism (VTE) Prophylaxis (When Indicated in ALL Patients),23,Medicare Part B Claims,Process,Y,,89.7840935672514,--,--,--,--,--,--,--,100,Yes,Yes,Y
-Perioperative Care: Venous Thromboembolism (VTE) Prophylaxis (When Indicated in ALL Patients),23,MIPS CQM,Process,Y,,87.9667318435754,95.45 - 99.9,99.91 - 99.99,--,--,--,--,--,100,Yes,Yes,Y
-Communication with the Physician or Other Clinician Managing On-Going Care Post-Fracture for Men and Women Aged 50 Years and Older,24,Medicare Part B Claims,Process,Y,,87.07,79.31 - 94.23,94.24 - 96.07,96.08 - 99.99,--,--,--,--,100,Yes,Yes,Y
-Communication with the Physician or Other Clinician Managing On-Going Care Post-Fracture for Men and Women Aged 50 Years and Older,24,MIPS CQM,Process,Y,,43.7145384615384,14.13 - 36.35,36.36 - 78.06,78.07 - 82.87,82.88 - 87.87,87.88 - 93.74,93.75 - 99.79,99.8 - 99.99,100,No,No,Y
-Screening for Osteoporosis for Women Aged 65-85 Years of Age,39,Medicare Part B Claims,Process,Y,,64.328880597015,37.13 - 49.56,49.57 - 59.3,59.31 - 66.37,66.38 - 76.02,76.03 - 87.2,87.21 - 96.33,96.34 - 99.99,100,No,No,N
-Screening for Osteoporosis for Women Aged 65-85 Years of Age,39,MIPS CQM,Process,Y,,45.7150154035736,13.41 - 28.58,28.59 - 39.79,39.8 - 51.48,51.49 - 61.46,61.47 - 70.34,70.35 - 79.67,79.68 - 90.84,>= 90.85,No,No,N
-Coronary Artery Bypass Graft (CABG): Preoperative Beta-Blocker in Patients with Isolated CABG Surgery,44,MIPS CQM,Process,Y,,96.5059322033898,94.29 - 96.5,96.51 - 98.56,98.57 - 99.99,--,--,--,--,100,Yes,Yes,N
-Advance Care Plan,47,Medicare Part B Claims,Process,Y,,82.0406559308719,84.39 - 97.45,97.46 - 99.69,99.7 - 99.99,--,--,--,--,100,Yes,Yes,Y
-Advance Care Plan,47,MIPS CQM,Process,Y,,59.7357802746567,20.33 - 43.83,43.84 - 64.43,64.44 - 79.01,79.02 - 89.23,89.24 - 95.59,95.6 - 98.94,98.95 - 99.99,100,No,No,Y
-Urinary Incontinence: Assessment of Presence or Absence of Urinary Incontinence in Women Aged 65 Years and Older,48,MIPS CQM,Process,Y,,59.2931132075471,23.56 - 40.06,40.07 - 57.37,57.38 - 73.74,73.75 - 82.38,82.39 - 93.04,93.05 - 98.53,98.54 - 99.99,100,No,No,N
-Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Years and Older,50,Medicare Part B Claims,Process,Y,,94.7019251336898,97.56 - 99.99,--,--,--,--,--,--,100,Yes,Yes,Y
-Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Years and Older,50,MIPS CQM,Process,Y,,75.47984,57.62 - 74.65,74.66 - 84.45,84.46 - 90.27,90.28 - 95.85,95.86 - 99.84,99.85 - 99.99,--,100,No,No,Y
-Chronic Obstructive Pulmonary Disease (COPD): Long-Acting Inhaled Bronchodilator Therapy,52,MIPS CQM,Process,Y,,92.141,84.62 - 94.99,95.0 - 98.28,98.29 - 99.66,99.67 - 99.99,--,--,--,100,Yes,Yes,N
-Appropriate Treatment for Upper Respiratory Infection (URI),65,eCQM,Process,Y,,84.7032034220532,76.15 - 80.78,80.79 - 84.38,84.39 - 87.09,87.1 - 90.1,90.11 - 92.85,92.86 - 95.57,95.58 - 99.99,100,No,No,Y
-Appropriate Treatment for Upper Respiratory Infection (URI),65,MIPS CQM,Process,Y,,95.4215851272015,93.33 - 95.44,95.45 - 97.13,97.14 - 98.43,98.44 - 99.4,99.41 - 99.99,--,--,100,Yes,Yes,Y
-Appropriate Testing for Pharyngitis,66,eCQM,Process,Y,,62.5310832025117,52.34 - 67.15,67.16 - 76.07,76.08 - 81.74,81.75 - 85.52,85.53 - 87.83,87.84 - 90.68,90.69 - 94.45,>= 94.46,No,No,Y
-Appropriate Testing for Pharyngitis,66,MIPS CQM,Process,Y,,88.5485748218527,80.85 - 88.08,88.09 - 93.09,93.1 - 97.1,97.11 - 99.99,--,--,--,100,Yes,No,Y
-Hematology: Myelodysplastic Syndrome (MDS) and Acute Leukemias: Baseline Cytogenetic Testing Performed on Bone Marrow,67,MIPS CQM,Process,Y,,86.4245945945946,96.41 - 99.99,--,--,--,--,--,--,100,Yes,No,N
-Hematology: Chronic Lymphocytic Leukemia (CLL): Baseline Flow Cytometry,70,MIPS CQM,Process,Y,,83.5231666666666,64.44 - 98.45,98.46 - 99.99,--,--,--,--,--,100,Yes,No,N
-Prevention of Central Venous Catheter (CVC) - Related Bloodstream Infections,76,Medicare Part B Claims,Process,Y,,95.2457598039215,99.7 - 99.99,--,--,--,--,--,--,100,Yes,Yes,Y
-Prevention of Central Venous Catheter (CVC) - Related Bloodstream Infections,76,MIPS CQM,Process,Y,,94.7033246301131,97.2 - 99.42,99.43 - 99.99,--,--,--,--,--,100,Yes,Yes,Y
-Acute Otitis Externa (AOE): Systemic Antimicrobial Therapy -Avoidance of Inappropriate Use,93,Medicare Part B Claims,Process,Y,,92.7283870967741,93.55 - 96.29,96.3 - 98.1,98.11 - 99.99,--,--,--,--,100,Yes,Yes,Y
-Acute Otitis Externa (AOE): Systemic Antimicrobial Therapy -Avoidance of Inappropriate Use,93,MIPS CQM,Process,Y,,90.0238735177865,83.89 - 89.45,89.46 - 92.85,92.86 - 95.51,95.52 - 97.25,97.26 - 98.83,98.84 - 99.99,--,100,Yes,Yes,Y
-Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients,102,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients,102,MIPS CQM,Process,Y,,93.6969047619047,90.61 - 97.11,97.12 - 99.99,--,--,--,--,--,100,Yes,Yes,Y
-Prostate Cancer: Combination Androgen Deprivation Therapy for High Risk or Very High Risk Prostate Cancer,104,MIPS CQM,Process,Y,,89.6194,95.85 - 99.6,99.61 - 99.99,--,--,--,--,--,100,Yes,Yes,N
-Adult Major Depressive Disorder (MDD): Suicide Risk Assessment,107,eCQM,Process,Y,,12.4506392694064,2.04 - 4.75,4.76 - 10.47,10.48 - 22.12,22.13 - 37.6,37.61 - 57.22,57.23 - 72.48,72.49 - 92.61,>= 92.62,No,No,N
-Preventive Care and Screening: Influenza Immunization,110,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Preventive Care and Screening: Influenza Immunization,110,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Preventive Care and Screening: Influenza Immunization,110,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Pneumococcal Vaccination Status for Older Adults,111,Medicare Part B Claims,Process,Y,,80.2478802992518,68.68 - 76.31,76.32 - 82.46,82.47 - 87.56,87.57 - 93.08,93.09 - 97.89,97.9 - 99.99,--,100,No,No,N
-Pneumococcal Vaccination Status for Older Adults,111,eCQM,Process,Y,,49.1972718720601,20.44 - 33.71,33.72 - 44.69,44.7 - 54.85,54.86 - 63.21,63.22 - 71.09,71.1 - 78.79,78.8 - 87.92,>= 87.93,No,No,N
-Pneumococcal Vaccination Status for Older Adults,111,MIPS CQM,Process,Y,,59.872691591947,35.11 - 51.28,51.29 - 61.89,61.9 - 69.15,69.16 - 74.99,75.0 - 79.89,79.9 - 85.82,85.83 - 94.99,>= 95.0,No,No,N
-Breast Cancer Screening,112,Medicare Part B Claims,Process,Y,,79.7034440559441,66.67 - 77.07,77.08 - 84.87,84.88 - 89.62,89.63 - 93.47,93.48 - 97.35,97.36 - 99.02,99.03 - 99.99,100,No,No,N
-Breast Cancer Screening,112,eCQM,Process,Y,,49.6088767463519,24.44 - 37.13,37.14 - 46.31,46.32 - 54.4,54.41 - 61.1,61.11 - 67.22,67.23 - 73.94,73.95 - 82.01,>= 82.02,No,No,N
-Breast Cancer Screening,112,MIPS CQM,Process,Y,,52.0179231692677,22.37 - 39.99,40.0 - 50.97,50.98 - 60.26,60.27 - 70.2,70.21 - 78.1,78.11 - 85.84,85.85 - 97.35,>= 97.36,No,No,N
-Colorectal Cancer Screening,113,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Colorectal Cancer Screening,113,eCQM,Process,Y,,47.2213975533785,15.15 - 27.51,27.52 - 38.73,38.74 - 49.04,49.05 - 58.3,58.31 - 67.54,67.55 - 76.05,76.06 - 85.05,>= 85.06,No,No,N
-Colorectal Cancer Screening,113,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Avoidance of Antibiotic Treatment for Acute Bronchitis/Bronchiolitis,116,MIPS CQM,Process,Y,,81.4741527001862,62.33 - 75.99,76.0 - 86.35,86.36 - 93.32,93.33 - 96.91,96.92 - 98.42,98.43 - 99.99,--,100,Yes,No,Y
-Diabetes: Eye Exam,117,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,Yes,Yes,N
-Diabetes: Eye Exam,117,eCQM,Process,Y,,40.5858287003907,12.0 - 20.54,20.55 - 30.68,30.69 - 44.81,44.82 - 69.39,69.4 - 94.16,94.17 - 98.42,98.43 - 99.92,>= 99.93,No,No,N
-Diabetes: Eye Exam,117,MIPS CQM,Process,Y,,83.6932025547445,89.93 - 96.67,96.68 - 98.85,98.86 - 99.69,99.7 - 99.99,--,--,--,100,Yes,Yes,N
-Coronary Artery Disease (CAD): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy - Diabetes or Left Ventricular Systolic Dysfunction (LVEF < 40%),118,MIPS CQM,Process,Y,,80.9126206896552,72.73 - 76.31,76.32 - 79.6,79.61 - 81.84,81.85 - 84.99,85.0 - 86.82,86.83 - 90.47,90.48 - 95.99,>= 96.0,No,No,N
-Diabetes: Medical Attention for Nephropathy,119,eCQM,Process,Y,,80.890559681217,70.31 - 76.91,76.92 - 81.54,81.55 - 85.22,85.23 - 88.23,88.24 - 91.4,91.41 - 94.77,94.78 - 98.54,>= 98.55,No,No,N
-Diabetes: Medical Attention for Nephropathy,119,MIPS CQM,Process,Y,,83.2002131979694,71.17 - 79.47,79.48 - 86.66,86.67 - 91.8,91.81 - 96.22,96.23 - 98.67,98.68 - 99.99,--,100,No,No,N
-"Diabetes Mellitus: Diabetic Foot and Ankle Care, Peripheral Neuropathy -Neurological Evaluation",126,MIPS CQM,Process,Y,,74.470623640319,59.55 - 74.75,74.76 - 86.48,86.49 - 94.86,94.87 - 99.31,99.32 - 99.99,--,--,100,No,No,N
-"Diabetes Mellitus: Diabetic Foot and Ankle Care, Ulcer Prevention -Evaluation of Footwear",127,MIPS CQM,Process,Y,,73.6955837563451,58.76 - 74.02,74.03 - 85.05,85.06 - 94.64,94.65 - 99.17,99.18 - 99.99,--,--,100,No,No,N
-Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,Medicare Part B Claims,Process,Y,,90.3953081264107,91.47 - 98.57,98.58 - 99.72,99.73 - 99.99,--,--,--,--,100,Yes,Yes,N
-Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,eCQM,Process,Y,,50.2093711591613,23.26 - 27.41,27.42 - 32.64,32.65 - 40.9,40.91 - 53.42,53.43 - 69.26,69.27 - 83.79,83.8 - 95.11,>= 95.12,No,No,N
-Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,MIPS CQM,Process,Y,,69.6454257185264,32.73 - 51.05,51.06 - 70.16,70.17 - 84.68,84.69 - 93.27,93.28 - 98.05,98.06 - 99.75,99.76 - 99.99,100,No,No,N
-Documentation of Current Medications in the Medical Record,130,Medicare Part B Claims,Process,Y,,96.6693510392611,99.67 - 99.93,99.94 - 99.99,--,--,--,--,--,100,Yes,Yes,Y
-Documentation of Current Medications in the Medical Record,130,eCQM,Process,Y,,87.7832238995999,83.73 - 91.27,91.28 - 94.9,94.91 - 96.99,97.0 - 98.3,98.31 - 99.17,99.18 - 99.69,99.7 - 99.94,>= 99.95,Yes,Yes,Y
-Documentation of Current Medications in the Medical Record,130,MIPS CQM,Process,Y,,86.7688172423549,86.71 - 96.31,96.32 - 98.94,98.95 - 99.67,99.68 - 99.9,99.91 - 99.99,--,--,100,Yes,Yes,Y
-Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,Medicare Part B Claims,Process,Y,,85.7614463705308,95.94 - 99.5,99.51 - 99.99,--,--,--,--,--,100,Yes,Yes,N
-Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,MIPS CQM,Process,Y,,48.8621452420701,14.76 - 37.43,37.44 - 55.92,55.93 - 71.73,71.74 - 84.68,84.69 - 95.55,95.56 - 99.21,99.22 - 99.99,100,No,No,N
-Melanoma: Continuity of Care -Recall System,137,MIPS CQM,Structure,Y,,90.6854179285281,95.0 - 98.83,98.84 - 99.99,--,--,--,--,--,100,No,No,Y
-Melanoma: Coordination of Care,138,MIPS CQM,Process,Y,,83.5092088091354,75.51 - 92.58,92.59 - 98.8,98.81 - 99.99,--,--,--,--,100,Yes,Yes,Y
-Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care,141,Medicare Part B Claims,Outcome,Y,,96.2794287184766,--,--,--,--,--,--,--,100,No,No,Y
-Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care,141,MIPS CQM,Outcome,Y,,72.8744573991031,32.62 - 60.31,60.32 - 82.13,82.14 - 93.47,93.48 - 98.54,98.55 - 99.99,--,--,100,No,No,Y
-Oncology: Medical and Radiation - Pain Intensity Quantified,143,eCQM,Process,Y,,72.9170072992699,67.56 - 85.31,85.32 - 91.88,91.89 - 95.33,95.34 - 97.06,97.07 - 97.95,97.96 - 98.79,98.8 - 99.8,>= 99.81,No,No,Y
-Oncology: Medical and Radiation - Pain Intensity Quantified,143,MIPS CQM,Process,Y,,88.3933073929961,93.65 - 97.65,97.66 - 99.2,99.21 - 99.83,99.84 - 99.99,--,--,--,100,Yes,Yes,Y
-Oncology: Medical and Radiation - Plan of Care for Pain,144,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Radiology: Exposure Dose Indices or Exposure Time and Number of Images Reported for Procedures Using Fluoroscopy,145,Medicare Part B Claims,Process,Y,,86.6393830334189,85.71 - 94.43,94.44 - 97.61,97.62 - 99.18,99.19 - 99.99,--,--,--,100,Yes,Yes,Y
-Radiology: Exposure Dose Indices or Exposure Time and Number of Images Reported for Procedures Using Fluoroscopy,145,MIPS CQM,Process,Y,,88.1613309352517,86.61 - 95.47,95.48 - 98.4,98.41 - 99.72,99.73 - 99.99,--,--,--,100,Yes,Yes,Y
-Nuclear Medicine: Correlation with Existing Imaging Studies for All Patients Undergoing Bone Scintigraphy,147,Medicare Part B Claims,Process,Y,,84.9635816618911,71.43 - 85.7,85.71 - 95.44,95.45 - 98.45,98.46 - 99.99,--,--,--,100,Yes,Yes,Y
-Nuclear Medicine: Correlation with Existing Imaging Studies for All Patients Undergoing Bone Scintigraphy,147,MIPS CQM,Process,Y,,94.1728539823008,93.66 - 98.91,98.92 - 99.99,--,--,--,--,--,100,Yes,Yes,Y
-Falls: Risk Assessment,154,Medicare Part B Claims,Process,Y,,93.97617076326,99.07 - 99.99,--,--,--,--,--,--,100,Yes,Yes,Y
-Falls: Risk Assessment,154,MIPS CQM,Process,Y,,89.8856579648375,87.86 - 96.12,96.13 - 98.81,98.82 - 99.99,--,--,--,--,100,Yes,Yes,Y
-Falls: Plan of Care,155,Medicare Part B Claims,Process,Y,,84.1366297322251,87.5 - 98.07,98.08 - 99.99,--,--,--,--,--,100,Yes,Yes,Y
-Falls: Plan of Care,155,MIPS CQM,Process,Y,,88.6247621809744,85.88 - 93.87,93.88 - 97.83,97.84 - 99.99,--,--,--,--,100,Yes,No,Y
-Coronary Artery Bypass Graft (CABG): Prolonged Intubation,164,MIPS CQM,Outcome,Y,,6.07689440993789,8.8 - 7.7,7.69 - 5.88,5.87 - 5.01,5.0 - 3.53,3.52 - 2.64,2.63 - 1.6,1.59 - 0.01,0,No,No,Y
-Coronary Artery Bypass Graft (CABG): Postoperative Renal Failure,167,MIPS CQM,Outcome,Y,,1.7751282051282,3.6 - 2.45,2.44 - 2.05,2.04 - 1.48,1.47 - 1.23,1.22 - 0.56,0.55 - 0.01,--,0,No,No,Y
-Coronary Artery Bypass Graft (CABG): Surgical Re-Exploration,168,MIPS CQM,Outcome,Y,,2.30433121019108,3.04 - 2.49,2.48 - 2.15,2.14 - 1.56,1.55 - 1.22,1.21 - 0.49,0.48 - 0.01,--,0,No,No,Y
-Tuberculosis Screening Prior to First Course Biologic Therapy,176,MIPS CQM,Process,Y,,80.827037037037,51.61 - 77.62,77.63 - 89.7,89.71 - 93.19,93.2 - 97.36,97.37 - 99.99,--,--,100,No,No,N
-Rheumatoid Arthritis (RA): Periodic Assessment of Disease Activity,177,MIPS CQM,Process,Y,,78.3961924686192,65.49 - 75.19,75.2 - 85.37,85.38 - 91.03,91.04 - 95.21,95.22 - 98.22,98.23 - 99.66,99.67 - 99.99,100,No,No,N
-Rheumatoid Arthritis (RA): Functional Status Assessment,178,MIPS CQM,Process,Y,,84.3917518248175,76.28 - 89.39,89.4 - 94.25,94.26 - 97.71,97.72 - 99.02,99.03 - 99.99,--,--,100,Yes,Yes,N
-Rheumatoid Arthritis (RA): Glucocorticoid Management,180,MIPS CQM,Process,Y,,93.0318518518518,98.26 - 99.68,99.69 - 99.99,--,--,--,--,--,100,Yes,No,N
-Elder Maltreatment Screen and Follow-Up Plan,181,Medicare Part B Claims,Process,Y,,71.4839729729729,98.88 - 99.99,--,--,--,--,--,--,100,Yes,Yes,Y
-Elder Maltreatment Screen and Follow-Up Plan,181,MIPS CQM,Process,Y,,59.839012345679,58.52 - 78.65,78.66 - 89.12,89.13 - 95.65,95.66 - 98.91,98.92 - 99.99,--,--,100,No,No,Y
-Functional Outcome Assessment,182,Medicare Part B Claims,Process,Y,,91.3948139797068,99.56 - 99.99,--,--,--,--,--,--,100,Yes,Yes,Y
-Functional Outcome Assessment,182,MIPS CQM,Process,Y,,88.4535928809789,98.57 - 99.58,99.59 - 99.83,99.84 - 99.99,--,--,--,--,100,Yes,No,Y
-Colonoscopy Interval for Patients with a History of Adenomatous Polyps -Avoidance of Inappropriate Use,185,MIPS CQM,Process,Y,,73.8619565217391,44.62 - 81.24,81.25 - 90.58,90.59 - 95.73,95.74 - 98.04,98.05 - 99.54,99.55 - 99.99,--,100,No,No,Y
-Stroke and Stroke Rehabilitation: Thrombolytic Therapy,187,MIPS CQM,Process,Y,,86.4108312958435,82.74 - 88.31,88.32 - 91.66,91.67 - 93.54,93.55 - 95.44,95.45 - 97.21,97.22 - 99.99,--,100,Yes,Yes,N
-Cataracts: 20/40 or Better Visual Acuity within 90 Days Following Cataract Surgery,191,eCQM,Outcome,Y,,89.6666764995084,88.04 - 93.45,93.46 - 95.7,95.71 - 97.12,97.13 - 98.22,98.23 - 98.85,98.86 - 99.49,99.5 - 99.99,100,No,No,Y
-Cataracts: 20/40 or Better Visual Acuity within 90 Days Following Cataract Surgery,191,MIPS CQM,Outcome,Y,,94.9035181236673,94.17 - 96.29,96.3 - 97.43,97.44 - 98.44,98.45 - 99.44,99.45 - 99.99,--,--,100,No,No,Y
-Radiology: Stenosis Measurement in Carotid Imaging Reports,195,Medicare Part B Claims,Process,Y,,95.4921433267587,97.77 - 99.39,99.4 - 99.99,--,--,--,--,--,100,Yes,Yes,N
-Radiology: Stenosis Measurement in Carotid Imaging Reports,195,MIPS CQM,Process,Y,,97.4846540880503,99.28 - 99.83,99.84 - 99.99,--,--,--,--,--,100,Yes,Yes,N
-"HIV/AIDS: Sexually Transmitted Disease Screening for Chlamydia, Gonorrhea, and Syphilis",205,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Functional Status Change for Patients with Knee Impairments,217,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Functional Status Change for Patients with Hip Impairments,218,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-"Functional Status Change for Patients with Lower Leg, Foot or Ankle Impairments",219,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Functional Status Change for Patients with Low Back Impairments,220,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Functional Status Change for Patients with Shoulder Impairments,221,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-"Functional Status Change for Patients with Elbow, Wrist or Hand Impairments",222,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Radiology: Reminder System for Screening Mammograms,225,Medicare Part B Claims,Structure,Y,,95.3990882134915,--,--,--,--,--,--,--,100,No,No,Y
-Radiology: Reminder System for Screening Mammograms,225,MIPS CQM,Structure,Y,,98.3717478510028,--,--,--,--,--,--,--,100,No,No,Y
-Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Controlling High Blood Pressure,236,Medicare Part B Claims,Intermediate Outcome,Y,,75.5984821811936,20 - 29.99,30 - 39.99,40 - 49.99,50 - 59.99,60 - 69.99,70 - 79.99,80 - 89.99,>= 90,No,No,Y
-Controlling High Blood Pressure,236,eCQM,Intermediate Outcome,Y,,62.8862114689167,51.69 - 57.07,57.08 - 61.32,61.33 - 64.79,64.8 - 68.44,68.45 - 72.03,72.04 - 76.35,76.36 - 82.37,>= 82.38,No,No,Y
-Controlling High Blood Pressure,236,MIPS CQM,Intermediate Outcome,Y,,65.1931454367984,20 - 29.99,30 - 39.99,40 - 49.99,50 - 59.99,60 - 69.99,70 - 79.99,80 - 89.99,>= 90,No,No,Y
-Use of High-Risk Medications in Older Adults,238,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Use of High-Risk Medications in Older Adults,238,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Weight Assessment and Counseling for Nutrition and Physical Activity for Children and Adolescents,239,eCQM,Process,Y,,35.2767064901519,27.47 - 30.48,30.49 - 32.12,32.13 - 33.32,33.33 - 34.47,34.48 - 38.53,38.54 - 47.92,47.93 - 63.64,>= 63.65,No,No,N
-Childhood Immunization Status,240,eCQM,Process,Y,,27.4728189910979,17.93 - 25.53,25.54 - 32.39,32.4 - 36.74,36.75 - 40.18,40.19 - 44.73,44.74 - 49.56,49.57 - 56.85,>= 56.86,No,No,N
-Cardiac Rehabilitation Patient Referral from an Outpatient Setting,243,MIPS CQM,Process,Y,,41.1488546255506,19.02 - 25.63,25.64 - 31.42,31.43 - 37.13,37.14 - 42.85,42.86 - 48.97,48.98 - 63.7,63.71 - 90.57,>= 90.58,No,No,Y
-Barrett's Esophagus,249,Medicare Part B Claims,Process,Y,,99.8581877022653,--,--,--,--,--,--,--,100,Yes,Yes,N
-Barrett's Esophagus,249,MIPS CQM,Process,Y,,99.2971287128712,--,--,--,--,--,--,--,100,Yes,Yes,N
-Radical Prostatectomy Pathology Reporting,250,Medicare Part B Claims,Process,Y,,98.2015714285714,--,--,--,--,--,--,--,100,Yes,Yes,N
-Radical Prostatectomy Pathology Reporting,250,MIPS CQM,Process,Y,,99.8214173228346,--,--,--,--,--,--,--,100,Yes,Yes,N
-Ultrasound Determination of Pregnancy Location for Pregnant Patients with Abdominal Pain,254,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Ultrasound Determination of Pregnancy Location for Pregnant Patients with Abdominal Pain,254,MIPS CQM,Process,Y,,93.0846037735849,88.64 - 92.24,92.25 - 95.25,95.26 - 96.76,96.77 - 98.24,98.25 - 99.17,99.18 - 99.99,--,100,Yes,Yes,N
-Rate of Open Repair of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post-Operative Day #7),258,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post-Operative Day #2),259,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-"Rate of Carotid Endarterectomy (CEA) for Asymptomatic Patients, without Major Complications (Discharged to Home by Post-Operative Day #2)",260,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Referral for Otologic Evaluation for Patients with Acute or Chronic Dizziness,261,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Referral for Otologic Evaluation for Patients with Acute or Chronic Dizziness,261,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Sentinel Lymph Node Biopsy for Invasive Breast Cancer,264,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Biopsy Follow-Up,265,MIPS CQM,Process,Y,,79.1830451936872,78.39 - 95.4,95.41 - 99.07,99.08 - 99.99,--,--,--,--,100,Yes,Yes,Y
-Epilepsy: Counseling for Women of Childbearing Potential with Epilepsy,268,MIPS CQM,Process,Y,,43.6021428571428,14.49 - 23.99,24.0 - 39.21,39.22 - 49.99,50.0 - 65.47,65.48 - 89.49,89.5 - 94.99,95.0 - 99.99,100,No,No,N
-Inflammatory Bowel Disease (IBD): Assessment of Hepatitis B Virus (HBV) Status Before Initiating Anti-TNF (Tumor Necrosis Factor) Therapy,275,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Sleep Apnea: Severity Assessment at Initial Diagnosis,277,MIPS CQM,Process,Y,,54.9790849673202,24.0 - 42.79,42.8 - 58.22,58.23 - 71.64,71.65 - 93.09,93.1 - 99.86,99.87 - 99.99,--,100,No,No,N
-Sleep Apnea: Assessment of Adherence to Positive Airway Pressure Therapy,279,MIPS CQM,Process,Y,,85.6362499999999,88.15 - 95.64,95.65 - 98.68,98.69 - 99.99,--,--,--,--,100,Yes,Yes,N
-Dementia: Cognitive Assessment,281,eCQM,Process,Y,,27.06210652304,8.33 - 13.63,13.64 - 21.73,21.74 - 31.57,31.58 - 44.82,44.83 - 59.73,59.74 - 73.9,73.91 - 91.88,>= 91.89,No,No,N
-Dementia: Functional Status Assessment,282,MIPS CQM,Process,Y,,64.8544918032786,43.54 - 68.17,68.18 - 91.03,91.04 - 98.23,98.24 - 99.99,--,--,--,100,No,No,N
-Dementia Associated Behavioral and Psychiatric Symptoms Screening and Management,283,MIPS CQM,Process,Y,,79.4561,75.0 - 92.44,92.45 - 96.36,96.37 - 98.67,98.68 - 99.99,--,--,--,100,Yes,Yes,N
-Dementia: Safety Concern Screening and Follow-Up for Patients with Dementia,286,MIPS CQM,Process,Y,,77.5369607843137,86.36 - 93.37,93.38 - 97.66,97.67 - 99.99,--,--,--,--,100,Yes,Yes,Y
-Dementia: Education and Support of Caregivers for Patients with Dementia,288,MIPS CQM,Process,Y,,68.2778155339805,43.28 - 66.66,66.67 - 83.32,83.33 - 95.38,95.39 - 98.32,98.33 - 99.99,--,--,100,No,No,Y
-Parkinson's Disease: Psychiatric Symptoms Assessment for Patients with Parkinson's Disease,290,MIPS CQM,Process,Y,,70.9461607142857,34.39 - 57.46,57.47 - 81.07,81.08 - 92.05,92.06 - 98.05,98.06 - 99.99,--,--,100,Yes,No,N
-Parkinson's Disease: Cognitive Impairment or Dysfunction Assessment for Patients with Parkinson's Disease,291,MIPS CQM,Process,Y,,69.3419791666666,25.57 - 59.88,59.89 - 89.27,89.28 - 98.93,98.94 - 99.99,--,--,--,100,Yes,Yes,N
-Parkinson's Disease: Rehabilitative Therapy Options,293,MIPS CQM,Process,Y,,65.6724489795918,48.35 - 65.7,65.71 - 85.7,85.71 - 93.72,93.73 - 99.99,--,--,--,100,Yes,Yes,Y
-Cataracts: Improvement in Patient's Visual Function within 90 Days Following Cataract Surgery,303,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Cataracts: Patient Satisfaction within 90 Days Following Cataract Surgery,304,MIPS CQM,Patient Engagement/Experience,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Initiation and Engagement of Alcohol and Other Drug Dependence Treatment,305,eCQM,Process,Y,,1.43877573131094,0.27 - 0.42,0.43 - 0.63,0.64 - 0.91,0.92 - 1.24,1.25 - 1.84,1.85 - 2.9,2.91 - 7.64,>= 7.65,No,No,Y
-Cervical Cancer Screening,309,eCQM,Process,Y,,30.8815560066873,11.36 - 18.36,18.37 - 24.99,25.0 - 32.28,32.29 - 39.56,39.57 - 46.8,46.81 - 55.55,55.56 - 68.16,>= 68.17,No,No,N
-Chlamydia Screening for Women,310,eCQM,Process,Y,,34.5808434712085,19.88 - 26.66,26.67 - 32.19,32.2 - 37.65,37.66 - 42.46,42.47 - 47.49,47.5 - 56.06,56.07 - 65.96,>= 65.97,No,No,N
-Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Falls: Screening for Future Fall Risk,318,eCQM,Process,Y,,48.7824093991916,18.81 - 36.27,36.28 - 52.33,52.34 - 66.64,66.65 - 78.71,78.72 - 87.49,87.5 - 94.18,94.19 - 98.26,>= 98.27,No,No,Y
-Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients,320,Medicare Part B Claims,Process,Y,,92.9267768595041,92.68 - 99.06,99.07 - 99.99,--,--,--,--,--,100,Yes,Yes,Y
-Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients,320,MIPS CQM,Process,Y,,82.7260753880266,81.69 - 89.01,89.02 - 93.29,93.3 - 95.8,95.81 - 97.46,97.47 - 98.6,98.61 - 99.99,--,100,Yes,Yes,Y
-Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low-Risk Surgery Patients,322,MIPS CQM,Efficiency,Y,,29.2517142857142,0.33 - 0.01,--,--,--,--,--,--,0,No,No,Y
-Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Routine Testing After Percutaneous Coronary Intervention (PCI),323,MIPS CQM,Efficiency,Y,,2.88305555555555,--,--,--,--,--,--,--,0,No,No,Y
-"Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Testing in Asymptomatic, Low-Risk Patients",324,MIPS CQM,Efficiency,Y,,8.14732558139534,2.51 - 0.72,0.71 - 0.01,--,--,--,--,--,0,No,No,Y
-Atrial Fibrillation and Atrial Flutter: Chronic Anticoagulation Therapy,326,Medicare Part B Claims,Process,Y,,96.9824736842105,98.63 - 99.99,--,--,--,--,--,--,100,Yes,Yes,N
-Atrial Fibrillation and Atrial Flutter: Chronic Anticoagulation Therapy,326,MIPS CQM,Process,Y,,88.3319076923077,79.1 - 83.67,83.68 - 88.45,88.46 - 94.5,94.51 - 98.7,98.71 - 99.99,--,--,100,Yes,Yes,N
-Adult Sinusitis: Antibiotic Prescribed for Acute Viral Sinusitis (Overuse),331,MIPS CQM,Process,Y,,45.6709751709246,75.95 - 62.51,62.5 - 50.13,50.12 - 37.58,37.57 - 25.13,25.12 - 14.82,14.81 - 5.29,5.28 - 0.01,0,No,No,Y
-Adult Sinusitis: Appropriate Choice of Antibiotic: Amoxicillin With or Without Clavulanate Prescribed for Patients with Acute Bacterial Sinusitis (Appropriate Use),332,MIPS CQM,Process,Y,,77.6143801652892,52.44 - 61.36,61.37 - 72.63,72.64 - 85.75,85.76 - 89.93,89.94 - 96.12,96.13 - 99.99,--,100,No,No,Y
-Maternity Care: Elective Delivery or Early Induction Without Medical Indication at < 39 Weeks (Overuse),335,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Maternity Care: Postpartum Follow-up and Care Coordination,336,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-"Psoriasis: Tuberculosis (TB) Prevention for Patients with Psoriasis, Psoriatic Arthritis and Rheumatoid Arthritis on a Biological Immune Response Modifier",337,MIPS CQM,Process,Y,,81.1451323654995,68.0 - 80.76,80.77 - 88.88,88.89 - 94.41,94.42 - 97.53,97.54 - 99.99,--,--,100,No,No,N
-HIV Viral Load Suppression,338,MIPS CQM,Outcome,Y,,78.5221311475409,76.89 - 84.2,84.21 - 87.32,87.33 - 91.54,91.55 - 95.36,95.37 - 96.96,96.97 - 99.99,--,100,No,No,Y
-HIV Medical Visit Frequency,340,MIPS CQM,Process,Y,,75.4488095238095,54.8 - 60.08,60.09 - 69.99,70.0 - 74.99,75.0 - 84.5,84.51 - 98.47,98.48 - 99.99,--,100,No,No,Y
-Pain Brought Under Control Within 48 Hours,342,MIPS CQM,Outcome,Y,,97.9841860465116,--,--,--,--,--,--,--,100,No,No,Y
-"Rate of Carotid Artery Stenting (CAS) for Asymptomatic Patients, Without Major Complications (Discharged to Home by Post-Operative Day #2)",344,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Total Knee Replacement: Shared Decision-Making: Trial of Conservative (Non-surgical) Therapy,350,MIPS CQM,Process,Y,,93.6550920245398,99.6 - 99.99,--,--,--,--,--,--,100,Yes,Yes,Y
-Total Knee Replacement: Venous Thromboembolic and Cardiovascular Risk Evaluation,351,MIPS CQM,Process,Y,,93.8951199999999,99.36 - 99.99,--,--,--,--,--,--,100,Yes,Yes,Y
-Anastomotic Leak Intervention,354,MIPS CQM,Outcome,Y,,4.2053488372093,3.23 - 1.8,1.79 - 0.01,--,--,--,--,--,0,No,No,Y
-Unplanned Reoperation within the 30 Day Postoperative Period,355,MIPS CQM,Outcome,Y,,7.14739010989011,2.45 - 1.34,1.33 - 0.8,0.79 - 0.19,0.18 - 0.01,--,--,--,0,No,No,Y
-Unplanned Hospital Readmission within 30 Days of Principal Procedure,356,MIPS CQM,Outcome,Y,,6.89044052863436,5.76 - 3.96,3.95 - 2.79,2.78 - 1.1,1.09 - 0.01,--,--,--,0,No,No,Y
-Surgical Site Infection (SSI),357,MIPS CQM,Outcome,Y,,11.8914114832535,3.33 - 1.83,1.82 - 0.78,0.77 - 0.01,--,--,--,--,0,No,No,Y
-Patient-Centered Surgical Risk Assessment and Communication,358,MIPS CQM,Process,Y,,54.0293280632411,34.62 - 72.42,72.43 - 91.22,91.23 - 98.5,98.51 - 99.99,--,--,--,100,No,No,Y
-Optimizing Patient Exposure to Ionizing Radiation: Count of Potential High Dose Radiation Imaging Studies: Computed Tomography (CT) and Cardiac Nuclear Medicine Studies,360,MIPS CQM,Process,Y,,81.1845744680851,85.51 - 98.76,98.77 - 99.93,99.94 - 99.99,--,--,--,--,100,Yes,Yes,Y
-Optimizing Patient Exposure to Ionizing Radiation: Appropriateness: Follow-up CT Imaging for Incidentally Detected Pulmonary Nodules According to Recommended Guidelines,364,MIPS CQM,Process,Y,,95.3193198992443,95.83 - 98.1,98.11 - 99.99,--,--,--,--,--,100,Yes,No,Y
-Follow-Up Care for Children Prescribed ADHD Medication (ADD),366,eCQM,Process,Y,,37.4164563106796,20.31 - 24.13,24.14 - 29.54,29.55 - 35.94,35.95 - 39.52,39.53 - 45.48,45.49 - 50.58,50.59 - 65.63,>= 65.64,No,No,N
-Depression Remission at Twelve Months,370,eCQM,Outcome,Y,,9.05646517739817,3.65 - 4.91,4.92 - 6.33,6.34 - 7.6,7.61 - 9.62,9.63 - 11.99,12.0 - 14.99,15.0 - 22.02,>= 22.03,No,No,Y
-Depression Remission at Twelve Months,370,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Closing the Referral Loop: Receipt of Specialist Report,374,eCQM,Process,Y,,36.6991446958688,9.72 - 16.97,16.98 - 25.5,25.51 - 34.92,34.93 - 46.42,46.43 - 59.99,60.0 - 74.59,74.6 - 89.65,>= 89.66,No,No,Y
-Closing the Referral Loop: Receipt of Specialist Report,374,MIPS CQM,Process,Y,,72.9680888290713,60.0 - 77.54,77.55 - 92.3,92.31 - 97.54,97.55 - 99.99,--,--,--,100,No,No,Y
-Functional Status Assessment for Total Knee Replacement,375,eCQM,Process,Y,,1.29369778869778,8.19 - 10.31,10.32 - 14.83,14.84 - 21.09,21.1 - 29.08,29.09 - 37.49,37.5 - 51.34,51.35 - 61.02,>= 61.03,No,No,Y
-Functional Status Assessment for Total Hip Replacement,376,eCQM,Process,Y,,1.73537280701754,4.73 - 8.32,8.33 - 11.53,11.54 - 15.82,15.83 - 19.74,19.75 - 33.32,33.33 - 53.56,53.57 - 99.99,100,No,No,Y
-Functional Status Assessments for Congestive Heart Failure,377,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Children Who Have Dental Decay or Cavities,378,eCQM,Outcome,Y,,.529196956889264,0.87 - 0.39,0.38 - 0.01,--,--,--,--,--,0,No,No,Y
-"Primary Caries Prevention Intervention as Offered by Primary Care Providers, including Dentists",379,eCQM,Process,Y,,1.06873433583959,0.26 - 0.53,0.54 - 1.09,1.1 - 2.18,2.19 - 3.84,3.85 - 5.22,5.23 - 7.3,7.31 - 13.66,>= 13.67,No,No,N
-Child and Adolescent Major Depressive Disorder (MDD): Suicide Risk Assessment,382,eCQM,Process,Y,,23.9799293286219,7.45 - 12.49,12.5 - 19.11,19.12 - 29.79,29.8 - 39.08,39.09 - 47.1,47.11 - 58.7,58.71 - 87.46,>= 87.47,No,No,Y
-Adherence to Antipsychotic Medications For Individuals with Schizophrenia,383,MIPS CQM,Intermediate Outcome,Y,,81.008125,51.52 - 80.84,80.85 - 96.51,96.52 - 99.99,--,--,--,--,100,No,No,Y
-Adult Primary Rhegmatogenous Retinal Detachment Surgery: No Return to the Operating Room Within 90 Days of Surgery,384,MIPS CQM,Outcome,Y,,96.0267647058823,96.0 - 99.99,--,--,--,--,--,--,100,No,No,Y
-Adult Primary Rhegmatogenous Retinal Detachment Surgery: Visual Acuity Improvement Within 90 Days of Surgery,385,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Amyotrophic Lateral Sclerosis (ALS) Patient Care Preferences,386,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Annual Hepatitis C Virus (HCV) Screening for Patients who are Active Injection Drug Users,387,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Cataract Surgery: Difference Between Planned and Final Refraction,389,MIPS CQM,Outcome,Y,,63.7319245283018,30.48 - 38.53,38.54 - 51.94,51.95 - 71.07,71.08 - 94.45,94.46 - 98.18,98.19 - 99.99,--,100,No,No,Y
-Follow-Up After Hospitalization for Mental Illness (FUH),391,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Cardiac Tamponade and/or Pericardiocentesis Following Atrial Fibrillation Ablation,392,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-"Infection within 180 Days of Cardiac Implantable Electronic Device (CIED) Implantation, Replacement, or Revision",393,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Immunizations for Adolescents,394,MIPS CQM,Process,Y,,14.0085937499999,3.28 - 7.68,7.69 - 18.58,18.59 - 22.72,22.73 - 23.96,23.97 - 30.42,30.43 - 38.72,38.73 - 46.66,>= 46.67,No,No,N
-Lung Cancer Reporting (Biopsy/Cytology Specimens),395,Medicare Part B Claims,Process,Y,,99.1657928802588,--,--,--,--,--,--,--,100,Yes,Yes,Y
-Lung Cancer Reporting (Biopsy/Cytology Specimens),395,MIPS CQM,Process,Y,,98.7408146067415,--,--,--,--,--,--,--,100,Yes,Yes,Y
-Lung Cancer Reporting (Resection Specimens),396,Medicare Part B Claims,Process,Y,,99.7918918918919,--,--,--,--,--,--,--,100,Yes,Yes,Y
-Lung Cancer Reporting (Resection Specimens),396,MIPS CQM,Process,Y,,99.7160732984293,--,--,--,--,--,--,--,100,Yes,Yes,Y
-Melanoma Reporting,397,Medicare Part B Claims,Process,Y,,96.4929761904761,--,--,--,--,--,--,--,100,Yes,Yes,Y
-Melanoma Reporting,397,MIPS CQM,Process,Y,,97.2853082191781,--,--,--,--,--,--,--,100,Yes,Yes,Y
-Optimal Asthma Control,398,MIPS CQM,Outcome,Y,,31.7328888888888,33.33 - 49.28,49.29 - 58.04,58.05 - 80.13,80.14 - 99.99,--,--,--,100,No,No,Y
-One-Time Screening for Hepatitis C Virus (HCV) for Patients at Risk,400,MIPS CQM,Process,Y,,19.6015012106537,1.39 - 2.02,2.03 - 3.93,3.94 - 9.28,9.29 - 18.02,18.03 - 28.77,28.78 - 43.81,43.82 - 75.52,>= 75.53,No,No,N
-Hepatitis C: Screening for Hepatocellular Carcinoma (HCC) in Patients with Cirrhosis,401,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Tobacco Use and Help with Quitting Among Adolescents,402,MIPS CQM,Process,Y,,91.4053365129835,88.14 - 93.54,93.55 - 96.54,96.55 - 98.45,98.46 - 99.55,99.56 - 99.99,--,--,100,Yes,Yes,N
-Anesthesiology Smoking Abstinence,404,MIPS CQM,Intermediate Outcome,Y,,69.0437335285505,53.27 - 62.19,62.2 - 68.17,68.18 - 73.17,73.18 - 79.18,79.19 - 84.42,84.43 - 91.75,91.76 - 98.2,>= 98.21,No,No,Y
-Appropriate Follow-up Imaging for Incidental Abdominal Lesions,405,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Appropriate Follow-up Imaging for Incidental Abdominal Lesions,405,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Appropriate Follow-up Imaging for Incidental Thyroid Nodules in Patients,406,Medicare Part B Claims,Process,Y,,11.3532647058823,0.4 - 0.01,--,--,--,--,--,--,0,Yes,Yes,Y
-Appropriate Follow-up Imaging for Incidental Thyroid Nodules in Patients,406,MIPS CQM,Process,Y,,4.60948012232415,2.27 - 0.01,--,--,--,--,--,--,0,Yes,Yes,Y
-Clinical Outcome Post Endovascular Stroke Treatment,409,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Psoriasis: Clinical Response to Systemic Medications,410,MIPS CQM,Outcome,Y,,74.3226846220677,56.12 - 70.58,70.59 - 79.99,80.0 - 87.87,87.88 - 93.32,93.33 - 97.43,97.44 - 99.99,--,100,No,No,Y
-Door to Puncture Time for Endovascular Stroke Treatment,413,MIPS CQM,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older,415,MIPS CQM,Efficiency,Y,,91.8041241496598,83.73 - 90.9,90.91 - 94.43,94.44 - 96.39,96.4 - 97.55,97.56 - 98.54,98.55 - 99.41,99.42 - 99.99,100,No,No,Y
-Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,416,Medicare Part B Claims,Efficiency,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,416,MIPS CQM,Efficiency,Y,,15.8907389937106,27.21 - 20.01,20.0 - 12.13,12.12 - 5.89,5.88 - 3.46,3.45 - 2.05,2.04 - 0.01,--,0,No,No,Y
-Osteoporosis Management in Women Who Had a Fracture,418,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Osteoporosis Management in Women Who Had a Fracture,418,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Overuse of Imaging for the Evaluation of Primary Headache,419,MIPS CQM,Process,Y,,16.7383809523809,28.52 - 16.36,16.35 - 10.44,10.43 - 5.36,5.35 - 3.24,3.23 - 1.63,1.62 - 0.21,0.2 - 0.01,0,Yes,No,Y
-Varicose Vein Treatment with Saphenous Ablation: Outcome Survey,420,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Appropriate Assessment of Retrievable Inferior Vena Cava (IVC) Filters for Removal,421,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Performing Cystoscopy at the Time of Hysterectomy for Pelvic Organ Prolapse to Detect Lower Urinary Tract Injury,422,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Performing Cystoscopy at the Time of Hysterectomy for Pelvic Organ Prolapse to Detect Lower Urinary Tract Injury,422,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Perioperative Temperature Management,424,MIPS CQM,Outcome,Y,,97.9629433272395,98.22 - 99.26,99.27 - 99.68,99.69 - 99.85,99.86 - 99.96,99.97 - 99.99,--,--,100,No,No,Y
-Photodocumentation of Cecal Intubation,425,Medicare Part B Claims,Process,Y,,99.0177987421383,98.8 - 99.43,99.44 - 99.99,--,--,--,--,--,100,Yes,No,N
-Photodocumentation of Cecal Intubation,425,MIPS CQM,Process,Y,,92.0179439252336,89.1 - 94.77,94.78 - 96.72,96.73 - 97.95,97.96 - 98.55,98.56 - 99.12,99.13 - 99.47,99.48 - 99.94,>= 99.95,Yes,No,N
-Pelvic Organ Prolapse: Preoperative Screening for Uterine Malignancy,429,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Pelvic Organ Prolapse: Preoperative Screening for Uterine Malignancy,429,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Prevention of Post-Operative Nausea and Vomiting (PONV) -Combination Therapy,430,MIPS CQM,Process,Y,,96.8483870967742,96.68 - 98.17,98.18 - 98.93,98.94 - 99.49,99.5 - 99.77,99.78 - 99.94,99.95 - 99.99,--,100,Yes,Yes,Y
-Preventive Care and Screening: Unhealthy Alcohol Use: Screening & Brief Counseling,431,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Proportion of Patients Sustaining a Bladder Injury at the Time of any Pelvic Organ Prolapse Repair,432,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Proportion of Patients Sustaining a Bowel Injury at the time of any Pelvic Organ Prolapse Repair,433,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Proportion of Patients Sustaining a Ureter Injury at the Time of Pelvic Organ Prolapse Repair,434,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Radiation Consideration for Adult CT: Utilization of Dose Lowering Techniques,436,Medicare Part B Claims,Process,Y,,93.1926809815949,96.5 - 98.67,98.68 - 99.56,99.57 - 99.87,99.88 - 99.99,--,--,--,100,Yes,Yes,N
-Radiation Consideration for Adult CT: Utilization of Dose Lowering Techniques,436,MIPS CQM,Process,Y,,96.2689352989353,98.96 - 99.76,99.77 - 99.96,99.97 - 99.99,--,--,--,--,100,Yes,Yes,N
-Statin Therapy for the Prevention and Treatment of Cardiovascular Disease,438,eCQM,Process,Y,,68.5675027685493,62.47 - 66.21,66.22 - 68.96,68.97 - 71.36,71.37 - 73.74,73.75 - 76.07,76.08 - 79.56,79.57 - 83.32,>= 83.33,No,No,N
-Statin Therapy for the Prevention and Treatment of Cardiovascular Disease,438,MIPS CQM,Process,Y,,80.7900487804878,67.31 - 73.02,73.03 - 76.49,76.5 - 82.39,82.4 - 87.43,87.44 - 93.09,93.1 - 99.99,--,100,No,No,N
-Age Appropriate Screening Colonoscopy,439,MIPS CQM,Efficiency,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Skin Cancer: Biopsy Reporting Time -Pathologist to Clinician,440,MIPS CQM,Process,Y,,97.465600814664,98.36 - 99.71,99.72 - 99.99,--,--,--,--,--,100,Yes,Yes,Y
-Ischemic Vascular Disease (IVD) All or None Outcome Measure (Optimal Control),441,MIPS CQM,Intermediate Outcome,Y,,33.282197309417,12.76 - 22.32,22.33 - 27.55,27.56 - 36.44,36.45 - 42.54,42.55 - 48.47,48.48 - 55.55,55.56 - 63.96,>= 63.97,No,No,Y
-Non-Recommended Cervical Cancer Screening in Adolescent Females,443,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Medication Management for People with Asthma,444,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Risk-Adjusted Operative Mortality for Coronary Artery Bypass Graft (CABG),445,MIPS CQM,Outcome,Y,,2.22376623376623,4.0 - 2.98,2.97 - 2.41,2.4 - 1.95,1.94 - 1.05,1.04 - 0.68,0.67 - 0.01,--,0,No,No,Y
-Appropriate Workup Prior to Endometrial Ablation,448,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Appropriate Treatment for Patients with Stage I (T1c) - III HER2 Positive Breast Cancer,450,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-RAS (KRAS and NRAS) Gene Mutation Testing Performed for Patients with Metastatic Colorectal Cancer who receive Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibody Therapy,451,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Patients with Metastatic Colorectal Cancer and RAS (KRAS or NRAS) Gene Mutation Spared Treatment with Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibodies,452,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Percentage of Patients Who Died from Cancer Receiving Chemotherapy in the Last 14 Days of Life (lower score -better),453,MIPS CQM,Process,Y,,12.8828187919463,18.18 - 15.57,15.56 - 13.96,13.95 - 11.28,11.27 - 10.01,10.0 - 8.58,8.57 - 6.07,6.06 - 0.01,0,No,No,Y
-Percentage of Patients Who Died from Cancer Admitted to the Intensive Care Unit (ICU) in the Last 30 Days of Life (lower score -better),455,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Percentage of Patients Who Died from Cancer Admitted to Hospice for Less than 3 days (lower score -better),457,MIPS CQM,Outcome,Y,,8.48145161290322,11.32 - 10.01,10.0 - 8.17,8.16 - 6.99,6.98 - 4.27,4.26 - 3.04,3.03 - 2.23,2.22 - 0.01,0,No,No,Y
-Back Pain After Lumbar Discectomy/Laminectomy,459,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Back Pain After Lumbar Fusion,460,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Leg Pain After Lumbar Discectomy/Laminectomy,461,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Bone Density Evaluation for Patients with Prostate Cancer and Receiving Androgen Deprivation Therapy,462,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Prevention of Post-Operative Vomiting (POV) -Combination Therapy (Pediatrics),463,MIPS CQM,Process,Y,,96.1175274725274,94.59 - 97.29,97.3 - 98.24,98.25 - 99.07,99.08 - 99.66,99.67 - 99.99,--,--,100,Yes,Yes,Y
-Otitis Media with Effusion: Systemic Antimicrobials - Avoidance of Inappropriate Use,464,MIPS CQM,Process,Y,,89.8478527607361,84.47 - 87.52,87.53 - 89.99,90.0 - 92.74,92.75 - 94.53,94.54 - 96.14,96.15 - 97.59,97.6 - 99.99,100,No,No,Y
-Uterine Artery Embolization Technique: Documentation of Angiographic Endpoints and Interrogation of Ovarian Arteries,465,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Continuity of Pharmacotherapy for Opioid Use Disorder (OUD),468,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Functional Status After Lumbar Fusion,469,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Functional Status After Primary Total Knee Replacement,470,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Functional Status After Lumbar Discectomy/Laminectomy,471,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Appropriate Use of DXA Scans in Women Under 65 Years Who Do Not Meet the Risk Factor Profile for Osteoporotic Fracture,472,eCQM,Process,Y,,1.22275193798449,--,--,--,--,--,--,--,0,Yes,No,Y
-Leg Pain After Lumbar Fusion,473,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-HIV Screening,475,eCQM,Process,Y,,7.33773333333333,1.46 - 2.44,2.45 - 5.31,5.32 - 9.48,9.49 - 25.5,25.51 - 99.99,--,--,100,No,No,N
-Urinary Symptom Score Change 6-12 Months After Diagnosis of Benign Prostatic Hyperplasia,476,eCQM,patientReportedOutcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Multimodal Pain Management,477,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Functional Status Change for Patients with Neck Impairments,478,MIPS CQM,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Asthma Control: Minimal Important Difference Improvement,AAAAI17,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Penicillin Allergy: Appropriate Removal or Confirmation,AAAAI18,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Asthma: Assessment of Asthma Control -Ambulatory Care Setting,AAAAI2,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Documentation of Clinical Response to Allergen Immunotherapy within One Year,AAAAI6,QCDR Measure,Process,Y,,100.,--,--,--,--,--,--,--,100,Yes,No,Y
-Achievement of Projected Effective Dose of Standardized Allergens for Patient Treated With Allergen Immunotherapy for at Least One Year,AAAAI8,QCDR Measure,Outcome,Y,,99.4083333333333,99.72 - 99.72,99.73 - 99.76,99.77 - 99.99,--,--,--,--,100,No,No,Y
-Dermatitis -Improvement in Patient-Reported Itch Severity,AAD10,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Skin Cancer Surgery: Post-Operative Complications,AAD11,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Melanoma: -Appropriate Surgical Margins,AAD12,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Skin Cancer: Biopsy Reporting Time - Clinician to Patient,AAD6,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Psoriasis: Screening for Psoriatic Arthritis,AAD7,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Chronic Skin Conditions: Patient Reported Quality-of-Life,AAD8,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Psoriasis -Improvement in Patient-Reported Itch Severity,AAD9,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Quality of Life Outcome for Patients with Neurologic Conditions,AAN22,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Pediatric Medication reconciliation,AAN25,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Activity counseling for back pain,AAN26,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Diabetes/Pre-Diabetes Screening for Patients with DSP,AAN28,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Comprehensive Epilepsy Care Center Referral or Discussion for Patients with Epilepsy,AAN29,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Migraine Preventive Therapy Management,AAN30,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Acute Treatment Prescribed for Cluster Headache,AAN31,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Preventive Treatment Prescribed for Cluster Headache,AAN32,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Fatigue Screening and Follow-Up for Patients with MS,AAN33,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Patient reported falls and plan of care,AAN34,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Medication Prescribed For Acute Migraine Attack,AAN5,QCDR Measure,Process,Y,,62.8229629629629,49.63 - 54.48,54.49 - 57.87,57.88 - 62.6,62.61 - 67.04,67.05 - 73.17,73.18 - 79.66,79.67 - 84.9,>= 84.91,No,No,N
-Exercise and Appropriate Physical Activity Counseling for Patients with MS,AAN8,QCDR Measure,Process,Y,,73.2660273972602,58.33 - 69.99,70.0 - 73.99,74.0 - 80.44,80.45 - 88.88,88.89 - 92.49,92.5 - 96.14,96.15 - 97.91,>= 97.92,No,No,N
-Querying About Symptoms of Autonomic Dysfunction for Patients with Parkinson's Disease,AAN9,QCDR Measure,Process,Y,,72.3732142857143,53.7 - 64.72,64.73 - 81.21,81.22 - 86.79,86.8 - 90.19,90.2 - 92.66,92.67 - 96.29,96.3 - 97.67,>= 97.68,No,No,N
-Tympanostomy Tubes: Topical Ear Drop Monotherapy Acute Otorrhea,AAO12,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Bell's Palsy: Inappropriate Use of Magnetic Resonance Imaging or Computed Tomography Scan (Inverse Measure),AAO13,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Age-related Hearing Loss: Audiometric Evaluation,AAO16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Tympanostomy Tubes: Hearing Test,AAO20,QCDR Measure,Process,Y,,96.3380769230769,96.03 - 97.49,97.5 - 98.07,98.08 - 98.41,98.42 - 98.8,98.81 - 98.97,98.98 - 99.39,99.4 - 99.99,100,Yes,No,N
-Otitis Media with Effusion: Hearing Test for Chronic OME > 3 months,AAO21,QCDR Measure,Process,Y,,37.2285714285714,21.29 - 25.69,25.7 - 36.07,36.08 - 42.07,42.08 - 43.16,43.17 - 44.5,44.51 - 46.44,46.45 - 52.1,>= 52.11,No,No,N
-Allergic Rhinitis: Intranasal Corticosteroids or Oral Antihistamines,AAO23,QCDR Measure,Process,Y,,69.6216129032258,61.71 - 67.54,67.55 - 70.41,70.42 - 72.81,72.82 - 75.71,75.72 - 77.35,77.36 - 80.08,80.09 - 84.43,>= 84.44,No,No,N
-Allergic Rhinitis: Avoidance of Leukotriene Inhibitors,AAO24,QCDR Measure,Process,Y,,89.47635,82.68 - 85.52,85.53 - 87.61,87.62 - 90.84,90.85 - 93.36,93.37 - 96.01,96.02 - 96.96,96.97 - 98.61,>= 98.62,No,No,Y
-Quality of Life for Patients with Neurotology Disorders,AAO29,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Otitis Media with Effusion (OME): Avoidance of Inappropriate Use of Medications,AAO31,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Standard BPPV Management,AAO32,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Dysphonia: Postoperative Laryngeal Examination,AAO34,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Benign Positional Paroxysmal Vertigo (BPPV): Dix-Hallpike and Canalith Repositioning,AAO35,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Tympanostomy Tubes: Resolution of Otitis Media with Effusion in Adults and Children,AAO36,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Pediatric OSA: Objective Assessment of Positive Airway Pressure Therapy Adherence,AASM1,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Pediatric OSA: Objective Assessment of OSA Signs and Symptoms in Children with Complex Medical Conditions,AASM2,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Adult OSA: Screening for Adult OSA by Primary Care Physicians,AASM3,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Person-Centered Primary Care Measure Performance Measure (PCPCM PRO-PM),ABFM11,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Measuring the Value-Functions of Primary Care: Provider Level Continuity Measure,ABFM9,QCDR Measure,Efficiency and Cost/Resource Use,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Hypotension Prevention After Spinal Placement for Elective Cesarean Section,ABG40,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Upper Extremity Nerve Blockade in Shoulder Surgery,ABG41,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Known or Suspected Difficult Airway Mitigation Strategies,ABG42,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Heart Failure: Patient Self Care Education,ACCPIN11,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Peripheral Artery Disease: Treatment of Blood Cholesterol to Reduce Atherosclerotic Cardiovascular Risk,ACCPIN7,QCDR Measure,Process,Y,,77.8094318181818,71.74 - 76.08,76.09 - 80.4,80.41 - 82.8,82.81 - 83.98,83.99 - 87.49,87.5 - 89.59,89.6 - 93.41,>= 93.42,No,No,N
-Hypertension Control (Stage 1 or 2),ACCPIN8,QCDR Measure,Intermediate Outcome,Y,,26.5656153846153,19.73 - 22.74,22.75 - 25.17,25.18 - 27.57,27.58 - 29.19,29.2 - 30.71,30.72 - 34.28,34.29 - 38.55,>= 38.56,No,No,Y
-Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older,ACEP19,QCDR Measure,Process,Y,,60.3532075471698,53.1 - 54.85,54.86 - 58.03,58.04 - 60.13,60.14 - 63.28,63.29 - 64.96,64.97 - 68.41,68.42 - 72.75,>= 72.76,No,No,Y
-Coagulation Studies in Patients Presenting with Chest Pain with No Coagulopathy or Bleeding,ACEP21,QCDR Measure,Process,Y,,9.90906040268455,14.87 - 11.0,10.99 - 9.23,9.22 - 6.56,6.55 - 4.82,4.81 - 3.7,3.69 - 2.78,2.77 - 0.01,0,No,No,Y
-Appropriate Emergency Department Utilization of CT for Pulmonary Embolism,ACEP22,QCDR Measure,Process,Y,,33.6521538461538,21.55 - 24.47,24.48 - 27.66,27.67 - 32.79,32.8 - 37.74,37.75 - 41.45,41.46 - 44.69,44.7 - 51.47,>= 51.48,No,No,Y
-Tobacco Use: Screening and Cessation Intervention for Patients with Asthma and COPD,ACEP25,QCDR Measure,Process,Y,,70.4149122807017,59.36 - 67.82,67.83 - 70.73,70.74 - 72.69,72.7 - 76.05,76.06 - 77.26,77.27 - 79.03,79.04 - 88.21,>= 88.22,No,No,N
-Sepsis Management: Septic Shock: Lactate Clearance Rate of >= 10%,ACEP30,QCDR Measure,Outcome,Y,,80.1643333333333,73.81 - 76.51,76.52 - 77.63,77.64 - 80.47,80.48 - 82.91,82.92 - 84.78,84.79 - 87.02,87.03 - 90.58,>= 90.59,No,No,Y
-Appropriate Foley catheter use in the emergency department,ACEP31,QCDR Measure,Process,Y,,67.1533333333333,48.44 - 54.35,54.36 - 57.2,57.21 - 73.9,73.91 - 75.24,75.25 - 77.77,77.78 - 85.25,85.26 - 89.2,>= 89.21,No,No,Y
-"Sepsis Management: Septic Shock: Lactate Level Measurement, Antibiotics Ordered, and Fluid Resuscitation",ACEP48,QCDR Measure,Process,Y,,87.5795652173913,83.63 - 85.95,85.96 - 87.49,87.5 - 89.57,89.58 - 90.9,90.91 - 92.15,92.16 - 94.24,94.25 - 96.6,>= 96.61,No,No,N
-ED Median Time from ED arrival to ED departure for all Adult Patients,ACEP50,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,N
-ED Median Time from ED arrival to ED departure for all Pediatric Patients,ACEP51,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Appropriate Emergency Department Utilization of Lumbar Spine Imaging for Atraumatic Low Back Pain,ACEP52,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Appropriate Use of Imaging for Recurrent Renal Colic,ACEP53,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Appropriate Utilization of FAST Exam in the Emergency Department,ACEP54,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,ACEP55,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Follow-Up Care Coordination Documented in Discharge Summary,ACEP56,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-"Avoidance of Opioid therapy for migraine, low back pain, dental pain",ACEP57,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Appropriate Treatment for Adults with Upper Respiratory Infection (URI),ACEP58,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Closing the Mohs Surgery Referral Loop: Transmission of Surgical Report,ACMS2,QCDR Measure,Process,Y,,85.335303030303,82.14 - 92.02,92.03 - 96.2,96.21 - 97.47,97.48 - 98.32,98.33 - 99.5,99.51 - 99.88,99.89 - 99.99,100,Yes,No,Y
-Antibiotic Prophylaxis for High Risk Cardiac / Orthopedic Cases prior to Mohs micrographic surgery - Prevention of Overuse,ACMS3,QCDR Measure,Process,Y,,80.111724137931,80.95 - 86.08,86.09 - 86.66,86.67 - 89.93,89.94 - 94.33,94.34 - 95.88,95.89 - 98.3,98.31 - 99.99,100,No,No,Y
-Surgical Site Infection Rate - Mohs Micrographic Surgery,ACMS4,QCDR Measure,Outcome,Y,,.868026315789473,1.27 - 1.09,1.08 - 0.92,0.91 - 0.76,0.75 - 0.37,0.36 - 0.16,0.15 - 0.09,0.08 - 0.01,0,No,No,Y
-Documentation of High-Risk Squamous Cell Carcinoma Stage in Mohs Micrographic Surgery Record,ACMS5,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Limit quantity of opioids prescribed for pain management in patients following Mohs micrographic surgery,ACMS8,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-ABCDEF Bundle - Early mobility for ICU patients,ACQR12,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Sepsis: Hour One bundle,ACQR13,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Use of a risk stratification tool in patients with CAP,ACQR15,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-COPD Exacerbation or CHF Exacerbation requiring Hospital Admission: Palliative Care Evaluation,ACQR16,QCDR Measure,Efficiency and Cost/Resource Use,Y,,75.5976923076923,66.41 - 69.99,70.0 - 73.07,73.08 - 75.69,75.7 - 80.03,80.04 - 83.92,83.93 - 87.58,87.59 - 92.85,>= 92.86,No,No,Y
-COPD: Steroids for no more than 5 days in COPD Exacerbation,ACQR3,QCDR Measure,Efficiency and Cost/Resource Use,Y,,94.0229333333333,90.91 - 92.58,92.59 - 94.43,94.44 - 95.71,95.72 - 96.77,96.78 - 97.36,97.37 - 98.38,98.39 - 99.01,>= 99.02,No,No,Y
-Use of ACE-I or ARB and beta blockade in CHF,ACQR9,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Hepatitis B Safety Screening,ACR10,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Disease Activity Measurement for Patients with PsA,ACR12,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Gout: Serum Urate Target,ACR14,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Safe Hydroxychloroquine Dosing,ACR15,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Rheumatoid Arthritis Patients with Low Disease Activity or Remission,ACR16,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Report Turnaround Time: Radiography,ACRAD15,QCDR Measure,Outcome,Y,,4.57878238341969,6.38 - 4.93,4.92 - 3.86,3.85 - 2.78,2.77 - 2.03,2.02 - 1.51,1.5 - 1.17,1.16 - 0.8,<= 0.79,No,No,Y
-Report Turnaround Time: Ultrasound (Excluding Breast US),ACRAD16,QCDR Measure,Outcome,Y,,6.42633587786259,8.2 - 6.45,6.44 - 5.16,5.15 - 4.15,4.14 - 3.3,3.29 - 2.42,2.41 - 1.83,1.82 - 1.08,<= 1.07,No,No,Y
-Report Turnaround Time: MRI,ACRAD17,QCDR Measure,Outcome,Y,,10.7413483146067,16.2 - 11.6,11.59 - 9.49,9.48 - 7.92,7.91 - 6.05,6.04 - 4.81,4.8 - 3.62,3.61 - 2.34,<= 2.33,No,No,Y
-Report Turnaround Time: CT,ACRAD18,QCDR Measure,Outcome,Y,,6.81127226463104,6.51 - 4.91,4.9 - 4.04,4.03 - 3.23,3.22 - 2.63,2.62 - 2.12,2.11 - 1.64,1.63 - 1.18,<= 1.17,No,No,Y
-Report Turnaround Time: PET,ACRAD19,QCDR Measure,Outcome,Y,,24.5643617021276,42.76 - 26.21,26.2 - 14.76,14.75 - 10.51,10.5 - 8.39,8.38 - 6.91,6.9 - 5.09,5.08 - 3.89,<= 3.88,No,No,Y
-Report Turnaround Time: Mammography,ACRAD25,QCDR Measure,Outcome,Y,,22.8680104712041,34.33 - 25.24,25.23 - 22.27,22.26 - 16.39,16.38 - 11.32,11.31 - 6.79,6.78 - 3.98,3.97 - 0.84,<= 0.83,No,No,Y
-"Multi-strata weighted average for 3 CT Exam Types: Overall Percent of CT exams for which Dose Length Product is at or below the size-specific diagnostic reference level (for CT Abdomen-pelvis with contrast/single phase scan, CT Chest without contrast/single phase scan and CT Head/Brain without contrast/single phase scan)",ACRAD34,QCDR Measure,Outcome,Y,,78.9054237288135,60.43 - 73.28,73.29 - 82.24,82.25 - 87.25,87.26 - 89.15,89.16 - 94.27,94.28 - 95.13,95.14 - 95.64,>= 95.65,No,No,Y
-Incidental Coronary Artery Calcification Reported on Chest CT,ACRAD36,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Interpretation of CT Pulmonary Angiography (CTPA) for Pulmonary Embolism,ACRAD37,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Use of Low Dose Cranial CT or MRI Examinations for Patients with Ventricular Shunts,ACRAD38,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Use of Low Dose CT Studies for Adults with Suspicion of Urolithiasis or Nephrolithiasis,ACRAD39,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Use of Structured Reporting in Prostate MRI,ACRAD40,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Use of Quantitative Criteria for Oncologic FDG PET Imaging,ACRAD41,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Surveillance Imaging for Liver Nodules <10mm in Patients at Risk for Hepatocellular Carcinoma (HCC),ACRAD42,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Ventral Hernia Repair: Pain and Functional Status Assessment,AHSQC10,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Abdominal Wall Reconstruction Surgical Site Occurrence Requiring Procedural Intervention within the 30 Day Postoperative Period,AHSQC6,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Hip Arthroplasty: Shared Decision-Making: Trial of Conservative (Non-surgical) Therapy,AJRR3,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Hip Arthroplasty: Venous Thromboembolic and Cardiovascular Risk Evaluation,AJRR4,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Hip/Knee Arthroplasty: Unplanned Readmission within 90 Days Following the Primary Procedure,AJRR6,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Hip/Knee Replacement: Postoperative Ambulation,AJRR7,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Coronary Artery Bypass Graft (CABG): Prolonged Intubation -Inverse Measure,AQI18,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Patient-Reported Experience with Anesthesia,AQI48,QCDR Measure,Patient Reported Outcome,Y,,92.2841780821917,89.93 - 91.0,91.01 - 91.9,91.91 - 92.57,92.58 - 93.08,93.09 - 94.52,94.53 - 95.58,95.59 - 96.37,>= 96.38,No,No,Y
-Adherence to Blood Conservation Guidelines for Cardiac Operations using Cardiopulmonary Bypass (CPB) -Composite,AQI49,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Team-Based Implementation of a Care-and-Communication Bundle for ICU Patients,AQI55,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Use of Neuraxial Techniques and/or Peripheral Nerve Blocks for Total Knee Arthroplasty (TKA),AQI56,QCDR Measure,Process,Y,,89.4729801324503,85.5 - 91.45,91.46 - 95.44,95.45 - 97.13,97.14 - 98.81,98.82 - 99.48,99.49 - 99.99,--,100,Yes,No,N
-Safe Opioid Prescribing Practices,AQI57,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Obstructive Sleep Apnea: Patient Education,AQI62,QCDR Measure,Process,Y,,87.0532608695652,81.0 - 92.28,92.29 - 97.15,97.16 - 99.55,99.56 - 99.9,99.91 - 99.99,--,--,100,Yes,No,N
-Avoidance of Cerebral Hyperthermia for Procedures Involving Cardiopulmonary Bypass,AQI65,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Consultation for Frail Patients,AQI67,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Obstructive Sleep Apnea: Mitigation Strategies,AQI68,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Intraoperative Antibiotic Redosing,AQI69,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Prevention of Arterial Line-Related Bloodstream Infections,AQI70,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Ambulatory Glucose Management,AQI71,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Perioperative Anemia Management,AQI72,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Stones: Inappropriate Repeat Shock Wave Lithotripsy (SWL) Within 6 Months of Initial Treatment,AQUA14,QCDR Measure,Outcome,Y,,31.06625,41.28 - 38.72,38.71 - 34.49,34.48 - 31.48,31.47 - 28.42,28.41 - 21.37,21.36 - 13.8,13.79 - 2.28,<= 2.27,No,No,Y
-Stones: Urinalysis Performed Before Surgical Stone Procedures,AQUA15,QCDR Measure,Process,Y,,65.0795454545454,47.84 - 53.18,53.19 - 63.14,63.15 - 69.66,69.67 - 74.65,74.66 - 76.97,76.98 - 84.09,84.1 - 92.24,>= 92.25,No,No,Y
-Non-Muscle Invasive Bladder Cancer: Repeat Transurethral Resection of Bladder Tumor (TURBT) for T1 disease,AQUA16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Non-Muscle Invasive Bladder Cancer: Early Surveillance Cystoscopy for Non-Muscle Invasive Bladder Cancer,AQUA18,QCDR Measure,Process,Y,,37.746923076923,26.39 - 28.12,28.13 - 28.37,28.38 - 29.36,29.37 - 33.32,33.33 - 45.31,45.32 - 58.53,58.54 - 66.66,>= 66.67,No,No,N
-Benign Prostate Hyperplasia (BPH): Inappropriate Lab & Imaging Services for Patients with BPH,AQUA26,QCDR Measure,Process,Y,,11.1280487804878,14.58 - 12.17,12.16 - 9.34,9.33 - 6.49,6.48 - 5.01,5.0 - 3.09,3.08 - 1.04,1.03 - 0.01,0,No,No,Y
-Hospital admissions/complications within 30 days of TRUS Biopsy,AQUA8,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Patient Satisfaction with Information Provided during Breast Reconstruction,ASPS10,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Airway Assessment for patients undergoing Rhinoplasty,ASPS16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Patient Satisfaction with Rhinoplasty Procedure,ASPS17,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Shared-decision making for post-operative management of discomfort following Rhinoplasty,ASPS18,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Coordination of Care for Anticoagulated Patients Undergoing Reconstruction After Skin Cancer Resection,ASPS22,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Visits to the ER or Urgent Care Following Reconstruction After Skin Cancer Resection,ASPS24,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Patient Satisfaction with Information Prior to Facial Reconstruction After Skin Cancer Resection Procedures,ASPS26,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Avoidance of Post-operative Systemic Antibiotics for Office-based Closures and Reconstruction After Skin Cancer Procedures,ASPS27,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Continuation of Anticoagulation Therapy in the Office-based Setting for Closure and Reconstruction After Skin Cancer Resection Procedures,ASPS28,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Avoidance of Opioid Prescriptions for Closure and Reconstruction After Skin Cancer Resection,ASPS29,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Breast Reconstruction: Return to OR,ASPS5,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Turnaround Time (TAT) - Biopsies,CAP22,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Helicobacter pylori Status and Turnaround Time,CAP28,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Urinary Bladder Biopsy Diagnostic Requirements For Appropriate Patient Management,CAP30,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-"Prostate Cancer Gleason Pattern, Score, and Grade Group",CAP32,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-"Mismatch Repair (MMR) or Microsatellite Instability (MSI) Biomarker Testing Status in Colorectal Carcinoma, Endometrial, Gastroesophageal, or Small Bowel Carcinoma",CAP33,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Biomarker Status to Inform Clinical Management and Treatment Decisions in Patients with Non-small Cell Lung Cancer,CAP34,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-"Cancer Protocol and Turnaround Time for Gastrointestinal Carcinomas: Gastric, Esophageal, Colorectal and Hepatocellular Carcinomas",CAP35,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-p16 Immunohistochemistry Reporting for Human Papillomavirus in Patients with Oropharyngeal Squamous Cell Carcinoma (OPSCC),CAP36,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-"Cancer Protocol and Turnaround Time for Gynecologic and Genitourinary Carcinomas: Carcinoma of the Endometrium, Prostate, and Renal Tubular Origin",CAP37,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Patient-Reported Pain and/or Function Improvement after Total Knee Arthroplasty,CCOME1,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Patient-Reported Pain and/or Function Improvement after ACLR Surgery,CCOME4,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Extent of Osteoarthritis Observed in Arthroscopic Partial Meniscectomy,CCOME5,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Patient-Reported Pain and/or Function Improvement after APM Surgery,CCOME6,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Patient-Reported Pain and/or Function Improvement after Total Hip Arthroplasty,CCOME7,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Patient-Reported Pain and/or Function Improvement after Total Shoulder Arthroplasty,CCOME8,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Adequate Off-loading of Diabetic Foot Ulcer at each visit,CDR1,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Diabetic Foot Ulcer (DFU) Healing or Closure,CDR2,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Adequate Compression at each visit for Patients with VLUs,CDR5,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Venous Leg Ulcer (VLU) outcome measure: Healing or Closure,CDR6,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Appropriate Use of hyperbaric oxygen therapy for patients with diabetic foot ulcers,CDR8,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Post operative hypocalcemia after thyroidectomy surgery,CESQIP1,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Pre operative ultrasound exam of patients with thyroid cancer,CESQIP3,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Related readmission for adrenal related problems,CESQIP5,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-qPTH >50% Reduction at End of Procedure,CESQIP9,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Avoid Head CT for Patients with Uncomplicated Syncope,ECPR39,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Initiation of the Initial Sepsis Bundle,ECPR40,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Rh Status Evaluation and Treatment of Pregnant Women at Risk of Fetal Blood Exposure,ECPR41,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Avoidance of Opiates for Low Back Pain or Migraines,ECPR46,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Door to Diagnostic Evaluation by a Provider Within 30 Minutes -Urgent Care Patients,ECPR50,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Discharge Prescription of Naloxone after Opioid Poisoning or Overdose,ECPR51,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Appropriate Treatment of Psychosis and Agitation in the Emergency Department,ECPR52,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Clinician Reporting of Loss of Consciousness to State Department of Public Health or Department of Motor Vehicles,ECPR53,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Avoidance of Co-Prescribing of Opioid Analgesic and Benzodiazepine,ECPR54,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Avoidance of Long-Acting (LA) or Extended-Release (ER) Opiate Prescriptions and Opiate Prescriptions for Greater Than 3 Days Duration for Acute Pain,ECPR55,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Opioid Withdrawal: Initiation of Medication-Assisted Treatment (MAT) and Referral to Outpatient Opioid Treatment,ECPR56,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Ultrasound Guidance for Peripheral Nerve Block with Patient Experience,EPREOP30,QCDR Measure,Outcome,Y,,91.3126666666666,87.68 - 89.66,89.67 - 90.71,90.72 - 91.37,91.38 - 92.86,92.87 - 93.95,93.96 - 95.51,95.52 - 96.52,>= 96.53,No,No,Y
-Intraoperative Hypotension among Non-Emergent Noncardiac Surgical Cases,EPREOP31,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Review of Pain Status Assessment for Patients with Osteoarthritis,FORCE21,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Functional Status Change for Patients Post Stroke: Lower Body,FOTO2,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Functional Status Change for Patients Post Stroke: Upper Body,FOTO3,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Functional Status Changes for Patients with Upper or Lower Extremity Regional Swelling,FOTO4,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Appropriate management of anticoagulation in the peri-procedural period rate -EGD,GIQIC10,QCDR Measure,Process,Y,,69.2643617021276,47.96 - 60.7,60.71 - 79.82,79.83 - 86.7,86.71 - 91.66,91.67 - 96.06,96.07 - 99.99,--,100,No,No,Y
-Screening Colonoscopy Adenoma Detection Rate,GIQIC22,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Appropriate follow-up interval based on pathology findings in screening colonoscopy,GIQIC23,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Venous Thromboembolism (VTE) Prophylaxis,HCPR14,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Physician's Orders for Life-Sustaining Treatment (POLST) Form,HCPR16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Pressure Ulcers -Risk Assessment and Plan of Care,HCPR17,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Unintentional Weight Loss -Risk Assessment and Plan of Care,HCPR18,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Clostridium Difficile -Risk Assessment and Plan of Care,HCPR20,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Critical Care Transfer of Care -Use of Verbal Checklist or Protocol,HCPR22,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Avoidance of Echocardiogram and Carotid Ultrasound for Syncope,HCPR23,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Outcomes of Hearing Loss Treatment,HM10,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Outcomes of Treatment of Subjective Tinnitus,HM11,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Outcomes of Treatment of Benign Paroxysmal Positional Vertigo,HM12,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Functional Status Change for Patients With Upper-limb Functional Status Deficit,HM4,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Functional Status Change for Patients With Neck Functional Status Deficit,HM5,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Functional Status Change for Patients With Low Back Functional Status Deficit,HM6,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Functional Status Change for Patients with Vestibular Dysfunction,HM7,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Functional Status Change for Patients With Lower Extremity Functional Status Deficit,HM8,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Functional Benefit of a Cochlear Implant,HM9,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Comprehensive TTE studies reporting a measured value of LVEF AND wall motion findings with LVEF < 50%,IGR1,QCDR Measure,Efficiency and Cost/Resource Use,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Transthoracic Echo (TTE) performance per ASE guidelines,IGR10,QCDR Measure,Efficiency and Cost/Resource Use,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Appropriate diagnosis verification and severity grading for valve disease through transthoracic echocardiography (TTE) quantitative parameters.,IGR12,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Appropriate Evaluation of Left Ventricular Structure and Systolic Function with Transthoracic Echocardiography (TTE) to Guide Heart Failure and Cardiomyopathy Management,IGR14,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Myocardial Perfusion Imaging (MPI) or Stress Echocardiography Imaging Studies - Adequate Exercise Protocol,IGR15,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-"Myocardial Perfusion Imaging (MPI) Studies, Transthoracic Echo (TTE), or Stress Echocardiography Imaging Studies - Adequate Reporting for Appropriate Interventions",IGR16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Myocardial Perfusion Imaging (MPI) studies - Radiation Reduction Strategies,IGR17,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Myocardial Perfusion Imaging (MPI) or Stress Echocardiography imaging studies - Improving Image Quality,IGR18,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-"Parameters in stress echocardiography dobutamine testing for low flow, low gradient aortic stenosis",IGR2,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Stress echo performance for shortness of breath per ASE guidelines,IGR9,QCDR Measure,Efficiency and Cost/Resource Use,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Endothelial Keratoplasty - Post-operative improvement in best corrected visual acuity to 20/40 or better,IRIS1,QCDR Measure,Outcome,Y,,55.1739130434782,38.75 - 46.14,46.15 - 48.71,48.72 - 55.87,55.88 - 56.39,56.4 - 66.98,66.99 - 71.78,71.79 - 79.99,>= 80.0,No,No,Y
-Glaucoma – Intraocular Pressure Reduction,IRIS2,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Diabetic Macular Edema - Loss of Visual Acuity,IRIS13,QCDR Measure,Outcome,Y,,86.0751923076923,70.84 - 82.47,82.48 - 87.43,87.44 - 88.74,88.75 - 89.86,89.87 - 92.24,92.25 - 93.87,93.88 - 98.07,>= 98.08,No,No,Y
-Acute Anterior Uveitis: Post-treatment Grade 0 anterior chamber cells,IRIS17,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Refractive Surgery: Patients with a postoperative uncorrected visual acuity (UCVA) of 20/20 or better within 30 days,IRIS23,QCDR Measure,Outcome,Y,,80.3240909090909,68.75 - 75.33,75.34 - 79.91,79.92 - 83.01,83.02 - 87.79,87.8 - 89.18,89.19 - 94.11,94.12 - 95.8,>= 95.81,No,No,Y
-Refractive Surgery: Patients with a postoperative correction within + or - 0.5 Diopter (D) of the intended correction,IRIS24,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Avoidance of Routine Antibiotic Use in Patients Before or After Intravitreal Injections,IRIS26,QCDR Measure,Efficiency and Cost/Resource Use,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Improvement of Macular Edema in Patients with Uveitis,IRIS35,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Endothelial Keratoplasty -Dislocation Requiring Surgical Intervention,IRIS38,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Intraocular Pressure Reduction Following Trabeculectomy or an Aqueous Shunt Procedure,IRIS39,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Improved visual acuity after epiretinal membrane treatment within 120 days,IRIS41,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Intraocular Pressure Reduction Following Laser Trabeculoplasty,IRIS43,QCDR Measure,Outcome,Y,,45.9873333333333,21.43 - 27.49,27.5 - 30.52,30.53 - 33.32,33.33 - 38.97,38.98 - 62.85,62.86 - 70.96,70.97 - 85.7,>= 85.71,No,No,Y
-Visual Field Progression in Glaucoma,IRIS44,QCDR Measure,Outcome,Y,,12.2051351351351,15.65 - 14.02,14.01 - 13.13,13.12 - 11.84,11.83 - 10.85,10.84 - 9.53,9.52 - 8.84,8.83 - 2.34,<= 2.33,No,No,Y
-Exudative Age-Related Macular Degeneration: Loss of Visual Acuity,IRIS45,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Evidence of anatomic closure of macular hole within 90 days after surgery as documented by OCT,IRIS46,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Adult Surgical Esotropia: Postoperative alignment,IRIS48,QCDR Measure,Outcome,Y,,17.9125,2.86 - 4.41,4.42 - 6.0,6.01 - 7.69,7.7 - 15.6,15.61 - 22.61,22.62 - 31.24,31.25 - 37.32,>= 37.33,No,No,Y
-Surgical Pediatric Esotropia: Postoperative alignment,IRIS49,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Surgery for Acquired Involutional Ptosis: Patients with an improvement of marginal reflex distance (MRD),IRIS5,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Amblyopia: Interocular visual acuity,IRIS50,QCDR Measure,Outcome,Y,,54.3538095238095,42.86 - 47.61,47.62 - 53.32,53.33 - 56.51,56.52 - 57.88,57.89 - 67.56,67.57 - 68.17,68.18 - 68.96,>= 68.97,No,No,Y
-Acute Anterior Uveitis: Post-treatment visual acuity,IRIS51,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Post-operative opioid management following ocular surgery,IRIS52,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Chronic Anterior Uveitis - Post-treatment visual acuity,IRIS53,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Complications After Cataract Surgery,IRIS54,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Visual Acuity Improvement Following Cataract Surgery and Minimally Invasive Glaucoma Surgery,IRIS55,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Adult Diplopia: Improvement of ocular deviation or absence of diplopia or functional improvement,IRIS56,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Idiopathic Intracranial Hypertension: Improvement of mean deviation or stability of mean deviation,IRIS57,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Improved Visual Acuity after Vitrectomy for Complications of Diabetic Retinopathy within 120 Days,IRIS58,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Regaining Vision After Cataract Surgery,IRIS59,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Acquired Involutional Entropion: Normalized lid position after surgical repair,IRIS6,QCDR Measure,Outcome,Y,,91.297619047619,91.74 - 93.85,93.86 - 95.69,95.7 - 98.27,98.28 - 99.99,--,--,--,100,No,No,Y
-Visual Acuity Improvement Following Cataract Surgery Combined with a Trabeculectomy or an Aqueous Shunt Procedure,IRIS60,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) to indicate functional improvement in knee rehabilitation of patients with knee injury measured via their validated Knee Outcome Survey (KOS) score, or equivalent instrument which has undergone peer reviewed published validation and demonstrates a peer reviewed published MCID.",IROMS11,QCDR Measure,Patient Reported Outcome,Y,,26.800022172949,42.45 - 32.6,32.59 - 30.01,30.0 - 27.05,27.04 - 25.01,25.0 - 22.62,22.61 - 21.63,21.62 - 15.59,<= 15.58,No,No,Y
-"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with knee injury pain.",IROMS12,QCDR Measure,Patient Reported Outcome,Y,,40.707676056338,46.15 - 44.08,44.07 - 43.02,43.01 - 40.32,40.31 - 39.59,39.58 - 38.11,38.1 - 35.96,35.95 - 24.01,<= 24.0,No,No,Y
-"Failure to Progress (FTP): Proportion of patients not achieving a Minimal Clinically Important Difference (MCID) to indicate functional improvement in rehabilitation of patients with hip, leg or ankle injuries using the validated Lower Extremity Function Scale (LEFS) score, or equivalent instrument which has undergone peer reviewed published validation and demonstrates a peer reviewed published MCID.",IROMS13,QCDR Measure,Patient Reported Outcome,Y,,35.2059594095941,39.66 - 38.27,38.26 - 36.94,36.93 - 35.01,35.0 - 33.65,33.64 - 32.83,32.82 - 31.59,31.58 - 20.98,<= 20.97,No,No,Y
-"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with hip, leg or ankle (lower extremity except knee) injury.",IROMS14,QCDR Measure,Patient Reported Outcome,Y,,45.2645303867403,52.31 - 50.57,50.56 - 49.26,49.25 - 47.95,47.94 - 46.68,46.67 - 45.54,45.53 - 43.54,43.53 - 18.8,<= 18.79,No,No,Y
-Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) to indicate functional improvement in rehabilitation of patients with neck pain/injury measured via the validated Neck Disability Index (NDI).,IROMS15,QCDR Measure,Patient Reported Outcome,Y,,40.2512468193384,46.15 - 43.86,43.85 - 43.09,43.08 - 42.02,42.01 - 40.92,40.91 - 39.45,39.44 - 35.72,35.71 - 3.18,<= 3.17,No,No,Y
-"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with neck pain/injury.",IROMS16,QCDR Measure,Patient Reported Outcome,Y,,39.3922102425876,46.05 - 43.99,43.98 - 42.77,42.76 - 41.6,41.59 - 40.09,40.08 - 38.93,38.92 - 37.05,37.04 - 5.84,<= 5.83,No,No,Y
-Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) to indicate functional improvement in rehabilitation patients with low back pain measured via the validated Modified Low Back Pain Disability Questionnaire (MDQ) score.,IROMS17,QCDR Measure,Patient Reported Outcome,Y,,32.4685519591141,37.8 - 36.37,36.36 - 35.17,35.16 - 34.35,34.34 - 33.34,33.33 - 32.3,32.29 - 30.5,30.49 - 18.53,<= 18.52,No,No,Y
-"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with low back pain.",IROMS18,QCDR Measure,Patient Reported Outcome,Y,,42.2747957371225,47.06 - 45.44,45.43 - 44.16,44.15 - 43.49,43.48 - 42.87,42.86 - 41.61,41.6 - 40.82,40.81 - 25.01,<= 25.0,No,No,Y
-"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) to indicate functional improvement in rehabilitation of patients with arm, shoulder, and hand injury measured via the validated Disability of Arm Shoulder and Hand (DASH) score, Quick Disability of Arm Shoulder and Hand (QDASH) score, or equivalent instrument which has undergone peer reviewed published validation and demonstrates a peer reviewed published MCID.",IROMS19,QCDR Measure,Patient Reported Outcome,Y,,24.8214691151919,28.57 - 27.57,27.56 - 25.77,25.76 - 24.42,24.41 - 23.43,23.42 - 22.23,22.22 - 20.66,20.65 - 6.74,<= 6.73,No,No,Y
-"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with arm, shoulder, or hand injury.",IROMS20,QCDR Measure,Patient Reported Outcome,Y,,40.6319512195122,46.81 - 45.3,45.29 - 44.86,44.85 - 43.76,43.75 - 41.8,41.79 - 40.71,40.7 - 39.3,39.29 - 15.61,<= 15.6,No,No,Y
-Use of Anxiety Severity Measure,MBHR1,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Symptom Improvement in adults with ADHD,MBHR10,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Cognitive Assessment with Counseling on Safety and Potential Risk,MBHR11,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Patient Feedback of Test Results Following Cognitive or Mental Status Assessment,MBHR12,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Anxiety Response at 6-months,MBHR2,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Pain Interference Response utilizing PROMIS,MBHR3,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Social Role Functioning Outcome utilizing PROMIS,MBHR4,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Screening and monitoring for psychosocial problems among children and youth,MBHR5,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Sleep Quality Assessment and Sleep Response at 3-months,MBHR6,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Posttraumatic Stress Disorder (PTSD) Outcome Assessment for Adults and Children,MBHR7,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Alcohol Use Disorder Outcome Response,MBHR8,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Outcome monitoring of ADHD functional impairment in children and youth,MBHR9,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Use of Capnography for Non-Operating Room Anesthesia,MEDNAX53,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Labor Epidural Failure when Converting from Labor Analgesia to Cesarean Section Anesthesia,MEDNAX54,QCDR Measure,Outcome,Y,,10.7765,22.11 - 12.75,12.74 - 8.67,8.66 - 5.6,5.59 - 4.13,4.12 - 3.17,3.16 - 2.4,2.39 - 0.71,<= 0.7,No,No,Y
-Use of ASPECTS (Alberta Stroke Program Early CT Score) for non-contrast CT Head performed for suspected acute stroke.,MEDNAX55,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Use of a “PEG Test” to Manage Patients Receiving Opioids,MEDNAX56,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Hammer Toe Outcome,MEX5,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Screening Coronary Calcium Scoring for Cardiovascular Risk Assessment Including Coronary Artery Calcification Regional Distribution Scoring,MSN13,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Use of Thyroid Imaging Reporting & Data System (TI-RADS) in Final Report to Stratify Thyroid Nodule Risk,MSN15,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Screening Abdominal Aortic Aneurysm Reporting with Recommendations,MSN16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Prostate Cancer: Confirmation Testing in low risk AS eligible patients,MUSIC10,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Prostate Cancer: Follow-Up Testing for patients on active surveillance for at least 30 months,MUSIC11,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Kidney Stones: ED visit within 30 days of ureteroscopy,MUSIC12,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Kidney Stones: SWL in patients with largest renal stone > 2 cm or lower pole stone > 1 cm,MUSIC15,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Kidney Stones: Opioid utilization after ureteroscopy and shockwave lithotripsy,MUSIC17,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Kidney Stones: Alpha-blockers at discharge for patients undergoing ureteroscopy or shockwave lithotripsy,MUSIC18,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Kidney Stones: Readmission within 30 days of ureteroscopy,MUSIC19,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Prostate Cancer: Complications within 30 days of radical prostatectomy,MUSIC20,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Prostate Cancer: Opioid utilization after radical prostatectomy,MUSIC21,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Prostate Cancer: Urinary continence at 12 months post-radical prostatectomy,MUSIC22,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Renal Mass: Documentation of the RENAL score for patients with small renal mass diagnoses,MUSIC23,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Kidney Stones: Post-ureteroscopy and shockwave lithotripsy imaging for any stones,MUSIC24,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Renal Mass: ED visit or Readmission within 30 days of radical nephrectomy,MUSIC25,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Renal Mass: ED Visit or Readmission within 30 days of partial nephrectomy,MUSIC26,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Prostate Cancer: Active Surveillance/Watchful Waiting for Low Risk Prostate Cancer Patients,MUSIC4,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Prostate Cancer: Radical Prostatectomy Cases LOS,MUSIC5,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Repeat screening or surveillance colonoscopy recommended within one year due to inadequate/poor bowel preparation,NHCR4,QCDR Measure,Process,Y,,49.8047368421052,17.65 - 24.99,25.0 - 37.92,37.93 - 51.99,52.0 - 60.77,60.78 - 72.13,72.14 - 86.43,86.44 - 90.47,>= 90.48,No,No,Y
-CHANGE IN PATIENT REPORTED QUALITY OF LIFE FOLLOWING EPIDURAL LYSIS OF ADHESIONS,NIPM18,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-CHANGE IN PATIENT REPORTED QUALITY OF LIFE AND FUNCTIONAL STATUS FOLLOWING MEDIAL BRANCH RADIOFREQUENCY ABLATION,NIPM19,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-CHANGE IN PATIENT REPORTED PAIN AND FUNCTIONAL STATUS FOLLOWING SPINAL CORD STIMULATOR IMPLANTATION,NIPM20,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-CHANGE IN PATIENT REPORTED QUALITY OF LIFE FOLLOWING EPIDURAL CORTICOSTEROID INJECTION,NIPM22,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-CHANGE IN PATIENT REPORTED QUALITY OF LIFE FOLLOWING MAJOR JOINT CORTICOSTEROID INJECTION,NIPM23,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-CHANGE IN PATIENT REPORTED QUALITY OF LIFE FOLLOWING INTRATHECAL PUMP IMPLANTATION,NIPM24,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-CHANGE IN PATIENT REPORTED QUALITY OF LIFE FOLLOWING INTERSPINOUS INDIRECT DECOMPRESSION (SPACER),NIPM25,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Notification to the ordering provider requesting myoglobin or CK-MB in the diagnosis of suspected acute myocardial infarction (AMI),NPQR1,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Rate of communicating results of an amended report with a major discrepancy to the responsible provider,NPQR11,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Rate of notification to clinical provider of a new diagnosis of malignancy,NPQR13,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Non-small cell lung carcinoma (NSCLC) ancillary biomarker testing status and turnaround time (TAT) from point of specimen accession date to ancillary biomarker testing completion and reporting date should be ≤ 10 days,NPQR15,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Notification to the provider ordering repeat blood chemistry panels in clinically stable patients within four days.,NPQR16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Notification to the provider ordering repeat C. difficile stool toxin testing within seven days,NPQR17,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Notification to the provider ordering repeat CBCs in clinically stable patients within four days,NPQR18,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Notification to the provider ordering repeat Hepatitis C serology testing on a patient with previously positive results,NPQR19,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Notification to the ordering provider requesting thyroid screening tests other than only a Thyroid Stimulating Hormone (TSH) test in the initial screening of a patient with a suspected thyroid disorder,NPQR2,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Notification to the ordering provider requesting amylase testing in the diagnosis of suspected acute pancreatitis,NPQR3,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Time interval: critical value reporting for chemistry,NPQR4,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Time interval: critical value reporting for cerebrospinal fluid - white blood cell (CSF - WBC),NPQR5,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Time interval: critical value reporting for toxicology,NPQR6,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Time interval: critical value reporting for troponin,NPQR7,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Quality of Life - Physical Health Outcomes,OBERD32,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Appropriate non-invasive arterial testing for patients with intermittent claudication who are undergoing a LE peripheral vascular intervention,OEIS6,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Structured Walking Program Prior to Intervention for Claudication,OEIS7,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Use of ultrasound guidance for vascular access,OEIS8,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Patient Reported Health-Related Quality of Life (HRQoL) during Treatment for Advanced Cancer,ONSQIR21,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-PCR Test with MR2 or greater result (BCR-ABL1 transcript level <= 1% [IS]) for patients receiving TKI for at least 6 months for Chronic Myelogenous Leukemia,ONSQIR22,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Assessment for and management of immune-related adverse events during cancer treatment with checkpoint inhibitors (ICPi),ONSQIR23,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Oncology: Advance Care Planning in metastatic cancer patients,PIMSH1,QCDR Measure,Patient Engagement/Experience,Y,,18.9278468899521,2.22 - 3.69,3.7 - 6.16,6.17 - 18.17,18.18 - 29.78,29.79 - 39.99,40.0 - 48.71,48.72 - 64.8,>= 64.81,No,No,Y
-Oncology: Hepatitis B serology testing and prophylactic treatment prior to receiving anti-CD20 targeting drugs,PIMSH10,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-"Oncology: Utilization of PET, PET/CT, or CT scans for breast cancer stage 0, I, or II at any time during the course of evaluation and treatment",PIMSH11,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Oncology: Utilization of GCSF in metastatic colorectal cancer,PIMSH2,QCDR Measure,Efficiency and Cost/Resource Use,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Oncology: Combination chemotherapy recommended or received within 4 months of diagnosis by women under 70 with AJCC stage T1cN0M0 to Stage 1B-III ER/PR negative breast cancer,PIMSH3,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Oncology: Patient-reported pain improvement,PIMSH4,QCDR Measure,Patient Reported Outcome,Y,,40.7223076923076,29.61 - 35.05,35.06 - 38.16,38.17 - 40.8,40.81 - 43.9,43.91 - 47.36,47.37 - 51.04,51.05 - 58.25,>= 58.26,No,No,Y
-Oncology: Mutation testing for lung cancer completed prior to start of targeted therapy,PIMSH8,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Oncology: Supportive care drug utilization in last 14 days of life,PIMSH9,QCDR Measure,Efficiency and Cost/Resource Use,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Appropriate Documentation of a Malnutrition Diagnosis,PINC55,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Assessment of Nutritionally At-Risk Patients for Malnutrition and Development of Nutrition Recommendations/Interventions by a Registered Dietitian Nutritionist,PINC56,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-"Measurement-based Care Processes: Baseline Assessment, Monitoring and Treatment Adjustment",PP8,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Improvement or Maintenance of Functioning for Individuals with a Mental Health and/or Substance Use Disorder,PP9,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-IVC Filter Management Confirmation,QMM16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Appropriate Follow-up Recommendations for Ovarian-Adnexal Lesions using the Ovarian-Adnexal Reporting and Data System (O-RADS),QMM17,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Use of Breast Cancer Risk Score on Mammography,QMM18,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-DEXA/DXA and Fracture Risk Assessment for Patients with Osteopenia,QMM19,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Opening Pressure in Lumbar Puncture,QMM20,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Concurrent Chemo radiation for Patients with a Diagnosis of Stage IIIB NSCLC,QOPI23,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Sentinel Lymph Node (SLN) Biopsies for Patients AJCC T1b-T4 Melanoma,QOPI26,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Appropriate Antiemetic Therapy for High- and Moderate Emetic Risk Antineoplastic Agents,QOPI27,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Central Line Ultrasound Guidance,QUANTUM31,QCDR Measure,Process,Y,,91.7532599118942,89.46 - 95.73,95.74 - 98.14,98.15 - 99.16,99.17 - 99.99,--,--,--,100,Yes,No,Y
-Upper Extremity Edema Improvement,RCOIR10,QCDR Measure,Patient Reported Outcome,Y,,74.628125,67.09 - 70.44,70.45 - 74.08,74.09 - 75.89,75.9 - 76.96,76.97 - 78.56,78.57 - 84.12,84.13 - 89.51,>= 89.52,No,No,Y
-Tunneled Hemodialysis Catheter Success,RCOIR12,QCDR Measure,Outcome,Y,,71.3988235294117,60.98 - 66.98,66.99 - 70.16,70.17 - 76.04,76.05 - 78.3,78.31 - 81.67,81.68 - 84.65,84.66 - 87.01,>= 87.02,No,No,Y
-Percutaneous Arteriovenous Fistula for Dialysis - Clinical Success Rate,RCOIR13,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-End Stage Renal Disease (ESRD) Initiation of Home Dialysis or Self-Care,RCOIR5,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Improved Access Site Bleeding,RCOIR7,QCDR Measure,Outcome,Y,,84.2947058823529,74.6 - 82.94,82.95 - 84.0,84.01 - 86.0,86.01 - 90.04,90.05 - 92.05,92.06 - 93.61,93.62 - 96.07,>= 96.08,No,No,Y
-Heel Pain Treatment Outcomes for Adults,REGCLR1,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Tendinitis/ Enthesopathy- Injection Treatment Outcomes for Adults,REGCLR2,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Bunion Outcome - Adult and Adolescent,REGCLR3,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Heel Pain Treatment Outcomes for Pediatric Patients,REGCLR4,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Offloading with Remote Monitoring,REGCLR5,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Use of Digital Imaging to Monitor and Improve Treatment Outcomes in Chronic Wound Healing,REGCLR6,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Use of Ankle Foot Orthotics to improve patient function,REGCLR7,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Rate of Timely Documentation Transmission to Dialysis Unit/Referring Physician,RPAQIR13,QCDR Measure,Process,Y,,82.4648780487804,91.72 - 92.18,92.19 - 95.18,95.19 - 96.7,96.71 - 96.93,96.94 - 97.48,97.49 - 97.81,97.82 - 99.81,>= 99.82,Yes,No,Y
-Arteriovenous Graft Thrombectomy Success Rate,RPAQIR14,QCDR Measure,Outcome,Y,,76.5662857142857,79.43 - 82.13,82.14 - 85.55,85.56 - 86.97,86.98 - 89.03,89.04 - 91.85,91.86 - 93.83,93.84 - 95.78,>= 95.79,No,No,Y
-Arteriovenous Fistulae Thrombectomy Success Rate,RPAQIR15,QCDR Measure,Outcome,Y,,77.2086666666666,78.35 - 81.64,81.65 - 82.67,82.68 - 84.19,84.2 - 86.06,86.07 - 90.99,91.0 - 91.68,91.69 - 93.14,>= 93.15,No,No,Y
-Peritoneal Dialysis Catheter Success Rate,RPAQIR16,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Advance Directives Completed,RPAQIR18,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Transplant Referral,RPAQIR5,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Percent of patients meeting SCB thresholds for back or neck pain,SPINETRACK4,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Percent of patients meeting SCB thresholds for leg or arm pain,SPINETRACK5,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Percent of patients meeting SCB thresholds for pain-related disability (ODI/NDI),SPINETRACK6,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Patient satisfaction following spinal fusion surgery,SPINETRACK8,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Unplanned hospital readmission following spinal fusion surgery.,SPINETRACK9,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Prolonged Length of Stay Following Coronary Artery Bypass Grafting,STS1,QCDR Measure,Outcome,Y,,2.6012925170068,5.63 - 5.27,5.26 - 4.95,4.94 - 4.08,4.07 - 3.71,3.7 - 2.68,2.67 - 2.29,2.28 - 0.01,0,No,No,Y
-Patient Centered Surgical Risk Assessment and Communication for Cardiac Surgery,STS7,QCDR Measure,Process,Y,,56.4682876712329,2.08 - 19.99,20.0 - 42.85,42.86 - 55.55,55.56 - 73.32,73.33 - 87.26,87.27 - 95.19,95.2 - 99.25,>= 99.26,No,No,Y
-Ankylosing Spondylitis: Controlled Disease,UREQA1,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Ankylosing Spondylitis: Appropriate Pharmacologic Therapy,UREQA2,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Folic or Folinic Acid Therapy for Patients Treated with Methotrexate,UREQA4,QCDR Measure,Process,Y,,92.049511447327,90.21 - 92.9,92.91 - 94.21,94.22 - 94.97,94.98 - 97.29,97.3 - 97.95,97.96 - 98.7,98.71 - 99.5,>= 99.51,No,No,N
-Patient Reported Nutritional Assessment in Patients with Wounds and Ulcers,USWR22,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Non Invasive Arterial Assessment of patients with lower extremity wounds or ulcers for determination of healing potential,USWR23,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Patient Reported Experience of Care: Wound Outcome,USWR24,QCDR Measure,Patient Reported Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Pressure Ulcer* (PU) Healing or Closure for ulcers on the torso (body),USWR25,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Patient Reported Outcome of late effects of radiation symptoms following treatment with Hyperbaric Oxygen Therapy (HBOT),USWR26,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Assessment of Nutritionally At-Risk Patients for Malnutrition and Development of Nutrition Recommendations/Interventions by a Registered Dietitian Nutritionist,USWR27,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Obtaining Preoperative Nutritional Recommendations from a Registered Dietitian Nutritionist (RDN) in Nutritionally At-Risk Surgical Patients,USWR28,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
-Diabetes Care All or None Outcome Measure: Optimal Control,WCHQ10,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
-Diabetes Care All or None Process Measure: Optimal Testing,WCHQ9,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
+Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),001,MIPS CQM,Intermediate Outcome,Y,28.350615930852474,37.54,79.99 - 70.01,70.00 - 60.01,60.00 - 50.01,50.00 - 40.01,40.00 - 30.01,30.00 - 20.01,20.00 - 10.01,<= 10.00,No,No,Y
+Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),001,Medicare Part B Claims,Intermediate Outcome,Y,22.24385892172491,18.70,79.99 - 70.01,70.00 - 60.01,60.00 - 50.01,50.00 - 40.01,40.00 - 30.01,30.00 - 20.01,20.00 - 10.01,<= 10.00,No,No,Y
+Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),001,eCQM,Intermediate Outcome,Y,26.39277658499758,47.96,79.99 - 70.01,70.00 - 60.01,60.00 - 50.01,50.00 - 40.01,40.00 - 30.01,30.00 - 20.01,20.00 - 10.01,<= 10.00,No,No,Y
+Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) or Angiotensin Receptor-Neprilysin Inhibitor (ARNI) Therapy for Left Ventricular Systolic Dysfunction (LVSD),005,MIPS CQM,Process,Y,11.818326377646711,94.50,92.31 - 96.29,96.30 - 98.30,98.31 - 99.99,--,--,--,--,100.00,Yes,Yes,N
+Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) or Angiotensin Receptor-Neprilysin Inhibitor (ARNI) Therapy for Left Ventricular Systolic Dysfunction (LVSD),005,eCQM,Process,Y,15.250286536539436,79.52,70.26 - 75.75,75.76 - 78.64,78.65 - 81.81,81.82 - 85.46,85.47 - 88.88,88.89 - 92.30,92.31 - 95.39,>= 95.40,No,No,N
+Coronary Artery Disease (CAD): Antiplatelet Therapy,006,MIPS CQM,Process,Y,14.356245030758245,86.66,77.91 - 83.11,83.12 - 86.50,86.51 - 89.42,89.43 - 92.62,92.63 - 95.90,95.91 - 99.66,99.67 - 99.99,100.00,No,No,N
+Coronary Artery Disease (CAD): Beta-Blocker Therapy  Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF < 40%),007,MIPS CQM,Process,Y,10.651483109106294,90.22,80.65 - 86.80,86.81 - 89.99,90.00 - 91.85,91.86 - 96.91,96.92 - 99.99,--,--,100.00,No,No,N
+Coronary Artery Disease (CAD): Beta-Blocker Therapy  Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF < 40%),007,eCQM,Process,Y,9.836280679315138,86.77,82.14 - 84.65,84.66 - 86.55,86.56 - 88.32,88.33 - 89.99,90.00 - 91.66,91.67 - 93.51,93.52 - 95.99,>= 96.00,No,No,N
+Heart Failure (HF): Beta-Blocker Therapy for Left Ventricular Systolic Dysfunction (LVSD),008,MIPS CQM,Process,Y,11.909241084854784,94.84,95.00 - 97.55,97.56 - 99.09,99.10 - 99.99,--,--,--,--,100.00,Yes,Yes,N
+Heart Failure (HF): Beta-Blocker Therapy for Left Ventricular Systolic Dysfunction (LVSD),008,eCQM,Process,Y,11.458766644611364,88.65,84.96 - 87.75,87.76 - 90.10,90.11 - 91.28,91.29 - 92.57,92.58 - 94.25,94.26 - 95.61,95.62 - 97.33,>= 97.34,No,No,N
+Anti-Depressant Medication Management,009,eCQM,Process,Y,17.10774315617552,75.44,66.30 - 74.22,74.23 - 78.17,78.18 - 80.42,80.43 - 82.49,82.50 - 84.64,84.65 - 86.72,86.73 - 90.90,>= 90.91,No,No,N
+Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation,012,eCQM,Process,Y,20.424231262749455,86.54,79.71 - 86.73,86.74 - 91.38,91.39 - 94.84,94.85 - 96.83,96.84 - 98.25,98.26 - 99.16,99.17 - 99.88,>= 99.89,No,No,N
+Age-Related Macular Degeneration (AMD): Dilated Macular Examination,014,MIPS CQM,Process,Y,17.77528803939919,90.95,88.05 - 92.58,92.59 - 95.84,95.85 - 97.86,97.87 - 99.33,99.34 - 99.99,--,--,100.00,Yes,Yes,N
+Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care,019,MIPS CQM,Process,Y,23.69830589878273,87.23,79.11 - 90.90,90.91 - 96.91,96.92 - 99.64,99.65 - 99.99,--,--,--,100.00,Yes,Yes,Y
+Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care,019,eCQM,Process,Y,23.780080640682268,77.48,62.50 - 72.40,72.41 - 80.36,80.37 - 85.82,85.83 - 90.31,90.32 - 93.70,93.71 - 96.86,96.87 - 99.02,>= 99.03,No,No,Y
+Communication with the Physician or Other Clinician Managing On-Going Care Post-Fracture for Men and Women Aged 50 Years and Older,024,MIPS CQM,Process,Y,37.10483787782119,63.48,12.07 - 44.99,45.00 - 61.64,61.65 - 77.96,77.97 - 87.35,87.36 - 97.05,97.06 - 99.99,--,100.00,No,No,Y
+Communication with the Physician or Other Clinician Managing On-Going Care Post-Fracture for Men and Women Aged 50 Years and Older,024,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Screening for Osteoporosis for Women Aged 65-85 Years of Age,039,MIPS CQM,Process,Y,31.74844989327246,52.72,17.30 - 31.00,31.01 - 45.22,45.23 - 56.70,56.71 - 66.26,66.27 - 75.29,75.30 - 83.32,83.33 - 95.59,>= 95.60,No,No,N
+Screening for Osteoporosis for Women Aged 65-85 Years of Age,039,Medicare Part B Claims,Process,Y,29.83233275490952,64.92,35.96 - 46.99,47.00 - 59.99,60.00 - 70.67,70.68 - 78.45,78.46 - 88.59,88.60 - 97.57,97.58 - 99.99,100.00,No,No,N
+Advance Care Plan,047,MIPS CQM,Process,Y,35.63421892966543,68.20,27.11 - 51.82,51.83 - 71.88,71.89 - 85.04,85.05 - 93.52,93.53 - 98.26,98.27 - 99.76,99.77 - 99.99,100.00,No,No,Y
+Advance Care Plan,047,Medicare Part B Claims,Process,Y,29.611211638173643,85.64,83.21 - 98.45,98.46 - 99.76,99.77 - 99.99,--,--,--,--,100.00,Yes,Yes,Y
+Urinary Incontinence: Assessment of Presence or Absence of Urinary Incontinence in Women Aged 65 Years and Older,048,MIPS CQM,Process,Y,36.041408568090446,62.19,17.86 - 37.81,37.82 - 57.44,57.45 - 71.42,71.43 - 85.59,85.60 - 95.61,95.62 - 99.66,99.67 - 99.99,100.00,No,No,N
+Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Years and Older,050,MIPS CQM,Process,Y,29.220105499660832,77.55,53.01 - 72.17,72.18 - 84.28,84.29 - 91.37,91.38 - 96.59,96.60 - 99.99,--,--,100.00,No,No,Y
+Chronic Obstructive Pulmonary Disease (COPD): Long-Acting Inhaled Bronchodilator Therapy,052,MIPS CQM,Process,Y,20.31503014115053,86.33,70.09 - 81.31,81.32 - 90.89,90.90 - 97.94,97.95 - 99.81,99.82 - 99.99,--,--,100.00,Yes,Yes,N
+Appropriate Treatment for Upper Respiratory Infection (URI),065,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Appropriate Treatment for Upper Respiratory Infection (URI),065,eCQM,Process,Y,13.317855397262061,87.86,81.70 - 85.41,85.42 - 88.32,88.33 - 90.90,90.91 - 92.94,92.95 - 95.42,95.43 - 97.72,97.73 - 99.99,100.00,No,No,Y
+Appropriate Testing for Pharyngitis,066,MIPS CQM,Process,Y,14.551362898435437,89.57,84.39 - 88.72,88.73 - 91.83,91.84 - 93.89,93.90 - 95.64,95.65 - 97.29,97.30 - 99.99,--,100.00,No,No,Y
+Appropriate Testing for Pharyngitis,066,eCQM,Process,Y,25.271923619725733,72.36,57.92 - 68.74,68.75 - 75.44,75.45 - 80.90,80.91 - 85.16,85.17 - 88.16,88.17 - 92.03,92.04 - 95.82,>= 95.83,No,No,Y
+Prevention of Central Venous Catheter (CVC) - Related Bloodstream Infections,076,MIPS CQM,Process,Y,13.310987206114374,95.27,95.92 - 99.30,99.31 - 99.99,--,--,--,--,--,100.00,Yes,Yes,Y
+Prevention of Central Venous Catheter (CVC) - Related Bloodstream Infections,076,Medicare Part B Claims,Process,Y,14.88960285930336,96.36,--,--,--,--,--,--,--,100.00,Yes,Yes,Y
+Acute Otitis Externa (AOE): Systemic Antimicrobial Therapy  Avoidance of Inappropriate Use,093,MIPS CQM,Process,Y,13.387386808291259,91.37,86.36 - 91.29,91.30 - 94.02,94.03 - 96.17,96.18 - 97.49,97.50 - 99.22,99.23 - 99.99,--,100.00,Yes,Yes,Y
+Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients,102,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients,102,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Prostate Cancer: Combination Androgen Deprivation Therapy for High Risk or Very High Risk Prostate Cancer,104,MIPS CQM,Process,Y,17.12534785428999,91.63,83.62 - 94.24,94.25 - 99.99,--,--,--,--,--,100.00,Yes,Yes,N
+Adult Major Depressive Disorder (MDD): Suicide Risk Assessment,107,eCQM,Process,Y,34.184598859113976,31.18,1.15 - 2.69,2.70 - 7.36,7.37 - 14.61,14.62 - 28.76,28.77 - 46.52,46.53 - 71.59,71.60 - 90.79,>= 90.80,No,No,N
+Preventive Care and Screening: Influenza Immunization,110,MIPS CQM,Process,Y,30.544015217690337,66.88,35.39 - 50.60,50.61 - 62.46,62.47 - 74.25,74.26 - 84.62,84.63 - 92.75,92.76 - 98.46,98.47 - 99.99,100.00,No,No,N
+Preventive Care and Screening: Influenza Immunization,110,Medicare Part B Claims,Process,Y,28.581561320715025,79.82,63.20 - 78.84,78.85 - 87.23,87.24 - 93.67,93.68 - 98.70,98.71 - 99.99,--,--,100.00,No,No,N
+Preventive Care and Screening: Influenza Immunization,110,eCQM,Process,Y,26.299997048923593,44.18,18.75 - 28.56,28.57 - 36.94,36.95 - 44.20,44.21 - 51.25,51.26 - 58.62,58.63 - 67.60,67.61 - 80.39,>= 80.40,No,No,N
+Pneumococcal Vaccination Status for Older Adults,111,MIPS CQM,Process,Y,26.44039234691005,64.12,42.58 - 55.57,55.58 - 64.49,64.50 - 70.29,70.30 - 74.99,75.00 - 79.62,79.63 - 85.87,85.88 - 96.29,>= 96.30,No,No,N
+Pneumococcal Vaccination Status for Older Adults,111,Medicare Part B Claims,Process,Y,22.679779322126336,80.48,67.34 - 75.92,75.93 - 81.10,81.11 - 86.87,86.88 - 92.78,92.79 - 97.69,97.70 - 99.99,--,100.00,No,No,N
+Pneumococcal Vaccination Status for Older Adults,111,eCQM,Process,Y,29.128222397433778,52.07,20.82 - 35.05,35.06 - 46.55,46.56 - 56.47,56.48 - 64.71,64.72 - 72.55,72.56 - 79.88,79.89 - 88.31,>= 88.32,No,No,N
+Breast Cancer Screening,112,MIPS CQM,Process,Y,30.366220194838874,56.34,24.55 - 41.49,41.50 - 51.24,51.25 - 60.64,60.65 - 68.27,68.28 - 74.86,74.87 - 84.77,84.78 - 97.66,>= 97.67,No,No,N
+Breast Cancer Screening,112,Medicare Part B Claims,Process,Y,24.59624922608836,78.46,64.66 - 74.99,75.00 - 81.65,81.66 - 86.44,86.45 - 91.03,91.04 - 95.82,95.83 - 98.84,98.85 - 99.99,100.00,No,No,N
+Breast Cancer Screening,112,eCQM,Process,Y,25.40013471939807,49.43,24.92 - 36.03,36.04 - 45.49,45.50 - 52.86,52.87 - 59.39,59.40 - 65.40,65.41 - 72.11,72.12 - 80.68,>= 80.69,No,No,N
+Colorectal Cancer Screening,113,MIPS CQM,Process,Y,33.87097049274731,56.79,17.93 - 34.79,34.80 - 51.80,51.81 - 61.05,61.06 - 74.18,74.19 - 82.03,82.04 - 92.40,92.41 - 99.42,>= 99.43,No,No,N
+Colorectal Cancer Screening,113,Medicare Part B Claims,Process,Y,26.65439656042094,78.12,57.94 - 70.46,70.47 - 82.00,82.01 - 89.66,89.67 - 95.56,95.57 - 99.31,99.32 - 99.99,--,100.00,No,No,N
+Colorectal Cancer Screening,113,eCQM,Process,Y,28.717893109006514,46.97,16.32 - 28.65,28.66 - 39.99,40.00 - 49.24,49.25 - 57.82,57.83 - 66.73,66.74 - 74.98,74.99 - 84.36,>= 84.37,No,No,N
+Avoidance of Antibiotic Treatment for Acute Bronchitis/Bronchiolitis,116,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Diabetes: Eye Exam,117,MIPS CQM,Process,Y,23.738385483873923,90.27,94.31 - 97.85,97.86 - 99.32,99.33 - 99.85,99.86 - 99.99,--,--,--,100.00,Yes,Yes,N
+Diabetes: Eye Exam,117,Medicare Part B Claims,Process,Y,0.0,100.00,--,--,--,--,--,--,--,100.00,Yes,No,N
+Diabetes: Eye Exam,117,eCQM,Process,Y,37.647815072552625,52.86,13.19 - 22.02,22.03 - 31.85,31.86 - 44.61,44.62 - 65.96,65.97 - 95.93,95.94 - 99.13,99.14 - 99.99,100.00,No,No,N
+Coronary Artery Disease (CAD): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy - Diabetes or Left Ventricular Systolic Dysfunction (LVEF < 40%),118,MIPS CQM,Process,Y,13.48857905772208,80.57,71.43 - 75.60,75.61 - 78.24,78.25 - 81.38,81.39 - 84.20,84.21 - 86.98,86.99 - 91.99,92.00 - 99.99,100.00,No,No,N
+Diabetes: Medical Attention for Nephropathy,119,MIPS CQM,Process,Y,17.806321491449427,84.43,70.74 - 79.50,79.51 - 85.05,85.06 - 89.73,89.74 - 94.02,94.03 - 98.09,98.10 - 99.99,--,100.00,No,No,N
+Diabetes: Medical Attention for Nephropathy,119,eCQM,Process,Y,15.72254123919505,81.63,72.45 - 77.77,77.78 - 81.70,81.71 - 84.66,84.67 - 87.34,87.35 - 90.42,90.43 - 93.97,93.98 - 98.86,>= 98.87,No,No,N
+"Diabetes Mellitus: Diabetic Foot and Ankle Care, Peripheral Neuropathy  Neurological Evaluation",126,MIPS CQM,Process,Y,26.110174948792157,84.06,73.01 - 84.96,84.97 - 93.57,93.58 - 98.55,98.56 - 99.99,--,--,--,100.00,Yes,No,N
+"Diabetes Mellitus: Diabetic Foot and Ankle Care, Ulcer Prevention  Evaluation of Footwear",127,MIPS CQM,Process,Y,27.87893305395298,82.19,66.30 - 80.11,80.12 - 92.70,92.71 - 98.69,98.70 - 99.99,--,--,--,100.00,Yes,No,N
+Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,MIPS CQM,Process,Y,30.80595249627927,72.81,35.17 - 55.71,55.72 - 76.03,76.04 - 88.50,88.51 - 95.80,95.81 - 99.07,99.08 - 99.99,--,100.00,No,No,N
+Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,Medicare Part B Claims,Process,Y,20.301832553396856,91.07,92.37 - 98.57,98.58 - 99.71,99.72 - 99.99,--,--,--,--,100.00,Yes,Yes,N
+Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,128,eCQM,Process,Y,29.11000695791344,51.51,23.35 - 28.13,28.14 - 34.67,34.68 - 43.56,43.57 - 56.80,56.81 - 73.59,73.60 - 86.17,86.18 - 95.38,>= 95.39,No,No,N
+Documentation of Current Medications in the Medical Record,130,MIPS CQM,Process,Y,27.55310012217565,84.65,77.92 - 90.46,90.47 - 95.59,95.60 - 98.14,98.15 - 99.68,99.69 - 99.99,--,--,100.00,Yes,Yes,Y
+Documentation of Current Medications in the Medical Record,130,Medicare Part B Claims,Process,Y,13.367224642320881,96.87,99.67 - 99.96,99.97 - 99.99,--,--,--,--,--,100.00,Yes,Yes,Y
+Documentation of Current Medications in the Medical Record,130,eCQM,Process,Y,19.765456256508198,87.13,80.38 - 88.23,88.24 - 92.35,92.36 - 95.25,95.26 - 97.16,97.17 - 98.41,98.42 - 99.32,99.33 - 99.89,>= 99.90,Yes,Yes,Y
+Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,MIPS CQM,Process,Y,34.88221711837133,71.82,34.63 - 60.10,60.11 - 79.69,79.70 - 89.60,89.61 - 97.13,97.14 - 99.41,99.42 - 99.99,--,100.00,No,No,N
+Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,Medicare Part B Claims,Process,Y,27.6422478764487,89.00,95.29 - 99.50,99.51 - 99.99,--,--,--,--,--,100.00,Yes,Yes,N
+Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,eCQM,Process,Y,31.12095272651875,37.83,6.33 - 12.66,12.67 - 20.79,20.80 - 30.76,30.77 - 42.71,42.72 - 55.95,55.96 - 70.43,70.44 - 87.35,>= 87.36,No,No,N
+Melanoma: Continuity of Care  Recall System,137,MIPS CQM,Structure,Y,17.008436822016424,94.40,98.18 - 99.99,--,--,--,--,--,--,100.00,No,No,Y
+Melanoma: Coordination of Care,138,MIPS CQM,Process,Y,24.523529191920765,87.92,81.28 - 95.99,96.00 - 99.99,--,--,--,--,--,100.00,Yes,Yes,Y
+Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care,141,MIPS CQM,Outcome,Y,29.89395806415984,75.52,46.38 - 69.02,69.03 - 81.81,81.82 - 90.43,90.44 - 95.41,95.42 - 98.27,98.28 - 99.99,--,100.00,No,No,Y
+Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care,141,Medicare Part B Claims,Outcome,Y,14.029899792867374,96.44,--,--,--,--,--,--,--,100.00,No,No,Y
+Oncology: Medical and Radiation  Pain Intensity Quantified,143,MIPS CQM,Process,Y,22.483619761211173,89.67,90.07 - 95.86,95.87 - 98.59,98.60 - 99.55,99.56 - 99.99,--,--,--,100.00,Yes,Yes,Y
+Oncology: Medical and Radiation  Pain Intensity Quantified,143,eCQM,Process,Y,24.85520844035345,83.97,75.43 - 87.05,87.06 - 92.85,92.86 - 95.98,95.99 - 97.43,97.44 - 98.31,98.32 - 98.98,98.99 - 99.82,>= 99.83,Yes,No,Y
+Oncology: Medical and Radiation - Plan of Care for Pain,144,MIPS CQM,Process,Y,26.820250785591874,80.46,66.67 - 78.71,78.72 - 87.38,87.39 - 93.21,93.22 - 96.79,96.80 - 98.96,98.97 - 99.99,--,100.00,No,No,Y
+Radiology: Exposure Dose Indices or Exposure Time and Number of Images Reported for Procedures Using Fluoroscopy,145,MIPS CQM,Process,Y,17.621400719744177,92.87,93.69 - 98.99,99.00 - 99.91,99.92 - 99.99,--,--,--,--,100.00,Yes,Yes,Y
+Radiology: Exposure Dose Indices or Exposure Time and Number of Images Reported for Procedures Using Fluoroscopy,145,Medicare Part B Claims,Process,Y,24.236351917394213,86.27,76.12 - 89.82,89.83 - 95.99,96.00 - 99.69,99.70 - 99.99,--,--,--,100.00,Yes,Yes,Y
+Nuclear Medicine: Correlation with Existing Imaging Studies for All Patients Undergoing Bone Scintigraphy,147,MIPS CQM,Process,Y,11.434364673032153,96.08,97.16 - 99.77,99.78 - 99.99,--,--,--,--,--,100.00,Yes,Yes,Y
+Nuclear Medicine: Correlation with Existing Imaging Studies for All Patients Undergoing Bone Scintigraphy,147,Medicare Part B Claims,Process,Y,24.702313645533476,83.91,60.77 - 82.21,82.22 - 95.23,95.24 - 98.32,98.33 - 99.99,--,--,--,100.00,Yes,Yes,Y
+Falls: Plan of Care,155,MIPS CQM,Process,Y,21.400845125374005,91.31,93.10 - 97.89,97.90 - 99.99,--,--,--,--,--,100.00,Yes,Yes,Y
+Falls: Plan of Care,155,Medicare Part B Claims,Process,Y,22.241374629049538,91.23,95.74 - 99.99,--,--,--,--,--,--,100.00,Yes,Yes,Y
+Coronary Artery Bypass Graft (CABG): Prolonged Intubation,164,MIPS CQM,Outcome,Y,4.564814797454562,6.04,9.52 - 7.90,7.89 - 5.67,5.66 - 5.18,5.17 - 3.86,3.85 - 3.46,3.45 - 2.71,2.70 - 0.01,0.00,No,No,Y
+Coronary Artery Bypass Graft (CABG): Postoperative Renal Failure,167,MIPS CQM,Outcome,Y,3.7397739087930018,2.71,3.96 - 3.52,3.51 - 2.56,2.55 - 1.97,1.96 - 1.52,1.51 - 0.96,0.95 - 0.01,--,0.00,No,No,Y
+Coronary Artery Bypass Graft (CABG): Surgical Re-Exploration,168,MIPS CQM,Outcome,Y,2.2539282879614264,2.65,4.20 - 3.47,3.46 - 2.68,2.67 - 2.31,2.30 - 1.71,1.70 - 1.61,1.60 - 0.59,0.58 - 0.01,0.00,No,No,Y
+Tuberculosis Screening Prior to First Course Biologic Therapy,176,MIPS CQM,Process,Y,25.40636474848573,82.95,60.00 - 81.96,81.97 - 90.90,90.91 - 97.94,97.95 - 99.99,--,--,--,100.00,Yes,No,N
+Rheumatoid Arthritis (RA): Periodic Assessment of Disease Activity,177,MIPS CQM,Process,Y,32.26390078637488,73.34,47.31 - 69.94,69.95 - 78.03,78.04 - 87.59,87.60 - 92.80,92.81 - 98.91,98.92 - 99.99,--,100.00,No,No,N
+Rheumatoid Arthritis (RA): Functional Status Assessment,178,MIPS CQM,Process,Y,19.162724834143724,90.59,87.85 - 92.44,92.45 - 96.70,96.71 - 99.06,99.07 - 99.99,--,--,--,100.00,Yes,Yes,N
+Rheumatoid Arthritis (RA): Glucocorticoid Management,180,MIPS CQM,Process,Y,13.992462062486924,97.21,--,--,--,--,--,--,--,100.00,Yes,Yes,N
+Elder Maltreatment Screen and Follow-Up Plan,181,MIPS CQM,Process,Y,19.280102599304215,92.50,92.48 - 97.80,97.81 - 99.59,99.60 - 99.99,--,--,--,--,100.00,Yes,No,Y
+Elder Maltreatment Screen and Follow-Up Plan,181,Medicare Part B Claims,Process,Y,19.872660855724035,93.77,99.10 - 99.83,99.84 - 99.99,--,--,--,--,--,100.00,Yes,Yes,Y
+Functional Outcome Assessment,182,MIPS CQM,Process,Y,21.92809487667928,93.02,98.52 - 99.65,99.66 - 99.86,99.87 - 99.99,--,--,--,--,100.00,Yes,Yes,Y
+Colonoscopy Interval for Patients with a History of Adenomatous Polyps  Avoidance of Inappropriate Use,185,MIPS CQM,Process,Y,26.698577271021456,85.92,81.25 - 89.36,89.37 - 97.86,97.87 - 99.48,99.49 - 99.99,--,--,--,100.00,Yes,No,Y
+Stroke and Stroke Rehabilitation: Thrombolytic Therapy,187,MIPS CQM,Process,Y,18.82842550428632,90.29,86.46 - 93.41,93.42 - 96.14,96.15 - 99.99,--,--,--,--,100.00,Yes,Yes,N
+Cataracts: 20/40 or Better Visual Acuity within 90 Days Following Cataract Surgery,191,MIPS CQM,Outcome,Y,11.006119683878746,94.63,92.83 - 95.51,95.52 - 97.32,97.33 - 98.54,98.55 - 99.99,--,--,--,100.00,No,No,Y
+Cataracts: 20/40 or Better Visual Acuity within 90 Days Following Cataract Surgery,191,eCQM,Outcome,Y,14.446354027318316,91.62,88.67 - 93.01,93.02 - 95.34,95.35 - 96.82,96.83 - 97.96,97.97 - 98.80,98.81 - 99.63,99.64 - 99.99,100.00,No,No,Y
+"HIV/AIDS: Sexually Transmitted Disease Screening for Chlamydia, Gonorrhea, and Syphilis",205,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Functional Status Change for Patients with Knee Impairments,217,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,Y,18.227134948381458,54.91,42.22 - 44.89,44.90 - 48.27,48.28 - 50.78,50.79 - 54.20,54.21 - 60.22,60.23 - 67.99,68.00 - 81.81,>= 81.82,No,No,Y
+Functional Status Change for Patients with Hip Impairments,218,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,Y,16.008437222375797,51.64,36.73 - 42.62,42.63 - 45.70,45.71 - 49.99,50.00 - 54.38,54.39 - 58.35,58.36 - 62.85,62.86 - 72.21,>= 72.22,No,No,Y
+"Functional Status Change for Patients with Lower Leg, Foot or Ankle Impairments",219,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,Y,16.21649728402826,50.97,35.48 - 43.99,44.00 - 47.99,48.00 - 51.12,51.13 - 53.84,53.85 - 57.75,57.76 - 63.32,63.33 - 68.74,>= 68.75,No,No,Y
+Functional Status Change for Patients with Low Back Impairments,220,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,Y,20.229483480088103,56.31,39.68 - 45.78,45.79 - 48.25,48.26 - 54.89,54.90 - 59.99,60.00 - 65.65,65.66 - 72.05,72.06 - 87.17,>= 87.18,No,No,Y
+Functional Status Change for Patients with Shoulder Impairments,221,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,Y,20.29238024629261,52.22,35.44 - 40.17,40.18 - 43.86,43.87 - 47.04,47.05 - 52.80,52.81 - 59.46,59.47 - 71.22,71.23 - 81.42,>= 81.43,No,No,Y
+"Functional Status Change for Patients with Elbow, Wrist or Hand Impairments",222,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,Y,18.199858946704122,54.72,41.41 - 44.35,44.36 - 49.47,49.48 - 51.91,51.92 - 58.32,58.33 - 61.89,61.90 - 71.92,71.93 - 79.99,>= 80.00,No,No,Y
+Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,MIPS CQM,Process,Y,32.259635887144924,68.51,30.91 - 49.08,49.09 - 66.66,66.67 - 80.87,80.88 - 90.77,90.78 - 96.45,96.46 - 99.99,--,100.00,No,No,N
+Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,Medicare Part B Claims,Process,Y,21.0950793132673,90.00,87.18 - 95.37,95.38 - 99.99,--,--,--,--,--,100.00,Yes,No,N
+Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,eCQM,Process,Y,30.711647670264682,49.26,18.92 - 25.80,25.81 - 34.16,34.17 - 44.43,44.44 - 56.62,56.63 - 70.36,70.37 - 84.10,84.11 - 95.41,>= 95.42,No,No,N
+Controlling High Blood Pressure,236,MIPS CQM,Intermediate Outcome,Y,21.532743028983234,63.74,20.00 - 29.99,30.00 - 39.99,40.00 - 49.99,50.00 - 59.99,60.00 - 69.99,70.00 - 79.99,80.00 - 89.99,>= 90.00,No,No,Y
+Controlling High Blood Pressure,236,Medicare Part B Claims,Intermediate Outcome,Y,18.668868031364333,74.89,20.00 - 29.99,30.00 - 39.99,40.00 - 49.99,50.00 - 59.99,60.00 - 69.99,70.00 - 79.99,80.00 - 89.99,>= 90.00,No,No,Y
+Controlling High Blood Pressure,236,eCQM,Intermediate Outcome,Y,16.443624064165398,62.16,51.06 - 56.30,56.31 - 60.13,60.14 - 63.63,63.64 - 67.04,67.05 - 70.64,70.65 - 74.94,74.95 - 80.83,>= 80.84,No,No,Y
+Use of High-Risk Medications in Older Adults,238,MIPS CQM,Process,Y,7.000488449440138,2.99,3.40 - 1.34,1.33 - 0.64,0.63 - 0.33,0.32 - 0.17,0.16 - 0.04,0.03 - 0.01,--,0.00,Yes,No,Y
+Use of High-Risk Medications in Older Adults,238,eCQM,Process,Y,9.580365543743198,6.53,12.98 - 7.57,7.56 - 3.88,3.87 - 1.65,1.64 - 0.64,0.63 - 0.19,0.18 - 0.01,--,0.00,Yes,No,Y
+Weight Assessment and Counseling for Nutrition and Physical Activity for Children/Adolescents,239,eCQM,Process,Y,18.58471324950724,36.99,25.64 - 29.12,29.13 - 31.20,31.21 - 32.85,32.86 - 34.66,34.67 - 39.76,39.77 - 49.68,49.69 - 63.87,>= 63.88,No,No,N
+Childhood Immunization Status,240,eCQM,Process,Y,17.61927796263764,39.40,23.44 - 31.81,31.82 - 37.26,37.27 - 41.62,41.63 - 45.93,45.94 - 50.04,50.05 - 53.22,53.23 - 59.68,>= 59.69,No,No,N
+Cardiac Rehabilitation Patient Referral from an Outpatient Setting,243,MIPS CQM,Process,Y,28.360979925066598,37.54,12.75 - 17.02,17.03 - 23.75,23.76 - 29.86,29.87 - 36.32,36.33 - 45.83,45.84 - 59.48,59.49 - 90.90,>= 90.91,No,No,Y
+Barretts Esophagus,249,MIPS CQM,Process,Y,3.3149067868807944,99.65,--,--,--,--,--,--,--,100.00,Yes,Yes,N
+Barretts Esophagus,249,Medicare Part B Claims,Process,Y,0.4316728757255558,99.93,--,--,--,--,--,--,--,100.00,Yes,Yes,N
+Radical Prostatectomy Pathology Reporting,250,MIPS CQM,Process,Y,1.0397061119059148,99.87,--,--,--,--,--,--,--,100.00,Yes,Yes,N
+Radical Prostatectomy Pathology Reporting,250,Medicare Part B Claims,Process,Y,9.89,98.59,--,--,--,--,--,--,--,100.00,Yes,Yes,N
+Ultrasound Determination of Pregnancy Location for Pregnant Patients with Abdominal Pain,254,MIPS CQM,Process,Y,9.072691129360685,94.21,91.09 - 93.41,93.42 - 95.37,95.38 - 96.69,96.70 - 98.00,98.01 - 99.52,99.53 - 99.99,--,100.00,Yes,Yes,N
+Rate of Open Repair of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post-Operative Day #7),258,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post-Operative Day #2),259,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+"Rate of Carotid Endarterectomy (CEA) for Asymptomatic Patients, without Major Complications (Discharged to Home by Post-Operative Day #2)",260,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Referral for Otologic Evaluation for Patients with Acute or Chronic Dizziness,261,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Referral for Otologic Evaluation for Patients with Acute or Chronic Dizziness,261,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Sentinel Lymph Node Biopsy for Invasive Breast Cancer,264,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Biopsy Follow-Up,265,MIPS CQM,Process,Y,28.28746056855719,86.38,85.06 - 97.19,97.20 - 99.99,--,--,--,--,--,100.00,Yes,Yes,Y
+Epilepsy: Counseling for Women of Childbearing Potential with Epilepsy,268,MIPS CQM,Process,Y,37.449475218541366,51.93,12.88 - 21.23,21.24 - 29.84,29.85 - 53.69,53.70 - 67.56,67.57 - 75.46,75.47 - 99.99,--,100.00,No,No,N
+Inflammatory Bowel Disease (IBD): Assessment of Hepatitis B Virus (HBV) Status Before Initiating Anti-TNF (Tumor Necrosis Factor) Therapy,275,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Sleep Apnea: Severity Assessment at Initial Diagnosis,277,MIPS CQM,Process,Y,36.58005777254427,65.00,24.14 - 40.33,40.34 - 58.91,58.92 - 78.78,78.79 - 94.15,94.16 - 99.99,--,--,100.00,No,No,N
+Sleep Apnea: Assessment of Adherence to Positive Airway Pressure Therapy,279,MIPS CQM,Process,Y,27.250470648897426,85.03,78.32 - 90.90,90.91 - 96.55,96.56 - 99.42,99.43 - 99.99,--,--,--,100.00,Yes,Yes,N
+Dementia: Cognitive Assessment,281,eCQM,Process,Y,31.24576851377409,38.27,7.19 - 13.03,13.04 - 21.30,21.31 - 29.99,30.00 - 41.83,41.84 - 55.99,56.00 - 71.52,71.53 - 88.88,>= 88.89,No,No,N
+Dementia: Functional Status Assessment,282,MIPS CQM,Process,Y,27.755196699953427,86.50,83.13 - 97.19,97.20 - 99.99,--,--,--,--,--,100.00,Yes,No,N
+Dementia Associated Behavioral and Psychiatric Symptoms Screening and Management,283,MIPS CQM,Process,Y,21.405292504106157,91.08,90.91 - 99.54,99.55 - 99.99,--,--,--,--,--,100.00,Yes,Yes,N
+Dementia: Safety Concern Screening and Follow-Up for Patients with Dementia,286,MIPS CQM,Process,Y,21.955258867922083,91.42,93.37 - 99.72,99.73 - 99.99,--,--,--,--,--,100.00,Yes,Yes,Y
+Dementia: Education and Support of Caregivers for Patients with Dementia,288,MIPS CQM,Process,Y,30.071476023944022,83.48,63.85 - 92.54,92.55 - 99.18,99.19 - 99.99,--,--,--,--,100.00,Yes,No,Y
+Assessment of Mood Disorders and Psychosis for Patients with Parkinsons Disease,290,MIPS CQM,Process,Y,28.178981960124545,83.17,64.07 - 86.35,86.36 - 94.43,94.44 - 99.99,--,--,--,--,100.00,Yes,Yes,N
+Assessment of Cognitive Impairment or Dysfunction for Patients with Parkinsons Disease,291,MIPS CQM,Process,Y,33.890520737716216,76.84,32.76 - 73.38,73.39 - 92.05,92.06 - 99.99,--,--,--,--,100.00,Yes,Yes,N
+Rehabilitative Therapy Referral for Patients with Parkinsons Disease,293,MIPS CQM,Process,Y,38.303532489307294,66.70,15.58 - 40.19,40.20 - 77.61,77.62 - 84.52,84.53 - 95.27,95.28 - 99.99,--,--,100.00,No,No,Y
+Cataracts: Improvement in Patients Visual Function within 90 Days Following Cataract Surgery,303,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Cataracts: Patient Satisfaction within 90 Days Following Cataract Surgery,304,MIPS CQM,Patient Engagement/Experience,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Initiation and Engagement of Alcohol and Other Drug Dependence Treatment,305,eCQM,Process,Y,5.891295660296799,3.23,0.76 - 1.05,1.06 - 1.31,1.32 - 1.60,1.61 - 1.93,1.94 - 2.55,2.56 - 3.95,3.96 - 7.04,>= 7.05,No,No,Y
+Cervical Cancer Screening,309,eCQM,Process,Y,23.45052824452815,34.00,11.25 - 17.64,17.65 - 24.55,24.56 - 31.62,31.63 - 38.79,38.80 - 45.88,45.89 - 53.49,53.50 - 65.78,>= 65.79,No,No,N
+Chlamydia Screening for Women,310,eCQM,Process,Y,19.155909256041916,36.41,19.12 - 26.12,26.13 - 30.73,30.74 - 35.71,35.72 - 40.36,40.37 - 45.82,45.83 - 52.16,52.17 - 63.39,>= 63.40,No,No,N
+Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,MIPS CQM,Process,Y,32.666869942487665,55.11,23.48 - 30.84,30.85 - 38.36,38.37 - 49.99,50.00 - 65.11,65.12 - 83.27,83.28 - 96.49,96.50 - 99.99,100.00,No,No,N
+Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,Medicare Part B Claims,Process,Y,25.62055954048287,88.29,88.31 - 97.86,97.87 - 99.46,99.47 - 99.99,--,--,--,--,100.00,Yes,No,N
+Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,eCQM,Process,Y,18.206926514830098,29.39,15.66 - 20.01,20.02 - 23.67,23.68 - 27.30,27.31 - 30.96,30.97 - 34.82,34.83 - 40.06,40.07 - 49.05,>= 49.06,No,No,N
+Falls: Screening for Future Fall Risk,318,eCQM,Process,Y,34.876631286796794,55.71,14.21 - 30.15,30.16 - 46.36,46.37 - 61.45,61.46 - 74.33,74.34 - 85.17,85.18 - 93.43,93.44 - 98.09,>= 98.10,No,No,Y
+Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients,320,MIPS CQM,Process,Y,23.778908639925596,87.72,87.65 - 93.14,93.15 - 95.34,95.35 - 97.06,97.07 - 98.35,98.36 - 99.61,99.62 - 99.99,--,100.00,Yes,Yes,Y
+Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients,320,Medicare Part B Claims,Process,Y,22.345417681936983,89.55,81.08 - 97.43,97.44 - 99.99,--,--,--,--,--,100.00,Yes,Yes,Y
+Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low-Risk Surgery Patients,322,MIPS CQM,Efficiency,Y,8.39795804750538,2.04,1.22 - 0.20,0.19 - 0.01,--,--,--,--,--,0.00,No,No,Y
+Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Routine Testing After Percutaneous Coronary Intervention (PCI),323,MIPS CQM,Efficiency,Y,5.318814538526239,0.87,0.05 - 0.01,--,--,--,--,--,--,0.00,No,No,Y
+"Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Testing in Asymptomatic, Low-Risk Patients",324,MIPS CQM,Efficiency,Y,7.419436374220828,2.77,3.50 - 0.43,0.42 - 0.01,--,--,--,--,--,0.00,No,No,Y
+Atrial Fibrillation and Atrial Flutter: Chronic Anticoagulation Therapy,326,MIPS CQM,Process,Y,14.274652281411896,92.25,82.65 - 95.99,96.00 - 99.07,99.08 - 99.99,--,--,--,--,100.00,Yes,Yes,N
+Adult Sinusitis: Antibiotic Prescribed for Acute Viral Sinusitis (Overuse),331,MIPS CQM,Process,Y,29.689212463028195,35.28,65.71 - 51.86,51.85 - 41.76,41.75 - 30.01,30.00 - 20.39,20.38 - 10.72,10.71 - 4.01,4.00 - 0.01,0.00,No,No,Y
+Adult Sinusitis: Appropriate Choice of Antibiotic: Amoxicillin With or Without Clavulanate Prescribed for Patients with Acute Bacterial Sinusitis (Appropriate Use),332,MIPS CQM,Process,Y,18.81564594173012,79.25,69.39 - 73.57,73.58 - 76.87,76.88 - 81.44,81.45 - 85.70,85.71 - 90.05,90.06 - 97.99,98.00 - 99.99,100.00,No,No,Y
+Maternity Care: Elective Delivery (Without Medical Indication) at < 39 Weeks (Overuse),335,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Maternity Care: Postpartum Follow-up and Care Coordination,336,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+HIV Viral Load Suppression,338,MIPS CQM,Outcome,Y,13.753902009954095,88.24,77.17 - 86.33,86.34 - 88.10,88.11 - 92.77,92.78 - 95.55,95.56 - 98.24,98.25 - 99.99,--,100.00,No,No,Y
+HIV Medical Visit Frequency,340,MIPS CQM,Process,Y,21.53043130268811,70.46,50.57 - 58.05,58.06 - 61.47,61.48 - 68.70,68.71 - 72.21,72.22 - 88.35,88.36 - 96.91,96.92 - 99.99,100.00,No,No,Y
+"Rate of Carotid Artery Stenting (CAS) for Asymptomatic Patients, Without Major Complications (Discharged to Home by Post-Operative Day #2)",344,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Total Knee or Hip Replacement: Shared Decision-Making: Trial of Conservative (Non-surgical) Therapy,350,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Total Knee or Hip Replacement: Venous Thromboembolic and Cardiovascular Risk Evaluation,351,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Anastomotic Leak Intervention,354,MIPS CQM,Outcome,Y,24.697588506050234,10.09,7.80 - 4.51,4.50 - 3.86,3.85 - 1.90,1.89 - 0.84,0.83 - 0.01,--,--,0.00,No,No,Y
+Unplanned Reoperation within the 30 Day Postoperative Period,355,MIPS CQM,Outcome,Y,11.763719297818056,3.71,3.55 - 2.03,2.02 - 1.21,1.20 - 0.65,0.64 - 0.01,--,--,--,0.00,No,No,Y
+Unplanned Hospital Readmission within 30 Days of Principal Procedure,356,MIPS CQM,Outcome,Y,7.368280997411886,3.96,6.19 - 4.01,4.00 - 2.79,2.78 - 2.15,2.14 - 1.07,1.06 - 0.01,--,--,0.00,No,No,Y
+Surgical Site Infection (SSI),357,MIPS CQM,Outcome,Y,11.55120771172402,3.36,2.71 - 1.06,1.05 - 0.40,0.39 - 0.01,--,--,--,--,0.00,No,No,Y
+Patient-Centered Surgical Risk Assessment and Communication,358,MIPS CQM,Process,Y,29.945588816954913,83.17,71.08 - 88.58,88.59 - 96.84,96.85 - 99.61,99.62 - 99.99,--,--,--,100.00,Yes,No,Y
+Optimizing Patient Exposure to Ionizing Radiation: Count of Potential High Dose Radiation Imaging Studies: Computed Tomography (CT) and Cardiac Nuclear Medicine Studies,360,MIPS CQM,Process,Y,33.130362079411036,82.72,67.86 - 96.47,96.48 - 99.71,99.72 - 99.99,--,--,--,--,100.00,Yes,Yes,Y
+Optimizing Patient Exposure to Ionizing Radiation: Appropriateness: Follow-up CT Imaging for Incidentally Detected Pulmonary Nodules According to Recommended Guidelines,364,MIPS CQM,Process,Y,23.967306066345866,84.28,61.97 - 79.06,79.07 - 96.36,96.37 - 99.99,--,--,--,--,100.00,Yes,Yes,Y
+Follow-Up Care for Children Prescribed ADHD Medication (ADD),366,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Depression Remission at Twelve Months,370,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Depression Remission at Twelve Months,370,eCQM,Outcome,Y,10.6400693772016,11.67,3.67 - 4.86,4.87 - 6.96,6.97 - 8.32,8.33 - 10.78,10.79 - 13.93,13.94 - 17.64,17.65 - 25.41,>= 25.42,No,No,Y
+Closing the Referral Loop: Receipt of Specialist Report,374,MIPS CQM,Process,Y,30.307716502655346,81.31,62.79 - 85.63,85.64 - 94.75,94.76 - 98.61,98.62 - 99.99,--,--,--,100.00,Yes,No,Y
+Closing the Referral Loop: Receipt of Specialist Report,374,eCQM,Process,Y,30.523649894059563,36.16,7.71 - 12.49,12.50 - 18.72,18.73 - 26.31,26.32 - 37.09,37.10 - 51.18,51.19 - 66.66,66.67 - 87.31,>= 87.32,No,No,Y
+Functional Status Assessment for Total Knee Replacement,375,eCQM,Process,Y,12.981691583288995,12.54,2.65 - 4.62,4.63 - 6.61,6.62 - 8.88,8.89 - 10.90,10.91 - 13.78,13.79 - 20.72,20.73 - 28.30,>= 28.31,No,No,Y
+Functional Status Assessment for Total Hip Replacement,376,eCQM,Process,Y,13.54191617059523,13.31,4.07 - 5.33,5.34 - 5.76,5.77 - 9.65,9.66 - 12.67,12.68 - 16.86,16.87 - 19.99,20.00 - 28.22,>= 28.23,No,No,Y
+Functional Status Assessments for Heart Failure,377,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Children Who Have Dental Decay or Cavities,378,eCQM,Outcome,Y,3.266932316483123,0.62,0.88 - 0.42,0.41 - 0.01,--,--,--,--,--,0.00,No,No,Y
+"Primary Caries Prevention Intervention as Offered by Primary Care Providers, including Dentists",379,eCQM,Process,Y,6.074992562634367,4.47,0.18 - 0.42,0.43 - 0.94,0.95 - 2.13,2.14 - 3.39,3.40 - 5.22,5.23 - 8.57,8.58 - 11.31,>= 11.32,No,No,N
+Child and Adolescent Major Depressive Disorder (MDD): Suicide Risk Assessment,382,eCQM,Process,Y,29.799612804845786,34.67,5.79 - 11.99,12.00 - 17.47,17.48 - 28.46,28.47 - 35.84,35.85 - 51.74,51.75 - 59.73,59.74 - 84.14,>= 84.15,No,No,Y
+Adherence to Antipsychotic Medications For Individuals with Schizophrenia,383,MIPS CQM,Intermediate Outcome,Y,20.805116482325626,88.83,81.08 - 93.01,93.02 - 95.55,95.56 - 99.31,99.32 - 99.99,--,--,--,100.00,No,No,Y
+Adult Primary Rhegmatogenous Retinal Detachment Surgery: No Return to the Operating Room Within 90 Days of Surgery,384,MIPS CQM,Outcome,Y,6.321183050233609,96.29,93.33 - 96.42,96.43 - 97.91,97.92 - 99.99,--,--,--,--,100.00,Yes,No,Y
+Adult Primary Rhegmatogenous Retinal Detachment Surgery: Visual Acuity Improvement Within 90 Days of Surgery,385,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Amyotrophic Lateral Sclerosis (ALS) Patient Care Preferences,386,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Annual Hepatitis C Virus (HCV) Screening for Patients who are Active Injection Drug Users,387,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Cataract Surgery: Difference Between Planned and Final Refraction,389,MIPS CQM,Outcome,Y,36.55538714941849,61.33,21.48 - 29.53,29.54 - 39.34,39.35 - 69.93,69.94 - 92.85,92.86 - 97.13,97.14 - 99.86,99.87 - 99.99,100.00,No,No,Y
+Follow-Up After Hospitalization for Mental Illness (FUH),391,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Cardiac Tamponade and/or Pericardiocentesis Following Atrial Fibrillation Ablation,392,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+"Infection within 180 Days of Cardiac Implantable Electronic Device (CIED) Implantation, Replacement, or Revision",393,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Immunizations for Adolescents,394,MIPS CQM,Process,Y,16.265454491100503,19.80,5.88 - 7.68,7.69 - 11.99,12.00 - 17.49,17.50 - 21.68,21.69 - 25.55,25.56 - 31.57,31.58 - 39.99,>= 40.00,No,No,N
+Lung Cancer Reporting (Biopsy/Cytology Specimens),395,MIPS CQM,Process,Y,8.619133042945434,98.92,--,--,--,--,--,--,--,100.00,Yes,Yes,Y
+Lung Cancer Reporting (Biopsy/Cytology Specimens),395,Medicare Part B Claims,Process,Y,6.849993243641624,98.93,--,--,--,--,--,--,--,100.00,Yes,Yes,Y
+Lung Cancer Reporting (Resection Specimens),396,MIPS CQM,Process,Y,3.9184028703998717,99.56,--,--,--,--,--,--,--,100.00,Yes,Yes,Y
+Lung Cancer Reporting (Resection Specimens),396,Medicare Part B Claims,Process,Y,1.1916644253161621,99.67,--,--,--,--,--,--,--,100.00,Yes,Yes,Y
+Melanoma Reporting,397,MIPS CQM,Process,Y,7.874602602526525,98.21,--,--,--,--,--,--,--,100.00,Yes,Yes,Y
+Melanoma Reporting,397,Medicare Part B Claims,Process,Y,3.426292983705312,98.88,99.26 - 99.99,--,--,--,--,--,--,100.00,Yes,Yes,Y
+Optimal Asthma Control,398,MIPS CQM,Outcome,Y,33.575756362684366,65.58,33.17 - 41.11,41.12 - 48.04,48.05 - 69.54,69.55 - 91.27,91.28 - 99.99,--,--,100.00,No,No,Y
+One-Time Screening for Hepatitis C Virus (HCV) for all Patients,400,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Hepatitis C: Screening for Hepatocellular Carcinoma (HCC) in Patients with Cirrhosis,401,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Tobacco Use and Help with Quitting Among Adolescents,402,MIPS CQM,Process,Y,14.237199553803697,92.73,89.41 - 94.11,94.12 - 96.87,96.88 - 98.63,98.64 - 99.73,99.74 - 99.99,--,--,100.00,Yes,Yes,N
+Anesthesiology Smoking Abstinence,404,MIPS CQM,Intermediate Outcome,Y,21.15230374382401,74.81,59.90 - 66.66,66.67 - 73.09,73.10 - 78.81,78.82 - 84.71,84.72 - 89.18,89.19 - 92.86,92.87 - 99.88,>= 99.89,No,No,Y
+Appropriate Follow-up Imaging for Incidental Abdominal Lesions,405,MIPS CQM,Process,Y,23.307273412508916,86.78,75.47 - 88.45,88.46 - 96.35,96.36 - 98.60,98.61 - 99.99,--,--,--,100.00,Yes,No,Y
+Appropriate Follow-up Imaging for Incidental Abdominal Lesions,405,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Appropriate Follow-up Imaging for Incidental Thyroid Nodules in Patients,406,MIPS CQM,Process,Y,15.282086727936063,6.13,6.67 - 3.18,3.17 - 0.01,--,--,--,--,--,0.00,Yes,Yes,Y
+Appropriate Follow-up Imaging for Incidental Thyroid Nodules in Patients,406,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Clinical Outcome Post Endovascular Stroke Treatment,409,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Psoriasis: Clinical Response to Systemic Medications,410,MIPS CQM,Outcome,Y,26.579951517025194,79.36,58.22 - 73.07,73.08 - 84.67,84.68 - 91.75,91.76 - 96.58,96.59 - 99.99,--,--,100.00,No,No,Y
+Door to Puncture Time for Endovascular Stroke Treatment,413,MIPS CQM,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older,415,MIPS CQM,Efficiency,Y,10.823906719887919,90.23,82.24 - 86.72,86.73 - 90.47,90.48 - 94.54,94.55 - 96.61,96.62 - 98.16,98.17 - 99.32,99.33 - 99.99,100.00,No,No,Y
+Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,416,MIPS CQM,Efficiency,Y,21.82355123037772,16.58,25.15 - 17.93,17.92 - 12.61,12.60 - 9.32,9.31 - 5.57,5.56 - 2.08,2.07 - 0.01,--,0.00,No,No,Y
+Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,416,Medicare Part B Claims,Efficiency,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Osteoporosis Management in Women Who Had a Fracture,418,MIPS CQM,Process,Y,25.10775210419695,18.25,3.33 - 3.99,4.00 - 5.06,5.07 - 8.08,8.09 - 10.70,10.71 - 15.11,15.12 - 21.61,21.62 - 54.54,>= 54.55,No,No,N
+Osteoporosis Management in Women Who Had a Fracture,418,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Overuse of Imaging for the Evaluation of Primary Headache,419,MIPS CQM,Process,Y,19.61277685887792,14.41,23.08 - 14.42,14.41 - 9.24,9.23 - 5.07,5.06 - 4.36,4.35 - 2.95,2.94 - 1.54,1.53 - 0.01,0.00,Yes,Yes,Y
+Varicose Vein Treatment with Saphenous Ablation: Outcome Survey,420,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Appropriate Assessment of Retrievable Inferior Vena Cava (IVC) Filters for Removal,421,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Performing Cystoscopy at the Time of Hysterectomy for Pelvic Organ Prolapse to Detect Lower Urinary Tract Injury,422,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Performing Cystoscopy at the Time of Hysterectomy for Pelvic Organ Prolapse to Detect Lower Urinary Tract Injury,422,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Perioperative Temperature Management,424,MIPS CQM,Outcome,Y,6.5649160915029485,97.92,98.08 - 99.27,99.28 - 99.74,99.75 - 99.90,99.91 - 99.96,99.97 - 99.99,--,--,100.00,Yes,No,Y
+Photodocumentation of Cecal Intubation,425,MIPS CQM,Process,Y,12.862110675881317,93.67,92.57 - 95.24,95.25 - 97.17,97.18 - 98.26,98.27 - 99.01,99.02 - 99.52,99.53 - 99.95,99.96 - 99.99,100.00,Yes,Yes,N
+Prevention of Post-Operative Nausea and Vomiting (PONV)  Combination Therapy,430,MIPS CQM,Process,Y,6.5882161897628,97.75,98.21 - 99.19,99.20 - 99.60,99.61 - 99.78,99.79 - 99.90,99.91 - 99.98,99.99 - 99.99,--,100.00,Yes,Yes,Y
+Preventive Care and Screening: Unhealthy Alcohol Use: Screening & Brief Counseling,431,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Proportion of Patients Sustaining a Bladder Injury at the Time of any Pelvic Organ Prolapse Repair,432,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Proportion of Patients Sustaining a Bowel Injury at the time of any Pelvic Organ Prolapse Repair,433,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Radiation Consideration for Adult CT: Utilization of Dose Lowering Techniques,436,MIPS CQM,Process,Y,13.793395145682661,96.83,99.54 - 99.90,99.91 - 99.98,99.99 - 99.99,--,--,--,--,100.00,Yes,Yes,N
+Radiation Consideration for Adult CT: Utilization of Dose Lowering Techniques,436,Medicare Part B Claims,Process,Y,18.702433184711104,93.67,96.37 - 98.66,98.67 - 99.53,99.54 - 99.92,99.93 - 99.99,--,--,--,100.00,Yes,Yes,N
+Statin Therapy for the Prevention and Treatment of Cardiovascular Disease,438,MIPS CQM,Process,Y,15.745079564619166,83.86,69.70 - 75.53,75.54 - 80.94,80.95 - 84.99,85.00 - 90.90,90.91 - 99.80,99.81 - 99.99,--,100.00,No,No,N
+Statin Therapy for the Prevention and Treatment of Cardiovascular Disease,438,eCQM,Process,Y,11.528772861889554,71.76,65.52 - 68.68,68.69 - 70.99,71.00 - 73.11,73.12 - 75.21,75.22 - 77.48,77.49 - 80.19,80.20 - 83.62,>= 83.63,No,No,N
+Age Appropriate Screening Colonoscopy,439,MIPS CQM,Efficiency,Y,3.8031541884188744,0.67,--,--,--,--,--,--,--,0.00,No,No,Y
+Skin Cancer: Biopsy Reporting Time  Pathologist to Clinician,440,MIPS CQM,Process,Y,2.652457497889701,99.24,99.55 - 99.99,--,--,--,--,--,--,100.00,Yes,Yes,Y
+Ischemic Vascular Disease (IVD) All or None Outcome Measure (Optimal Control),441,MIPS CQM,Intermediate Outcome,Y,24.841253888472053,54.41,30.23 - 39.98,39.99 - 51.48,51.49 - 61.89,61.90 - 67.58,67.59 - 72.54,72.55 - 76.39,76.40 - 80.60,>= 80.61,No,No,Y
+Non-Recommended Cervical Cancer Screening in Adolescent Females,443,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Risk-Adjusted Operative Mortality for Coronary Artery Bypass Graft (CABG),445,MIPS CQM,Outcome,Y,2.2875631028443673,2.43,3.36 - 2.87,2.86 - 2.55,2.54 - 2.28,2.27 - 1.73,1.72 - 1.24,1.23 - 0.01,--,0.00,No,No,Y
+Appropriate Workup Prior to Endometrial Ablation,448,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Appropriate Treatment for Patients with Stage I (T1c) - III HER2 Positive Breast Cancer,450,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+RAS (KRAS and NRAS) Gene Mutation Testing Performed for Patients with Metastatic Colorectal Cancer who receive Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibody Therapy,451,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Patients with Metastatic Colorectal Cancer and RAS (KRAS or NRAS) Gene Mutation Spared Treatment with Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibodies,452,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Percentage of Patients Who Died from Cancer Receiving Chemotherapy in the Last 14 Days of Life (lower score  better),453,MIPS CQM,Process,Y,7.776164020382502,11.92,17.86 - 15.23,15.22 - 13.69,13.68 - 11.31,11.30 - 9.39,9.38 - 6.32,6.31 - 4.77,4.76 - 0.01,0.00,No,No,Y
+Percentage of Patients Who Died from Cancer Admitted to the Intensive Care Unit (ICU) in the Last 30 Days of Life (lower score  better),455,MIPS CQM,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Percentage of Patients Who Died from Cancer Admitted to Hospice for Less than 3 days (lower score  better),457,MIPS CQM,Outcome,Y,11.219683429820554,8.88,14.81 - 11.27,11.26 - 8.78,8.77 - 5.39,5.38 - 4.16,4.15 - 2.54,2.53 - 1.36,1.35 - 0.01,0.00,No,No,Y
+Back Pain After Lumbar Discectomy/Laminectomy,459,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Back Pain After Lumbar Fusion,460,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Leg Pain After Lumbar Discectomy/Laminectomy,461,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Bone Density Evaluation for Patients with Prostate Cancer and Receiving Androgen Deprivation Therapy,462,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Prevention of Post-Operative Vomiting (POV)  Combination Therapy (Pediatrics),463,MIPS CQM,Process,Y,6.504251374426914,97.71,97.30 - 98.92,98.93 - 99.73,99.74 - 99.99,--,--,--,--,100.00,Yes,Yes,Y
+Otitis Media with Effusion: Systemic Antimicrobials - Avoidance of Inappropriate Use,464,MIPS CQM,Process,Y,8.627095271255248,92.26,86.79 - 91.22,91.23 - 93.03,93.04 - 95.58,95.59 - 96.39,96.40 - 97.61,97.62 - 98.46,98.47 - 99.99,100.00,Yes,No,Y
+Uterine Artery Embolization Technique: Documentation of Angiographic Endpoints and Interrogation of Ovarian Arteries,465,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Continuity of Pharmacotherapy for Opioid Use Disorder (OUD),468,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Functional Status After Lumbar Fusion,469,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Functional Status After Primary Total Knee Replacement,470,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Functional Status After Lumbar Discectomy/Laminectomy,471,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Appropriate Use of DXA Scans in Women Under 65 Years Who Do Not Meet the Risk Factor Profile for Osteoporotic Fracture,472,eCQM,Process,Y,1.3247170573987015,0.23,--,--,--,--,--,--,--,0.00,Yes,Yes,Y
+Leg Pain After Lumbar Fusion,473,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+HIV Screening,475,eCQM,Process,Y,13.627676290894684,15.19,3.56 - 6.41,6.42 - 9.15,9.16 - 12.31,12.32 - 15.83,15.84 - 19.06,19.07 - 23.61,23.62 - 33.17,>= 33.18,No,No,N
+Urinary Symptom Score Change 6-12 Months After Diagnosis of Benign Prostatic Hyperplasia,476,eCQM,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Multimodal Pain Management,477,MIPS CQM,Process,Y,17.012614579001074,88.40,80.46 - 85.94,85.95 - 91.91,91.92 - 96.15,96.16 - 98.70,98.71 - 99.59,99.60 - 99.92,99.93 - 99.99,100.00,Yes,No,Y
+Functional Status Change for Patients with Neck Impairments,478,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,Y,17.850321668627416,53.79,38.72 - 43.27,43.28 - 47.61,47.62 - 49.28,49.29 - 55.21,55.22 - 66.07,66.08 - 70.36,70.37 - 78.06,>= 78.07,No,No,Y
+Intravesical Bacillus-Calmette Guerin for Non-muscle Invasive Bladder Cancer,481,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Hemodialysis Vascular Access: Practitioner Level Long-term Catheter Rate,482,MIPS CQM,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Person-Centered Primary Care Measure Patient Reported Outcome Performance Measure (PCPCM PRO-PM),483,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Achievement of Projected Effective Dose of Standardized Allergens for Patient Treated With Allergen Immunotherapy for at Least One Year,AAAAI8,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Penicillin Allergy: Appropriate Removal or Confirmation,AAAAI18,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Asthma Control: Minimal Important Difference Improvement,AAAAI17,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Asthma: Assessment of Asthma Control – Ambulatory Care Setting,AAAAI2,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Documentation of Clinical Response to Allergen Immunotherapy within One Year,AAAAI6,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Melanoma: – Appropriate Surgical Margins,AAD12,QCDR Measure,Intermediate Outcome,Y,5.160402715920165,96.56,91.80 - 96.42,96.43 - 98.54,98.55 - 99.99,--,--,--,--,100.00,Yes,No,Y
+Skin Cancer Surgery: Post-Operative Complications,AAD11,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Melanoma: Tracking and Evaluation of Recurrence,AAD14,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Psoriasis – Improvement in Patient-Reported Itch Severity,AAD9,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Dermatitis – Improvement in Patient-Reported Itch Severity,AAD10,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Chronic Skin Conditions: Patient Reported Quality-of-Life,AAD8,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Mildly Atypical Dysplastic Nevi – Appropriate Non-Excision,AAD13,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Skin Cancer: Biopsy Reporting Time - Clinician to Patient,AAD6,QCDR Measure,Process,Y,20.16643050382244,93.23,96.99 - 98.80,98.81 - 99.79,99.80 - 99.99,--,--,--,--,100.00,Yes,No,Y
+Psoriasis: Screening for Psoriatic Arthritis,AAD7,QCDR Measure,Process,Y,30.249371739683315,84.84,82.68 - 95.25,95.26 - 97.69,97.70 - 99.36,99.37 - 99.99,--,--,--,100.00,Yes,No,Y
+Patient reported falls and plan of care,AAN34,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Quality of Life Outcome for Patients with Neurologic Conditions,AAN22,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Medication Prescribed For Acute Migraine Attack,AAN5,QCDR Measure,Process,Y,15.618193091201032,61.55,47.33 - 53.69,53.70 - 57.15,57.16 - 62.85,62.86 - 67.36,67.37 - 71.42,71.43 - 76.34,76.35 - 80.72,>= 80.73,No,No,N
+Diabetes/Pre-Diabetes Screening for Patients with DSP,AAN28,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Exercise and Appropriate Physical Activity Counseling for Patients with MS,AAN8,QCDR Measure,Process,Y,23.175668193900393,74.68,56.67 - 67.79,67.80 - 74.16,74.17 - 80.02,80.03 - 86.59,86.60 - 91.52,91.53 - 94.51,94.52 - 98.97,>= 98.98,No,No,N
+Comprehensive Epilepsy Care Center Referral or Discussion for Patients with Epilepsy,AAN29,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Migraine Preventive Therapy Management,AAN30,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Acute Treatment Prescribed for Cluster Headache,AAN31,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Preventive Treatment Prescribed for Cluster Headache,AAN32,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Pediatric Medication reconciliation,AAN25,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Querying and Follow-Up About Symptoms of Autonomic Dysfunction for Patients with Parkinson's Disease,AAN9,QCDR Measure,Process,Y,32.60854113959295,70.18,38.82 - 59.99,60.00 - 70.19,70.20 - 87.10,87.11 - 91.68,91.69 - 96.25,96.26 - 97.33,97.34 - 99.99,100.00,No,No,N
+Activity counseling for back pain,AAN26,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Tympanostomy Tubes: Resolution of Otitis Media with Effusion (OME) in Adults and Children,AAO36,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Tympanostomy Tubes: Topical Ear Drop Monotherapy for Acute Otorrhea,AAO12,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Standard Benign Positional Paroxysmal Vertigo (BPPV) Management,AAO32,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Bell's Palsy: Inappropriate Use of Magnetic Resonance Imaging or Computed Tomography Scan,AAO13,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Dysphonia: Postoperative Laryngeal Examination,AAO34,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Age-Related Hearing Loss: Audiometric Evaluation,AAO16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Benign Positional Paroxysmal Vertigo (BPPV): Dix-Hallpike and Canalith Repositioning,AAO35,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Tympanostomy Tubes: Hearing Test,AAO20,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Allergic Rhinitis: Avoidance of Leukotriene Inhibitors,AAO24,QCDR Measure,Process,Y,5.37011290937469,95.87,91.19 - 94.67,94.68 - 97.27,97.28 - 98.92,98.93 - 99.38,99.39 - 99.99,--,--,100.00,Yes,No,Y
+Otitis Media with Effusion (OME): Hearing Test for Chronic OME > 3 months,AAO21,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Allergic Rhinitis: Intranasal Corticosteroids or Oral Antihistamines,AAO23,QCDR Measure,Process,Y,22.268127049014744,64.70,49.92 - 58.77,58.78 - 64.46,64.47 - 67.99,68.00 - 72.07,72.08 - 75.96,75.97 - 86.17,86.18 - 89.51,>= 89.52,No,No,N
+Pediatric OSA: Objective Assessment of Positive Airway Pressure Therapy Adherence,AASM1,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Pediatric OSA: Objective Assessment of OSA Signs and Symptoms in Children with Complex Medical Conditions,AASM2,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Adult OSA: Screening for Adult OSA by Primary Care Physicians,AASM3,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Measuring the Value-Functions of Primary Care: Physician Level Continuity of Care Measure,ABFM12,QCDR Measure,Efficiency and Cost/Resource Use,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Hypotension Prevention After Spinal Placement for Elective Cesarean Section,ABG40,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Use of Capnography for non-Operating Room anesthesia Measure,ABG43,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Known or Suspected Difficult Airway Mitigation Strategies,ABG42,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Upper Extremity Nerve Blockade in Shoulder Surgery,ABG41,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Chest Pain – Avoidance of admission for adult patients with low-risk chest pain.,ACEP59,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+ED Median Time from ED arrival to ED departure for all Adult Patients,ACEP50,QCDR Measure,Outcome,Y,0.3115318214693823,-0.11,0.11 - 0.03,0.02 - -0.05,-0.06 - -0.12,-0.13 - -0.18,-0.19 - -0.28,-0.29 - -0.37,-0.38 - -0.49,<= -0.50,No,No,Y
+Syncope – Avoidance of admission for adult patients with low-risk syncope,ACEP60,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+ED Median Time from ED arrival to ED departure for all Pediatric ED Patients,ACEP51,QCDR Measure,Outcome,Y,0.28222993591009526,-0.10,0.13 - 0.01,0.00 - -0.06,-0.07 - -0.10,-0.11 - -0.16,-0.17 - -0.20,-0.21 - -0.29,-0.30 - -0.43,<= -0.44,No,No,Y
+Sepsis Management: Septic Shock: Lactate Clearance Rate of >=10,ACEP30,QCDR Measure,Outcome,Y,6.352834376511372,79.37,73.73 - 74.99,75.00 - 77.21,77.22 - 78.71,78.72 - 79.99,80.00 - 82.60,82.61 - 86.41,86.42 - 88.88,>= 88.89,No,No,Y
+Appropriate Utilization of Focused Assessment with Sonography for Trauma (FAST) Exam in the Emergency Department,ACEP54,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Appropriate Emergency Department Utilization of CT for Pulmonary Embolism,ACEP22,QCDR Measure,Process,Y,15.69956626178191,34.26,22.92 - 25.43,25.44 - 28.78,28.79 - 30.63,30.64 - 37.79,37.80 - 40.61,40.62 - 46.13,46.14 - 52.35,>= 52.36,No,No,Y
+Appropriate Use of Imaging for Recurrent Renal Colic,ACEP53,QCDR Measure,Process,Y,25.452517405798783,80.70,63.64 - 79.99,80.00 - 84.71,84.72 - 91.05,91.06 - 94.63,94.64 - 97.05,97.06 - 98.84,98.85 - 99.99,100.00,No,No,Y
+Coagulation Studies in Patients Presenting with Chest Pain with No Coagulopathy or Bleeding,ACEP21,QCDR Measure,Process,Y,8.015966181301817,8.23,12.85 - 9.40,9.39 - 7.49,7.48 - 5.95,5.94 - 4.74,4.73 - 3.58,3.57 - 2.68,2.67 - 0.01,0.00,No,No,Y
+Avoidance of Opioid therapy for dental pain.,ACEP62,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older,ACEP19,QCDR Measure,Process,Y,10.698397614019777,68.21,59.44 - 62.23,62.24 - 65.51,65.52 - 66.86,66.87 - 69.87,69.88 - 71.92,71.93 - 77.26,77.27 - 82.09,>= 82.10,No,No,Y
+"Avoidance of Chest X-ray in pediatric patients with Asthma, Bronchiolitis or Croup",ACEP61,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Tobacco Use: Screening and Cessation Intervention for Patients with Asthma and COPD,ACEP25,QCDR Measure,Process,Y,15.27573716495145,69.80,56.31 - 60.19,60.20 - 68.01,68.02 - 70.97,70.98 - 74.14,74.15 - 77.85,77.86 - 83.65,83.66 - 90.31,>= 90.32,No,No,N
+Follow-Up Care Coordination Documented in Discharge Summary,ACEP56,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Appropriate Foley catheter use in the emergency department,ACEP31,QCDR Measure,Process,Y,16.794761654980963,76.42,64.41 - 66.17,66.18 - 77.82,77.83 - 78.70,78.71 - 85.87,85.88 - 89.51,89.52 - 92.06,92.07 - 93.47,>= 93.48,No,No,Y
+Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,ACEP55,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+"Sepsis Management: Septic Shock: Lactate Level Measurement, Antibiotics Ordered, and Fluid Resuscitation",ACEP48,QCDR Measure,Process,Y,15.66051581768625,83.66,75.00 - 79.16,79.17 - 84.43,84.44 - 88.93,88.94 - 92.12,92.13 - 93.87,93.88 - 94.68,94.69 - 96.49,>= 96.50,No,No,N
+Appropriate Emergency Department Utilization of Lumbar Spine Imaging for Atraumatic Low Back Pain,ACEP52,QCDR Measure,Process,Y,20.066187639001992,56.84,46.33 - 55.25,55.26 - 57.75,57.76 - 62.25,62.26 - 67.73,67.74 - 69.78,69.79 - 72.17,72.18 - 75.88,>= 75.89,No,No,Y
+Surgical Site Infection Rate - Mohs Micrographic Surgery,ACMS4,QCDR Measure,Outcome,Y,4.407433167551924,3.97,--,10.00 - 1.98,1.97 - 1.18,1.17 - 0.91,0.90 - 0.62,0.61 - 0.39,0.38 - 0.18,<= 0.17,No,No,Y
+Photographic and/or Anatomic Map Documentation to Prevent Wrong-Site Surgery,ACMS10,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Post-Operative Management of Field Cancerization after Mohs Micrographic Surgery,ACMS9,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Limit quantity of opioids prescribed for pain management in patients following Mohs micrographic surgery,ACMS8,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Documentation of High-Risk Squamous Cell Carcinoma Stage in Mohs Micrographic Surgery Record,ACMS5,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Antibiotic Prophylaxis for High Risk Cardiac / Orthopedic Cases prior to Mohs micrographic surgery - Prevention of Overuse,ACMS3,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+COPD Exacerbation or CHF Exacerbation requiring Hospital Admission: Palliative Care Evaluation,ACQR16,QCDR Measure,Efficiency and Cost/Resource Use,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+COPD: Steroids for no more than 5 days in COPD Exacerbation,ACQR3,QCDR Measure,Efficiency and Cost/Resource Use,Y,4.03708994661378,95.68,92.21 - 95.07,95.08 - 95.91,95.92 - 96.35,96.36 - 97.34,97.35 - 98.47,98.48 - 99.01,99.02 - 99.99,100.00,No,No,Y
+ABCDEF Bundle - Early mobility for ICU patients,ACQR12,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Sepsis: Hour One bundle,ACQR13,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Rheumatoid Arthritis Patients with Low Disease Activity or Remission,ACR16,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Gout: Serum Urate Target,ACR14,QCDR Measure,Intermediate Outcome,Y,16.875755149456477,44.86,31.94 - 35.70,35.71 - 40.90,40.91 - 43.23,43.24 - 49.99,50.00 - 54.54,54.55 - 61.53,61.54 - 66.66,>= 66.67,No,No,Y
+"Multi-strata weighted average for 3 CT Exam Types: Overall Percent of CT exams for which Dose Length Product is at or below the size-specific diagnostic reference level (for CT Abdomen-pelvis with contrast/single phase scan, CT Chest without contrast/single phase scan and CT Head/Brain without contrast/single phase scan)",ACRAD34,QCDR Measure,Outcome,Y,18.29327442457705,83.05,76.09 - 84.85,84.86 - 85.49,85.50 - 89.22,89.23 - 92.07,92.08 - 95.11,--,95.12 - 96.21,>= 96.22,No,No,Y
+Report Turnaround Time: Mammography,ACRAD25,QCDR Measure,Outcome,Y,33.72493253983911,23.85,37.52 - 26.52,26.51 - 19.64,19.63 - 14.59,14.58 - 10.13,10.12 - 5.33,5.32 - 2.14,2.13 - 0.59,<= 0.58,No,No,Y
+Report Turnaround Time: Radiography,ACRAD15,QCDR Measure,Outcome,Y,5.515527083340101,4.94,6.65 - 5.29,5.28 - 4.11,4.10 - 3.43,3.42 - 2.79,2.78 - 1.93,1.92 - 1.38,1.37 - 0.82,<= 0.81,No,No,Y
+Report Turnaround Time: Ultrasound (Excluding Breast US),ACRAD16,QCDR Measure,Outcome,Y,12.66921806390143,6.56,7.79 - 6.34,6.33 - 5.03,5.02 - 4.23,4.22 - 3.19,3.18 - 2.46,2.45 - 1.71,1.70 - 0.97,<= 0.96,No,No,Y
+Report Turnaround Time: MRI,ACRAD17,QCDR Measure,Outcome,Y,8.117850698651726,10.63,16.66 - 12.76,12.75 - 10.17,10.16 - 8.60,8.59 - 6.83,6.82 - 5.31,5.30 - 4.06,4.05 - 2.62,<= 2.61,No,No,Y
+Report Turnaround Time: CT,ACRAD18,QCDR Measure,Outcome,Y,12.049889637836865,6.54,6.98 - 5.31,5.30 - 4.43,4.42 - 3.95,3.94 - 3.11,3.10 - 2.47,2.46 - 1.69,1.68 - 1.16,<= 1.15,No,No,Y
+Report Turnaround Time: PET,ACRAD19,QCDR Measure,Outcome,Y,21.889585476251554,20.20,29.79 - 24.91,24.90 - 16.14,16.13 - 11.62,11.61 - 9.73,9.72 - 6.96,6.95 - 4.04,4.03 - 2.76,<= 2.75,No,No,Y
+Safe Hydroxychloroquine Dosing,ACR15,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Interpretation of CT Pulmonary Angiography (CTPA) for Pulmonary Embolism,ACRAD37,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Hepatitis B Safety Screening,ACR10,QCDR Measure,Process,Y,21.774457578941956,36.49,13.00 - 21.13,21.14 - 30.76,30.77 - 38.08,38.09 - 44.01,44.02 - 51.34,51.35 - 55.41,55.42 - 62.02,>= 62.03,No,No,Y
+Incidental Coronary Artery Calcification Reported on Chest CT,ACRAD36,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Disease Activity Measurement for Patients with PsA,ACR12,QCDR Measure,Process,Y,29.473229817463437,37.15,9.33 - 12.04,12.05 - 19.43,19.44 - 33.43,33.44 - 41.22,41.23 - 48.47,48.48 - 68.86,68.87 - 85.02,>= 85.03,No,No,N
+Surveillance Imaging for Liver Nodules less than 10mm in Patients at Risk for Hepatocellular Carcinoma (HCC),ACRAD42,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Use of Quantitative Criteria for Oncologic FDG PET Imaging,ACRAD41,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Use of Structured Reporting in Prostate MRI,ACRAD40,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Use of Low Dose Cranial CT or MRI Examinations for Patients with Ventricular Shunts,ACRAD38,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Avoidance of Cerebral Hyperthermia for Procedures Involving Cardiopulmonary Bypass,AQI65,QCDR Measure,Outcome,Y,25.2787878044482,83.00,66.67 - 87.23,87.24 - 92.58,92.59 - 95.58,95.59 - 97.01,97.02 - 99.67,99.68 - 99.99,--,100.00,No,No,Y
+Coronary Artery Bypass Graft (CABG): Prolonged Intubation – Inverse Measure,AQI18,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Patient-Reported Experience with Anesthesia,AQI48,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,Y,3.0375880919701985,92.47,90.28 - 90.79,90.80 - 91.72,91.73 - 92.29,92.30 - 92.94,92.95 - 94.03,94.04 - 95.30,95.31 - 96.35,>= 96.36,No,No,Y
+Prevention of Arterial Line-Related Bloodstream Infections,AQI73,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Perioperative Anemia Management,AQI72,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Adherence to Blood Conservation Guidelines for Cardiac Operations using Cardiopulmonary Bypass (CPB) – Composite,AQI49,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Use of Neuraxial Techniques and/or Peripheral Nerve Blocks for Total Knee Arthroplasty (TKA),AQI56,QCDR Measure,Process,Y,7.97201075987455,97.27,96.74 - 98.75,98.76 - 99.24,99.25 - 99.77,99.78 - 99.99,--,--,--,100.00,Yes,Yes,Y
+Safe Opioid Prescribing Practices,AQI57,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Obstructive Sleep Apnea: Patient Education,AQI62,QCDR Measure,Process,Y,14.520360206972251,94.73,95.66 - 98.32,98.33 - 99.39,99.40 - 99.67,99.68 - 99.87,99.88 - 99.99,--,--,100.00,Yes,Yes,N
+Consultation for Frail Patients,AQI67,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Obstructive Sleep Apnea: Mitigation Strategies,AQI68,QCDR Measure,Process,Y,17.87176402304382,91.51,89.99 - 95.65,95.66 - 97.46,97.47 - 98.37,98.38 - 99.33,99.34 - 99.67,99.68 - 99.95,99.96 - 99.99,100.00,Yes,No,Y
+Intraoperative Antibiotic Redosing,AQI69,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Ambulatory Glucose Management,AQI71,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Stones: Repeat Shock Wave Lithotripsy (SWL) Within 6 Months of Initial Treatment,AQUA14,QCDR Measure,Outcome,Y,14.97502586108718,17.18,34.27 - 31.25,31.24 - 19.90,19.89 - 13.01,13.00 - 7.47,7.46 - 4.61,4.60 - 1.75,1.74 - 0.01,0.00,No,No,Y
+Hospital admissions or infectious complications within 30 days of TRUS Biopsy,AQUA8,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Non-Muscle Invasive Bladder Cancer: Early Surveillance Cystoscopy for Non-Muscle Invasive Bladder Cancer,AQUA18,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Non-Muscle Invasive Bladder Cancer: Repeat Transurethral Resection of Bladder Tumor (TURBT) for T1 disease,AQUA16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Benign Prostate Hyperplasia (BPH): Inappropriate Lab & Imaging Services for Patients with BPH,AQUA26,QCDR Measure,Process,Y,10.117881162536909,10.29,17.11 - 14.80,14.79 - 12.51,12.50 - 8.02,8.01 - 5.64,5.63 - 3.19,3.18 - 1.79,1.78 - 0.01,0.00,No,No,Y
+Stones: Urinalysis Performed Before Surgical Stone Procedures,AQUA15,QCDR Measure,Process,Y,19.068841094981234,61.63,41.04 - 44.87,44.88 - 49.38,49.39 - 60.24,60.25 - 73.52,73.53 - 78.36,78.37 - 80.02,80.03 - 84.49,>= 84.50,No,No,Y
+Visits to the ER or Urgent Care Following Reconstruction After Skin Cancer Resection,ASPS24,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Patient Satisfaction with Information Prior to Facial Reconstruction After Skin Cancer Resection Procedures,ASPS26,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Avoidance of Opioid Prescriptions for Closure and Reconstruction After Skin Cancer Resection,ASPS29,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Continuation of Anticoagulation Therapy in the Office-based Setting for Closure and Reconstruction After Skin Cancer Resection Procedures,ASPS28,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Avoidance of Post-operative Systemic Antibiotics for Office-based Closures and Reconstruction After Skin Cancer Procedures,ASPS27,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Coordination of Care for Anticoagulated Patients Undergoing Reconstruction After Skin Cancer Resection,ASPS22,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+"Cancer Protocol and Turnaround Time for Gastrointestinal Carcinomas: Gastric, Esophageal, Colorectal and Hepatocellular Carcinomas",CAP35,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+p16 Immunohistochemistry Reporting for Human Papillomavirus in Patients with Oropharyngeal Squamous Cell Carcinoma (OPSCC),CAP36,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+"Cancer Protocol and Turnaround Time for Gynecologic and Genitourinary Carcinomas: Carcinoma of the Endometrium, Prostate, and Renal Tubular Origin",CAP37,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Prostate Cancer Reporting Best Practices,CAP38,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Helicobacter pylori Status and Turnaround Time,CAP28,QCDR Measure,Process,Y,11.286763690334325,88.01,81.41 - 85.55,85.56 - 88.74,88.75 - 90.88,90.89 - 91.87,91.88 - 93.60,93.61 - 97.45,97.46 - 97.91,>= 97.92,No,No,Y
+Turnaround Time (TAT) - Biopsies,CAP22,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Biomarker Status to Inform Clinical Management and Treatment Decisions in Patients with Non-small Cell Lung Cancer,CAP34,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Urinary Bladder Biopsy Diagnostic Requirements For Appropriate Patient Management,CAP30,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+"Mismatch Repair (MMR) or Microsatellite Instability (MSI) Biomarker Testing Status in Colorectal Carcinoma, Endometrial, Gastroesophageal, or Small Bowel Carcinoma",CAP33,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Patient-Reported Pain and/or Function Improvement after Total Shoulder Arthroplasty,CCOME8,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Patient-Reported Pain and/or Function Improvement after Total Hip Arthroplasty,CCOME7,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Patient-Reported Pain and/or Function Improvement after ACLR Surgery,CCOME4,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Patient-Reported Pain and/or Function Improvement after APM Surgery,CCOME6,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Diabetic Foot Ulcer (DFU) Healing or Closure,CDR2,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Screening for Osteoporosis for Men Aged 70 Years and Older,CDR6,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Appropriate Use of hyperbaric oxygen therapy for patients with diabetic foot ulcers,CDR8,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+qPTH >50% Reduction at End of Procedure,CESQIP9,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Post operative hypocalcemia after thyroidectomy surgery,CESQIP1,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Related readmission for adrenal related problems,CESQIP5,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Door to Diagnostic Evaluation by a Provider Within 30 Minutes – Urgent Care Patients,ECPR50,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Discharge Prescription of Naloxone after Opioid Poisoning or Overdose,ECPR51,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Appropriate Treatment of Psychosis and Agitation in the Emergency Department,ECPR52,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Avoidance of Long-Acting (LA) or Extended-Release (ER) Opiate Prescriptions and Opiate Prescriptions for Greater Than 3 Days Duration for Acute Pain,ECPR55,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Avoidance of Opiates for Low Back Pain or Migraines,ECPR46,QCDR Measure,Process,Y,5.221391331354086,96.35,92.58 - 96.67,96.68 - 98.16,98.17 - 98.78,98.79 - 99.06,99.07 - 99.38,99.39 - 99.99,--,100.00,Yes,No,Y
+Opioid Withdrawal: Initiation of Medication-Assisted Treatment (MAT) and Referral to Outpatient Opioid Treatment,ECPR56,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Clinician Reporting of Loss of Consciousness to State Department of Public Health or Department of Motor Vehicles,ECPR57,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Rh Status Evaluation and Treatment of Pregnant Women at Risk of Fetal Blood Exposure,ECPR41,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Avoid Head CT for Patients with Uncomplicated Syncope,ECPR39,QCDR Measure,Process,Y,6.604904692726463,92.13,86.90 - 88.20,88.21 - 90.54,90.55 - 92.58,92.59 - 94.48,94.49 - 97.09,97.10 - 99.99,--,100.00,No,No,Y
+Intraoperative Hypotension among Non-Emergent Noncardiac Surgical Cases,EPREOP31,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Ultrasound Guidance for Peripheral Nerve Block with Patient Experience,EPREOP30,QCDR Measure,Outcome,Y,4.714241586075545,87.92,82.86 - 86.57,86.58 - 86.95,86.96 - 87.94,87.95 - 88.64,88.65 - 90.31,90.32 - 92.77,92.78 - 94.02,>= 94.03,No,No,Y
+Functional Status Change in Balance Confidence,FOTO5,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Functional Status Change in Dizziness Impact,FOTO6,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Functional Status Change for Patients Post Stroke,FOTO7,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Functional Status Changes for Patients with Upper or Lower Quadrant Edema,FOTO4,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Screening Colonoscopy Adenoma Detection Rate - Male,GIQIC24,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Screening Colonoscopy Adenoma Detection Rate - Female,GIQIC25,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Appropriate follow-up interval based on pathology findings in screening colonoscopy,GIQIC23,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Appropriate management of anticoagulation in the peri-procedural period rate – EGD,GIQIC10,QCDR Measure,Process,Y,18.774096822695267,89.36,82.05 - 94.33,94.34 - 96.07,96.08 - 98.36,98.37 - 99.99,--,--,--,100.00,Yes,No,Y
+Physician’s Orders for Life-Sustaining Treatment (POLST) Form,HCPR16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Pressure Ulcers – Risk Assessment and Plan of Care,HCPR17,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Unintentional Weight Loss – Risk Assessment and Plan of Care,HCPR18,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Clostridium Difficile – Risk Assessment and Plan of Care,HCPR20,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Critical Care Transfer of Care – Use of Verbal Checklist or Protocol,HCPR22,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Avoidance of Echocardiogram and Carotid Ultrasound for Syncope,HCPR23,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Appropriate Utilization of Vancomycin for Cellulitis,HCPR24,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Venous Thromboembolism (VTE) Prophylaxis,HCPR14,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Outcomes of Treatment of Subjective Tinnitus,HM11,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Outcomes of Hearing Loss Treatment,HM10,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Outcomes of Treatment of Benign Paroxysmal Positional Vertigo,HM12,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Functional Status Change for Patients with Vestibular Dysfunction,HM7,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Functional Benefit of a Cochlear Implant,HM9,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Transthoracic Echo (TTE) performance per ASE guidelines,IGR10,QCDR Measure,Efficiency and Cost/Resource Use,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Stress echo performance for shortness of breath per ASE guidelines,IGR9,QCDR Measure,Efficiency and Cost/Resource Use,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Comprehensive TTE studies reporting a measured value of LVEF AND wall motion findings with LVEF less than 50%,IGR1,QCDR Measure,Efficiency and Cost/Resource Use,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Myocardial Perfusion Imaging (MPI) studies - Radiation Reduction Strategies,IGR17,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Appropriate Evaluation of Left Ventricular Structure and Systolic Function with Transthoracic Echocardiography (TTE) to Guide Heart Failure and Cardiomyopathy Management,IGR14,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+"Parameters in stress echocardiography dobutamine testing for low flow, low gradient aortic stenosis",IGR2,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Appropriate diagnosis verification and severity grading for valve disease through transthoracic echocardiography (TTE) quantitative parameters.,IGR12,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Myocardial Perfusion Imaging (MPI) or Stress Echocardiography Imaging Studies - Adequate Exercise Protocol,IGR15,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+"Myocardial Perfusion Imaging (MPI) Studies, Transthoracic Echo (TTE), or Stress Echocardiography Imaging Studies - Adequate Reporting for Appropriate Interventions",IGR16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Myocardial Perfusion Imaging (MPI) or Stress Echocardiography imaging studies - Improving Image Quality,IGR18,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Glaucoma – Intraocular Pressure Reduction,IRIS2,QCDR Measure,Intermediate Outcome,Y,22.6494756929666,40.99,23.67 - 29.07,29.08 - 32.95,32.96 - 38.20,38.21 - 41.35,41.36 - 45.54,45.55 - 53.72,53.73 - 76.80,>= 76.81,No,No,Y
+Intraocular Pressure Reduction Following Laser Trabeculoplasty,IRIS43,QCDR Measure,Outcome,Y,32.34965066704075,37.17,11.00 - 13.63,13.64 - 15.72,15.73 - 20.82,20.83 - 26.38,26.39 - 54.96,54.97 - 74.99,75.00 - 90.31,>= 90.32,No,No,Y
+Acquired Involutional Entropion: Normalized lid position after surgical repair,IRIS6,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Adult Surgical Esotropia: Postoperative alignment,IRIS48,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Endothelial Keratoplasty - Post-operative improvement in best corrected visual acuity to 20/40 or better,IRIS1,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Diabetic Macular Edema - Loss of Visual Acuity,IRIS13,QCDR Measure,Outcome,Y,8.137543420585724,85.52,80.35 - 83.11,83.12 - 85.53,85.54 - 87.00,87.01 - 88.18,88.19 - 89.21,89.22 - 91.15,91.16 - 93.93,>= 93.94,No,No,Y
+Evidence of anatomic closure of macular hole within 90 days after surgery as documented by OCT,IRIS46,QCDR Measure,Outcome,Y,30.830950733769924,58.58,15.79 - 51.91,51.92 - 61.21,61.22 - 68.21,68.22 - 71.99,72.00 - 73.32,73.33 - 88.09,88.10 - 97.55,>= 97.56,No,No,Y
+Acute Anterior Uveitis: Post-treatment Grade 0 anterior chamber cells,IRIS17,QCDR Measure,Outcome,Y,19.601795963635578,60.39,47.83 - 54.39,54.40 - 57.13,57.14 - 59.08,59.09 - 64.51,64.52 - 69.22,69.23 - 74.99,75.00 - 81.64,>= 81.65,No,No,Y
+Visual Field Progression in Glaucoma,IRIS44,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Refractive Surgery: Patients with a postoperative uncorrected visual acuity (UCVA) of 20/20 or better within 30 days,IRIS23,QCDR Measure,Outcome,Y,22.039739757343515,77.06,57.50 - 80.94,80.95 - 82.85,82.86 - 83.99,84.00 - 87.03,87.04 - 90.27,90.28 - 92.30,92.31 - 95.08,>= 95.09,No,No,Y
+Visual Acuity Improvement Following Cataract Surgery Combined with a Trabeculectomy or an Aqueous Shunt Procedure,IRIS60,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Refractive Surgery: Patients with a postoperative correction within + or - 0.5 Diopter (D) of the intended correction,IRIS24,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Regaining Vision After Cataract Surgery,IRIS59,QCDR Measure,Outcome,Y,11.571662257040696,12.39,1.85 - 3.17,3.18 - 4.95,4.96 - 8.13,8.14 - 12.30,12.31 - 18.06,18.07 - 26.42,26.43 - 31.22,>= 31.23,No,No,Y
+Improvement of Macular Edema in Patients with Uveitis,IRIS35,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Improved Visual Acuity after Vitrectomy for Complications of Diabetic Retinopathy within 120 Days,IRIS58,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Endothelial Keratoplasty – Dislocation Requiring Surgical Intervention,IRIS38,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Idiopathic Intracranial Hypertension: Improvement of mean deviation or stability of mean deviation,IRIS57,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Intraocular Pressure Reduction Following Trabeculectomy or an Aqueous Shunt Procedure,IRIS39,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Adult Diplopia: Improvement of ocular deviation or absence of diplopia or functional improvement,IRIS56,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Improved visual acuity after epiretinal membrane treatment within 120 days,IRIS41,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Visual Acuity Improvement Following Cataract Surgery and Minimally Invasive Glaucoma Surgery,IRIS55,QCDR Measure,Outcome,Y,10.141639479097428,35.35,27.85 - 28.88,28.89 - 31.36,31.37 - 33.32,33.33 - 36.06,36.07 - 43.48,43.49 - 45.09,45.10 - 49.30,>= 49.31,No,No,Y
+Complications After Cataract Surgery,IRIS54,QCDR Measure,Outcome,Y,6.862154261284654,2.20,2.41 - 2.01,2.00 - 1.65,1.64 - 1.22,1.21 - 0.83,0.82 - 0.57,0.56 - 0.19,0.18 - 0.01,0.00,No,No,Y
+Chronic Anterior Uveitis - Post-treatment visual acuity,IRIS53,QCDR Measure,Outcome,Y,7.974328434325652,89.36,86.96 - 87.99,88.00 - 89.44,89.45 - 90.78,90.79 - 91.17,91.18 - 94.43,94.44 - 94.51,94.52 - 96.66,>= 96.67,No,No,Y
+Acute Anterior Uveitis: Post-treatment visual acuity,IRIS51,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Amblyopia: Interocular visual acuity,IRIS50,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Surgical Pediatric Esotropia: Postoperative alignment,IRIS49,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+"Failure to Progress (FTP): Proportion of patients not achieving a Minimal Clinically Important Difference (MCID) to indicate functional improvement in rehabilitation of patients with hip, leg or ankle injuries using the validated Lower Extremity Function Scale (LEFS) score, or equivalent instrument which has undergone peer reviewed published validation and demonstrates a peer reviewed published MCID.",IROMS13,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) to indicate functional improvement in knee rehabilitation of patients with knee injury measured via their validated Knee Outcome Survey (KOS) score, or equivalent instrument which has undergone peer reviewed published validation and demonstrates a peer reviewed published MCID.",IROMS11,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with hip, leg or ankle (lower extremity except knee) injury.",IROMS14,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with knee injury pain.",IROMS12,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with neck pain/injury.",IROMS16,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) to indicate functional improvement in rehabilitation patients with low back pain measured via the validated Modified Low Back Pain Disability Questionnaire (MDQ) score.",IROMS17,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with low back pain.",IROMS18,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) to indicate functional improvement in rehabilitation of patients with arm, shoulder, and hand injury measured via the validated Disability of Arm Shoulder and Hand (DASH) score, Quick Disability of Arm Shoulder and Hand (QDASH) score, or equivalent instrument which has undergone peer reviewed published validation and demonstrates a peer reviewed published MCID.",IROMS19,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+"Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with arm, shoulder, or hand injury.",IROMS20,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) to indicate functional improvement in rehabilitation of patients with neck pain/injury measured via the validated Neck Disability Index (NDI).,KEET01,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Patients Suffering From a Hip Injury who Improve Physical Function,LMBR4,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Patients Suffering From a Shoulder Injury who Demonstrate Improved Pain,LMBR10,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Patients Suffering From a Cervical Spine (Neck) Injury who Improve Physical Function,LMBR3,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Patients Suffering From a Lumbar Spine (Low Back) Injury who Improve Physical Function,LMBR2,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Patients Suffering From a Knee Injury who Improve Physical Function,LMBR1,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Patients Suffering From a Hip Injury who Demonstrate Improved Pain,LMBR9,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Patients Suffering From a Cervical Spine (Neck) Injury who Demonstrate Improved Pain,LMBR8,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Patients Suffering From a Lumbar Spine (Low Back) Injury who Demonstrate Improved Pain,LMBR7,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Patients Suffering From a Knee Injury who Demonstrate Improved Pain,LMBR6,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Patients Suffering From a Shoulder Injury who Improve Physical Function,LMBR5,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Sleep Quality Response at 3-months,MBHR14,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Monitoring for psychosocial problems among children and youth,MBHR5,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Symptom Improvement in adults with ADHD,MBHR10,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Outcome monitoring of ADHD functional impairment in children and youth,MBHR9,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Social Role Functioning Assessment utilizing PROMIS Adult Ability to Participate in Social Roles and Activities,MBHR13,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Posttraumatic Stress Disorder (PTSD) Outcome Assessment for Adults and Children,MBHR7,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Anxiety Response at 6-months,MBHR2,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Pain Interference Response utilizing PROMIS,MBHR3,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Alcohol Use Disorder Outcome Response,MBHR8,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Consideration of Cultural-Linguistic and Demographic Factors in Cognitive Assessment,MBHR15,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Use of Anxiety Severity Measure,MBHR1,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Comprehensive Cognitive Assessment Assists with Differential Diagnosis,MBHR16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Improved Efficiency: Time Interval for reporting results of cognitive assessment,MBHR17,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Cognitive Assessment with Counseling on Safety and Potential Risk,MBHR11,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Provision of Feedback Following a Cognitive or Mental Status Assessment with Documentation of Understanding of Test Results and Subsequent Healthcare Plan,MBHR12,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Labor Epidural Failure when Converting from Labor Analgesia to Cesarean Section Anesthesia,MEDNAX54,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Use of a “PEG Test” to Manage Patients Receiving Opioids,MEDNAX56,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Use of ASPECTS (Alberta Stroke Program Early CT Score) for non-contrast CT Head performed for suspected acute stroke.,MEDNAX55,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Hammer Toe Outcome,MEX5,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Screening Coronary Calcium Scoring for Cardiovascular Risk Assessment Including Coronary Artery Calcification Regional Distribution Scoring,MSN13,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Use of Thyroid Imaging Reporting & Data System (TI-RADS) in Final Report to Stratify Thyroid Nodule Risk,MSN15,QCDR Measure,Process,Y,18.856670565682982,86.52,78.00 - 88.99,89.00 - 91.99,92.00 - 94.49,94.50 - 95.99,96.00 - 96.99,97.00 - 98.99,--,>= 99.00,No,No,Y
+Screening Abdominal Aortic Aneurysm Reporting with Recommendations,MSN16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Prostate Cancer: Active Surveillance/Watchful Waiting for Low Risk Prostate Cancer Patients,MUSIC4,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Prostate Cancer: Confirmation testing in low risk active surveillance eligible patients,MUSIC10,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Prostate Cancer: Follow-up testing for patients on active surveillance for at least 30 months,MUSIC11,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Repeat screening or surveillance colonoscopy recommended within one year due to inadequate/poor bowel preparation,NHCR4,QCDR Measure,Process,Y,29.53145645044563,63.55,31.25 - 48.38,48.39 - 64.32,64.33 - 69.50,69.51 - 76.91,76.92 - 85.55,85.56 - 94.11,94.12 - 95.23,>= 95.24,No,No,Y
+Screening and Referral for Transportation Insecurity,NHII1,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Use of ultrasound guidance for vascular access,OEIS8,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Structured Walking Program Prior to Intervention for Claudication,OEIS7,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Appropriate non-invasive arterial testing for patients with intermittent claudication who are undergoing a LE peripheral vascular intervention,OEIS6,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Oncology: Utilization of GCSF in Metastatic Colorectal Cancer,PIMSH2,QCDR Measure,Efficiency and Cost/Resource Use,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Oncology: Supportive Care Drug Utilization in Last 14 Days of Life,PIMSH9,QCDR Measure,Efficiency and Cost/Resource Use,Y,5.452675313585569,6.11,10.03 - 8.01,8.00 - 6.26,6.25 - 4.47,4.46 - 3.58,3.57 - 2.95,2.94 - 1.38,1.37 - 0.01,0.00,No,No,Y
+Oncology: Advance Care Planning in Metastatic Cancer Patients,PIMSH1,QCDR Measure,Patient Engagement/Experience,Y,27.61434795722823,31.45,3.41 - 4.70,4.71 - 11.10,11.11 - 30.83,30.84 - 38.29,38.30 - 46.42,46.43 - 57.29,57.30 - 64.45,>= 64.46,No,No,Y
+Oncology: Patient-Reported Pain Improvement,PIMSH4,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,Y,12.100591064663213,43.29,33.33 - 37.12,37.13 - 39.70,39.71 - 43.54,43.55 - 46.82,46.83 - 49.99,50.00 - 52.87,52.88 - 58.84,>= 58.85,No,No,Y
+Oncology: Hepatitis B serology testing and prophylactic treatment prior to receiving anti-CD20 targeting drugs,PIMSH10,QCDR Measure,Process,Y,24.925135842988773,47.91,17.65 - 38.70,38.71 - 40.39,40.40 - 47.91,47.92 - 57.68,57.69 - 64.23,64.24 - 73.32,73.33 - 79.99,>= 80.00,No,No,Y
+Oncology: Mutation testing for lung cancer completed prior to start of targeted therapy,PIMSH8,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+COVID-19 Vaccinations,PIMSH12,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Antiemetic Therapy for Low- and Minimal-Emetic-Risk Antineoplastic Agents - Avoidance of Overuse (Lower Score - Better).,POLAR1,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Improvement or Maintenance in Recovery for Individuals with a Mental Health and/or Substance Use Disorder,PP11,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Reduction in Suicidal Ideation or Behavior Symptoms,PP13,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+"Utilization and Review of Suicide Safety Plan for Individuals with Suicidal Ideation, Behavior or Suicide Risk",PP12,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+"Measurement-based Care Processes: Index Assessment, Monitoring and Care Plan Review",PP10,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Use of Subarachnoid Block (SAB) in Older Patients Undergoing Low Energy Hip Fracture Repair,PQRANES2,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Use of Peripheral Nerve Block within the Emergency Department in Patients Admitted with Low Energy Hip Fracture,PQRANES1,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Multi-gene next-generation sequencing panel recommended on Fine Needle Aspirations (FNA) of Thyroid Nodule(s) with indeterminate cytology,QMM22,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+DEXA/DXA and Fracture Risk Assessment for Patients with Osteopenia,QMM19,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+"Incorporating results of concurrent studies into Final Reports for Bone Marrow Aspirate of patients with Leukemia, Myelodysplastic syndrome, or Chronic Anemia",QMM21,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Use of Breast Cancer Risk Score on Mammography,QMM18,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Opening Pressure in Lumbar Puncture,QMM20,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Appropriate Follow-up Recommendations for Ovarian-Adnexal Lesions using the Ovarian-Adnexal Reporting and Data System (O-RADS),QMM17,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+IVC Filter Management Confirmation,QMM16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Appropriate Antiemetic Therapy for High- and Moderate Emetic Risk Antineoplastic Agents,QOPI27,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Concurrent Chemo radiation for Patients with a Diagnosis of Stage IIIB NSCLC,QOPI23,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Central Line Ultrasound Guidance,QUANTUM31,QCDR Measure,Process,Y,12.378179453718761,94.94,94.55 - 98.43,98.44 - 99.45,99.46 - 99.99,--,--,--,--,100.00,Yes,Yes,Y
+Improved Access Site Bleeding,RCOIR7,QCDR Measure,Outcome,Y,7.373743938045686,88.52,80.40 - 85.44,85.45 - 87.66,87.67 - 92.14,92.15 - 92.95,92.96 - 94.18,94.19 - 94.94,94.95 - 95.74,>= 95.75,No,No,Y
+Percutaneous Arteriovenous Fistula for Dialysis - Clinical Success Rate,RCOIR13,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Tunneled Hemodialysis Catheter Success,RCOIR12,QCDR Measure,Outcome,Y,9.74999247455957,77.91,67.57 - 69.68,69.69 - 72.71,72.72 - 78.04,78.05 - 82.90,82.91 - 85.91,85.92 - 87.84,87.85 - 89.86,>= 89.87,No,No,Y
+Upper Extremity Edema Improvement,RCOIR10,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,Y,9.273229337881231,79.89,70.05 - 72.96,72.97 - 77.61,77.62 - 80.40,80.41 - 81.82,81.83 - 83.58,83.59 - 88.92,88.93 - 93.25,>= 93.26,No,No,Y
+End Stage Renal Disease (ESRD) Initiation of Home Dialysis or Self-Care,RCOIR5,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Use of Ankle Foot Orthotics to improve patient function,REGCLR7,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Heel Pain Treatment Outcomes for Adults,REGCLR1,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Offloading with Remote Monitoring,REGCLR5,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Tendinitis/ Enthesopathy- Injection Treatment Outcomes for Adults,REGCLR2,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Use of Digital Imaging to Monitor and Improve Treatment Outcomes in Chronic Wound Healing,REGCLR6,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Bunion Outcome - Adult and Adolescent,REGCLR3,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Heel Pain Treatment Outcomes for Pediatric Patients,REGCLR4,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Peritoneal Dialysis Catheter Success Rate,RPAQIR16,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Arteriovenous Fistulae Thrombectomy Success Rate,RPAQIR15,QCDR Measure,Outcome,Y,22.38014972455289,81.33,78.05 - 80.94,80.95 - 83.07,83.08 - 87.29,87.30 - 89.65,89.66 - 92.30,92.31 - 94.04,94.05 - 95.73,>= 95.74,No,No,Y
+Arteriovenous Graft Thrombectomy Success Rate,RPAQIR14,QCDR Measure,Outcome,Y,20.99125406207346,82.79,76.16 - 81.24,81.25 - 86.40,86.41 - 88.71,88.72 - 90.95,90.96 - 93.09,93.10 - 93.74,93.75 - 95.23,>= 95.24,No,No,Y
+Rate of Timely Documentation Transmission to Dialysis Unit/Referring Physician,RPAQIR13,QCDR Measure,Process,Y,28.63743097510883,89.35,95.86 - 97.23,97.24 - 98.07,98.08 - 98.66,98.67 - 99.22,99.23 - 99.39,99.40 - 99.57,99.58 - 99.92,>= 99.93,Yes,Yes,Y
+Transplant Referral,RPAQIR5,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Advance Directives Completed,RPAQIR18,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Ankylosing Spondylitis: Controlled Disease,UREQA1,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Ankylosing Spondylitis: Improved Disease Function,UREQA7,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Vitamin D level: Effective Control of Low Bone Mass/Osteopenia and Osteoporosis: Therapeutic Level Of 25 OH Vitamin D Level Achieved,UREQA8,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Screening for Osteoporosis for Men Aged 70 Years and Older,UREQA9,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Ankylosing Spondylitis: Appropriate Pharmacologic Therapy,UREQA2,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Adequate Compression at each visit for Patients with Venous Leg Ulcers (VLUs) appropriate to arterial supply,USWR32,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Pressure Ulcer* (PU) Healing or Closure (not on the lower extremity ),USWR31,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Patient Reported Outcome of late effects of radiation symptoms following treatment with Hyperbaric Oxygen Therapy (HBOT),USWR26,QCDR Measure,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Patient Reported Nutritional Assessment and Intervention Plan in patients with Wounds and Ulcers,USWR22,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+"Adequate Off-loading of Diabetic Foot Ulcers performed at each visit, appropriate to location of ulcer",USWR29,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Non-Invasive Arterial Assessment of patients with lower extremity wounds or ulcers for determination of healing potential at the initial visit,USWR30,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N

--- a/staging/2022/benchmarks/benchmarks.csv
+++ b/staging/2022/benchmarks/benchmarks.csv
@@ -99,14 +99,14 @@ Functional Status Change for Patients with Hip Impairments,218,MIPS CQM,Patient-
 Functional Status Change for Patients with Low Back Impairments,220,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,Y,20.229483480088103,56.31,39.68 - 45.78,45.79 - 48.25,48.26 - 54.89,54.90 - 59.99,60.00 - 65.65,65.66 - 72.05,72.06 - 87.17,>= 87.18,No,No,Y
 Functional Status Change for Patients with Shoulder Impairments,221,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,Y,20.29238024629261,52.22,35.44 - 40.17,40.18 - 43.86,43.87 - 47.04,47.05 - 52.80,52.81 - 59.46,59.47 - 71.22,71.23 - 81.42,>= 81.43,No,No,Y
 "Functional Status Change for Patients with Elbow, Wrist or Hand Impairments",222,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,Y,18.199858946704122,54.72,41.41 - 44.35,44.36 - 49.47,49.48 - 51.91,51.92 - 58.32,58.33 - 61.89,61.90 - 71.92,71.93 - 79.99,>= 80.00,No,No,Y
-Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,MIPS CQM,Process,Y,32.259635887144924,68.51,30.91 - 49.08,49.09 - 66.66,66.67 - 80.87,80.88 - 90.77,90.78 - 96.45,96.46 - 99.99,--,100.00,No,No,N
-Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,Medicare Part B Claims,Process,Y,21.0950793132673,90.00,87.18 - 95.37,95.38 - 99.99,--,--,--,--,--,100.00,Yes,No,N
-Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,eCQM,Process,Y,30.711647670264682,49.26,18.92 - 25.80,25.81 - 34.16,34.17 - 44.43,44.44 - 56.62,56.63 - 70.36,70.37 - 84.10,84.11 - 95.41,>= 95.42,No,No,N
+Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
 Controlling High Blood Pressure,236,MIPS CQM,Intermediate Outcome,Y,21.532743028983234,63.74,20.00 - 29.99,30.00 - 39.99,40.00 - 49.99,50.00 - 59.99,60.00 - 69.99,70.00 - 79.99,80.00 - 89.99,>= 90.00,No,No,Y
 Controlling High Blood Pressure,236,Medicare Part B Claims,Intermediate Outcome,Y,18.668868031364333,74.89,20.00 - 29.99,30.00 - 39.99,40.00 - 49.99,50.00 - 59.99,60.00 - 69.99,70.00 - 79.99,80.00 - 89.99,>= 90.00,No,No,Y
 Controlling High Blood Pressure,236,eCQM,Intermediate Outcome,Y,16.443624064165398,62.16,51.06 - 56.30,56.31 - 60.13,60.14 - 63.63,63.64 - 67.04,67.05 - 70.64,70.65 - 74.94,74.95 - 80.83,>= 80.84,No,No,Y
-Use of High-Risk Medications in Older Adults,238,MIPS CQM,Process,Y,7.000488449440138,2.99,3.40 - 1.34,1.33 - 0.64,0.63 - 0.33,0.32 - 0.17,0.16 - 0.04,0.03 - 0.01,--,0.00,Yes,No,Y
-Use of High-Risk Medications in Older Adults,238,eCQM,Process,Y,9.580365543743198,6.53,12.98 - 7.57,7.56 - 3.88,3.87 - 1.65,1.64 - 0.64,0.63 - 0.19,0.18 - 0.01,--,0.00,Yes,No,Y
+Use of High-Risk Medications in Older Adults,238,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
+Use of High-Risk Medications in Older Adults,238,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
 Weight Assessment and Counseling for Nutrition and Physical Activity for Children/Adolescents,239,eCQM,Process,Y,18.58471324950724,36.99,25.64 - 29.12,29.13 - 31.20,31.21 - 32.85,32.86 - 34.66,34.67 - 39.76,39.77 - 49.68,49.69 - 63.87,>= 63.88,No,No,N
 Childhood Immunization Status,240,eCQM,Process,Y,17.61927796263764,39.40,23.44 - 31.81,31.82 - 37.26,37.27 - 41.62,41.63 - 45.93,45.94 - 50.04,50.05 - 53.22,53.23 - 59.68,>= 59.69,No,No,N
 Cardiac Rehabilitation Patient Referral from an Outpatient Setting,243,MIPS CQM,Process,Y,28.360979925066598,37.54,12.75 - 17.02,17.03 - 23.75,23.76 - 29.86,29.87 - 36.32,36.33 - 45.83,45.84 - 59.48,59.49 - 90.90,>= 90.91,No,No,Y
@@ -139,9 +139,9 @@ Cataracts: Patient Satisfaction within 90 Days Following Cataract Surgery,304,MI
 Initiation and Engagement of Alcohol and Other Drug Dependence Treatment,305,eCQM,Process,Y,5.891295660296799,3.23,0.76 - 1.05,1.06 - 1.31,1.32 - 1.60,1.61 - 1.93,1.94 - 2.55,2.56 - 3.95,3.96 - 7.04,>= 7.05,No,No,Y
 Cervical Cancer Screening,309,eCQM,Process,Y,23.45052824452815,34.00,11.25 - 17.64,17.65 - 24.55,24.56 - 31.62,31.63 - 38.79,38.80 - 45.88,45.89 - 53.49,53.50 - 65.78,>= 65.79,No,No,N
 Chlamydia Screening for Women,310,eCQM,Process,Y,19.155909256041916,36.41,19.12 - 26.12,26.13 - 30.73,30.74 - 35.71,35.72 - 40.36,40.37 - 45.82,45.83 - 52.16,52.17 - 63.39,>= 63.40,No,No,N
-Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,MIPS CQM,Process,Y,32.666869942487665,55.11,23.48 - 30.84,30.85 - 38.36,38.37 - 49.99,50.00 - 65.11,65.12 - 83.27,83.28 - 96.49,96.50 - 99.99,100.00,No,No,N
-Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,Medicare Part B Claims,Process,Y,25.62055954048287,88.29,88.31 - 97.86,97.87 - 99.46,99.47 - 99.99,--,--,--,--,100.00,Yes,No,N
-Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,eCQM,Process,Y,18.206926514830098,29.39,15.66 - 20.01,20.02 - 23.67,23.68 - 27.30,27.31 - 30.96,30.97 - 34.82,34.83 - 40.06,40.07 - 49.05,>= 49.06,No,No,N
+Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,Medicare Part B Claims,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
+Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,317,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
 Falls: Screening for Future Fall Risk,318,eCQM,Process,Y,34.876631286796794,55.71,14.21 - 30.15,30.16 - 46.36,46.37 - 61.45,61.46 - 74.33,74.34 - 85.17,85.18 - 93.43,93.44 - 98.09,>= 98.10,No,No,Y
 Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients,320,MIPS CQM,Process,Y,23.778908639925596,87.72,87.65 - 93.14,93.15 - 95.34,95.35 - 97.06,97.07 - 98.35,98.36 - 99.61,99.62 - 99.99,--,100.00,Yes,Yes,Y
 Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients,320,Medicare Part B Claims,Process,Y,22.345417681936983,89.55,81.08 - 97.43,97.44 - 99.99,--,--,--,--,--,100.00,Yes,Yes,Y
@@ -224,7 +224,7 @@ Radiation Consideration for Adult CT: Utilization of Dose Lowering Techniques,43
 Radiation Consideration for Adult CT: Utilization of Dose Lowering Techniques,436,Medicare Part B Claims,Process,Y,18.702433184711104,93.67,96.37 - 98.66,98.67 - 99.53,99.54 - 99.92,99.93 - 99.99,--,--,--,100.00,Yes,Yes,N
 Statin Therapy for the Prevention and Treatment of Cardiovascular Disease,438,MIPS CQM,Process,Y,15.745079564619166,83.86,69.70 - 75.53,75.54 - 80.94,80.95 - 84.99,85.00 - 90.90,90.91 - 99.80,99.81 - 99.99,--,100.00,No,No,N
 Statin Therapy for the Prevention and Treatment of Cardiovascular Disease,438,eCQM,Process,Y,11.528772861889554,71.76,65.52 - 68.68,68.69 - 70.99,71.00 - 73.11,73.12 - 75.21,75.22 - 77.48,77.49 - 80.19,80.20 - 83.62,>= 83.63,No,No,N
-Age Appropriate Screening Colonoscopy,439,MIPS CQM,Efficiency,Y,3.8031541884188744,0.67,--,--,--,--,--,--,--,0.00,No,No,Y
+Age Appropriate Screening Colonoscopy,439,MIPS CQM,Efficiency,N,,--,--,--,--,--,--,--,--,--,--,--,Y
 Skin Cancer: Biopsy Reporting Time  Pathologist to Clinician,440,MIPS CQM,Process,Y,2.652457497889701,99.24,99.55 - 99.99,--,--,--,--,--,--,100.00,Yes,Yes,Y
 Ischemic Vascular Disease (IVD) All or None Outcome Measure (Optimal Control),441,MIPS CQM,Intermediate Outcome,Y,24.841253888472053,54.41,30.23 - 39.98,39.99 - 51.48,51.49 - 61.89,61.90 - 67.58,67.59 - 72.54,72.55 - 76.39,76.40 - 80.60,>= 80.61,No,No,Y
 Non-Recommended Cervical Cancer Screening in Adolescent Females,443,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
@@ -252,7 +252,7 @@ Leg Pain After Lumbar Fusion,473,MIPS CQM,Patient-Reported Outcome-Based Perform
 HIV Screening,475,eCQM,Process,Y,13.627676290894684,15.19,3.56 - 6.41,6.42 - 9.15,9.16 - 12.31,12.32 - 15.83,15.84 - 19.06,19.07 - 23.61,23.62 - 33.17,>= 33.18,No,No,N
 Urinary Symptom Score Change 6-12 Months After Diagnosis of Benign Prostatic Hyperplasia,476,eCQM,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
 Multimodal Pain Management,477,MIPS CQM,Process,Y,17.012614579001074,88.40,80.46 - 85.94,85.95 - 91.91,91.92 - 96.15,96.16 - 98.70,98.71 - 99.59,99.60 - 99.92,99.93 - 99.99,100.00,Yes,No,Y
-Functional Status Change for Patients with Neck Impairments,478,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,Y,17.850321668627416,53.79,38.72 - 43.27,43.28 - 47.61,47.62 - 49.28,49.29 - 55.21,55.22 - 66.07,66.08 - 70.36,70.37 - 78.06,>= 78.07,No,No,Y
+Functional Status Change for Patients with Neck Impairments,478,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
 Intravesical Bacillus-Calmette Guerin for Non-muscle Invasive Bladder Cancer,481,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
 Hemodialysis Vascular Access: Practitioner Level Long-term Catheter Rate,482,MIPS CQM,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
 Person-Centered Primary Care Measure Patient Reported Outcome Performance Measure (PCPCM PRO-PM),483,MIPS CQM,Patient-Reported Outcome-Based Performance Measure,N,,--,--,--,--,--,--,--,--,--,--,--,Y
@@ -302,9 +302,9 @@ Use of Capnography for non-Operating Room anesthesia Measure,ABG43,QCDR Measure,
 Known or Suspected Difficult Airway Mitigation Strategies,ABG42,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
 Upper Extremity Nerve Blockade in Shoulder Surgery,ABG41,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
 Chest Pain – Avoidance of admission for adult patients with low-risk chest pain.,ACEP59,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
-ED Median Time from ED arrival to ED departure for all Adult Patients,ACEP50,QCDR Measure,Outcome,Y,0.3115318214693823,-0.11,0.11 - 0.03,0.02 - -0.05,-0.06 - -0.12,-0.13 - -0.18,-0.19 - -0.28,-0.29 - -0.37,-0.38 - -0.49,<= -0.50,No,No,Y
+ED Median Time from ED arrival to ED departure for all Adult Patients,ACEP50,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
 Syncope – Avoidance of admission for adult patients with low-risk syncope,ACEP60,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
-ED Median Time from ED arrival to ED departure for all Pediatric ED Patients,ACEP51,QCDR Measure,Outcome,Y,0.28222993591009526,-0.10,0.13 - 0.01,0.00 - -0.06,-0.07 - -0.10,-0.11 - -0.16,-0.17 - -0.20,-0.21 - -0.29,-0.30 - -0.43,<= -0.44,No,No,Y
+ED Median Time from ED arrival to ED departure for all Pediatric ED Patients,ACEP51,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
 Sepsis Management: Septic Shock: Lactate Clearance Rate of >=10,ACEP30,QCDR Measure,Outcome,Y,6.352834376511372,79.37,73.73 - 74.99,75.00 - 77.21,77.22 - 78.71,78.72 - 79.99,80.00 - 82.60,82.61 - 86.41,86.42 - 88.88,>= 88.89,No,No,Y
 Appropriate Utilization of Focused Assessment with Sonography for Trauma (FAST) Exam in the Emergency Department,ACEP54,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
 Appropriate Emergency Department Utilization of CT for Pulmonary Embolism,ACEP22,QCDR Measure,Process,Y,15.69956626178191,34.26,22.92 - 25.43,25.44 - 28.78,28.79 - 30.63,30.64 - 37.79,37.80 - 40.61,40.62 - 46.13,46.14 - 52.35,>= 52.36,No,No,Y

--- a/staging/2022/benchmarks/json/benchmarks.json
+++ b/staging/2022/benchmarks/json/benchmarks.json
@@ -3,20 +3,40 @@
     "measureId": "001",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      79.99,
+      70,
+      60,
+      50,
+      40,
+      30,
+      20,
+      10
+    ]
+  },
+  {
+    "measureId": "001",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": false,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      90.5,
-      69.42,
-      53.6,
-      42.11,
-      34.06,
-      28.32,
-      23.56,
-      19.1
+      79.99,
+      70,
+      60,
+      50,
+      40,
+      30,
+      20,
+      10
     ]
   },
   {
@@ -29,14 +49,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      90.69,
-      72.51,
-      55.17,
-      41.98,
-      32.56,
-      25.48,
-      19.15,
-      12.87
+      79.99,
+      70,
+      60,
+      50,
+      40,
+      30,
+      20,
+      10
     ]
   },
   {
@@ -49,14 +69,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      1.09,
-      65.52,
-      71.95,
-      75.28,
-      78.09,
-      80.47,
-      82.98,
-      86.36
+      70.26,
+      75.76,
+      78.65,
+      81.82,
+      85.47,
+      88.89,
+      92.31,
+      95.4
     ]
   },
   {
@@ -66,13 +86,13 @@
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": false,
-    "isToppedOutByProgram": false,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      90,
-      95.71,
-      98.02,
-      99.27,
+      92.31,
+      96.3,
+      98.31,
+      100,
       100,
       100,
       100,
@@ -89,13 +109,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      77.58,
-      82.98,
-      86.98,
-      90.35,
-      93.27,
-      95.87,
-      98.94,
+      77.91,
+      83.12,
+      86.51,
+      89.43,
+      92.63,
+      95.91,
+      99.67,
       100
     ]
   },
@@ -109,14 +129,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      45.83,
-      71.57,
-      83.88,
-      88.75,
-      91.79,
-      94.11,
-      95.79,
-      97.75
+      82.14,
+      84.66,
+      86.56,
+      88.33,
+      90,
+      91.67,
+      93.52,
+      96
     ]
   },
   {
@@ -129,12 +149,12 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      49.07,
-      74.04,
-      84.79,
-      91.93,
-      94.72,
-      97.73,
+      80.65,
+      86.81,
+      90,
+      91.86,
+      96.92,
+      100,
       100,
       100
     ]
@@ -144,19 +164,19 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": true,
+    "isToppedOut": false,
     "isHighPriority": false,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      86.69,
-      90.14,
-      92.31,
-      94.05,
-      95.24,
-      96.37,
-      97.44,
-      100
+      84.96,
+      87.76,
+      90.11,
+      91.29,
+      92.58,
+      94.26,
+      95.62,
+      97.34
     ]
   },
   {
@@ -170,8 +190,8 @@
     "deciles": [
       0,
       95,
-      97.5,
-      99.14,
+      97.56,
+      99.1,
       100,
       100,
       100,
@@ -189,14 +209,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      65.38,
-      70.69,
-      74.34,
-      78.04,
-      80.95,
-      83.77,
-      86.67,
-      90.56
+      66.3,
+      74.23,
+      78.18,
+      80.43,
+      82.5,
+      84.65,
+      86.73,
+      90.91
     ]
   },
   {
@@ -209,34 +229,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      83.62,
-      88.72,
-      92.31,
-      95.06,
-      96.97,
-      98.33,
-      99.29,
-      100
-    ]
-  },
-  {
-    "measureId": "014",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
+      79.71,
+      86.74,
+      91.39,
+      94.85,
+      96.84,
+      98.26,
+      99.17,
+      99.89
     ]
   },
   {
@@ -249,12 +249,12 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      86.18,
-      91.75,
-      95.02,
-      96.93,
-      98.52,
-      99.59,
+      88.05,
+      92.59,
+      95.85,
+      97.87,
+      99.34,
+      100,
       100,
       100
     ]
@@ -269,14 +269,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      54.33,
-      66.67,
-      75.34,
-      81.6,
-      87.18,
-      91.37,
-      95.08,
-      97.88
+      62.5,
+      72.41,
+      80.37,
+      85.83,
+      90.32,
+      93.71,
+      96.87,
+      99.03
     ]
   },
   {
@@ -289,233 +289,113 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      83.62,
+      79.11,
+      90.91,
+      96.92,
+      99.65,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "024",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      12.07,
+      45,
+      61.65,
+      77.97,
+      87.36,
+      97.06,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "039",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      35.96,
+      47,
+      60,
+      70.68,
+      78.46,
+      88.6,
+      97.58,
+      100
+    ]
+  },
+  {
+    "measureId": "039",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      17.3,
+      31.01,
+      45.23,
+      56.71,
+      66.27,
+      75.3,
+      83.33,
+      95.6
+    ]
+  },
+  {
+    "measureId": "047",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      83.21,
+      98.46,
+      99.77,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "047",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      27.11,
+      51.83,
+      71.89,
+      85.05,
       93.53,
-      97.83,
-      99.93,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "021",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "021",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      78.79,
-      97.51,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "023",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "023",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      95.45,
-      99.91,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "024",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      79.31,
-      94.24,
-      96.08,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "024",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      14.13,
-      36.36,
-      78.07,
-      82.88,
-      87.88,
-      93.75,
-      99.8,
-      100
-    ]
-  },
-  {
-    "measureId": "039",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      37.13,
-      49.57,
-      59.31,
-      66.38,
-      76.03,
-      87.21,
-      96.34,
-      100
-    ]
-  },
-  {
-    "measureId": "039",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      13.41,
-      28.59,
-      39.8,
-      51.49,
-      61.47,
-      70.35,
-      79.68,
-      90.85
-    ]
-  },
-  {
-    "measureId": "044",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      94.29,
-      96.51,
-      98.57,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "047",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      84.39,
-      97.46,
-      99.7,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "047",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      20.33,
-      43.84,
-      64.44,
-      79.02,
-      89.24,
-      95.6,
-      98.95,
+      98.27,
+      99.77,
       100
     ]
   },
@@ -529,33 +409,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      23.56,
-      40.07,
-      57.38,
-      73.75,
-      82.39,
-      93.05,
-      98.54,
-      100
-    ]
-  },
-  {
-    "measureId": "050",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      97.56,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
+      17.86,
+      37.82,
+      57.45,
+      71.43,
+      85.6,
+      95.62,
+      99.67,
       100
     ]
   },
@@ -569,12 +429,12 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      57.62,
-      74.66,
-      84.46,
-      90.28,
-      95.86,
-      99.85,
+      53.01,
+      72.18,
+      84.29,
+      91.38,
+      96.6,
+      100,
       100,
       100
     ]
@@ -589,11 +449,11 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      84.62,
-      95,
-      98.29,
-      99.67,
-      100,
+      70.09,
+      81.32,
+      90.9,
+      97.95,
+      99.82,
       100,
       100,
       100
@@ -609,112 +469,52 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      76.15,
-      80.79,
+      81.7,
+      85.42,
+      88.33,
+      90.91,
+      92.95,
+      95.43,
+      97.73,
+      100
+    ]
+  },
+  {
+    "measureId": "066",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      57.92,
+      68.75,
+      75.45,
+      80.91,
+      85.17,
+      88.17,
+      92.04,
+      95.83
+    ]
+  },
+  {
+    "measureId": "066",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
       84.39,
-      87.1,
-      90.11,
-      92.86,
-      95.58,
-      100
-    ]
-  },
-  {
-    "measureId": "065",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      93.33,
-      95.45,
-      97.14,
-      98.44,
-      99.41,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "066",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      52.34,
-      67.16,
-      76.08,
-      81.75,
-      85.53,
-      87.84,
-      90.69,
-      94.46
-    ]
-  },
-  {
-    "measureId": "066",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      80.85,
-      88.09,
-      93.1,
-      97.11,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "067",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      96.41,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "070",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      64.44,
-      98.46,
-      100,
-      100,
-      100,
-      100,
+      88.73,
+      91.84,
+      93.9,
+      95.65,
+      97.3,
       100,
       100
     ]
@@ -729,7 +529,7 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      99.7,
+      100,
       100,
       100,
       100,
@@ -749,29 +549,9 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      97.2,
-      99.43,
+      95.92,
+      99.31,
       100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "093",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      93.55,
-      96.3,
-      98.11,
       100,
       100,
       100,
@@ -789,32 +569,12 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      83.89,
-      89.46,
-      92.86,
-      95.52,
-      97.26,
-      98.84,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "102",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      90.61,
-      97.12,
-      100,
-      100,
-      100,
-      100,
+      86.36,
+      91.3,
+      94.03,
+      96.18,
+      97.5,
+      99.23,
       100,
       100
     ]
@@ -829,8 +589,8 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      95.85,
-      99.61,
+      83.62,
+      94.25,
       100,
       100,
       100,
@@ -849,14 +609,74 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      2.04,
-      4.76,
-      10.48,
-      22.13,
-      37.61,
-      57.23,
-      72.49,
-      92.62
+      1.15,
+      2.7,
+      7.37,
+      14.62,
+      28.77,
+      46.53,
+      71.6,
+      90.8
+    ]
+  },
+  {
+    "measureId": "110",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      63.2,
+      78.85,
+      87.24,
+      93.68,
+      98.71,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "110",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      18.75,
+      28.57,
+      36.95,
+      44.21,
+      51.26,
+      58.63,
+      67.61,
+      80.4
+    ]
+  },
+  {
+    "measureId": "110",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      35.39,
+      50.61,
+      62.47,
+      74.26,
+      84.63,
+      92.76,
+      98.47,
+      100
     ]
   },
   {
@@ -869,12 +689,12 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      68.68,
-      76.32,
-      82.47,
-      87.57,
-      93.09,
-      97.9,
+      67.34,
+      75.93,
+      81.11,
+      86.88,
+      92.79,
+      97.7,
       100,
       100
     ]
@@ -889,14 +709,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      20.44,
-      33.72,
-      44.7,
-      54.86,
-      63.22,
-      71.1,
-      78.8,
-      87.93
+      20.82,
+      35.06,
+      46.56,
+      56.48,
+      64.72,
+      72.56,
+      79.89,
+      88.32
     ]
   },
   {
@@ -909,14 +729,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      35.11,
-      51.29,
-      61.9,
-      69.16,
+      42.58,
+      55.58,
+      64.5,
+      70.3,
       75,
-      79.9,
-      85.83,
-      95
+      79.63,
+      85.88,
+      96.3
     ]
   },
   {
@@ -929,13 +749,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      66.67,
-      77.08,
-      84.88,
-      89.63,
-      93.48,
-      97.36,
-      99.03,
+      64.66,
+      75,
+      81.66,
+      86.45,
+      91.04,
+      95.83,
+      98.85,
       100
     ]
   },
@@ -949,14 +769,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      24.44,
-      37.14,
-      46.32,
-      54.41,
-      61.11,
-      67.23,
-      73.95,
-      82.02
+      24.92,
+      36.04,
+      45.5,
+      52.87,
+      59.4,
+      65.41,
+      72.12,
+      80.69
     ]
   },
   {
@@ -969,14 +789,34 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      22.37,
-      40,
-      50.98,
-      60.27,
-      70.21,
-      78.11,
-      85.85,
-      97.36
+      24.55,
+      41.5,
+      51.25,
+      60.65,
+      68.28,
+      74.87,
+      84.78,
+      97.67
+    ]
+  },
+  {
+    "measureId": "113",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      57.94,
+      70.47,
+      82.01,
+      89.67,
+      95.57,
+      99.32,
+      100,
+      100
     ]
   },
   {
@@ -989,32 +829,52 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      15.15,
-      27.52,
-      38.74,
-      49.05,
-      58.31,
-      67.55,
-      76.06,
-      85.06
+      16.32,
+      28.66,
+      40,
+      49.25,
+      57.83,
+      66.74,
+      74.99,
+      84.37
     ]
   },
   {
-    "measureId": "116",
+    "measureId": "113",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
+    "isToppedOut": false,
+    "isHighPriority": false,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      62.33,
-      76,
-      86.36,
-      93.33,
-      96.92,
-      98.43,
+      17.93,
+      34.8,
+      51.81,
+      61.06,
+      74.19,
+      82.04,
+      92.41,
+      99.43
+    ]
+  },
+  {
+    "measureId": "117",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
       100,
       100
     ]
@@ -1029,14 +889,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      12,
-      20.55,
-      30.69,
-      44.82,
-      69.4,
-      94.17,
-      98.43,
-      99.93
+      13.19,
+      22.03,
+      31.86,
+      44.62,
+      65.97,
+      95.94,
+      99.14,
+      100
     ]
   },
   {
@@ -1049,10 +909,10 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      89.93,
-      96.68,
-      98.86,
-      99.7,
+      94.31,
+      97.86,
+      99.33,
+      99.86,
       100,
       100,
       100,
@@ -1069,14 +929,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      72.73,
-      76.32,
-      79.61,
-      81.85,
-      85,
-      86.83,
-      90.48,
-      96
+      71.43,
+      75.61,
+      78.25,
+      81.39,
+      84.21,
+      86.99,
+      92,
+      100
     ]
   },
   {
@@ -1089,14 +949,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      70.31,
-      76.92,
-      81.55,
-      85.23,
-      88.24,
-      91.41,
-      94.78,
-      98.55
+      72.45,
+      77.78,
+      81.71,
+      84.67,
+      87.35,
+      90.43,
+      93.98,
+      98.87
     ]
   },
   {
@@ -1109,12 +969,12 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      71.17,
-      79.48,
-      86.67,
-      91.81,
-      96.23,
-      98.68,
+      70.74,
+      79.51,
+      85.06,
+      89.74,
+      94.03,
+      98.1,
       100,
       100
     ]
@@ -1124,16 +984,16 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": false,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      59.55,
-      74.76,
-      86.49,
-      94.87,
-      99.32,
+      73.01,
+      84.97,
+      93.58,
+      98.56,
+      100,
       100,
       100,
       100
@@ -1144,16 +1004,16 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": false,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      58.76,
-      74.03,
-      85.06,
-      94.65,
-      99.18,
+      66.3,
+      80.12,
+      92.71,
+      98.7,
+      100,
       100,
       100,
       100
@@ -1169,9 +1029,9 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      91.47,
+      92.37,
       98.58,
-      99.73,
+      99.72,
       100,
       100,
       100,
@@ -1189,14 +1049,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      23.26,
-      27.42,
-      32.65,
-      40.91,
-      53.43,
-      69.27,
-      83.8,
-      95.12
+      23.35,
+      28.14,
+      34.68,
+      43.57,
+      56.81,
+      73.6,
+      86.18,
+      95.39
     ]
   },
   {
@@ -1209,13 +1069,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      32.73,
-      51.06,
-      70.17,
-      84.69,
-      93.28,
-      98.06,
-      99.76,
+      35.17,
+      55.72,
+      76.04,
+      88.51,
+      95.81,
+      99.08,
+      100,
       100
     ]
   },
@@ -1230,7 +1090,7 @@
     "deciles": [
       0,
       99.67,
-      99.94,
+      99.97,
       100,
       100,
       100,
@@ -1249,14 +1109,14 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      83.73,
-      91.28,
-      94.91,
-      97,
-      98.31,
-      99.18,
-      99.7,
-      99.95
+      80.38,
+      88.24,
+      92.36,
+      95.26,
+      97.17,
+      98.42,
+      99.33,
+      99.9
     ]
   },
   {
@@ -1269,11 +1129,11 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      86.71,
-      96.32,
-      98.95,
-      99.68,
-      99.91,
+      77.92,
+      90.47,
+      95.6,
+      98.15,
+      99.69,
       100,
       100,
       100
@@ -1289,7 +1149,7 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      95.94,
+      95.29,
       99.51,
       100,
       100,
@@ -1303,19 +1163,39 @@
     "measureId": "134",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      6.33,
+      12.67,
+      20.8,
+      30.77,
+      42.72,
+      55.96,
+      70.44,
+      87.36
+    ]
+  },
+  {
+    "measureId": "134",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
     "submissionMethod": "registry",
     "isToppedOut": false,
     "isHighPriority": false,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      14.76,
-      37.44,
-      55.93,
-      71.74,
-      84.69,
-      95.56,
-      99.22,
+      34.63,
+      60.11,
+      79.7,
+      89.61,
+      97.14,
+      99.42,
+      100,
       100
     ]
   },
@@ -1329,8 +1209,8 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      95,
-      98.84,
+      98.18,
+      100,
       100,
       100,
       100,
@@ -1349,9 +1229,9 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      75.51,
-      92.59,
-      98.81,
+      81.28,
+      96,
+      100,
       100,
       100,
       100,
@@ -1389,12 +1269,12 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      32.62,
-      60.32,
-      82.14,
-      93.48,
-      98.55,
-      100,
+      46.38,
+      69.03,
+      81.82,
+      90.44,
+      95.42,
+      98.28,
       100,
       100
     ]
@@ -1404,19 +1284,19 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      67.56,
-      85.32,
-      91.89,
-      95.34,
-      97.07,
-      97.96,
-      98.8,
-      99.81
+      75.43,
+      87.06,
+      92.86,
+      95.99,
+      97.44,
+      98.32,
+      98.99,
+      99.83
     ]
   },
   {
@@ -1429,10 +1309,10 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      93.65,
-      97.66,
-      99.21,
-      99.84,
+      90.07,
+      95.87,
+      98.6,
+      99.56,
       100,
       100,
       100,
@@ -1440,158 +1320,138 @@
     ]
   },
   {
-    "measureId": "145",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      85.71,
-      94.44,
-      97.62,
-      99.19,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "145",
+    "measureId": "144",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      86.61,
-      95.48,
-      98.41,
-      99.73,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "147",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      71.43,
-      85.71,
-      95.45,
-      98.46,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "147",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      93.66,
-      98.92,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "154",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      99.07,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "154",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      87.86,
-      96.13,
-      98.82,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "155",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      87.5,
-      98.08,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "155",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
+    "isToppedOut": false,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      85.88,
-      93.88,
-      97.84,
+      66.67,
+      78.72,
+      87.39,
+      93.22,
+      96.8,
+      98.97,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "145",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      76.12,
+      89.83,
+      96,
+      99.7,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "145",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      93.69,
+      99,
+      99.92,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "147",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      60.77,
+      82.22,
+      95.24,
+      98.33,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "147",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      97.16,
+      99.78,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "155",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      95.74,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "155",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      93.1,
+      97.9,
+      100,
       100,
       100,
       100,
@@ -1609,13 +1469,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      8.8,
-      7.69,
-      5.87,
-      5,
-      3.52,
-      2.63,
-      1.59,
+      9.52,
+      7.89,
+      5.66,
+      5.17,
+      3.85,
+      3.45,
+      2.7,
       0
     ]
   },
@@ -1629,12 +1489,12 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      3.6,
-      2.44,
-      2.04,
-      1.47,
-      1.22,
-      0.55,
+      3.96,
+      3.51,
+      2.55,
+      1.96,
+      1.51,
+      0.95,
       0,
       0
     ]
@@ -1649,13 +1509,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      3.04,
-      2.48,
-      2.14,
-      1.55,
-      1.21,
-      0.48,
-      0,
+      4.2,
+      3.46,
+      2.67,
+      2.3,
+      1.7,
+      1.6,
+      0.58,
       0
     ]
   },
@@ -1664,16 +1524,16 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": false,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      51.61,
-      77.63,
-      89.71,
-      93.2,
-      97.37,
+      60,
+      81.97,
+      90.91,
+      97.95,
+      100,
       100,
       100,
       100
@@ -1689,13 +1549,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      65.49,
-      75.2,
-      85.38,
-      91.04,
-      95.22,
-      98.23,
-      99.67,
+      47.31,
+      69.95,
+      78.04,
+      87.6,
+      92.81,
+      98.92,
+      100,
       100
     ]
   },
@@ -1709,11 +1569,11 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      76.28,
-      89.4,
-      94.26,
-      97.72,
-      99.03,
+      87.85,
+      92.45,
+      96.71,
+      99.07,
+      100,
       100,
       100,
       100
@@ -1726,11 +1586,11 @@
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": false,
-    "isToppedOutByProgram": false,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      98.26,
-      99.69,
+      100,
+      100,
       100,
       100,
       100,
@@ -1749,69 +1609,49 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      98.88,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "181",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      58.52,
-      78.66,
-      89.13,
-      95.66,
-      98.92,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "182",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      99.56,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "182",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      98.57,
-      99.59,
+      99.1,
       99.84,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "181",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      92.48,
+      97.81,
+      99.6,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "182",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      98.52,
+      99.66,
+      99.87,
       100,
       100,
       100,
@@ -1824,17 +1664,17 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      44.62,
       81.25,
-      90.59,
-      95.74,
-      98.05,
-      99.55,
+      89.37,
+      97.87,
+      99.49,
+      100,
+      100,
       100,
       100
     ]
@@ -1849,12 +1689,12 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      82.74,
-      88.32,
-      91.67,
-      93.55,
-      95.45,
-      97.22,
+      86.46,
+      93.42,
+      96.15,
+      100,
+      100,
+      100,
       100,
       100
     ]
@@ -1869,13 +1709,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      88.04,
-      93.46,
-      95.71,
-      97.13,
-      98.23,
-      98.86,
-      99.5,
+      88.67,
+      93.02,
+      95.35,
+      96.83,
+      97.97,
+      98.81,
+      99.64,
       100
     ]
   },
@@ -1889,30 +1729,10 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      94.17,
-      96.3,
-      97.44,
-      98.45,
-      99.45,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "195",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      97.77,
-      99.4,
-      100,
-      100,
+      92.83,
+      95.52,
+      97.33,
+      98.55,
       100,
       100,
       100,
@@ -1920,47 +1740,7 @@
     ]
   },
   {
-    "measureId": "195",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      99.28,
-      99.84,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "225",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "225",
+    "measureId": "217",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
@@ -1969,12 +1749,172 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
+      42.22,
+      44.9,
+      48.28,
+      50.79,
+      54.21,
+      60.23,
+      68,
+      81.82
+    ]
+  },
+  {
+    "measureId": "218",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      36.73,
+      42.63,
+      45.71,
+      50,
+      54.39,
+      58.36,
+      62.86,
+      72.22
+    ]
+  },
+  {
+    "measureId": "219",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      35.48,
+      44,
+      48,
+      51.13,
+      53.85,
+      57.76,
+      63.33,
+      68.75
+    ]
+  },
+  {
+    "measureId": "220",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      39.68,
+      45.79,
+      48.26,
+      54.9,
+      60,
+      65.66,
+      72.06,
+      87.18
+    ]
+  },
+  {
+    "measureId": "221",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      35.44,
+      40.18,
+      43.87,
+      47.05,
+      52.81,
+      59.47,
+      71.23,
+      81.43
+    ]
+  },
+  {
+    "measureId": "222",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      41.41,
+      44.36,
+      49.48,
+      51.92,
+      58.33,
+      61.9,
+      71.93,
+      80
+    ]
+  },
+  {
+    "measureId": "226",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      87.18,
+      95.38,
       100,
       100,
       100,
       100,
       100,
-      100,
+      100
+    ]
+  },
+  {
+    "measureId": "226",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      18.92,
+      25.81,
+      34.17,
+      44.44,
+      56.63,
+      70.37,
+      84.11,
+      95.42
+    ]
+  },
+  {
+    "measureId": "226",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      30.91,
+      49.09,
+      66.67,
+      80.88,
+      90.78,
+      96.46,
       100,
       100
     ]
@@ -2009,14 +1949,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      51.69,
-      57.08,
-      61.33,
-      64.8,
-      68.45,
-      72.04,
-      76.36,
-      82.38
+      51.06,
+      56.31,
+      60.14,
+      63.64,
+      67.05,
+      70.65,
+      74.95,
+      80.84
     ]
   },
   {
@@ -2037,6 +1977,46 @@
       70,
       80,
       90
+    ]
+  },
+  {
+    "measureId": "238",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      12.98,
+      7.56,
+      3.87,
+      1.64,
+      0.63,
+      0.18,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "238",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      3.4,
+      1.33,
+      0.63,
+      0.32,
+      0.16,
+      0.03,
+      0,
+      0
     ]
   },
   {
@@ -2049,14 +2029,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      27.47,
-      30.49,
-      32.13,
-      33.33,
-      34.48,
-      38.54,
-      47.93,
-      63.65
+      25.64,
+      29.13,
+      31.21,
+      32.86,
+      34.67,
+      39.77,
+      49.69,
+      63.88
     ]
   },
   {
@@ -2069,14 +2049,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      17.93,
-      25.54,
-      32.4,
-      36.75,
-      40.19,
-      44.74,
-      49.57,
-      56.86
+      23.44,
+      31.82,
+      37.27,
+      41.63,
+      45.94,
+      50.05,
+      53.23,
+      59.69
     ]
   },
   {
@@ -2089,14 +2069,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      19.02,
-      25.64,
-      31.43,
-      37.14,
-      42.86,
-      48.98,
-      63.71,
-      90.58
+      12.75,
+      17.03,
+      23.76,
+      29.87,
+      36.33,
+      45.84,
+      59.49,
+      90.91
     ]
   },
   {
@@ -2189,12 +2169,12 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      88.64,
-      92.25,
-      95.26,
-      96.77,
-      98.25,
-      99.18,
+      91.09,
+      93.42,
+      95.38,
+      96.7,
+      98.01,
+      99.53,
       100,
       100
     ]
@@ -2209,9 +2189,9 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      78.39,
-      95.41,
-      99.08,
+      85.06,
+      97.2,
+      100,
       100,
       100,
       100,
@@ -2229,13 +2209,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      14.49,
-      24,
-      39.22,
-      50,
-      65.48,
-      89.5,
-      95,
+      12.88,
+      21.24,
+      29.85,
+      53.7,
+      67.57,
+      75.47,
+      100,
       100
     ]
   },
@@ -2249,12 +2229,12 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      24,
-      42.8,
-      58.23,
-      71.65,
-      93.1,
-      99.87,
+      24.14,
+      40.34,
+      58.92,
+      78.79,
+      94.16,
+      100,
       100,
       100
     ]
@@ -2269,10 +2249,10 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      88.15,
-      95.65,
-      98.69,
-      100,
+      78.32,
+      90.91,
+      96.56,
+      99.43,
       100,
       100,
       100,
@@ -2289,14 +2269,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      8.33,
-      13.64,
-      21.74,
-      31.58,
-      44.83,
-      59.74,
-      73.91,
-      91.89
+      7.19,
+      13.04,
+      21.31,
+      30,
+      41.84,
+      56,
+      71.53,
+      88.89
     ]
   },
   {
@@ -2304,15 +2284,15 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": false,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      43.54,
-      68.18,
-      91.04,
-      98.24,
+      83.13,
+      97.2,
+      100,
+      100,
       100,
       100,
       100,
@@ -2329,10 +2309,10 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      75,
-      92.45,
-      96.37,
-      98.68,
+      90.91,
+      99.55,
+      100,
+      100,
       100,
       100,
       100,
@@ -2349,9 +2329,9 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      86.36,
-      93.38,
-      97.67,
+      93.37,
+      99.73,
+      100,
       100,
       100,
       100,
@@ -2364,16 +2344,16 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      43.28,
-      66.67,
-      83.33,
-      95.39,
-      98.33,
+      63.85,
+      92.55,
+      99.19,
+      100,
+      100,
       100,
       100,
       100
@@ -2386,14 +2366,14 @@
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": false,
-    "isToppedOutByProgram": false,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      34.39,
-      57.47,
-      81.08,
-      92.06,
-      98.06,
+      64.07,
+      86.36,
+      94.44,
+      100,
+      100,
       100,
       100,
       100
@@ -2409,10 +2389,10 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      25.57,
-      59.89,
-      89.28,
-      98.94,
+      32.76,
+      73.39,
+      92.06,
+      100,
       100,
       100,
       100,
@@ -2424,16 +2404,16 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": true,
+    "isToppedOut": false,
     "isHighPriority": true,
-    "isToppedOutByProgram": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
-      48.35,
-      65.71,
-      85.71,
-      93.73,
-      100,
+      15.58,
+      40.2,
+      77.62,
+      84.53,
+      95.28,
       100,
       100,
       100
@@ -2449,14 +2429,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      0.27,
-      0.43,
-      0.64,
-      0.92,
-      1.25,
-      1.85,
-      2.91,
-      7.65
+      0.76,
+      1.06,
+      1.32,
+      1.61,
+      1.94,
+      2.56,
+      3.96,
+      7.05
     ]
   },
   {
@@ -2469,14 +2449,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      11.36,
-      18.37,
-      25,
-      32.29,
-      39.57,
-      46.81,
-      55.56,
-      68.17
+      11.25,
+      17.65,
+      24.56,
+      31.63,
+      38.8,
+      45.89,
+      53.5,
+      65.79
     ]
   },
   {
@@ -2489,14 +2469,74 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      19.88,
-      26.67,
-      32.2,
-      37.66,
-      42.47,
-      47.5,
-      56.07,
-      65.97
+      19.12,
+      26.13,
+      30.74,
+      35.72,
+      40.37,
+      45.83,
+      52.17,
+      63.4
+    ]
+  },
+  {
+    "measureId": "317",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      88.31,
+      97.87,
+      99.47,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "317",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      15.66,
+      20.02,
+      23.68,
+      27.31,
+      30.97,
+      34.83,
+      40.07,
+      49.06
+    ]
+  },
+  {
+    "measureId": "317",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      23.48,
+      30.85,
+      38.37,
+      50,
+      65.12,
+      83.28,
+      96.5,
+      100
     ]
   },
   {
@@ -2509,14 +2549,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      18.81,
-      36.28,
-      52.34,
-      66.65,
-      78.72,
-      87.5,
-      94.19,
-      98.27
+      14.21,
+      30.16,
+      46.37,
+      61.46,
+      74.34,
+      85.18,
+      93.44,
+      98.1
     ]
   },
   {
@@ -2529,8 +2569,8 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      92.68,
-      99.07,
+      81.08,
+      97.44,
       100,
       100,
       100,
@@ -2549,12 +2589,12 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      81.69,
-      89.02,
-      93.3,
-      95.81,
-      97.47,
-      98.61,
+      87.65,
+      93.15,
+      95.35,
+      97.07,
+      98.36,
+      99.62,
       100,
       100
     ]
@@ -2569,8 +2609,8 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      0.33,
-      0,
+      1.22,
+      0.19,
       0,
       0,
       0,
@@ -2589,7 +2629,7 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      0,
+      0.05,
       0,
       0,
       0,
@@ -2609,8 +2649,8 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      2.51,
-      0.71,
+      3.5,
+      0.42,
       0,
       0,
       0,
@@ -2623,37 +2663,17 @@
     "measureId": "326",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      98.63,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "326",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": false,
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      79.1,
-      83.68,
-      88.46,
-      94.51,
-      98.71,
+      82.65,
+      96,
+      99.08,
+      100,
+      100,
       100,
       100,
       100
@@ -2669,13 +2689,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      75.95,
-      62.5,
-      50.12,
-      37.57,
-      25.12,
-      14.81,
-      5.28,
+      65.71,
+      51.85,
+      41.75,
+      30,
+      20.38,
+      10.71,
+      4,
       0
     ]
   },
@@ -2689,33 +2709,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      52.44,
-      61.37,
-      72.64,
-      85.76,
-      89.94,
-      96.13,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "337",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      68,
-      80.77,
-      88.89,
-      94.42,
-      97.54,
-      100,
-      100,
+      69.39,
+      73.58,
+      76.88,
+      81.45,
+      85.71,
+      90.06,
+      98,
       100
     ]
   },
@@ -2729,12 +2729,12 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      76.89,
-      84.21,
-      87.33,
-      91.55,
-      95.37,
-      96.97,
+      77.17,
+      86.34,
+      88.11,
+      92.78,
+      95.56,
+      98.25,
       100,
       100
     ]
@@ -2749,73 +2749,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      54.8,
-      60.09,
-      70,
-      75,
-      84.51,
-      98.48,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "342",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "350",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      99.6,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "351",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": true,
-    "deciles": [
-      0,
-      99.36,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
+      50.57,
+      58.06,
+      61.48,
+      68.71,
+      72.22,
+      88.36,
+      96.92,
       100
     ]
   },
@@ -2829,11 +2769,11 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      3.23,
-      1.79,
-      0,
-      0,
-      0,
+      7.8,
+      4.5,
+      3.85,
+      1.89,
+      0.83,
       0,
       0,
       0
@@ -2849,10 +2789,10 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      2.45,
-      1.33,
-      0.79,
-      0.18,
+      3.55,
+      2.02,
+      1.2,
+      0.64,
       0,
       0,
       0,
@@ -2869,11 +2809,11 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      5.76,
-      3.95,
+      6.19,
+      4,
       2.78,
-      1.09,
-      0,
+      2.14,
+      1.06,
       0,
       0,
       0
@@ -2889,9 +2829,9 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      3.33,
-      1.82,
-      0.77,
+      2.71,
+      1.05,
+      0.39,
       0,
       0,
       0,
@@ -2904,15 +2844,15 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      34.62,
-      72.43,
-      91.23,
-      98.51,
+      71.08,
+      88.59,
+      96.85,
+      99.62,
       100,
       100,
       100,
@@ -2929,9 +2869,9 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      85.51,
-      98.77,
-      99.94,
+      67.86,
+      96.48,
+      99.72,
       100,
       100,
       100,
@@ -2946,37 +2886,17 @@
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": true,
-    "isToppedOutByProgram": false,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      95.83,
-      98.11,
-      100,
+      61.97,
+      79.07,
+      96.37,
       100,
       100,
       100,
       100,
       100
-    ]
-  },
-  {
-    "measureId": "366",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      20.31,
-      24.14,
-      29.55,
-      35.95,
-      39.53,
-      45.49,
-      50.59,
-      65.64
     ]
   },
   {
@@ -2989,14 +2909,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      3.65,
-      4.92,
-      6.34,
-      7.61,
-      9.63,
-      12,
-      15,
-      22.03
+      3.67,
+      4.87,
+      6.97,
+      8.33,
+      10.79,
+      13.94,
+      17.65,
+      25.42
     ]
   },
   {
@@ -3009,14 +2929,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      9.72,
-      16.98,
-      25.51,
-      34.93,
-      46.43,
-      60,
-      74.6,
-      89.66
+      7.71,
+      12.5,
+      18.73,
+      26.32,
+      37.1,
+      51.19,
+      66.67,
+      87.32
     ]
   },
   {
@@ -3024,15 +2944,15 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      60,
-      77.55,
-      92.31,
-      97.55,
+      62.79,
+      85.64,
+      94.76,
+      98.62,
       100,
       100,
       100,
@@ -3049,14 +2969,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      8.19,
-      10.32,
-      14.84,
-      21.1,
-      29.09,
-      37.5,
-      51.35,
-      61.03
+      2.65,
+      4.63,
+      6.62,
+      8.89,
+      10.91,
+      13.79,
+      20.73,
+      28.31
     ]
   },
   {
@@ -3069,14 +2989,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      4.73,
-      8.33,
-      11.54,
-      15.83,
-      19.75,
-      33.33,
-      53.57,
-      100
+      4.07,
+      5.34,
+      5.77,
+      9.66,
+      12.68,
+      16.87,
+      20,
+      28.23
     ]
   },
   {
@@ -3089,8 +3009,8 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      0.87,
-      0.38,
+      0.88,
+      0.41,
       0,
       0,
       0,
@@ -3109,14 +3029,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      0.26,
-      0.54,
-      1.1,
-      2.19,
-      3.85,
+      0.18,
+      0.43,
+      0.95,
+      2.14,
+      3.4,
       5.23,
-      7.31,
-      13.67
+      8.58,
+      11.32
     ]
   },
   {
@@ -3129,14 +3049,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      7.45,
-      12.5,
-      19.12,
-      29.8,
-      39.09,
-      47.11,
-      58.71,
-      87.47
+      5.79,
+      12,
+      17.48,
+      28.47,
+      35.85,
+      51.75,
+      59.74,
+      84.15
     ]
   },
   {
@@ -3149,10 +3069,10 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      51.52,
-      80.85,
-      96.52,
-      100,
+      81.08,
+      93.02,
+      95.56,
+      99.32,
       100,
       100,
       100,
@@ -3164,14 +3084,14 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      96,
-      100,
-      100,
+      93.33,
+      96.43,
+      97.92,
       100,
       100,
       100,
@@ -3189,13 +3109,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      30.48,
-      38.54,
-      51.95,
-      71.08,
-      94.46,
-      98.19,
-      100,
+      21.48,
+      29.54,
+      39.35,
+      69.94,
+      92.86,
+      97.14,
+      99.87,
       100
     ]
   },
@@ -3209,14 +3129,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      3.28,
+      5.88,
       7.69,
-      18.59,
-      22.73,
-      23.97,
-      30.43,
-      38.73,
-      46.67
+      12,
+      17.5,
+      21.69,
+      25.56,
+      31.58,
+      40
     ]
   },
   {
@@ -3309,7 +3229,7 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      100,
+      99.26,
       100,
       100,
       100,
@@ -3349,34 +3269,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      33.33,
-      49.29,
-      58.05,
-      80.14,
-      100,
+      33.17,
+      41.12,
+      48.05,
+      69.55,
+      91.28,
       100,
       100,
       100
-    ]
-  },
-  {
-    "measureId": "400",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      1.39,
-      2.03,
-      3.94,
-      9.29,
-      18.03,
-      28.78,
-      43.82,
-      75.53
     ]
   },
   {
@@ -3389,11 +3289,11 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      88.14,
-      93.55,
-      96.55,
-      98.46,
-      99.56,
+      89.41,
+      94.12,
+      96.88,
+      98.64,
+      99.74,
       100,
       100,
       100
@@ -3409,34 +3309,34 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      53.27,
-      62.2,
-      68.18,
-      73.18,
-      79.19,
-      84.43,
-      91.76,
-      98.21
+      59.9,
+      66.67,
+      73.1,
+      78.82,
+      84.72,
+      89.19,
+      92.87,
+      99.89
     ]
   },
   {
-    "measureId": "406",
+    "measureId": "405",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
-    "submissionMethod": "claims",
+    "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": true,
-    "isToppedOutByProgram": true,
+    "isToppedOutByProgram": false,
     "deciles": [
+      0,
+      75.47,
+      88.46,
+      96.36,
+      98.61,
       100,
-      0.4,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
+      100,
+      100,
+      100
     ]
   },
   {
@@ -3449,8 +3349,8 @@
     "isToppedOutByProgram": true,
     "deciles": [
       100,
-      2.27,
-      0,
+      6.67,
+      3.17,
       0,
       0,
       0,
@@ -3469,12 +3369,12 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      56.12,
-      70.59,
-      80,
-      87.88,
-      93.33,
-      97.44,
+      58.22,
+      73.08,
+      84.68,
+      91.76,
+      96.59,
+      100,
       100,
       100
     ]
@@ -3489,13 +3389,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      83.73,
-      90.91,
-      94.44,
-      96.4,
-      97.56,
-      98.55,
-      99.42,
+      82.24,
+      86.73,
+      90.48,
+      94.55,
+      96.62,
+      98.17,
+      99.33,
       100
     ]
   },
@@ -3509,14 +3409,34 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      27.21,
-      20,
-      12.12,
-      5.88,
-      3.45,
-      2.04,
+      25.15,
+      17.92,
+      12.6,
+      9.31,
+      5.56,
+      2.07,
       0,
       0
+    ]
+  },
+  {
+    "measureId": "418",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      3.33,
+      4,
+      5.07,
+      8.09,
+      10.71,
+      15.12,
+      21.62,
+      54.55
     ]
   },
   {
@@ -3526,16 +3446,16 @@
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": true,
-    "isToppedOutByProgram": false,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
-      28.52,
-      16.35,
-      10.43,
-      5.35,
-      3.23,
-      1.62,
-      0.2,
+      23.08,
+      14.41,
+      9.23,
+      5.06,
+      4.35,
+      2.94,
+      1.53,
       0
     ]
   },
@@ -3544,15 +3464,15 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      98.22,
-      99.27,
-      99.69,
-      99.86,
+      98.08,
+      99.28,
+      99.75,
+      99.91,
       99.97,
       100,
       100,
@@ -3563,40 +3483,20 @@
     "measureId": "425",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      98.8,
-      99.44,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "425",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": false,
-    "isToppedOutByProgram": false,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      89.1,
-      94.78,
-      96.73,
-      97.96,
-      98.56,
-      99.13,
-      99.48,
-      99.95
+      92.57,
+      95.25,
+      97.18,
+      98.27,
+      99.02,
+      99.53,
+      99.96,
+      100
     ]
   },
   {
@@ -3609,12 +3509,12 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      96.68,
-      98.18,
-      98.94,
-      99.5,
-      99.78,
-      99.95,
+      98.21,
+      99.2,
+      99.61,
+      99.79,
+      99.91,
+      99.99,
       100,
       100
     ]
@@ -3629,10 +3529,10 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      96.5,
-      98.68,
-      99.57,
-      99.88,
+      96.37,
+      98.67,
+      99.54,
+      99.93,
       100,
       100,
       100,
@@ -3649,9 +3549,9 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      98.96,
-      99.77,
-      99.97,
+      99.54,
+      99.91,
+      99.99,
       100,
       100,
       100,
@@ -3669,14 +3569,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      62.47,
-      66.22,
-      68.97,
-      71.37,
-      73.75,
-      76.08,
-      79.57,
-      83.33
+      65.52,
+      68.69,
+      71,
+      73.12,
+      75.22,
+      77.49,
+      80.2,
+      83.63
     ]
   },
   {
@@ -3689,14 +3589,34 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      67.31,
-      73.03,
-      76.5,
-      82.4,
-      87.44,
-      93.1,
+      69.7,
+      75.54,
+      80.95,
+      85,
+      90.91,
+      99.81,
       100,
       100
+    ]
+  },
+  {
+    "measureId": "439",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
     ]
   },
   {
@@ -3709,8 +3629,8 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      98.36,
-      99.72,
+      99.55,
+      100,
       100,
       100,
       100,
@@ -3729,14 +3649,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      12.76,
-      22.33,
-      27.56,
-      36.45,
-      42.55,
-      48.48,
-      55.56,
-      63.97
+      30.23,
+      39.99,
+      51.49,
+      61.9,
+      67.59,
+      72.55,
+      76.4,
+      80.61
     ]
   },
   {
@@ -3749,12 +3669,12 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      4,
-      2.97,
-      2.4,
-      1.94,
-      1.04,
-      0.67,
+      3.36,
+      2.86,
+      2.54,
+      2.27,
+      1.72,
+      1.23,
       0,
       0
     ]
@@ -3769,13 +3689,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      18.18,
-      15.56,
-      13.95,
-      11.27,
-      10,
-      8.57,
-      6.06,
+      17.86,
+      15.22,
+      13.68,
+      11.3,
+      9.38,
+      6.31,
+      4.76,
       0
     ]
   },
@@ -3789,13 +3709,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      11.32,
-      10,
-      8.16,
-      6.98,
-      4.26,
-      3.03,
-      2.22,
+      14.81,
+      11.26,
+      8.77,
+      5.38,
+      4.15,
+      2.53,
+      1.35,
       0
     ]
   },
@@ -3809,11 +3729,11 @@
     "isToppedOutByProgram": true,
     "deciles": [
       0,
-      94.59,
       97.3,
-      98.25,
-      99.08,
-      99.67,
+      98.93,
+      99.74,
+      100,
+      100,
       100,
       100,
       100
@@ -3824,18 +3744,18 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      84.47,
-      87.53,
-      90,
-      92.75,
-      94.54,
-      96.15,
-      97.6,
+      86.79,
+      91.23,
+      93.04,
+      95.59,
+      96.4,
+      97.62,
+      98.47,
       100
     ]
   },
@@ -3846,7 +3766,7 @@
     "submissionMethod": "electronicHealthRecord",
     "isToppedOut": true,
     "isHighPriority": true,
-    "isToppedOutByProgram": false,
+    "isToppedOutByProgram": true,
     "deciles": [
       100,
       0,
@@ -3869,18 +3789,18 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      1.46,
-      2.45,
-      5.32,
-      9.49,
-      25.51,
-      100,
-      100,
-      100
+      3.56,
+      6.42,
+      9.16,
+      12.32,
+      15.84,
+      19.07,
+      23.62,
+      33.18
     ]
   },
   {
-    "measureId": "AAAAI6",
+    "measureId": "477",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
@@ -3889,18 +3809,18 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
+      80.46,
+      85.95,
+      91.92,
+      96.16,
+      98.71,
+      99.6,
+      99.93,
       100
     ]
   },
   {
-    "measureId": "AAAAI8",
+    "measureId": "478",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
@@ -3909,10 +3829,70 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      99.72,
-      99.73,
-      99.77,
+      38.72,
+      43.28,
+      47.62,
+      49.29,
+      55.22,
+      66.08,
+      70.37,
+      78.07
+    ]
+  },
+  {
+    "measureId": "AAD12",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      91.8,
+      96.43,
+      98.55,
       100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "AAD6",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      96.99,
+      98.81,
+      99.8,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "AAD7",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      82.68,
+      95.26,
+      97.7,
+      99.37,
       100,
       100,
       100,
@@ -3929,14 +3909,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      49.63,
-      54.49,
-      57.88,
-      62.61,
-      67.05,
-      73.18,
-      79.67,
-      84.91
+      47.33,
+      53.7,
+      57.16,
+      62.86,
+      67.37,
+      71.43,
+      76.35,
+      80.73
     ]
   },
   {
@@ -3949,14 +3929,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      58.33,
-      70,
-      74,
-      80.45,
-      88.89,
-      92.5,
-      96.15,
-      97.92
+      56.67,
+      67.8,
+      74.17,
+      80.03,
+      86.6,
+      91.53,
+      94.52,
+      98.98
     ]
   },
   {
@@ -3969,54 +3949,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      53.7,
-      64.73,
-      81.22,
-      86.8,
-      90.2,
-      92.67,
-      96.3,
-      97.68
-    ]
-  },
-  {
-    "measureId": "AAO20",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      96.03,
-      97.5,
-      98.08,
-      98.42,
-      98.81,
-      98.98,
-      99.4,
+      38.82,
+      60,
+      70.2,
+      87.11,
+      91.69,
+      96.26,
+      97.34,
       100
-    ]
-  },
-  {
-    "measureId": "AAO21",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      21.29,
-      25.7,
-      36.08,
-      42.08,
-      43.17,
-      44.51,
-      46.45,
-      52.11
     ]
   },
   {
@@ -4029,14 +3969,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      61.71,
-      67.55,
-      70.42,
-      72.82,
-      75.72,
-      77.36,
-      80.09,
-      84.44
+      49.92,
+      58.78,
+      64.47,
+      68,
+      72.08,
+      75.97,
+      86.18,
+      89.52
     ]
   },
   {
@@ -4044,59 +3984,19 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      82.68,
-      85.53,
-      87.62,
-      90.85,
-      93.37,
-      96.02,
-      96.97,
-      98.62
-    ]
-  },
-  {
-    "measureId": "ACCPIN7",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      71.74,
-      76.09,
-      80.41,
-      82.81,
-      83.99,
-      87.5,
-      89.6,
-      93.42
-    ]
-  },
-  {
-    "measureId": "ACCPIN8",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      19.73,
-      22.75,
-      25.18,
-      27.58,
-      29.2,
-      30.72,
-      34.29,
-      38.56
+      91.19,
+      94.68,
+      97.28,
+      98.93,
+      99.39,
+      100,
+      100,
+      100
     ]
   },
   {
@@ -4109,14 +4009,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      53.1,
-      54.86,
-      58.04,
-      60.14,
-      63.29,
-      64.97,
-      68.42,
-      72.76
+      59.44,
+      62.24,
+      65.52,
+      66.87,
+      69.88,
+      71.93,
+      77.27,
+      82.1
     ]
   },
   {
@@ -4129,13 +4029,13 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      14.87,
-      10.99,
-      9.22,
-      6.55,
-      4.81,
-      3.69,
-      2.77,
+      12.85,
+      9.39,
+      7.48,
+      5.94,
+      4.73,
+      3.57,
+      2.67,
       0
     ]
   },
@@ -4149,14 +4049,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      21.55,
-      24.48,
-      27.67,
-      32.8,
-      37.75,
-      41.46,
-      44.7,
-      51.48
+      22.92,
+      25.44,
+      28.79,
+      30.64,
+      37.8,
+      40.62,
+      46.14,
+      52.36
     ]
   },
   {
@@ -4169,14 +4069,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      59.36,
-      67.83,
-      70.74,
-      72.7,
-      76.06,
-      77.27,
-      79.04,
-      88.22
+      56.31,
+      60.2,
+      68.02,
+      70.98,
+      74.15,
+      77.86,
+      83.66,
+      90.32
     ]
   },
   {
@@ -4189,14 +4089,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      73.81,
-      76.52,
-      77.64,
-      80.48,
-      82.92,
-      84.79,
-      87.03,
-      90.59
+      73.73,
+      75,
+      77.22,
+      78.72,
+      80,
+      82.61,
+      86.42,
+      88.89
     ]
   },
   {
@@ -4209,14 +4109,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      48.44,
-      54.36,
-      57.21,
-      73.91,
-      75.25,
-      77.78,
-      85.26,
-      89.21
+      64.41,
+      66.18,
+      77.83,
+      78.71,
+      85.88,
+      89.52,
+      92.07,
+      93.48
     ]
   },
   {
@@ -4229,38 +4129,58 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      83.63,
-      85.96,
-      87.5,
-      89.58,
-      90.91,
-      92.16,
-      94.25,
-      96.61
+      75,
+      79.17,
+      84.44,
+      88.94,
+      92.13,
+      93.88,
+      94.69,
+      96.5
     ]
   },
   {
-    "measureId": "ACMS2",
+    "measureId": "ACEP50",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": true,
+    "isToppedOut": false,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
-      0,
-      82.14,
-      92.03,
-      96.21,
-      97.48,
-      98.33,
-      99.51,
-      99.89,
-      100
+      100,
+      0.11,
+      0.02,
+      0.06,
+      0.13,
+      0.19,
+      0.29,
+      0.38,
+      0.5
     ]
   },
   {
-    "measureId": "ACMS3",
+    "measureId": "ACEP51",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      0.13,
+      0,
+      0.07,
+      0.11,
+      0.17,
+      0.21,
+      0.3,
+      0.44
+    ]
+  },
+  {
+    "measureId": "ACEP52",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
@@ -4269,13 +4189,33 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      80.95,
-      86.09,
-      86.67,
-      89.94,
-      94.34,
-      95.89,
-      98.31,
+      46.33,
+      55.26,
+      57.76,
+      62.26,
+      67.74,
+      69.79,
+      72.18,
+      75.89
+    ]
+  },
+  {
+    "measureId": "ACEP53",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      63.64,
+      80,
+      84.72,
+      91.06,
+      94.64,
+      97.06,
+      98.85,
       100
     ]
   },
@@ -4289,34 +4229,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      1.27,
-      1.08,
-      0.91,
-      0.75,
-      0.36,
-      0.15,
-      0.08,
-      0
-    ]
-  },
-  {
-    "measureId": "ACQR16",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      66.41,
-      70,
-      73.08,
-      75.7,
-      80.04,
-      83.93,
-      87.59,
-      92.86
+      100,
+      10,
+      1.97,
+      1.17,
+      0.9,
+      0.61,
+      0.38,
+      0.17
     ]
   },
   {
@@ -4329,14 +4249,74 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      90.91,
-      92.59,
-      94.44,
-      95.72,
-      96.78,
-      97.37,
-      98.39,
-      99.02
+      92.21,
+      95.08,
+      95.92,
+      96.36,
+      97.35,
+      98.48,
+      99.02,
+      100
+    ]
+  },
+  {
+    "measureId": "ACR10",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      13,
+      21.14,
+      30.77,
+      38.09,
+      44.02,
+      51.35,
+      55.42,
+      62.03
+    ]
+  },
+  {
+    "measureId": "ACR12",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      9.33,
+      12.05,
+      19.44,
+      33.44,
+      41.23,
+      48.48,
+      68.87,
+      85.03
+    ]
+  },
+  {
+    "measureId": "ACR14",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      31.94,
+      35.71,
+      40.91,
+      43.24,
+      50,
+      54.55,
+      61.54,
+      66.67
     ]
   },
   {
@@ -4349,14 +4329,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      6.38,
-      4.92,
-      3.85,
-      2.77,
-      2.02,
-      1.5,
-      1.16,
-      0.79
+      6.65,
+      5.28,
+      4.1,
+      3.42,
+      2.78,
+      1.92,
+      1.37,
+      0.81
     ]
   },
   {
@@ -4369,14 +4349,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      8.2,
-      6.44,
-      5.15,
-      4.14,
-      3.29,
-      2.41,
-      1.82,
-      1.07
+      7.79,
+      6.33,
+      5.02,
+      4.22,
+      3.18,
+      2.45,
+      1.7,
+      0.96
     ]
   },
   {
@@ -4389,14 +4369,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      16.2,
-      11.59,
-      9.48,
-      7.91,
-      6.04,
-      4.8,
-      3.61,
-      2.33
+      16.66,
+      12.75,
+      10.16,
+      8.59,
+      6.82,
+      5.3,
+      4.05,
+      2.61
     ]
   },
   {
@@ -4409,14 +4389,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      6.51,
-      4.9,
-      4.03,
-      3.22,
-      2.62,
-      2.11,
-      1.63,
-      1.17
+      6.98,
+      5.3,
+      4.42,
+      3.94,
+      3.1,
+      2.46,
+      1.68,
+      1.15
     ]
   },
   {
@@ -4429,14 +4409,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      42.76,
-      26.2,
-      14.75,
-      10.5,
-      8.38,
-      6.9,
-      5.08,
-      3.88
+      29.79,
+      24.9,
+      16.13,
+      11.61,
+      9.72,
+      6.95,
+      4.03,
+      2.75
     ]
   },
   {
@@ -4449,14 +4429,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      34.33,
-      25.23,
-      22.26,
-      16.38,
-      11.31,
-      6.78,
-      3.97,
-      0.83
+      37.52,
+      26.51,
+      19.63,
+      14.58,
+      10.12,
+      5.32,
+      2.13,
+      0.58
     ]
   },
   {
@@ -4469,14 +4449,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      60.43,
-      73.29,
-      82.25,
-      87.26,
-      89.16,
-      94.28,
-      95.14,
-      95.65
+      76.09,
+      84.86,
+      85.5,
+      89.23,
+      92.08,
+      95.12,
+      95.12,
+      96.22
     ]
   },
   {
@@ -4489,14 +4469,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      89.93,
-      91.01,
-      91.91,
-      92.58,
-      93.09,
-      94.53,
-      95.59,
-      96.38
+      90.28,
+      90.8,
+      91.73,
+      92.3,
+      92.95,
+      94.04,
+      95.31,
+      96.36
     ]
   },
   {
@@ -4505,16 +4485,16 @@
     "performanceYear": 2022,
     "submissionMethod": "registry",
     "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      85.5,
-      91.46,
-      95.45,
-      97.14,
-      98.82,
-      99.49,
+      96.74,
+      98.76,
+      99.25,
+      99.78,
+      100,
+      100,
       100,
       100
     ]
@@ -4526,16 +4506,56 @@
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      95.66,
+      98.33,
+      99.4,
+      99.68,
+      99.88,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "AQI65",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      81,
-      92.29,
-      97.16,
-      99.56,
-      99.91,
+      66.67,
+      87.24,
+      92.59,
+      95.59,
+      97.02,
+      99.68,
       100,
-      100,
+      100
+    ]
+  },
+  {
+    "measureId": "AQI68",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      89.99,
+      95.66,
+      97.47,
+      98.38,
+      99.34,
+      99.68,
+      99.96,
       100
     ]
   },
@@ -4549,14 +4569,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      41.28,
-      38.71,
-      34.48,
-      31.47,
-      28.41,
-      21.36,
-      13.79,
-      2.27
+      34.27,
+      31.24,
+      19.89,
+      13,
+      7.46,
+      4.6,
+      1.74,
+      0
     ]
   },
   {
@@ -4569,34 +4589,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      47.84,
-      53.19,
-      63.15,
-      69.67,
-      74.66,
-      76.98,
-      84.1,
-      92.25
-    ]
-  },
-  {
-    "measureId": "AQUA18",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      26.39,
-      28.13,
-      28.38,
-      29.37,
-      33.33,
-      45.32,
-      58.54,
-      66.67
+      41.04,
+      44.88,
+      49.39,
+      60.25,
+      73.53,
+      78.37,
+      80.03,
+      84.5
     ]
   },
   {
@@ -4609,14 +4609,74 @@
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      14.58,
-      12.16,
-      9.33,
-      6.48,
-      5,
-      3.08,
-      1.03,
+      17.11,
+      14.79,
+      12.5,
+      8.01,
+      5.63,
+      3.18,
+      1.78,
       0
+    ]
+  },
+  {
+    "measureId": "CAP28",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      81.41,
+      85.56,
+      88.75,
+      90.89,
+      91.88,
+      93.61,
+      97.46,
+      97.92
+    ]
+  },
+  {
+    "measureId": "ECPR39",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      86.9,
+      88.21,
+      90.55,
+      92.59,
+      94.49,
+      97.1,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "ECPR46",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      92.58,
+      96.68,
+      98.17,
+      98.79,
+      99.07,
+      99.39,
+      100,
+      100
     ]
   },
   {
@@ -4629,14 +4689,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      87.68,
-      89.67,
-      90.72,
-      91.38,
-      92.87,
-      93.96,
-      95.52,
-      96.53
+      82.86,
+      86.58,
+      86.96,
+      87.95,
+      88.65,
+      90.32,
+      92.78,
+      94.03
     ]
   },
   {
@@ -4644,39 +4704,19 @@
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
-    "isToppedOut": false,
+    "isToppedOut": true,
     "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      47.96,
-      60.71,
-      79.83,
-      86.71,
-      91.67,
-      96.07,
+      82.05,
+      94.34,
+      96.08,
+      98.37,
+      100,
+      100,
       100,
       100
-    ]
-  },
-  {
-    "measureId": "IRIS1",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      38.75,
-      46.15,
-      48.72,
-      55.88,
-      56.4,
-      66.99,
-      71.79,
-      80
     ]
   },
   {
@@ -4689,14 +4729,54 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      70.84,
-      82.48,
-      87.44,
-      88.75,
-      89.87,
-      92.25,
-      93.88,
-      98.08
+      80.35,
+      83.12,
+      85.54,
+      87.01,
+      88.19,
+      89.22,
+      91.16,
+      93.94
+    ]
+  },
+  {
+    "measureId": "IRIS17",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      47.83,
+      54.4,
+      57.14,
+      59.09,
+      64.52,
+      69.23,
+      75,
+      81.65
+    ]
+  },
+  {
+    "measureId": "IRIS2",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      23.67,
+      29.08,
+      32.96,
+      38.21,
+      41.36,
+      45.55,
+      53.73,
+      76.81
     ]
   },
   {
@@ -4709,14 +4789,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      68.75,
-      75.34,
-      79.92,
-      83.02,
-      87.8,
-      89.19,
-      94.12,
-      95.81
+      57.5,
+      80.95,
+      82.86,
+      84,
+      87.04,
+      90.28,
+      92.31,
+      95.09
     ]
   },
   {
@@ -4729,38 +4809,98 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      21.43,
-      27.5,
-      30.53,
+      11,
+      13.64,
+      15.73,
+      20.83,
+      26.39,
+      54.97,
+      75,
+      90.32
+    ]
+  },
+  {
+    "measureId": "IRIS46",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      15.79,
+      51.92,
+      61.22,
+      68.22,
+      72,
+      73.33,
+      88.1,
+      97.56
+    ]
+  },
+  {
+    "measureId": "IRIS53",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      86.96,
+      88,
+      89.45,
+      90.79,
+      91.18,
+      94.44,
+      94.52,
+      96.67
+    ]
+  },
+  {
+    "measureId": "IRIS54",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      2.41,
+      2,
+      1.64,
+      1.21,
+      0.82,
+      0.56,
+      0.18,
+      0
+    ]
+  },
+  {
+    "measureId": "IRIS55",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      27.85,
+      28.89,
+      31.37,
       33.33,
-      38.98,
-      62.86,
-      70.97,
-      85.71
+      36.07,
+      43.49,
+      45.1,
+      49.31
     ]
   },
   {
-    "measureId": "IRIS44",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      15.65,
-      14.01,
-      13.12,
-      11.83,
-      10.84,
-      9.52,
-      8.83,
-      2.33
-    ]
-  },
-  {
-    "measureId": "IRIS48",
+    "measureId": "IRIS59",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
@@ -4769,18 +4909,18 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      2.86,
-      4.42,
-      6.01,
-      7.7,
-      15.61,
-      22.62,
-      31.25,
-      37.33
+      1.85,
+      3.18,
+      4.96,
+      8.14,
+      12.31,
+      18.07,
+      26.43,
+      31.23
     ]
   },
   {
-    "measureId": "IRIS50",
+    "measureId": "MSN15",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
     "submissionMethod": "registry",
@@ -4789,254 +4929,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      42.86,
-      47.62,
-      53.33,
-      56.52,
-      57.89,
-      67.57,
-      68.18,
-      68.97
-    ]
-  },
-  {
-    "measureId": "IRIS6",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      91.74,
-      93.86,
-      95.7,
-      98.28,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "IROMS11",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      42.45,
-      32.59,
-      30,
-      27.04,
-      25,
-      22.61,
-      21.62,
-      15.58
-    ]
-  },
-  {
-    "measureId": "IROMS12",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      46.15,
-      44.07,
-      43.01,
-      40.31,
-      39.58,
-      38.1,
-      35.95,
-      24
-    ]
-  },
-  {
-    "measureId": "IROMS13",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      39.66,
-      38.26,
-      36.93,
-      35,
-      33.64,
-      32.82,
-      31.58,
-      20.97
-    ]
-  },
-  {
-    "measureId": "IROMS14",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      52.31,
-      50.56,
-      49.25,
-      47.94,
-      46.67,
-      45.53,
-      43.53,
-      18.79
-    ]
-  },
-  {
-    "measureId": "IROMS15",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      46.15,
-      43.85,
-      43.08,
-      42.01,
-      40.91,
-      39.44,
-      35.71,
-      3.17
-    ]
-  },
-  {
-    "measureId": "IROMS16",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      46.05,
-      43.98,
-      42.76,
-      41.59,
-      40.08,
-      38.92,
-      37.04,
-      5.83
-    ]
-  },
-  {
-    "measureId": "IROMS17",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      37.8,
-      36.36,
-      35.16,
-      34.34,
-      33.33,
-      32.29,
-      30.49,
-      18.52
-    ]
-  },
-  {
-    "measureId": "IROMS18",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      47.06,
-      45.43,
-      44.15,
-      43.48,
-      42.86,
-      41.6,
-      40.81,
-      25
-    ]
-  },
-  {
-    "measureId": "IROMS19",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      28.57,
-      27.56,
-      25.76,
-      24.41,
-      23.42,
-      22.22,
-      20.65,
-      6.73
-    ]
-  },
-  {
-    "measureId": "IROMS20",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      46.81,
-      45.29,
-      44.85,
-      43.75,
-      41.79,
-      40.7,
-      39.29,
-      15.6
-    ]
-  },
-  {
-    "measureId": "MEDNAX54",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      22.11,
-      12.74,
-      8.66,
-      5.59,
-      4.12,
-      3.16,
-      2.39,
-      0.7
+      78,
+      89,
+      92,
+      94.5,
+      96,
+      97,
+      99,
+      99
     ]
   },
   {
@@ -5049,14 +4949,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      17.65,
-      25,
-      37.93,
-      52,
-      60.78,
-      72.14,
-      86.44,
-      90.48
+      31.25,
+      48.39,
+      64.33,
+      69.51,
+      76.92,
+      85.56,
+      94.12,
+      95.24
     ]
   },
   {
@@ -5069,14 +4969,34 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      2.22,
-      3.7,
-      6.17,
-      18.18,
-      29.79,
-      40,
-      48.72,
-      64.81
+      3.41,
+      4.71,
+      11.11,
+      30.84,
+      38.3,
+      46.43,
+      57.3,
+      64.46
+    ]
+  },
+  {
+    "measureId": "PIMSH10",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      17.65,
+      38.71,
+      40.4,
+      47.92,
+      57.69,
+      64.24,
+      73.33,
+      80
     ]
   },
   {
@@ -5089,14 +5009,34 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      29.61,
-      35.06,
-      38.17,
-      40.81,
-      43.91,
-      47.37,
-      51.05,
-      58.26
+      33.33,
+      37.13,
+      39.71,
+      43.55,
+      46.83,
+      50,
+      52.88,
+      58.85
+    ]
+  },
+  {
+    "measureId": "PIMSH9",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      10.03,
+      8,
+      6.25,
+      4.46,
+      3.57,
+      2.94,
+      1.37,
+      0
     ]
   },
   {
@@ -5106,13 +5046,13 @@
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": true,
-    "isToppedOutByProgram": false,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      89.46,
-      95.74,
-      98.15,
-      99.17,
+      94.55,
+      98.44,
+      99.46,
+      100,
       100,
       100,
       100,
@@ -5129,14 +5069,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      67.09,
-      70.45,
-      74.09,
-      75.9,
-      76.97,
-      78.57,
-      84.13,
-      89.52
+      70.05,
+      72.97,
+      77.62,
+      80.41,
+      81.83,
+      83.59,
+      88.93,
+      93.26
     ]
   },
   {
@@ -5149,14 +5089,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      60.98,
-      66.99,
-      70.17,
-      76.05,
-      78.31,
-      81.68,
-      84.66,
-      87.02
+      67.57,
+      69.69,
+      72.72,
+      78.05,
+      82.91,
+      85.92,
+      87.85,
+      89.87
     ]
   },
   {
@@ -5169,14 +5109,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      74.6,
-      82.95,
-      84.01,
-      86.01,
-      90.05,
-      92.06,
-      93.62,
-      96.08
+      80.4,
+      85.45,
+      87.67,
+      92.15,
+      92.96,
+      94.19,
+      94.95,
+      95.75
     ]
   },
   {
@@ -5186,17 +5126,17 @@
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": true,
-    "isToppedOutByProgram": false,
+    "isToppedOutByProgram": true,
     "deciles": [
       0,
-      91.72,
-      92.19,
-      95.19,
-      96.71,
-      96.94,
-      97.49,
-      97.82,
-      99.82
+      95.86,
+      97.24,
+      98.08,
+      98.67,
+      99.23,
+      99.4,
+      99.58,
+      99.93
     ]
   },
   {
@@ -5209,14 +5149,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      79.43,
-      82.14,
-      85.56,
-      86.98,
-      89.04,
-      91.86,
-      93.84,
-      95.79
+      76.16,
+      81.25,
+      86.41,
+      88.72,
+      90.96,
+      93.1,
+      93.75,
+      95.24
     ]
   },
   {
@@ -5229,74 +5169,14 @@
     "isToppedOutByProgram": false,
     "deciles": [
       0,
-      78.35,
-      81.65,
-      82.68,
-      84.2,
-      86.07,
-      91,
-      91.69,
-      93.15
-    ]
-  },
-  {
-    "measureId": "STS1",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      5.63,
-      5.26,
-      4.94,
-      4.07,
-      3.7,
-      2.67,
-      2.28,
-      0
-    ]
-  },
-  {
-    "measureId": "STS7",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      2.08,
-      20,
-      42.86,
-      55.56,
-      73.33,
-      87.27,
-      95.2,
-      99.26
-    ]
-  },
-  {
-    "measureId": "UREQA4",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      90.21,
-      92.91,
-      94.22,
-      94.98,
-      97.3,
-      97.96,
-      98.71,
-      99.51
+      78.05,
+      80.95,
+      83.08,
+      87.3,
+      89.66,
+      92.31,
+      94.05,
+      95.74
     ]
   }
 ]

--- a/staging/2022/benchmarks/json/benchmarks.json
+++ b/staging/2022/benchmarks/json/benchmarks.json
@@ -1860,66 +1860,6 @@
     ]
   },
   {
-    "measureId": "226",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      87.18,
-      95.38,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "226",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      18.92,
-      25.81,
-      34.17,
-      44.44,
-      56.63,
-      70.37,
-      84.11,
-      95.42
-    ]
-  },
-  {
-    "measureId": "226",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      30.91,
-      49.09,
-      66.67,
-      80.88,
-      90.78,
-      96.46,
-      100,
-      100
-    ]
-  },
-  {
     "measureId": "236",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
@@ -1977,46 +1917,6 @@
       70,
       80,
       90
-    ]
-  },
-  {
-    "measureId": "238",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      12.98,
-      7.56,
-      3.87,
-      1.64,
-      0.63,
-      0.18,
-      0,
-      0
-    ]
-  },
-  {
-    "measureId": "238",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": true,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      3.4,
-      1.33,
-      0.63,
-      0.32,
-      0.16,
-      0.03,
-      0,
-      0
     ]
   },
   {
@@ -2477,66 +2377,6 @@
       45.83,
       52.17,
       63.4
-    ]
-  },
-  {
-    "measureId": "317",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "claims",
-    "isToppedOut": true,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      88.31,
-      97.87,
-      99.47,
-      100,
-      100,
-      100,
-      100,
-      100
-    ]
-  },
-  {
-    "measureId": "317",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      15.66,
-      20.02,
-      23.68,
-      27.31,
-      30.97,
-      34.83,
-      40.07,
-      49.06
-    ]
-  },
-  {
-    "measureId": "317",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      23.48,
-      30.85,
-      38.37,
-      50,
-      65.12,
-      83.28,
-      96.5,
-      100
     ]
   },
   {
@@ -3600,26 +3440,6 @@
     ]
   },
   {
-    "measureId": "439",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
     "measureId": "440",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
@@ -3817,26 +3637,6 @@
       99.6,
       99.93,
       100
-    ]
-  },
-  {
-    "measureId": "478",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      38.72,
-      43.28,
-      47.62,
-      49.29,
-      55.22,
-      66.08,
-      70.37,
-      78.07
     ]
   },
   {
@@ -4137,46 +3937,6 @@
       93.88,
       94.69,
       96.5
-    ]
-  },
-  {
-    "measureId": "ACEP50",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      0.11,
-      0.02,
-      0.06,
-      0.13,
-      0.19,
-      0.29,
-      0.38,
-      0.5
-    ]
-  },
-  {
-    "measureId": "ACEP51",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      100,
-      0.13,
-      0,
-      0.07,
-      0.11,
-      0.17,
-      0.21,
-      0.3,
-      0.44
     ]
   },
   {

--- a/staging/2022/benchmarks/json/benchmarks.json
+++ b/staging/2022/benchmarks/json/benchmarks.json
@@ -1,0 +1,5302 @@
+[
+  {
+    "measureId": "001",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      90.5,
+      69.42,
+      53.6,
+      42.11,
+      34.06,
+      28.32,
+      23.56,
+      19.1
+    ]
+  },
+  {
+    "measureId": "001",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      90.69,
+      72.51,
+      55.17,
+      41.98,
+      32.56,
+      25.48,
+      19.15,
+      12.87
+    ]
+  },
+  {
+    "measureId": "005",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      1.09,
+      65.52,
+      71.95,
+      75.28,
+      78.09,
+      80.47,
+      82.98,
+      86.36
+    ]
+  },
+  {
+    "measureId": "005",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      90,
+      95.71,
+      98.02,
+      99.27,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "006",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      77.58,
+      82.98,
+      86.98,
+      90.35,
+      93.27,
+      95.87,
+      98.94,
+      100
+    ]
+  },
+  {
+    "measureId": "007",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      45.83,
+      71.57,
+      83.88,
+      88.75,
+      91.79,
+      94.11,
+      95.79,
+      97.75
+    ]
+  },
+  {
+    "measureId": "007",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      49.07,
+      74.04,
+      84.79,
+      91.93,
+      94.72,
+      97.73,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "008",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      86.69,
+      90.14,
+      92.31,
+      94.05,
+      95.24,
+      96.37,
+      97.44,
+      100
+    ]
+  },
+  {
+    "measureId": "008",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      95,
+      97.5,
+      99.14,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "009",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      65.38,
+      70.69,
+      74.34,
+      78.04,
+      80.95,
+      83.77,
+      86.67,
+      90.56
+    ]
+  },
+  {
+    "measureId": "012",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      83.62,
+      88.72,
+      92.31,
+      95.06,
+      96.97,
+      98.33,
+      99.29,
+      100
+    ]
+  },
+  {
+    "measureId": "014",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "014",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      86.18,
+      91.75,
+      95.02,
+      96.93,
+      98.52,
+      99.59,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "019",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      54.33,
+      66.67,
+      75.34,
+      81.6,
+      87.18,
+      91.37,
+      95.08,
+      97.88
+    ]
+  },
+  {
+    "measureId": "019",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      83.62,
+      93.53,
+      97.83,
+      99.93,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "021",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "021",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      78.79,
+      97.51,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "023",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "023",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      95.45,
+      99.91,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "024",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      79.31,
+      94.24,
+      96.08,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "024",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      14.13,
+      36.36,
+      78.07,
+      82.88,
+      87.88,
+      93.75,
+      99.8,
+      100
+    ]
+  },
+  {
+    "measureId": "039",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      37.13,
+      49.57,
+      59.31,
+      66.38,
+      76.03,
+      87.21,
+      96.34,
+      100
+    ]
+  },
+  {
+    "measureId": "039",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      13.41,
+      28.59,
+      39.8,
+      51.49,
+      61.47,
+      70.35,
+      79.68,
+      90.85
+    ]
+  },
+  {
+    "measureId": "044",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      94.29,
+      96.51,
+      98.57,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "047",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      84.39,
+      97.46,
+      99.7,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "047",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      20.33,
+      43.84,
+      64.44,
+      79.02,
+      89.24,
+      95.6,
+      98.95,
+      100
+    ]
+  },
+  {
+    "measureId": "048",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      23.56,
+      40.07,
+      57.38,
+      73.75,
+      82.39,
+      93.05,
+      98.54,
+      100
+    ]
+  },
+  {
+    "measureId": "050",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      97.56,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "050",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      57.62,
+      74.66,
+      84.46,
+      90.28,
+      95.86,
+      99.85,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "052",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      84.62,
+      95,
+      98.29,
+      99.67,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "065",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      76.15,
+      80.79,
+      84.39,
+      87.1,
+      90.11,
+      92.86,
+      95.58,
+      100
+    ]
+  },
+  {
+    "measureId": "065",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      93.33,
+      95.45,
+      97.14,
+      98.44,
+      99.41,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "066",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      52.34,
+      67.16,
+      76.08,
+      81.75,
+      85.53,
+      87.84,
+      90.69,
+      94.46
+    ]
+  },
+  {
+    "measureId": "066",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      80.85,
+      88.09,
+      93.1,
+      97.11,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "067",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      96.41,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "070",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      64.44,
+      98.46,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "076",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      99.7,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "076",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      97.2,
+      99.43,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "093",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      93.55,
+      96.3,
+      98.11,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "093",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      83.89,
+      89.46,
+      92.86,
+      95.52,
+      97.26,
+      98.84,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "102",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      90.61,
+      97.12,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "104",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      95.85,
+      99.61,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "107",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      2.04,
+      4.76,
+      10.48,
+      22.13,
+      37.61,
+      57.23,
+      72.49,
+      92.62
+    ]
+  },
+  {
+    "measureId": "111",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      68.68,
+      76.32,
+      82.47,
+      87.57,
+      93.09,
+      97.9,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "111",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      20.44,
+      33.72,
+      44.7,
+      54.86,
+      63.22,
+      71.1,
+      78.8,
+      87.93
+    ]
+  },
+  {
+    "measureId": "111",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      35.11,
+      51.29,
+      61.9,
+      69.16,
+      75,
+      79.9,
+      85.83,
+      95
+    ]
+  },
+  {
+    "measureId": "112",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      66.67,
+      77.08,
+      84.88,
+      89.63,
+      93.48,
+      97.36,
+      99.03,
+      100
+    ]
+  },
+  {
+    "measureId": "112",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      24.44,
+      37.14,
+      46.32,
+      54.41,
+      61.11,
+      67.23,
+      73.95,
+      82.02
+    ]
+  },
+  {
+    "measureId": "112",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      22.37,
+      40,
+      50.98,
+      60.27,
+      70.21,
+      78.11,
+      85.85,
+      97.36
+    ]
+  },
+  {
+    "measureId": "113",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      15.15,
+      27.52,
+      38.74,
+      49.05,
+      58.31,
+      67.55,
+      76.06,
+      85.06
+    ]
+  },
+  {
+    "measureId": "116",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      62.33,
+      76,
+      86.36,
+      93.33,
+      96.92,
+      98.43,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "117",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      12,
+      20.55,
+      30.69,
+      44.82,
+      69.4,
+      94.17,
+      98.43,
+      99.93
+    ]
+  },
+  {
+    "measureId": "117",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      89.93,
+      96.68,
+      98.86,
+      99.7,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "118",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      72.73,
+      76.32,
+      79.61,
+      81.85,
+      85,
+      86.83,
+      90.48,
+      96
+    ]
+  },
+  {
+    "measureId": "119",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      70.31,
+      76.92,
+      81.55,
+      85.23,
+      88.24,
+      91.41,
+      94.78,
+      98.55
+    ]
+  },
+  {
+    "measureId": "119",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      71.17,
+      79.48,
+      86.67,
+      91.81,
+      96.23,
+      98.68,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "126",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      59.55,
+      74.76,
+      86.49,
+      94.87,
+      99.32,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "127",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      58.76,
+      74.03,
+      85.06,
+      94.65,
+      99.18,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "128",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      91.47,
+      98.58,
+      99.73,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "128",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      23.26,
+      27.42,
+      32.65,
+      40.91,
+      53.43,
+      69.27,
+      83.8,
+      95.12
+    ]
+  },
+  {
+    "measureId": "128",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      32.73,
+      51.06,
+      70.17,
+      84.69,
+      93.28,
+      98.06,
+      99.76,
+      100
+    ]
+  },
+  {
+    "measureId": "130",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      99.67,
+      99.94,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "130",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      83.73,
+      91.28,
+      94.91,
+      97,
+      98.31,
+      99.18,
+      99.7,
+      99.95
+    ]
+  },
+  {
+    "measureId": "130",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      86.71,
+      96.32,
+      98.95,
+      99.68,
+      99.91,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "134",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      95.94,
+      99.51,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "134",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      14.76,
+      37.44,
+      55.93,
+      71.74,
+      84.69,
+      95.56,
+      99.22,
+      100
+    ]
+  },
+  {
+    "measureId": "137",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      95,
+      98.84,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "138",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      75.51,
+      92.59,
+      98.81,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "141",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "141",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      32.62,
+      60.32,
+      82.14,
+      93.48,
+      98.55,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "143",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      67.56,
+      85.32,
+      91.89,
+      95.34,
+      97.07,
+      97.96,
+      98.8,
+      99.81
+    ]
+  },
+  {
+    "measureId": "143",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      93.65,
+      97.66,
+      99.21,
+      99.84,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "145",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      85.71,
+      94.44,
+      97.62,
+      99.19,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "145",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      86.61,
+      95.48,
+      98.41,
+      99.73,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "147",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      71.43,
+      85.71,
+      95.45,
+      98.46,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "147",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      93.66,
+      98.92,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "154",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      99.07,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "154",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      87.86,
+      96.13,
+      98.82,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "155",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      87.5,
+      98.08,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "155",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      85.88,
+      93.88,
+      97.84,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "164",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      8.8,
+      7.69,
+      5.87,
+      5,
+      3.52,
+      2.63,
+      1.59,
+      0
+    ]
+  },
+  {
+    "measureId": "167",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      3.6,
+      2.44,
+      2.04,
+      1.47,
+      1.22,
+      0.55,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "168",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      3.04,
+      2.48,
+      2.14,
+      1.55,
+      1.21,
+      0.48,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "176",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      51.61,
+      77.63,
+      89.71,
+      93.2,
+      97.37,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "177",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      65.49,
+      75.2,
+      85.38,
+      91.04,
+      95.22,
+      98.23,
+      99.67,
+      100
+    ]
+  },
+  {
+    "measureId": "178",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      76.28,
+      89.4,
+      94.26,
+      97.72,
+      99.03,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "180",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      98.26,
+      99.69,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "181",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      98.88,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "181",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      58.52,
+      78.66,
+      89.13,
+      95.66,
+      98.92,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "182",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      99.56,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "182",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      98.57,
+      99.59,
+      99.84,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "185",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      44.62,
+      81.25,
+      90.59,
+      95.74,
+      98.05,
+      99.55,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "187",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      82.74,
+      88.32,
+      91.67,
+      93.55,
+      95.45,
+      97.22,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "191",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      88.04,
+      93.46,
+      95.71,
+      97.13,
+      98.23,
+      98.86,
+      99.5,
+      100
+    ]
+  },
+  {
+    "measureId": "191",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      94.17,
+      96.3,
+      97.44,
+      98.45,
+      99.45,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "195",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      97.77,
+      99.4,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "195",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      99.28,
+      99.84,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "225",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "225",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "236",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      20,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "236",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      51.69,
+      57.08,
+      61.33,
+      64.8,
+      68.45,
+      72.04,
+      76.36,
+      82.38
+    ]
+  },
+  {
+    "measureId": "236",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      20,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ]
+  },
+  {
+    "measureId": "239",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      27.47,
+      30.49,
+      32.13,
+      33.33,
+      34.48,
+      38.54,
+      47.93,
+      63.65
+    ]
+  },
+  {
+    "measureId": "240",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      17.93,
+      25.54,
+      32.4,
+      36.75,
+      40.19,
+      44.74,
+      49.57,
+      56.86
+    ]
+  },
+  {
+    "measureId": "243",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      19.02,
+      25.64,
+      31.43,
+      37.14,
+      42.86,
+      48.98,
+      63.71,
+      90.58
+    ]
+  },
+  {
+    "measureId": "249",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "249",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "250",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "250",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "254",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      88.64,
+      92.25,
+      95.26,
+      96.77,
+      98.25,
+      99.18,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "265",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      78.39,
+      95.41,
+      99.08,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "268",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      14.49,
+      24,
+      39.22,
+      50,
+      65.48,
+      89.5,
+      95,
+      100
+    ]
+  },
+  {
+    "measureId": "277",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      24,
+      42.8,
+      58.23,
+      71.65,
+      93.1,
+      99.87,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "279",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      88.15,
+      95.65,
+      98.69,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "281",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      8.33,
+      13.64,
+      21.74,
+      31.58,
+      44.83,
+      59.74,
+      73.91,
+      91.89
+    ]
+  },
+  {
+    "measureId": "282",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      43.54,
+      68.18,
+      91.04,
+      98.24,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "283",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      75,
+      92.45,
+      96.37,
+      98.68,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "286",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      86.36,
+      93.38,
+      97.67,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "288",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      43.28,
+      66.67,
+      83.33,
+      95.39,
+      98.33,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "290",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      34.39,
+      57.47,
+      81.08,
+      92.06,
+      98.06,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "291",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      25.57,
+      59.89,
+      89.28,
+      98.94,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "293",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      48.35,
+      65.71,
+      85.71,
+      93.73,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "305",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0.27,
+      0.43,
+      0.64,
+      0.92,
+      1.25,
+      1.85,
+      2.91,
+      7.65
+    ]
+  },
+  {
+    "measureId": "309",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      11.36,
+      18.37,
+      25,
+      32.29,
+      39.57,
+      46.81,
+      55.56,
+      68.17
+    ]
+  },
+  {
+    "measureId": "310",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      19.88,
+      26.67,
+      32.2,
+      37.66,
+      42.47,
+      47.5,
+      56.07,
+      65.97
+    ]
+  },
+  {
+    "measureId": "318",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      18.81,
+      36.28,
+      52.34,
+      66.65,
+      78.72,
+      87.5,
+      94.19,
+      98.27
+    ]
+  },
+  {
+    "measureId": "320",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      92.68,
+      99.07,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "320",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      81.69,
+      89.02,
+      93.3,
+      95.81,
+      97.47,
+      98.61,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "322",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      0.33,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "323",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "324",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      2.51,
+      0.71,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "326",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      98.63,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "326",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      79.1,
+      83.68,
+      88.46,
+      94.51,
+      98.71,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "331",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      75.95,
+      62.5,
+      50.12,
+      37.57,
+      25.12,
+      14.81,
+      5.28,
+      0
+    ]
+  },
+  {
+    "measureId": "332",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      52.44,
+      61.37,
+      72.64,
+      85.76,
+      89.94,
+      96.13,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "337",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      68,
+      80.77,
+      88.89,
+      94.42,
+      97.54,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "338",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      76.89,
+      84.21,
+      87.33,
+      91.55,
+      95.37,
+      96.97,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "340",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      54.8,
+      60.09,
+      70,
+      75,
+      84.51,
+      98.48,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "342",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "350",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      99.6,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "351",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      99.36,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "354",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      3.23,
+      1.79,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "355",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      2.45,
+      1.33,
+      0.79,
+      0.18,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "356",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      5.76,
+      3.95,
+      2.78,
+      1.09,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "357",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      3.33,
+      1.82,
+      0.77,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "358",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      34.62,
+      72.43,
+      91.23,
+      98.51,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "360",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      85.51,
+      98.77,
+      99.94,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "364",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      95.83,
+      98.11,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "366",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      20.31,
+      24.14,
+      29.55,
+      35.95,
+      39.53,
+      45.49,
+      50.59,
+      65.64
+    ]
+  },
+  {
+    "measureId": "370",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      3.65,
+      4.92,
+      6.34,
+      7.61,
+      9.63,
+      12,
+      15,
+      22.03
+    ]
+  },
+  {
+    "measureId": "374",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      9.72,
+      16.98,
+      25.51,
+      34.93,
+      46.43,
+      60,
+      74.6,
+      89.66
+    ]
+  },
+  {
+    "measureId": "374",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      60,
+      77.55,
+      92.31,
+      97.55,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "375",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      8.19,
+      10.32,
+      14.84,
+      21.1,
+      29.09,
+      37.5,
+      51.35,
+      61.03
+    ]
+  },
+  {
+    "measureId": "376",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      4.73,
+      8.33,
+      11.54,
+      15.83,
+      19.75,
+      33.33,
+      53.57,
+      100
+    ]
+  },
+  {
+    "measureId": "378",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      0.87,
+      0.38,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "379",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      0.26,
+      0.54,
+      1.1,
+      2.19,
+      3.85,
+      5.23,
+      7.31,
+      13.67
+    ]
+  },
+  {
+    "measureId": "382",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      7.45,
+      12.5,
+      19.12,
+      29.8,
+      39.09,
+      47.11,
+      58.71,
+      87.47
+    ]
+  },
+  {
+    "measureId": "383",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      51.52,
+      80.85,
+      96.52,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "384",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      96,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "389",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      30.48,
+      38.54,
+      51.95,
+      71.08,
+      94.46,
+      98.19,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "394",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      3.28,
+      7.69,
+      18.59,
+      22.73,
+      23.97,
+      30.43,
+      38.73,
+      46.67
+    ]
+  },
+  {
+    "measureId": "395",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "395",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "396",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "396",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "397",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "397",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "398",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      33.33,
+      49.29,
+      58.05,
+      80.14,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "400",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      1.39,
+      2.03,
+      3.94,
+      9.29,
+      18.03,
+      28.78,
+      43.82,
+      75.53
+    ]
+  },
+  {
+    "measureId": "402",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      88.14,
+      93.55,
+      96.55,
+      98.46,
+      99.56,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "404",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      53.27,
+      62.2,
+      68.18,
+      73.18,
+      79.19,
+      84.43,
+      91.76,
+      98.21
+    ]
+  },
+  {
+    "measureId": "406",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      100,
+      0.4,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "406",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      100,
+      2.27,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "410",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      56.12,
+      70.59,
+      80,
+      87.88,
+      93.33,
+      97.44,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "415",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      83.73,
+      90.91,
+      94.44,
+      96.4,
+      97.56,
+      98.55,
+      99.42,
+      100
+    ]
+  },
+  {
+    "measureId": "416",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      27.21,
+      20,
+      12.12,
+      5.88,
+      3.45,
+      2.04,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "419",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      28.52,
+      16.35,
+      10.43,
+      5.35,
+      3.23,
+      1.62,
+      0.2,
+      0
+    ]
+  },
+  {
+    "measureId": "424",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      98.22,
+      99.27,
+      99.69,
+      99.86,
+      99.97,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "425",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      98.8,
+      99.44,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "425",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      89.1,
+      94.78,
+      96.73,
+      97.96,
+      98.56,
+      99.13,
+      99.48,
+      99.95
+    ]
+  },
+  {
+    "measureId": "430",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      96.68,
+      98.18,
+      98.94,
+      99.5,
+      99.78,
+      99.95,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "436",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "claims",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      96.5,
+      98.68,
+      99.57,
+      99.88,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "436",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      98.96,
+      99.77,
+      99.97,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "438",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      62.47,
+      66.22,
+      68.97,
+      71.37,
+      73.75,
+      76.08,
+      79.57,
+      83.33
+    ]
+  },
+  {
+    "measureId": "438",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      67.31,
+      73.03,
+      76.5,
+      82.4,
+      87.44,
+      93.1,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "440",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      98.36,
+      99.72,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "441",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      12.76,
+      22.33,
+      27.56,
+      36.45,
+      42.55,
+      48.48,
+      55.56,
+      63.97
+    ]
+  },
+  {
+    "measureId": "445",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      4,
+      2.97,
+      2.4,
+      1.94,
+      1.04,
+      0.67,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "453",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      18.18,
+      15.56,
+      13.95,
+      11.27,
+      10,
+      8.57,
+      6.06,
+      0
+    ]
+  },
+  {
+    "measureId": "457",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      11.32,
+      10,
+      8.16,
+      6.98,
+      4.26,
+      3.03,
+      2.22,
+      0
+    ]
+  },
+  {
+    "measureId": "463",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": true,
+    "deciles": [
+      0,
+      94.59,
+      97.3,
+      98.25,
+      99.08,
+      99.67,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "464",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      84.47,
+      87.53,
+      90,
+      92.75,
+      94.54,
+      96.15,
+      97.6,
+      100
+    ]
+  },
+  {
+    "measureId": "472",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "measureId": "475",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "electronicHealthRecord",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      1.46,
+      2.45,
+      5.32,
+      9.49,
+      25.51,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "AAAAI6",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "AAAAI8",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      99.72,
+      99.73,
+      99.77,
+      100,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "AAN5",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      49.63,
+      54.49,
+      57.88,
+      62.61,
+      67.05,
+      73.18,
+      79.67,
+      84.91
+    ]
+  },
+  {
+    "measureId": "AAN8",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      58.33,
+      70,
+      74,
+      80.45,
+      88.89,
+      92.5,
+      96.15,
+      97.92
+    ]
+  },
+  {
+    "measureId": "AAN9",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      53.7,
+      64.73,
+      81.22,
+      86.8,
+      90.2,
+      92.67,
+      96.3,
+      97.68
+    ]
+  },
+  {
+    "measureId": "AAO20",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      96.03,
+      97.5,
+      98.08,
+      98.42,
+      98.81,
+      98.98,
+      99.4,
+      100
+    ]
+  },
+  {
+    "measureId": "AAO21",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      21.29,
+      25.7,
+      36.08,
+      42.08,
+      43.17,
+      44.51,
+      46.45,
+      52.11
+    ]
+  },
+  {
+    "measureId": "AAO23",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      61.71,
+      67.55,
+      70.42,
+      72.82,
+      75.72,
+      77.36,
+      80.09,
+      84.44
+    ]
+  },
+  {
+    "measureId": "AAO24",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      82.68,
+      85.53,
+      87.62,
+      90.85,
+      93.37,
+      96.02,
+      96.97,
+      98.62
+    ]
+  },
+  {
+    "measureId": "ACCPIN7",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      71.74,
+      76.09,
+      80.41,
+      82.81,
+      83.99,
+      87.5,
+      89.6,
+      93.42
+    ]
+  },
+  {
+    "measureId": "ACCPIN8",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      19.73,
+      22.75,
+      25.18,
+      27.58,
+      29.2,
+      30.72,
+      34.29,
+      38.56
+    ]
+  },
+  {
+    "measureId": "ACEP19",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      53.1,
+      54.86,
+      58.04,
+      60.14,
+      63.29,
+      64.97,
+      68.42,
+      72.76
+    ]
+  },
+  {
+    "measureId": "ACEP21",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      14.87,
+      10.99,
+      9.22,
+      6.55,
+      4.81,
+      3.69,
+      2.77,
+      0
+    ]
+  },
+  {
+    "measureId": "ACEP22",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      21.55,
+      24.48,
+      27.67,
+      32.8,
+      37.75,
+      41.46,
+      44.7,
+      51.48
+    ]
+  },
+  {
+    "measureId": "ACEP25",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      59.36,
+      67.83,
+      70.74,
+      72.7,
+      76.06,
+      77.27,
+      79.04,
+      88.22
+    ]
+  },
+  {
+    "measureId": "ACEP30",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      73.81,
+      76.52,
+      77.64,
+      80.48,
+      82.92,
+      84.79,
+      87.03,
+      90.59
+    ]
+  },
+  {
+    "measureId": "ACEP31",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      48.44,
+      54.36,
+      57.21,
+      73.91,
+      75.25,
+      77.78,
+      85.26,
+      89.21
+    ]
+  },
+  {
+    "measureId": "ACEP48",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      83.63,
+      85.96,
+      87.5,
+      89.58,
+      90.91,
+      92.16,
+      94.25,
+      96.61
+    ]
+  },
+  {
+    "measureId": "ACMS2",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      82.14,
+      92.03,
+      96.21,
+      97.48,
+      98.33,
+      99.51,
+      99.89,
+      100
+    ]
+  },
+  {
+    "measureId": "ACMS3",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      80.95,
+      86.09,
+      86.67,
+      89.94,
+      94.34,
+      95.89,
+      98.31,
+      100
+    ]
+  },
+  {
+    "measureId": "ACMS4",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      1.27,
+      1.08,
+      0.91,
+      0.75,
+      0.36,
+      0.15,
+      0.08,
+      0
+    ]
+  },
+  {
+    "measureId": "ACQR16",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      66.41,
+      70,
+      73.08,
+      75.7,
+      80.04,
+      83.93,
+      87.59,
+      92.86
+    ]
+  },
+  {
+    "measureId": "ACQR3",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      90.91,
+      92.59,
+      94.44,
+      95.72,
+      96.78,
+      97.37,
+      98.39,
+      99.02
+    ]
+  },
+  {
+    "measureId": "ACRAD15",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      6.38,
+      4.92,
+      3.85,
+      2.77,
+      2.02,
+      1.5,
+      1.16,
+      0.79
+    ]
+  },
+  {
+    "measureId": "ACRAD16",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      8.2,
+      6.44,
+      5.15,
+      4.14,
+      3.29,
+      2.41,
+      1.82,
+      1.07
+    ]
+  },
+  {
+    "measureId": "ACRAD17",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      16.2,
+      11.59,
+      9.48,
+      7.91,
+      6.04,
+      4.8,
+      3.61,
+      2.33
+    ]
+  },
+  {
+    "measureId": "ACRAD18",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      6.51,
+      4.9,
+      4.03,
+      3.22,
+      2.62,
+      2.11,
+      1.63,
+      1.17
+    ]
+  },
+  {
+    "measureId": "ACRAD19",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      42.76,
+      26.2,
+      14.75,
+      10.5,
+      8.38,
+      6.9,
+      5.08,
+      3.88
+    ]
+  },
+  {
+    "measureId": "ACRAD25",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      34.33,
+      25.23,
+      22.26,
+      16.38,
+      11.31,
+      6.78,
+      3.97,
+      0.83
+    ]
+  },
+  {
+    "measureId": "ACRAD34",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      60.43,
+      73.29,
+      82.25,
+      87.26,
+      89.16,
+      94.28,
+      95.14,
+      95.65
+    ]
+  },
+  {
+    "measureId": "AQI48",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      89.93,
+      91.01,
+      91.91,
+      92.58,
+      93.09,
+      94.53,
+      95.59,
+      96.38
+    ]
+  },
+  {
+    "measureId": "AQI56",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      85.5,
+      91.46,
+      95.45,
+      97.14,
+      98.82,
+      99.49,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "AQI62",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      81,
+      92.29,
+      97.16,
+      99.56,
+      99.91,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "AQUA14",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      41.28,
+      38.71,
+      34.48,
+      31.47,
+      28.41,
+      21.36,
+      13.79,
+      2.27
+    ]
+  },
+  {
+    "measureId": "AQUA15",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      47.84,
+      53.19,
+      63.15,
+      69.67,
+      74.66,
+      76.98,
+      84.1,
+      92.25
+    ]
+  },
+  {
+    "measureId": "AQUA18",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      26.39,
+      28.13,
+      28.38,
+      29.37,
+      33.33,
+      45.32,
+      58.54,
+      66.67
+    ]
+  },
+  {
+    "measureId": "AQUA26",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      14.58,
+      12.16,
+      9.33,
+      6.48,
+      5,
+      3.08,
+      1.03,
+      0
+    ]
+  },
+  {
+    "measureId": "EPREOP30",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      87.68,
+      89.67,
+      90.72,
+      91.38,
+      92.87,
+      93.96,
+      95.52,
+      96.53
+    ]
+  },
+  {
+    "measureId": "GIQIC10",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      47.96,
+      60.71,
+      79.83,
+      86.71,
+      91.67,
+      96.07,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "IRIS1",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      38.75,
+      46.15,
+      48.72,
+      55.88,
+      56.4,
+      66.99,
+      71.79,
+      80
+    ]
+  },
+  {
+    "measureId": "IRIS13",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      70.84,
+      82.48,
+      87.44,
+      88.75,
+      89.87,
+      92.25,
+      93.88,
+      98.08
+    ]
+  },
+  {
+    "measureId": "IRIS23",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      68.75,
+      75.34,
+      79.92,
+      83.02,
+      87.8,
+      89.19,
+      94.12,
+      95.81
+    ]
+  },
+  {
+    "measureId": "IRIS43",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      21.43,
+      27.5,
+      30.53,
+      33.33,
+      38.98,
+      62.86,
+      70.97,
+      85.71
+    ]
+  },
+  {
+    "measureId": "IRIS44",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      15.65,
+      14.01,
+      13.12,
+      11.83,
+      10.84,
+      9.52,
+      8.83,
+      2.33
+    ]
+  },
+  {
+    "measureId": "IRIS48",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      2.86,
+      4.42,
+      6.01,
+      7.7,
+      15.61,
+      22.62,
+      31.25,
+      37.33
+    ]
+  },
+  {
+    "measureId": "IRIS50",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      42.86,
+      47.62,
+      53.33,
+      56.52,
+      57.89,
+      67.57,
+      68.18,
+      68.97
+    ]
+  },
+  {
+    "measureId": "IRIS6",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      91.74,
+      93.86,
+      95.7,
+      98.28,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "IROMS11",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      42.45,
+      32.59,
+      30,
+      27.04,
+      25,
+      22.61,
+      21.62,
+      15.58
+    ]
+  },
+  {
+    "measureId": "IROMS12",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      46.15,
+      44.07,
+      43.01,
+      40.31,
+      39.58,
+      38.1,
+      35.95,
+      24
+    ]
+  },
+  {
+    "measureId": "IROMS13",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      39.66,
+      38.26,
+      36.93,
+      35,
+      33.64,
+      32.82,
+      31.58,
+      20.97
+    ]
+  },
+  {
+    "measureId": "IROMS14",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      52.31,
+      50.56,
+      49.25,
+      47.94,
+      46.67,
+      45.53,
+      43.53,
+      18.79
+    ]
+  },
+  {
+    "measureId": "IROMS15",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      46.15,
+      43.85,
+      43.08,
+      42.01,
+      40.91,
+      39.44,
+      35.71,
+      3.17
+    ]
+  },
+  {
+    "measureId": "IROMS16",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      46.05,
+      43.98,
+      42.76,
+      41.59,
+      40.08,
+      38.92,
+      37.04,
+      5.83
+    ]
+  },
+  {
+    "measureId": "IROMS17",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      37.8,
+      36.36,
+      35.16,
+      34.34,
+      33.33,
+      32.29,
+      30.49,
+      18.52
+    ]
+  },
+  {
+    "measureId": "IROMS18",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      47.06,
+      45.43,
+      44.15,
+      43.48,
+      42.86,
+      41.6,
+      40.81,
+      25
+    ]
+  },
+  {
+    "measureId": "IROMS19",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      28.57,
+      27.56,
+      25.76,
+      24.41,
+      23.42,
+      22.22,
+      20.65,
+      6.73
+    ]
+  },
+  {
+    "measureId": "IROMS20",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      46.81,
+      45.29,
+      44.85,
+      43.75,
+      41.79,
+      40.7,
+      39.29,
+      15.6
+    ]
+  },
+  {
+    "measureId": "MEDNAX54",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      22.11,
+      12.74,
+      8.66,
+      5.59,
+      4.12,
+      3.16,
+      2.39,
+      0.7
+    ]
+  },
+  {
+    "measureId": "NHCR4",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      17.65,
+      25,
+      37.93,
+      52,
+      60.78,
+      72.14,
+      86.44,
+      90.48
+    ]
+  },
+  {
+    "measureId": "PIMSH1",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      2.22,
+      3.7,
+      6.17,
+      18.18,
+      29.79,
+      40,
+      48.72,
+      64.81
+    ]
+  },
+  {
+    "measureId": "PIMSH4",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      29.61,
+      35.06,
+      38.17,
+      40.81,
+      43.91,
+      47.37,
+      51.05,
+      58.26
+    ]
+  },
+  {
+    "measureId": "QUANTUM31",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      89.46,
+      95.74,
+      98.15,
+      99.17,
+      100,
+      100,
+      100,
+      100
+    ]
+  },
+  {
+    "measureId": "RCOIR10",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      67.09,
+      70.45,
+      74.09,
+      75.9,
+      76.97,
+      78.57,
+      84.13,
+      89.52
+    ]
+  },
+  {
+    "measureId": "RCOIR12",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      60.98,
+      66.99,
+      70.17,
+      76.05,
+      78.31,
+      81.68,
+      84.66,
+      87.02
+    ]
+  },
+  {
+    "measureId": "RCOIR7",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      74.6,
+      82.95,
+      84.01,
+      86.01,
+      90.05,
+      92.06,
+      93.62,
+      96.08
+    ]
+  },
+  {
+    "measureId": "RPAQIR13",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": true,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      91.72,
+      92.19,
+      95.19,
+      96.71,
+      96.94,
+      97.49,
+      97.82,
+      99.82
+    ]
+  },
+  {
+    "measureId": "RPAQIR14",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      79.43,
+      82.14,
+      85.56,
+      86.98,
+      89.04,
+      91.86,
+      93.84,
+      95.79
+    ]
+  },
+  {
+    "measureId": "RPAQIR15",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      78.35,
+      81.65,
+      82.68,
+      84.2,
+      86.07,
+      91,
+      91.69,
+      93.15
+    ]
+  },
+  {
+    "measureId": "STS1",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      100,
+      5.63,
+      5.26,
+      4.94,
+      4.07,
+      3.7,
+      2.67,
+      2.28,
+      0
+    ]
+  },
+  {
+    "measureId": "STS7",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": true,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      2.08,
+      20,
+      42.86,
+      55.56,
+      73.33,
+      87.27,
+      95.2,
+      99.26
+    ]
+  },
+  {
+    "measureId": "UREQA4",
+    "benchmarkYear": 2020,
+    "performanceYear": 2022,
+    "submissionMethod": "registry",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      0,
+      90.21,
+      92.91,
+      94.22,
+      94.98,
+      97.3,
+      97.96,
+      98.71,
+      99.51
+    ]
+  }
+]


### PR DESCRIPTION
Initial 2022 benchmarks

#### Motivation for change

Initial 2022 benchmark file generation from the historical benchmarks

#### What is being changed

Pulled from Run #2065

```
select measurename, measureid, collectiontype, measuretype, benchmark, standarddeviation, average, decile3, decile4, decile5, decile6, decile7, decile8, decile9, decile10, toppedout, sevenpointcap, highpriority 
from final_scoring_prod.historicalbenchmark_qpp_measures_report_2065 where benchmark = 'Y' order by lpad(measureid, 3, '0'), measuretype, collectiontype
```

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [x] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [ ] Unit tests added/passing
* [ ] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-XXXX
