### PR TITLE
QPPA-6274: PY22 Update the "isToppedOutByProgram" for Measure 117 (Claims)

### DIFF
--- a/benchmarks/2022.json
+++ b/benchmarks/2022.json
@@ -866,7 +866,7 @@
     "submissionMethod": "claims",
     "isToppedOut": true,
     "isHighPriority": false,
-    "isToppedOutByProgram": true,
+    "isToppedOutByProgram": false,
     "deciles": [
       0,
       100,


### PR DESCRIPTION
#### Motivation for change

Measure 117 submissionMethod = claims is suppressed in 2021, thus it cannot be ToppedOutByProgram in 2022.

#### What is being changed

Updates the PY2022 Benchmark repo for Measure ID 117 submissionMethod = claims:
`isToppedOutByProgram = true --> isToppedOutByProgram = false`

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [ ] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [x] Unit tests added/passing
* [ ] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-6274
