### PR TITLE
QPPSF-9970 - PY21 Performance Benchmarks

### DIFF
--- a/benchmarks/2021.json
+++ b/benchmarks/2021.json
@@ -5098,6 +5098,7 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
+      155.995,
       127.228,
       117.9865,
       111.896,
@@ -5106,8 +5107,7 @@
       98.8234,
       94.6961,
       90.0213,
-      84.3452,
-      49.6086
+      84.3452
     ],
     "isToppedOut": false,
     "isToppedOutByProgram": false
@@ -5118,6 +5118,7 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
+      147.395,
       114.921,
       107.823,
       104.667,
@@ -5126,8 +5127,7 @@
       91.5498,
       86.6811,
       83.3691,
-      76.1444,
-      38.3893
+      76.1444
     ],
     "isToppedOut": false,
     "isToppedOutByProgram": false

--- a/benchmarks/2021.json
+++ b/benchmarks/2021.json
@@ -40,6 +40,24 @@
   },
   {
     "measureId": "001",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      99.52,
+      93.33,
+      75,
+      57.6,
+      46.15,
+      38.165,
+      32.26,
+      27.32,
+      22.5,
+      17.07
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "001",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -57,6 +75,23 @@
       19.15,
       12.87
     ]
+  },
+  {
+    "measureId": "001",
+    "submissionMethod": "registry",
+    "deciles": [
+      90,
+      80,
+      70,
+      60,
+      50,
+      40,
+      30,
+      20,
+      10
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "005",
@@ -80,6 +115,24 @@
   },
   {
     "measureId": "005",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      24,
+      60.8,
+      68.89,
+      73.61,
+      77.43,
+      80.03,
+      82.39,
+      85.53,
+      88.14,
+      91.67
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "005",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -97,6 +150,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "005",
+    "submissionMethod": "registry",
+    "deciles": [
+      67.35,
+      88,
+      95.45,
+      98.55,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "006",
@@ -117,6 +188,24 @@
       98.94,
       100
     ]
+  },
+  {
+    "measureId": "006",
+    "submissionMethod": "registry",
+    "deciles": [
+      41.67,
+      70.83,
+      77.71,
+      83.02,
+      86.8,
+      90.4,
+      93.66,
+      97.04,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "007",
@@ -140,6 +229,24 @@
   },
   {
     "measureId": "007",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      54.55,
+      75.76,
+      80.77,
+      83.81,
+      86.26,
+      88.095,
+      90,
+      91.8,
+      93.33,
+      95.83
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "007",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -157,6 +264,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "007",
+    "submissionMethod": "registry",
+    "deciles": [
+      56.91,
+      77.92,
+      82.845,
+      86.67,
+      90,
+      93.24,
+      96.235,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "008",
@@ -180,6 +305,24 @@
   },
   {
     "measureId": "008",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      42.86,
+      80.49,
+      85.71,
+      88.52,
+      90.7,
+      92.31,
+      93.64,
+      95,
+      96.39,
+      98.15
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "008",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -197,6 +340,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "008",
+    "submissionMethod": "registry",
+    "deciles": [
+      38.46,
+      91.21,
+      96.97,
+      98.86,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "009",
@@ -219,6 +380,24 @@
     ]
   },
   {
+    "measureId": "009",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      25,
+      62.22,
+      71.33,
+      75.56,
+      77.78,
+      80.205,
+      82.26,
+      83.82,
+      85.68,
+      88.49
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "012",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -237,6 +416,24 @@
       99.29,
       100
     ]
+  },
+  {
+    "measureId": "012",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      3.88,
+      68.62,
+      83.13,
+      88.69,
+      91.94,
+      94.165,
+      96.08,
+      97.66,
+      98.96,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "014",
@@ -260,6 +457,24 @@
   },
   {
     "measureId": "014",
+    "submissionMethod": "claims",
+    "deciles": [
+      22.83,
+      97.515,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "014",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -277,6 +492,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "014",
+    "submissionMethod": "registry",
+    "deciles": [
+      5.91,
+      74.55,
+      89.16,
+      93.79,
+      96.31,
+      98.075,
+      99.14,
+      99.77,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "019",
@@ -300,6 +533,24 @@
   },
   {
     "measureId": "019",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      6.41,
+      52.985,
+      70.175,
+      80.36,
+      86.32,
+      90.91,
+      93.75,
+      96.045,
+      98,
+      99.55
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "019",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -317,6 +568,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "019",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.33,
+      72.335,
+      91.445,
+      98.71,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "021",
@@ -337,6 +606,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "021",
+    "submissionMethod": "claims",
+    "deciles": [
+      5.26,
+      99.62,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "021",
@@ -359,6 +646,24 @@
     ]
   },
   {
+    "measureId": "021",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.94,
+      38.3,
+      92.31,
+      98.55,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "023",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -380,6 +685,24 @@
   },
   {
     "measureId": "023",
+    "submissionMethod": "claims",
+    "deciles": [
+      2.86,
+      95.74,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "023",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -397,6 +720,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "023",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.69,
+      47.12,
+      93.21,
+      98.84,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "024",
@@ -439,6 +780,24 @@
     ]
   },
   {
+    "measureId": "024",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.04,
+      1.35,
+      31.62,
+      64.15,
+      83.1,
+      98.08,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "039",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -457,6 +816,24 @@
       96.34,
       100
     ]
+  },
+  {
+    "measureId": "039",
+    "submissionMethod": "claims",
+    "deciles": [
+      1.1,
+      24.29,
+      42.64,
+      53.7,
+      68.72,
+      77.94,
+      86.025,
+      95.18,
+      99.285,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "039",
@@ -479,6 +856,24 @@
     ]
   },
   {
+    "measureId": "039",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.53,
+      7.51,
+      19.66,
+      32.59,
+      44.63,
+      57.44,
+      69.25,
+      79.69,
+      87.68,
+      97.77
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "044",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -497,6 +892,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "044",
+    "submissionMethod": "registry",
+    "deciles": [
+      68.57,
+      91.95,
+      98.63,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "047",
@@ -520,6 +933,24 @@
   },
   {
     "measureId": "047",
+    "submissionMethod": "claims",
+    "deciles": [
+      0.65,
+      43.14,
+      96.34,
+      99.83,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "047",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -537,6 +968,24 @@
       98.95,
       100
     ]
+  },
+  {
+    "measureId": "047",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.13,
+      5.4,
+      34.06,
+      60.46,
+      79.06,
+      90.86,
+      96.78,
+      99.1,
+      99.91,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "048",
@@ -557,6 +1006,24 @@
       98.54,
       100
     ]
+  },
+  {
+    "measureId": "048",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.32,
+      32.46,
+      58.07,
+      74.83,
+      85.25,
+      95.01,
+      98.39,
+      99.7,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "050",
@@ -580,6 +1047,24 @@
   },
   {
     "measureId": "050",
+    "submissionMethod": "claims",
+    "deciles": [
+      23.81,
+      96,
+      98.31,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "050",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -597,6 +1082,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "050",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.7,
+      46.96,
+      68.25,
+      75.18,
+      80.62,
+      83.8,
+      88.46,
+      96.97,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "052",
@@ -617,6 +1120,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "052",
+    "submissionMethod": "registry",
+    "deciles": [
+      8.5,
+      58.44,
+      72.165,
+      88.54,
+      97.26,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "065",
@@ -640,6 +1161,24 @@
   },
   {
     "measureId": "065",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      37.1,
+      77.5,
+      86.67,
+      90.12,
+      92.8,
+      94.74,
+      96.26,
+      97.78,
+      99.25,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "065",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -657,6 +1196,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "065",
+    "submissionMethod": "registry",
+    "deciles": [
+      55.99,
+      87.23,
+      93.185,
+      95.24,
+      96.715,
+      97.76,
+      98.5,
+      99.12,
+      99.55,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "066",
@@ -680,6 +1237,24 @@
   },
   {
     "measureId": "066",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.54,
+      7.41,
+      22,
+      36.8,
+      52.43,
+      63.82,
+      72.73,
+      80,
+      84.11,
+      88.42
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "066",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -697,6 +1272,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "066",
+    "submissionMethod": "registry",
+    "deciles": [
+      26.09,
+      76.92,
+      86.89,
+      92,
+      95.45,
+      97.64,
+      98.9,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "067",
@@ -719,6 +1312,24 @@
     ]
   },
   {
+    "measureId": "067",
+    "submissionMethod": "registry",
+    "deciles": [
+      11.48,
+      34.48,
+      50.23,
+      54.17,
+      68,
+      98.31,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "070",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -737,6 +1348,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "070",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.61,
+      25.81,
+      57.935,
+      68.31,
+      72.83,
+      87.855,
+      95.425,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "076",
@@ -760,6 +1389,24 @@
   },
   {
     "measureId": "076",
+    "submissionMethod": "claims",
+    "deciles": [
+      6.45,
+      96.15,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "076",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -777,6 +1424,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "076",
+    "submissionMethod": "registry",
+    "deciles": [
+      45.16,
+      93.06,
+      98.56,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "093",
@@ -800,6 +1465,24 @@
   },
   {
     "measureId": "093",
+    "submissionMethod": "claims",
+    "deciles": [
+      2.27,
+      58.62,
+      82.26,
+      92.78,
+      95.35,
+      96.97,
+      98.26,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "093",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -817,6 +1500,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "093",
+    "submissionMethod": "registry",
+    "deciles": [
+      37.16,
+      79.31,
+      90.39,
+      93.86,
+      96.28,
+      97.8,
+      99.015,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "102",
@@ -879,6 +1580,42 @@
     ]
   },
   {
+    "measureId": "107",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.07,
+      0.68,
+      2.37,
+      7.05,
+      13.125,
+      21.045,
+      38.545,
+      55.27,
+      78.71,
+      93.7
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "110",
+    "submissionMethod": "claims",
+    "deciles": [
+      1.57,
+      30.56,
+      69.89,
+      81.29,
+      90.18,
+      96.83,
+      99.33,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "110",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -896,6 +1633,42 @@
       80,
       90
     ]
+  },
+  {
+    "measureId": "110",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.19,
+      5.33,
+      17.7,
+      27.74,
+      36.15,
+      43.91,
+      51.19,
+      58.14,
+      67.23,
+      82.04
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "110",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.51,
+      18.67,
+      40.36,
+      57.41,
+      68.37,
+      81.415,
+      90.6,
+      96.17,
+      99.37,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "111",
@@ -919,6 +1692,24 @@
   },
   {
     "measureId": "111",
+    "submissionMethod": "claims",
+    "deciles": [
+      1.52,
+      53.13,
+      68.7,
+      76.21,
+      82.17,
+      87.85,
+      93.87,
+      98.43,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "111",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -936,6 +1727,24 @@
       85.83,
       95
     ]
+  },
+  {
+    "measureId": "111",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.8,
+      31.24,
+      51.62,
+      62.82,
+      69.63,
+      74.7,
+      79.23,
+      83.71,
+      89.62,
+      98.23
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "112",
@@ -956,6 +1765,24 @@
       99.03,
       100
     ]
+  },
+  {
+    "measureId": "112",
+    "submissionMethod": "claims",
+    "deciles": [
+      2.55,
+      43.62,
+      64.55,
+      75.82,
+      83.43,
+      89.12,
+      94.97,
+      98.35,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "112",
@@ -998,6 +1825,24 @@
   },
   {
     "measureId": "112",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.27,
+      9.23,
+      27.56,
+      39.42,
+      48.18,
+      54.84,
+      60.57,
+      66.82,
+      73.31,
+      82.05
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "112",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1015,6 +1860,42 @@
       85.85,
       97.36
     ]
+  },
+  {
+    "measureId": "112",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.24,
+      15.37,
+      36.27,
+      47.83,
+      59.02,
+      68.59,
+      76.82,
+      83.9,
+      93.75,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "113",
+    "submissionMethod": "claims",
+    "deciles": [
+      3.64,
+      38.16,
+      68.98,
+      80.27,
+      88.17,
+      95.67,
+      98.73,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "113",
@@ -1056,6 +1937,42 @@
     ]
   },
   {
+    "measureId": "113",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.18,
+      7.22,
+      22.61,
+      34.53,
+      43.9,
+      51.89,
+      59.65,
+      66.98,
+      75.51,
+      85.69
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "113",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.3,
+      4.555,
+      18.09,
+      37.7,
+      52.67,
+      63.665,
+      72.415,
+      80.945,
+      90.25,
+      99.55
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "116",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -1074,6 +1991,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "116",
+    "submissionMethod": "registry",
+    "deciles": [
+      41.84,
+      77.03,
+      87.09,
+      92.45,
+      95.83,
+      97.88,
+      98.82,
+      99.65,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "117",
@@ -1097,6 +2032,24 @@
   },
   {
     "measureId": "117",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.59,
+      5.9,
+      13.82,
+      23,
+      33.26,
+      46.04,
+      80.51,
+      97.65,
+      99.21,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "117",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1114,6 +2067,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "117",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.3,
+      48.29,
+      95.68,
+      99.04,
+      99.74,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "118",
@@ -1134,6 +2105,24 @@
       90.48,
       96
     ]
+  },
+  {
+    "measureId": "118",
+    "submissionMethod": "registry",
+    "deciles": [
+      55.56,
+      70.69,
+      76.67,
+      79.62,
+      82.09,
+      84.96,
+      87.5,
+      90.32,
+      96.15,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "119",
@@ -1157,6 +2146,24 @@
   },
   {
     "measureId": "119",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      20.29,
+      64.23,
+      73.01,
+      78.12,
+      81.82,
+      84.75,
+      87.565,
+      90.36,
+      93.75,
+      98.32
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "119",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1174,6 +2181,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "119",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.09,
+      66.89,
+      77.04,
+      82.08,
+      87.35,
+      90.975,
+      94.15,
+      98.06,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "126",
@@ -1196,6 +2221,24 @@
     ]
   },
   {
+    "measureId": "126",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.62,
+      49.57,
+      80.13,
+      92.91,
+      98.65,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "127",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -1214,6 +2257,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "127",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.84,
+      67.77,
+      89.415,
+      96.24,
+      99.635,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "128",
@@ -1237,6 +2298,24 @@
   },
   {
     "measureId": "128",
+    "submissionMethod": "claims",
+    "deciles": [
+      14.71,
+      66.67,
+      95.78,
+      99.26,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "128",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1254,6 +2333,24 @@
       99.76,
       100
     ]
+  },
+  {
+    "measureId": "128",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.28,
+      31.82,
+      64.94,
+      85.33,
+      94.62,
+      98.35,
+      99.72,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "130",
@@ -1277,6 +2374,24 @@
   },
   {
     "measureId": "130",
+    "submissionMethod": "claims",
+    "deciles": [
+      7.39,
+      98.58,
+      99.82,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "130",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "electronicHealthRecord",
@@ -1297,6 +2412,24 @@
   },
   {
     "measureId": "130",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      7.66,
+      66.25,
+      83.08,
+      89.82,
+      93.63,
+      96.12,
+      97.75,
+      98.79,
+      99.47,
+      99.87
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "130",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1314,6 +2447,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "130",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.6,
+      30.29,
+      87.26,
+      95.57,
+      98.62,
+      99.74,
+      99.99,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "134",
@@ -1337,6 +2488,42 @@
   },
   {
     "measureId": "134",
+    "submissionMethod": "claims",
+    "deciles": [
+      17.33,
+      95.875,
+      99.48,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "134",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.07,
+      1.8,
+      7.13,
+      15.39,
+      24.395,
+      33.79,
+      45.425,
+      58.935,
+      72.82,
+      90.515
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "134",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1354,6 +2541,24 @@
       99.22,
       100
     ]
+  },
+  {
+    "measureId": "134",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.05,
+      27.21,
+      72.82,
+      90.13,
+      96.65,
+      98.72,
+      99.65,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "137",
@@ -1376,6 +2581,24 @@
     ]
   },
   {
+    "measureId": "137",
+    "submissionMethod": "registry",
+    "deciles": [
+      15.56,
+      92.16,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "138",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -1394,6 +2617,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "138",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.33,
+      60.78,
+      93.02,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "141",
@@ -1417,6 +2658,24 @@
   },
   {
     "measureId": "141",
+    "submissionMethod": "claims",
+    "deciles": [
+      8.57,
+      95.77,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "141",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1434,6 +2693,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "141",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.39,
+      52.27,
+      75.17,
+      86.31,
+      93.41,
+      96.255,
+      98.26,
+      99.38,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "143",
@@ -1457,6 +2734,24 @@
   },
   {
     "measureId": "143",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      2.31,
+      43.535,
+      79.995,
+      90.645,
+      94.685,
+      96.89,
+      98.015,
+      98.92,
+      99.64,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "143",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1474,6 +2769,42 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "143",
+    "submissionMethod": "registry",
+    "deciles": [
+      20.27,
+      74.86,
+      94.89,
+      97.55,
+      98.72,
+      99.31,
+      99.9,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "144",
+    "submissionMethod": "registry",
+    "deciles": [
+      4,
+      18.42,
+      44.62,
+      68.21,
+      80.88,
+      90.435,
+      94.6,
+      97.63,
+      99.7,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "145",
@@ -1497,6 +2828,24 @@
   },
   {
     "measureId": "145",
+    "submissionMethod": "claims",
+    "deciles": [
+      3.54,
+      65.12,
+      88.89,
+      96.15,
+      98.67,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "145",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1514,6 +2863,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "145",
+    "submissionMethod": "registry",
+    "deciles": [
+      12.53,
+      82.16,
+      95.79,
+      98.44,
+      99.77,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "147",
@@ -1537,6 +2904,24 @@
   },
   {
     "measureId": "147",
+    "submissionMethod": "claims",
+    "deciles": [
+      10.34,
+      51.415,
+      78.685,
+      93.295,
+      97.405,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "147",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1554,6 +2939,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "147",
+    "submissionMethod": "registry",
+    "deciles": [
+      33.94,
+      96.11,
+      99.875,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "154",
@@ -1577,6 +2980,24 @@
   },
   {
     "measureId": "154",
+    "submissionMethod": "claims",
+    "deciles": [
+      18.42,
+      94.74,
+      99.83,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "154",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1594,6 +3015,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "154",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.7,
+      92.11,
+      98.63,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "155",
@@ -1617,6 +3056,24 @@
   },
   {
     "measureId": "155",
+    "submissionMethod": "claims",
+    "deciles": [
+      3.85,
+      75,
+      97.895,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "155",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1634,6 +3091,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "155",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.07,
+      80.68,
+      97.06,
+      99.71,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "164",
@@ -1716,6 +3191,24 @@
     ]
   },
   {
+    "measureId": "176",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.35,
+      47.06,
+      66.67,
+      84.52,
+      95.33,
+      98.01,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "177",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -1734,6 +3227,24 @@
       99.67,
       100
     ]
+  },
+  {
+    "measureId": "177",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.68,
+      63.035,
+      78.8,
+      89.195,
+      94.315,
+      98.755,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "178",
@@ -1756,6 +3267,24 @@
     ]
   },
   {
+    "measureId": "178",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.34,
+      74.61,
+      89.38,
+      95.11,
+      98.44,
+      99.54,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "180",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -1774,6 +3303,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "180",
+    "submissionMethod": "registry",
+    "deciles": [
+      6.37,
+      97.53,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "181",
@@ -1797,6 +3344,24 @@
   },
   {
     "measureId": "181",
+    "submissionMethod": "claims",
+    "deciles": [
+      0.37,
+      94.03,
+      99.61,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "181",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1814,6 +3379,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "181",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.08,
+      92,
+      98.64,
+      99.47,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "182",
@@ -1837,6 +3420,24 @@
   },
   {
     "measureId": "182",
+    "submissionMethod": "claims",
+    "deciles": [
+      1.09,
+      98.11,
+      99.79,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "182",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1854,6 +3455,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "182",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.06,
+      97.89,
+      99.55,
+      99.92,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "185",
@@ -1876,6 +3495,24 @@
     ]
   },
   {
+    "measureId": "185",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.35,
+      73.33,
+      95.74,
+      98.27,
+      99.74,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "187",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -1894,6 +3531,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "187",
+    "submissionMethod": "registry",
+    "deciles": [
+      53.33,
+      85.45,
+      93.875,
+      97.385,
+      99.44,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "191",
@@ -1917,6 +3572,24 @@
   },
   {
     "measureId": "191",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      17.24,
+      74.48,
+      88.08,
+      92.67,
+      95.14,
+      96.765,
+      97.86,
+      98.63,
+      99.27,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "191",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1934,6 +3607,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "191",
+    "submissionMethod": "registry",
+    "deciles": [
+      23.55,
+      85.71,
+      92.91,
+      97.03,
+      98.36,
+      99.18,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "195",
@@ -1957,6 +3648,24 @@
   },
   {
     "measureId": "195",
+    "submissionMethod": "claims",
+    "deciles": [
+      40.86,
+      88.62,
+      97.02,
+      99.27,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "195",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1974,6 +3683,132 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "195",
+    "submissionMethod": "registry",
+    "deciles": [
+      65.35,
+      99.1,
+      99.98,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "217",
+    "submissionMethod": "registry",
+    "deciles": [
+      20.41,
+      37.65,
+      42.94,
+      47.06,
+      52.7,
+      56.67,
+      61.05,
+      65.31,
+      81.2,
+      96.88
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "218",
+    "submissionMethod": "registry",
+    "deciles": [
+      17.36,
+      35.71,
+      41.525,
+      46.13,
+      49.395,
+      53.375,
+      56.64,
+      59.98,
+      69.225,
+      95.225
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "219",
+    "submissionMethod": "registry",
+    "deciles": [
+      16.42,
+      34,
+      37.5,
+      41.67,
+      47.56,
+      51.465,
+      56.49,
+      60.67,
+      74.07,
+      95.24
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "220",
+    "submissionMethod": "registry",
+    "deciles": [
+      24.78,
+      33.33,
+      40,
+      45.38,
+      49.54,
+      55.89,
+      60.24,
+      67.5,
+      84.47,
+      95.83
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "221",
+    "submissionMethod": "registry",
+    "deciles": [
+      23.08,
+      33.78,
+      38.61,
+      44.35,
+      50,
+      55.115,
+      61.18,
+      71.43,
+      86.67,
+      97.67
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "222",
+    "submissionMethod": "registry",
+    "deciles": [
+      21.43,
+      37.04,
+      44.44,
+      49.4,
+      53.48,
+      60.34,
+      67.27,
+      72,
+      78.57,
+      87.27
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "225",
@@ -1997,6 +3832,24 @@
   },
   {
     "measureId": "225",
+    "submissionMethod": "claims",
+    "deciles": [
+      11.17,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "225",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -2014,6 +3867,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "225",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "226",
@@ -2035,6 +3906,42 @@
     ]
   },
   {
+    "measureId": "226",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      2.05,
+      13.95,
+      25,
+      36.11,
+      48,
+      60.36,
+      72.5,
+      84,
+      92.31,
+      98.33
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "226",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.88,
+      17.3,
+      34.62,
+      53.74,
+      72,
+      84.85,
+      92.86,
+      97.78,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "236",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2053,6 +3960,23 @@
       80,
       90
     ]
+  },
+  {
+    "measureId": "236",
+    "submissionMethod": "claims",
+    "deciles": [
+      10,
+      20,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "236",
@@ -2095,6 +4019,24 @@
   },
   {
     "measureId": "236",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      2.74,
+      41.96,
+      51.36,
+      56.61,
+      60.71,
+      64.235,
+      67.55,
+      71.1,
+      75.28,
+      81.35
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "236",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -2112,6 +4054,59 @@
       80,
       90
     ]
+  },
+  {
+    "measureId": "236",
+    "submissionMethod": "registry",
+    "deciles": [
+      10,
+      20,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "238",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      21.82,
+      10.55,
+      6.7,
+      3.84,
+      1.79,
+      0.64,
+      0.16,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "238",
+    "submissionMethod": "registry",
+    "deciles": [
+      20,
+      3.73,
+      0.625,
+      0.05,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "239",
@@ -2134,6 +4129,24 @@
     ]
   },
   {
+    "measureId": "239",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      3.25,
+      25.73,
+      29.79,
+      31.71,
+      33.13,
+      34.48,
+      37.98,
+      43.76,
+      52.67,
+      66.56
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "240",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2152,6 +4165,24 @@
       49.57,
       56.86
     ]
+  },
+  {
+    "measureId": "240",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      1.75,
+      13.1,
+      22.58,
+      31.01,
+      36.67,
+      40.48,
+      43.54,
+      49.17,
+      53.59,
+      59.96
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "243",
@@ -2174,6 +4205,24 @@
     ]
   },
   {
+    "measureId": "243",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.69,
+      5.16,
+      11.24,
+      18.09,
+      26.98,
+      32.975,
+      38.35,
+      51.92,
+      64.58,
+      95.05
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "249",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2195,6 +4244,24 @@
   },
   {
     "measureId": "249",
+    "submissionMethod": "claims",
+    "deciles": [
+      97.5,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "249",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -2212,6 +4279,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "249",
+    "submissionMethod": "registry",
+    "deciles": [
+      96.25,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "250",
@@ -2235,6 +4320,24 @@
   },
   {
     "measureId": "250",
+    "submissionMethod": "claims",
+    "deciles": [
+      36.84,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "250",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -2252,6 +4355,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "250",
+    "submissionMethod": "registry",
+    "deciles": [
+      97.78,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "254",
@@ -2274,6 +4395,24 @@
     ]
   },
   {
+    "measureId": "254",
+    "submissionMethod": "registry",
+    "deciles": [
+      72.47,
+      90.13,
+      93.33,
+      95.88,
+      97.06,
+      98.145,
+      98.93,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "265",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2292,6 +4431,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "265",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.31,
+      52.38,
+      94.12,
+      99.13,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "268",
@@ -2314,6 +4471,24 @@
     ]
   },
   {
+    "measureId": "268",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.03,
+      6.97,
+      10.94,
+      30.14,
+      40.91,
+      55.78,
+      80,
+      91.67,
+      99.38,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "277",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2332,6 +4507,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "277",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.65,
+      3.3,
+      9.17,
+      23.21,
+      52.63,
+      68.99,
+      90.32,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "279",
@@ -2354,6 +4547,24 @@
     ]
   },
   {
+    "measureId": "279",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.94,
+      73.13,
+      92.105,
+      98.79,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "281",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2372,6 +4583,24 @@
       73.91,
       91.89
     ]
+  },
+  {
+    "measureId": "281",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.53,
+      4,
+      10,
+      16.67,
+      24.44,
+      34.78,
+      44.12,
+      56.02,
+      66.67,
+      84.78
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "282",
@@ -2394,6 +4623,24 @@
     ]
   },
   {
+    "measureId": "282",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.6,
+      84.62,
+      97.97,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "283",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2412,6 +4659,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "283",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.94,
+      89.86,
+      98.59,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "286",
@@ -2434,6 +4699,24 @@
     ]
   },
   {
+    "measureId": "286",
+    "submissionMethod": "registry",
+    "deciles": [
+      33.33,
+      93.07,
+      99.32,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "288",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2452,6 +4735,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "288",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.19,
+      27.36,
+      76.855,
+      91.31,
+      98.615,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "290",
@@ -2474,6 +4775,24 @@
     ]
   },
   {
+    "measureId": "290",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.565,
+      26.445,
+      72.345,
+      89.475,
+      96.22,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "291",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2492,6 +4811,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "291",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.82,
+      8.6,
+      34.91,
+      76.92,
+      92.31,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "293",
@@ -2514,6 +4851,24 @@
     ]
   },
   {
+    "measureId": "293",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.79,
+      17.33,
+      36.84,
+      68.97,
+      86.36,
+      92.96,
+      98.55,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "305",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2532,6 +4887,24 @@
       2.91,
       7.65
     ]
+  },
+  {
+    "measureId": "305",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.34,
+      1.06,
+      1.65,
+      2.17,
+      2.7,
+      3.35,
+      4.23,
+      5.18,
+      6.67,
+      10.16
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "309",
@@ -2554,6 +4927,24 @@
     ]
   },
   {
+    "measureId": "309",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.44,
+      7.77,
+      15.59,
+      21.88,
+      27.955,
+      34.04,
+      40.17,
+      46.99,
+      54.55,
+      68.52
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "310",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2572,6 +4963,78 @@
       56.07,
       65.97
     ]
+  },
+  {
+    "measureId": "310",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      1.35,
+      11.11,
+      18.255,
+      25,
+      30,
+      35.48,
+      40.865,
+      45.48,
+      53.015,
+      61.9
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "317",
+    "submissionMethod": "claims",
+    "deciles": [
+      0.32,
+      31.91,
+      84.62,
+      96.66,
+      99.04,
+      99.73,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "317",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.06,
+      5.78,
+      13.7,
+      17.68,
+      21.05,
+      23.96,
+      27.1,
+      30.59,
+      35.34,
+      44.34
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "317",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.05,
+      12.04,
+      21.49,
+      28.33,
+      35.87,
+      50.25,
+      71.53,
+      91.76,
+      98.69,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "318",
@@ -2613,6 +5076,24 @@
     ]
   },
   {
+    "measureId": "318",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.14,
+      3.91,
+      16.8,
+      35.7,
+      52.47,
+      66.87,
+      79.39,
+      88.69,
+      95.37,
+      98.92
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "320",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2631,6 +5112,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "320",
+    "submissionMethod": "claims",
+    "deciles": [
+      15.22,
+      75,
+      92.73,
+      96,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "320",
@@ -2653,6 +5152,24 @@
     ]
   },
   {
+    "measureId": "320",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.77,
+      77.38,
+      91.3,
+      96.3,
+      97.72,
+      98.7,
+      99.44,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "322",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2671,6 +5188,24 @@
       0,
       0
     ]
+  },
+  {
+    "measureId": "322",
+    "submissionMethod": "registry",
+    "deciles": [
+      48.9,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "323",
@@ -2693,6 +5228,24 @@
     ]
   },
   {
+    "measureId": "323",
+    "submissionMethod": "registry",
+    "deciles": [
+      48.39,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "324",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2711,6 +5264,24 @@
       0,
       0
     ]
+  },
+  {
+    "measureId": "324",
+    "submissionMethod": "registry",
+    "deciles": [
+      50,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "326",
@@ -2734,6 +5305,24 @@
   },
   {
     "measureId": "326",
+    "submissionMethod": "claims",
+    "deciles": [
+      77.22,
+      96.88,
+      99.26,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "326",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -2751,6 +5340,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "326",
+    "submissionMethod": "registry",
+    "deciles": [
+      38,
+      67.08,
+      74.32,
+      80.65,
+      86.11,
+      96.15,
+      99.69,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "331",
@@ -2773,6 +5380,24 @@
     ]
   },
   {
+    "measureId": "331",
+    "submissionMethod": "registry",
+    "deciles": [
+      96.32,
+      81.08,
+      64.645,
+      46.945,
+      32.11,
+      17.725,
+      8,
+      3.755,
+      0.39,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "332",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2791,6 +5416,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "332",
+    "submissionMethod": "registry",
+    "deciles": [
+      10,
+      59.38,
+      66.67,
+      75,
+      80.56,
+      84.465,
+      88.89,
+      93.18,
+      96.97,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "337",
@@ -2813,6 +5456,24 @@
     ]
   },
   {
+    "measureId": "337",
+    "submissionMethod": "registry",
+    "deciles": [
+      9.23,
+      75.89,
+      93.68,
+      98.04,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "338",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2831,6 +5492,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "338",
+    "submissionMethod": "registry",
+    "deciles": [
+      57.32,
+      81.74,
+      87.33,
+      91.32,
+      93.26,
+      94.495,
+      95.82,
+      98.98,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "340",
@@ -2853,6 +5532,24 @@
     ]
   },
   {
+    "measureId": "340",
+    "submissionMethod": "registry",
+    "deciles": [
+      27.94,
+      38.46,
+      51.22,
+      73.26,
+      79.63,
+      84.39,
+      90.68,
+      93.43,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "342",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2871,6 +5568,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "342",
+    "submissionMethod": "registry",
+    "deciles": [
+      73.36,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "350",
@@ -2893,6 +5608,24 @@
     ]
   },
   {
+    "measureId": "350",
+    "submissionMethod": "registry",
+    "deciles": [
+      27.6,
+      93.7,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "351",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2911,6 +5644,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "351",
+    "submissionMethod": "registry",
+    "deciles": [
+      7.62,
+      90.39,
+      96.5,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "354",
@@ -2933,6 +5684,24 @@
     ]
   },
   {
+    "measureId": "354",
+    "submissionMethod": "registry",
+    "deciles": [
+      76.12,
+      17.14,
+      8.49,
+      4.86,
+      1.05,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "355",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2951,6 +5720,24 @@
       0,
       0
     ]
+  },
+  {
+    "measureId": "355",
+    "submissionMethod": "registry",
+    "deciles": [
+      40,
+      8.6,
+      2.7,
+      1.08,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "356",
@@ -2973,6 +5760,24 @@
     ]
   },
   {
+    "measureId": "356",
+    "submissionMethod": "registry",
+    "deciles": [
+      32.26,
+      8.655,
+      6.105,
+      3.39,
+      1.81,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "357",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2991,6 +5796,24 @@
       0,
       0
     ]
+  },
+  {
+    "measureId": "357",
+    "submissionMethod": "registry",
+    "deciles": [
+      80.06,
+      6.34,
+      1.17,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "358",
@@ -3013,6 +5836,24 @@
     ]
   },
   {
+    "measureId": "358",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.5,
+      9.26,
+      66.01,
+      93.75,
+      98.4,
+      99.76,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "360",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3031,6 +5872,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "360",
+    "submissionMethod": "registry",
+    "deciles": [
+      5.01,
+      56.1,
+      98.48,
+      99.85,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "364",
@@ -3053,6 +5912,24 @@
     ]
   },
   {
+    "measureId": "364",
+    "submissionMethod": "registry",
+    "deciles": [
+      13.27,
+      45.34,
+      68.35,
+      92.11,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "366",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3073,6 +5950,24 @@
     ]
   },
   {
+    "measureId": "366",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      2.9412,
+      11.6279,
+      15.4738,
+      22.0588,
+      25.7751,
+      29.6552,
+      34.345,
+      39.1304,
+      43.8987,
+      51.938
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "370",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3091,6 +5986,24 @@
       15,
       22.03
     ]
+  },
+  {
+    "measureId": "370",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.5181,
+      1.9231,
+      3.125,
+      4.4693,
+      5.9412,
+      8,
+      9.7288,
+      12.1951,
+      16.6667,
+      24.6637
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "374",
@@ -3114,6 +6027,24 @@
   },
   {
     "measureId": "374",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.5,
+      4.85,
+      11.36,
+      17.31,
+      23.48,
+      30.5,
+      38.83,
+      50.51,
+      66.57,
+      85.71
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "374",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -3131,6 +6062,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "374",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.9,
+      30.43,
+      66.94,
+      84.38,
+      95.12,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "375",
@@ -3153,6 +6102,24 @@
     ]
   },
   {
+    "measureId": "375",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.99,
+      1.67,
+      2.23,
+      3.48,
+      6.94,
+      7.7,
+      10.03,
+      14.71,
+      25.32,
+      46.75
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "376",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3171,6 +6138,24 @@
       53.57,
       100
     ]
+  },
+  {
+    "measureId": "376",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.47,
+      1.995,
+      2.58,
+      3.45,
+      4.1,
+      5.955,
+      10.4,
+      15.76,
+      22.92,
+      44.045
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "378",
@@ -3193,6 +6178,24 @@
     ]
   },
   {
+    "measureId": "378",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      92.31,
+      68.29,
+      50.04,
+      34.04,
+      15.62,
+      7.565,
+      3.67,
+      1.59,
+      0.87,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "379",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3211,6 +6214,24 @@
       7.31,
       13.67
     ]
+  },
+  {
+    "measureId": "379",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.01,
+      0.12,
+      0.25,
+      0.46,
+      0.93,
+      1.87,
+      3.02,
+      4.79,
+      7.89,
+      11.86
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "382",
@@ -3233,6 +6254,24 @@
     ]
   },
   {
+    "measureId": "382",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.62,
+      2.94,
+      7.31,
+      13.66,
+      20.79,
+      33.94,
+      43.41,
+      54.6,
+      71.205,
+      93.41
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "383",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3251,6 +6290,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "383",
+    "submissionMethod": "registry",
+    "deciles": [
+      22.73,
+      81.45,
+      95.75,
+      99.53,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "384",
@@ -3273,6 +6330,42 @@
     ]
   },
   {
+    "measureId": "384",
+    "submissionMethod": "registry",
+    "deciles": [
+      75.76,
+      89.14,
+      95.1,
+      96.77,
+      98.26,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "385",
+    "submissionMethod": "registry",
+    "deciles": [
+      6.52,
+      16.81,
+      21.9,
+      34.78,
+      38.78,
+      56.94,
+      62.28,
+      64.71,
+      77.29,
+      81.48
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "389",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3291,6 +6384,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "389",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.35,
+      14.83,
+      24.11,
+      33.08,
+      45.01,
+      64.67,
+      91.13,
+      98,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "394",
@@ -3313,6 +6424,24 @@
     ]
   },
   {
+    "measureId": "394",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.975,
+      4.07,
+      5.98,
+      11.7,
+      16.175,
+      21.39,
+      25.075,
+      29.565,
+      36.69,
+      45.58
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "395",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3334,6 +6463,24 @@
   },
   {
     "measureId": "395",
+    "submissionMethod": "claims",
+    "deciles": [
+      91.3,
+      95.83,
+      98.11,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "395",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -3351,6 +6498,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "395",
+    "submissionMethod": "registry",
+    "deciles": [
+      88.03,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "396",
@@ -3393,6 +6558,24 @@
     ]
   },
   {
+    "measureId": "396",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "397",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3414,6 +6597,24 @@
   },
   {
     "measureId": "397",
+    "submissionMethod": "claims",
+    "deciles": [
+      90.62,
+      95.16,
+      98.44,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "397",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -3431,6 +6632,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "397",
+    "submissionMethod": "registry",
+    "deciles": [
+      41.33,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "398",
@@ -3453,6 +6672,24 @@
     ]
   },
   {
+    "measureId": "398",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.44,
+      41.94,
+      52.27,
+      61.29,
+      69.7,
+      85.71,
+      97.06,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "400",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3471,6 +6708,24 @@
       43.82,
       75.53
     ]
+  },
+  {
+    "measureId": "400",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.12,
+      0.6,
+      1.18,
+      1.96,
+      3.53,
+      7.55,
+      24.34,
+      47.28,
+      65.92,
+      97.08
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "402",
@@ -3493,6 +6748,24 @@
     ]
   },
   {
+    "measureId": "402",
+    "submissionMethod": "registry",
+    "deciles": [
+      37.84,
+      84.09,
+      92.41,
+      96.67,
+      98.72,
+      99.645,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "404",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3511,6 +6784,60 @@
       91.76,
       98.21
     ]
+  },
+  {
+    "measureId": "404",
+    "submissionMethod": "registry",
+    "deciles": [
+      7.64,
+      30.97,
+      50,
+      61.67,
+      69.96,
+      76.14,
+      80.33,
+      86.44,
+      91.94,
+      97.06
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "405",
+    "submissionMethod": "claims",
+    "deciles": [
+      0.71,
+      2.08,
+      6.12,
+      23.81,
+      46.07,
+      70.46,
+      96.3,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "405",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.51,
+      3.83,
+      14.5,
+      50,
+      87.225,
+      99.49,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "406",
@@ -3553,6 +6880,24 @@
     ]
   },
   {
+    "measureId": "406",
+    "submissionMethod": "registry",
+    "deciles": [
+      50,
+      13.04,
+      6.06,
+      2.43,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "410",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3571,6 +6916,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "410",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.55,
+      45.495,
+      70.135,
+      85.19,
+      93.455,
+      97.56,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "415",
@@ -3593,6 +6956,24 @@
     ]
   },
   {
+    "measureId": "415",
+    "submissionMethod": "registry",
+    "deciles": [
+      81.7,
+      93.94,
+      96.31,
+      97.54,
+      98.33,
+      98.94,
+      99.39,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "416",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3611,6 +6992,42 @@
       0,
       0
     ]
+  },
+  {
+    "measureId": "416",
+    "submissionMethod": "registry",
+    "deciles": [
+      52.38,
+      20,
+      13.51,
+      7.04,
+      3.85,
+      1.985,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "418",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.06,
+      4.17,
+      6.82,
+      14.29,
+      20.65,
+      29.755,
+      38.21,
+      49.21,
+      79.76,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "419",
@@ -3633,6 +7050,24 @@
     ]
   },
   {
+    "measureId": "419",
+    "submissionMethod": "registry",
+    "deciles": [
+      68.04,
+      37.82,
+      16.48,
+      8.86,
+      6.21,
+      2.975,
+      0.59,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "424",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3651,6 +7086,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "424",
+    "submissionMethod": "registry",
+    "deciles": [
+      88.68,
+      98.46,
+      99.64,
+      99.9,
+      99.98,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "425",
@@ -3674,6 +7127,24 @@
   },
   {
     "measureId": "425",
+    "submissionMethod": "claims",
+    "deciles": [
+      36.54,
+      96.545,
+      98.9,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "425",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -3691,6 +7162,24 @@
       99.48,
       99.95
     ]
+  },
+  {
+    "measureId": "425",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.74,
+      84.66,
+      93.74,
+      97.075,
+      98.72,
+      99.28,
+      99.55,
+      99.82,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "430",
@@ -3711,6 +7200,42 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "430",
+    "submissionMethod": "registry",
+    "deciles": [
+      76.53,
+      98.39,
+      99.665,
+      99.825,
+      99.93,
+      99.99,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "431",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.4,
+      8.91,
+      31.17,
+      48.93,
+      64.66,
+      77.545,
+      89.76,
+      96.58,
+      99.85,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "436",
@@ -3734,6 +7259,24 @@
   },
   {
     "measureId": "436",
+    "submissionMethod": "claims",
+    "deciles": [
+      1.29,
+      88.43,
+      97.16,
+      99.05,
+      99.79,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "436",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -3751,6 +7294,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "436",
+    "submissionMethod": "registry",
+    "deciles": [
+      20.53,
+      98.96,
+      99.87,
+      99.99,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "438",
@@ -3774,6 +7335,24 @@
   },
   {
     "measureId": "438",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      32.98,
+      60.84,
+      66.645,
+      69.78,
+      72.385,
+      74.61,
+      76.62,
+      78.79,
+      81.415,
+      84.75
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "438",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -3791,6 +7370,42 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "438",
+    "submissionMethod": "registry",
+    "deciles": [
+      20.5,
+      62.01,
+      70.7,
+      76.65,
+      79.88,
+      83.95,
+      87.63,
+      91.78,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "439",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.96,
+      0.28,
+      0.07,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "440",
@@ -3813,6 +7428,24 @@
     ]
   },
   {
+    "measureId": "440",
+    "submissionMethod": "registry",
+    "deciles": [
+      71.05,
+      96.74,
+      98.985,
+      99.735,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "441",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3831,6 +7464,42 @@
       55.56,
       63.97
     ]
+  },
+  {
+    "measureId": "441",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.35,
+      18.18,
+      26.985,
+      34.19,
+      40.735,
+      44.23,
+      47.615,
+      50.89,
+      54.49,
+      59.38
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "444",
+    "submissionMethod": "registry",
+    "deciles": [
+      13.89,
+      53.64,
+      74.07,
+      81.82,
+      98.57,
+      99.79,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "445",
@@ -3853,6 +7522,24 @@
     ]
   },
   {
+    "measureId": "450",
+    "submissionMethod": "registry",
+    "deciles": [
+      30,
+      39.39,
+      42.405,
+      50,
+      54.42,
+      63.3,
+      78.18,
+      87.8,
+      95.89,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "453",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3871,6 +7558,24 @@
       6.06,
       0
     ]
+  },
+  {
+    "measureId": "453",
+    "submissionMethod": "registry",
+    "deciles": [
+      32.56,
+      24.39,
+      19.23,
+      15.58,
+      13.19,
+      11.21,
+      9.68,
+      7.14,
+      5.22,
+      3.57
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "457",
@@ -3893,6 +7598,24 @@
     ]
   },
   {
+    "measureId": "457",
+    "submissionMethod": "registry",
+    "deciles": [
+      34.78,
+      24.14,
+      18.18,
+      15.49,
+      13.64,
+      10.855,
+      8.73,
+      7.23,
+      4.35,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "463",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3911,6 +7634,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "463",
+    "submissionMethod": "registry",
+    "deciles": [
+      82.445,
+      97.68,
+      99.18,
+      99.785,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "464",
@@ -3933,6 +7674,24 @@
     ]
   },
   {
+    "measureId": "464",
+    "submissionMethod": "registry",
+    "deciles": [
+      5.88,
+      70,
+      83.56,
+      88.83,
+      95.06,
+      97.075,
+      98.21,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "472",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3953,6 +7712,24 @@
     ]
   },
   {
+    "measureId": "472",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      12.5,
+      4.1,
+      1.74,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "475",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3971,6 +7748,96 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "475",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.13,
+      3.005,
+      5.83,
+      8.82,
+      11.8,
+      14.62,
+      17.96,
+      21.74,
+      26.425,
+      34.675
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "477",
+    "submissionMethod": "registry",
+    "deciles": [
+      62.56,
+      86.39,
+      94.17,
+      96.64,
+      97.96,
+      98.77,
+      99.49,
+      99.99,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "478",
+    "submissionMethod": "registry",
+    "deciles": [
+      22.5,
+      33.61,
+      40,
+      44.44,
+      50,
+      53.33,
+      57.45,
+      61.97,
+      66.67,
+      89.66
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "479",
+    "submissionMethod": "administrativeClaims",
+    "deciles": [
+      0.1852,
+      0.1668,
+      0.161,
+      0.1571,
+      0.1539,
+      0.1517,
+      0.1496,
+      0.1468,
+      0.143,
+      0.1373
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "480",
+    "submissionMethod": "administrativeClaims",
+    "deciles": [
+      0.0378,
+      0.0287,
+      0.0263,
+      0.0247,
+      0.0234,
+      0.023,
+      0.0225,
+      0.0219,
+      0.0209,
+      0.0194
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "AAAAI6",
@@ -4013,6 +7880,42 @@
     ]
   },
   {
+    "measureId": "AAD6",
+    "submissionMethod": "registry",
+    "deciles": [
+      30.86,
+      88.73,
+      94.82,
+      98.51,
+      99.46,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "AAD7",
+    "submissionMethod": "registry",
+    "deciles": [
+      22.57,
+      64.52,
+      88.66,
+      93.65,
+      95.58,
+      96.94,
+      98.68,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "AAN5",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4031,6 +7934,24 @@
       79.67,
       84.91
     ]
+  },
+  {
+    "measureId": "AAN5",
+    "submissionMethod": "registry",
+    "deciles": [
+      40.74,
+      50.85,
+      57.14,
+      66.84,
+      71.09,
+      77.2,
+      80.65,
+      81.82,
+      86.67,
+      95.31
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "AAN8",
@@ -4053,6 +7974,24 @@
     ]
   },
   {
+    "measureId": "AAN8",
+    "submissionMethod": "registry",
+    "deciles": [
+      25,
+      50.56,
+      64.885,
+      79.63,
+      82.14,
+      89.66,
+      92.195,
+      95.52,
+      97.985,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "AAN9",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4071,6 +8010,42 @@
       96.3,
       97.68
     ]
+  },
+  {
+    "measureId": "AAN9",
+    "submissionMethod": "registry",
+    "deciles": [
+      9.15,
+      59.12,
+      66.67,
+      75.51,
+      82.82,
+      90.06,
+      93.96,
+      95.75,
+      96.67,
+      98
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "AAO16",
+    "submissionMethod": "registry",
+    "deciles": [
+      23.26,
+      82.07,
+      93.37,
+      95.09,
+      97.41,
+      98.35,
+      99.82,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "AAO20",
@@ -4113,6 +8088,24 @@
     ]
   },
   {
+    "measureId": "AAO21",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.14,
+      13.73,
+      19.46,
+      35,
+      37.5,
+      51.64,
+      71.13,
+      77.27,
+      83.58,
+      91.3
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "AAO23",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4131,6 +8124,24 @@
       80.09,
       84.44
     ]
+  },
+  {
+    "measureId": "AAO23",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.98,
+      47.15,
+      59.87,
+      67.38,
+      72.36,
+      77.105,
+      80.43,
+      83.77,
+      84.91,
+      90.59
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "AAO24",
@@ -4153,6 +8164,78 @@
     ]
   },
   {
+    "measureId": "AAO24",
+    "submissionMethod": "registry",
+    "deciles": [
+      81.48,
+      88.92,
+      96.3,
+      98.48,
+      99.59,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "AAO31",
+    "submissionMethod": "registry",
+    "deciles": [
+      78.38,
+      91.76,
+      95.25,
+      96.74,
+      97.92,
+      98.495,
+      98.65,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "ABFM9",
+    "submissionMethod": "registry",
+    "deciles": [
+      37.19,
+      50.01,
+      59.33,
+      74.3,
+      92.75,
+      99.92,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "ACCPIN11",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.45,
+      31.25,
+      64.01,
+      74.07,
+      83.87,
+      89.18,
+      94.14,
+      97.06,
+      99.2,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "ACCPIN7",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4171,6 +8254,24 @@
       89.6,
       93.42
     ]
+  },
+  {
+    "measureId": "ACCPIN7",
+    "submissionMethod": "registry",
+    "deciles": [
+      43.21,
+      58.82,
+      66.67,
+      71.63,
+      74.47,
+      77.92,
+      79.54,
+      81.7,
+      84.78,
+      86.92
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "ACCPIN8",
@@ -4193,6 +8294,24 @@
     ]
   },
   {
+    "measureId": "ACCPIN8",
+    "submissionMethod": "registry",
+    "deciles": [
+      15.81,
+      25.97,
+      30.2,
+      34.35,
+      36.96,
+      39.875,
+      43.6,
+      45.65,
+      49.45,
+      53.1
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "ACEP19",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4211,6 +8330,24 @@
       68.42,
       72.76
     ]
+  },
+  {
+    "measureId": "ACEP19",
+    "submissionMethod": "registry",
+    "deciles": [
+      53.96,
+      58.89,
+      65.07,
+      72.47,
+      77.57,
+      81.87,
+      85.25,
+      87.73,
+      91.04,
+      94.09
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "ACEP21",
@@ -4233,6 +8370,24 @@
     ]
   },
   {
+    "measureId": "ACEP21",
+    "submissionMethod": "registry",
+    "deciles": [
+      23.03,
+      11.65,
+      8.44,
+      7.14,
+      5.08,
+      4.17,
+      3.36,
+      2.64,
+      2.05,
+      1.22
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "ACEP22",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4253,6 +8408,24 @@
     ]
   },
   {
+    "measureId": "ACEP22",
+    "submissionMethod": "registry",
+    "deciles": [
+      22.52,
+      28.47,
+      34.8,
+      40.73,
+      48.42,
+      54.26,
+      57.68,
+      62.63,
+      70.5,
+      79.76
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "ACEP25",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4271,6 +8444,24 @@
       79.04,
       88.22
     ]
+  },
+  {
+    "measureId": "ACEP25",
+    "submissionMethod": "registry",
+    "deciles": [
+      15.51,
+      61.12,
+      71.64,
+      78.63,
+      81.01,
+      84.12,
+      86.74,
+      88.17,
+      92.67,
+      96.05
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "ACEP30",
@@ -4313,6 +8504,24 @@
     ]
   },
   {
+    "measureId": "ACEP31",
+    "submissionMethod": "registry",
+    "deciles": [
+      51.29,
+      60.64,
+      66.67,
+      74.19,
+      76.32,
+      79.395,
+      81.16,
+      85.12,
+      87.39,
+      88.79
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "ACEP48",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4331,6 +8540,114 @@
       94.25,
       96.61
     ]
+  },
+  {
+    "measureId": "ACEP48",
+    "submissionMethod": "registry",
+    "deciles": [
+      65.18,
+      86.49,
+      89.515,
+      91.49,
+      92.025,
+      93.1,
+      93.93,
+      96.25,
+      98.19,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "ACEP50",
+    "submissionMethod": "registry",
+    "deciles": [
+      127.228,
+      117.9865,
+      111.896,
+      106.929,
+      103.0555,
+      98.8234,
+      94.6961,
+      90.0213,
+      84.3452,
+      49.6086
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "ACEP51",
+    "submissionMethod": "registry",
+    "deciles": [
+      114.921,
+      107.823,
+      104.667,
+      99.7479,
+      95.5479,
+      91.5498,
+      86.6811,
+      83.3691,
+      76.1444,
+      38.3893
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "ACEP52",
+    "submissionMethod": "registry",
+    "deciles": [
+      5.17,
+      12.73,
+      21.43,
+      54.25,
+      59.18,
+      62.99,
+      64.35,
+      66.58,
+      67.73,
+      70.88
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "ACEP55",
+    "submissionMethod": "registry",
+    "deciles": [
+      24.14,
+      37.31,
+      46.43,
+      55.38,
+      60,
+      69.88,
+      73.77,
+      77.03,
+      81.43,
+      84.05
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "ACEP58",
+    "submissionMethod": "registry",
+    "deciles": [
+      39.9,
+      34.33,
+      30.64,
+      29.15,
+      27.92,
+      26.265,
+      23.8,
+      23.1,
+      19.46,
+      11.78
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "ACMS2",
@@ -4433,6 +8750,96 @@
     ]
   },
   {
+    "measureId": "ACQR3",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.85,
+      0.915,
+      0.945,
+      0.96,
+      0.97,
+      0.97,
+      0.975,
+      0.985,
+      0.995,
+      1
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "ACR10",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.35,
+      6.98,
+      13.33,
+      20.37,
+      23.62,
+      30.35,
+      34.38,
+      36.01,
+      41.06,
+      55.25
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "ACR12",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.18,
+      6.45,
+      31.87,
+      45.24,
+      63.16,
+      67.11,
+      79.31,
+      85.23,
+      90.44,
+      94.15
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "ACR14",
+    "submissionMethod": "registry",
+    "deciles": [
+      17.24,
+      30,
+      38.46,
+      43.24,
+      45.21,
+      46.58,
+      50,
+      52.38,
+      58.97,
+      65.22
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "ACR15",
+    "submissionMethod": "registry",
+    "deciles": [
+      32.53,
+      44.22,
+      50.55,
+      58.68,
+      68.86,
+      70.89,
+      75.07,
+      80.22,
+      85.15,
+      90.24
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "ACRAD15",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4451,6 +8858,24 @@
       1.16,
       0.79
     ]
+  },
+  {
+    "measureId": "ACRAD15",
+    "submissionMethod": "registry",
+    "deciles": [
+      5.24,
+      3.61,
+      2.71,
+      2.21,
+      1.77,
+      1.53,
+      1.26,
+      1.01,
+      0.72,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "ACRAD16",
@@ -4473,6 +8898,24 @@
     ]
   },
   {
+    "measureId": "ACRAD16",
+    "submissionMethod": "registry",
+    "deciles": [
+      10.37,
+      5.795,
+      4.11,
+      3.275,
+      2.82,
+      2.29,
+      1.8,
+      1.38,
+      0.95,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "ACRAD17",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4491,6 +8934,24 @@
       3.61,
       2.33
     ]
+  },
+  {
+    "measureId": "ACRAD17",
+    "submissionMethod": "registry",
+    "deciles": [
+      21.19,
+      15.39,
+      12.8,
+      10.44,
+      8.19,
+      6.06,
+      4.4,
+      3.24,
+      2.14,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "ACRAD18",
@@ -4513,6 +8974,24 @@
     ]
   },
   {
+    "measureId": "ACRAD18",
+    "submissionMethod": "registry",
+    "deciles": [
+      10.11,
+      3.86,
+      2.8,
+      2.33,
+      2.01,
+      1.66,
+      1.36,
+      1.11,
+      0.78,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "ACRAD19",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4531,6 +9010,24 @@
       5.08,
       3.88
     ]
+  },
+  {
+    "measureId": "ACRAD19",
+    "submissionMethod": "registry",
+    "deciles": [
+      31.9,
+      24.2,
+      19.16,
+      13.09,
+      9.96,
+      6.99,
+      4.77,
+      3.41,
+      2.54,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "ACRAD25",
@@ -4553,6 +9050,24 @@
     ]
   },
   {
+    "measureId": "ACRAD25",
+    "submissionMethod": "registry",
+    "deciles": [
+      46.495,
+      27.765,
+      21.2,
+      16.455,
+      11.85,
+      6.815,
+      4.165,
+      2.195,
+      0.595,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "ACRAD34",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4571,6 +9086,24 @@
       95.14,
       95.65
     ]
+  },
+  {
+    "measureId": "ACRAD34",
+    "submissionMethod": "registry",
+    "deciles": [
+      36.6808,
+      78.0275,
+      83.1584,
+      84.4009,
+      90.0213,
+      93.4405,
+      94.9784,
+      96.1203,
+      96.1203,
+      96.1203
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "AQI48",
@@ -4593,6 +9126,24 @@
     ]
   },
   {
+    "measureId": "AQI48",
+    "submissionMethod": "registry",
+    "deciles": [
+      83.72,
+      90,
+      91.14,
+      91.84,
+      92.67,
+      93.515,
+      94.29,
+      95.49,
+      96.15,
+      97.71
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "AQI56",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4611,6 +9162,24 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "AQI56",
+    "submissionMethod": "registry",
+    "deciles": [
+      66.67,
+      93.12,
+      95.53,
+      98.05,
+      99.55,
+      99.905,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "AQI62",
@@ -4633,6 +9202,114 @@
     ]
   },
   {
+    "measureId": "AQI62",
+    "submissionMethod": "registry",
+    "deciles": [
+      6.01,
+      93.12,
+      97.8,
+      99.25,
+      99.68,
+      99.86,
+      99.97,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "AQI65",
+    "submissionMethod": "registry",
+    "deciles": [
+      20.83,
+      56.38,
+      81.7,
+      90.37,
+      97.2,
+      98.32,
+      99.22,
+      99.84,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "AQI68",
+    "submissionMethod": "registry",
+    "deciles": [
+      29.01,
+      75.39,
+      86.71,
+      93.27,
+      96.2,
+      98.52,
+      99.35,
+      99.79,
+      99.99,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "AQI69",
+    "submissionMethod": "registry",
+    "deciles": [
+      31.41,
+      95.6,
+      97.61,
+      98.7,
+      99.21,
+      99.62,
+      99.97,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "AQI70",
+    "submissionMethod": "registry",
+    "deciles": [
+      57.14,
+      97.15,
+      99.62,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "AQI72",
+    "submissionMethod": "registry",
+    "deciles": [
+      89.61,
+      94.95,
+      98.11,
+      99.84,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "AQUA14",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4651,6 +9328,24 @@
       13.79,
       2.27
     ]
+  },
+  {
+    "measureId": "AQUA14",
+    "submissionMethod": "registry",
+    "deciles": [
+      66.1,
+      22.22,
+      15.89,
+      12,
+      9.06,
+      7.69,
+      4.6,
+      3.06,
+      2.08,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "AQUA15",
@@ -4673,6 +9368,24 @@
     ]
   },
   {
+    "measureId": "AQUA15",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.17,
+      26.27,
+      47.22,
+      55.77,
+      65.09,
+      73.47,
+      79.31,
+      85.19,
+      87.76,
+      94.44
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "AQUA18",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4693,6 +9406,24 @@
     ]
   },
   {
+    "measureId": "AQUA18",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.67,
+      15.54,
+      18.37,
+      21.62,
+      24.24,
+      27.59,
+      28.12,
+      31.25,
+      35,
+      41.43
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "AQUA26",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4711,6 +9442,60 @@
       1.03,
       0
     ]
+  },
+  {
+    "measureId": "AQUA26",
+    "submissionMethod": "registry",
+    "deciles": [
+      95.93,
+      0.03,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "AQUA8",
+    "submissionMethod": "registry",
+    "deciles": [
+      40,
+      7.74,
+      4,
+      2.76,
+      2.27,
+      1.615,
+      0.62,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "ASPS29",
+    "submissionMethod": "registry",
+    "deciles": [
+      27.43,
+      7.24,
+      4.42,
+      1.06,
+      0.74,
+      0.395,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "CAHPS_1",
@@ -4873,6 +9658,204 @@
     ]
   },
   {
+    "measureId": "CAP22",
+    "submissionMethod": "registry",
+    "deciles": [
+      68.5,
+      70.85,
+      87.24,
+      90.61,
+      93.5,
+      94.41,
+      95.68,
+      96.07,
+      99.47,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "CAP28",
+    "submissionMethod": "registry",
+    "deciles": [
+      65.13,
+      83,
+      92.13,
+      94.01,
+      95.77,
+      97.275,
+      98.91,
+      99.3,
+      99.84,
+      99.95
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "CAP32",
+    "submissionMethod": "registry",
+    "deciles": [
+      40.5,
+      90.6,
+      96.83,
+      99.22,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "CAP33",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.56,
+      55.67,
+      59.38,
+      60,
+      62.59,
+      75.65,
+      79.12,
+      93.77,
+      98.31,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "CDR1",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.25,
+      16.67,
+      33.77,
+      45.94,
+      58.97,
+      68.46,
+      74.73,
+      82.59,
+      92.63,
+      96.3
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "CDR2",
+    "submissionMethod": "registry",
+    "deciles": [
+      4,
+      7.69,
+      11.54,
+      13.21,
+      14.77,
+      16.89,
+      19.05,
+      19.7,
+      22.61,
+      24.44
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "CDR5",
+    "submissionMethod": "registry",
+    "deciles": [
+      5.11,
+      31.26,
+      50.39,
+      57.565,
+      65.4,
+      68.14,
+      72.265,
+      76.7,
+      84.4,
+      92.475
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "CDR6",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.56,
+      8.67,
+      17.15,
+      19.1,
+      20.78,
+      21.73,
+      23.39,
+      27.58,
+      32.31,
+      37.04
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "ECPR39",
+    "submissionMethod": "registry",
+    "deciles": [
+      13.3,
+      80.89,
+      93.75,
+      96.67,
+      97.65,
+      98.355,
+      98.9,
+      99.25,
+      99.67,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "ECPR40",
+    "submissionMethod": "registry",
+    "deciles": [
+      71.43,
+      94.12,
+      97.65,
+      99.03,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "ECPR46",
+    "submissionMethod": "registry",
+    "deciles": [
+      80.66,
+      92.32,
+      99.31,
+      99.69,
+      99.9,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "EPREOP30",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4911,6 +9894,96 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "GIQIC22",
+    "submissionMethod": "registry",
+    "deciles": [
+      15.27,
+      21.86,
+      26.62,
+      32.05,
+      37.81,
+      41.3,
+      44.87,
+      46.67,
+      51.09,
+      55.84
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "GIQIC23",
+    "submissionMethod": "registry",
+    "deciles": [
+      18.86,
+      42.86,
+      60,
+      70.27,
+      76.29,
+      87.225,
+      89.13,
+      94.69,
+      97.67,
+      99.27
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "HM5",
+    "submissionMethod": "registry",
+    "deciles": [
+      25,
+      42.86,
+      50,
+      58.33,
+      61.76,
+      65.22,
+      66.67,
+      69.57,
+      86.67,
+      92
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "HM6",
+    "submissionMethod": "registry",
+    "deciles": [
+      12,
+      28.57,
+      40.43,
+      46.88,
+      52.475,
+      61.54,
+      65.74,
+      72.97,
+      80.925,
+      89.58
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "HM8",
+    "submissionMethod": "registry",
+    "deciles": [
+      8.57,
+      31.75,
+      40,
+      48.51,
+      53.52,
+      61.29,
+      65.99,
+      70,
+      77.94,
+      83.9
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "IRIS1",
@@ -4953,6 +10026,60 @@
     ]
   },
   {
+    "measureId": "IRIS13",
+    "submissionMethod": "registry",
+    "deciles": [
+      56.86,
+      80.44,
+      84.62,
+      86.52,
+      88.02,
+      89.415,
+      90.37,
+      92.06,
+      93.83,
+      96.36
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "IRIS17",
+    "submissionMethod": "registry",
+    "deciles": [
+      13.33,
+      32.2,
+      50,
+      60.75,
+      67.86,
+      71.37,
+      74.02,
+      77.78,
+      82.14,
+      87.18
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "IRIS2",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.8,
+      50.93,
+      61.7,
+      66.91,
+      71.09,
+      74.29,
+      77.61,
+      80.13,
+      83.5,
+      87.59
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "IRIS23",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4971,6 +10098,42 @@
       94.12,
       95.81
     ]
+  },
+  {
+    "measureId": "IRIS23",
+    "submissionMethod": "registry",
+    "deciles": [
+      24.29,
+      44,
+      68.55,
+      77.58,
+      81.25,
+      82.35,
+      84.21,
+      89.2,
+      94.29,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "IRIS26",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.94,
+      0.86,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "IRIS43",
@@ -4993,6 +10156,24 @@
     ]
   },
   {
+    "measureId": "IRIS43",
+    "submissionMethod": "registry",
+    "deciles": [
+      5,
+      8.7,
+      14.29,
+      17.42,
+      21.62,
+      24.35,
+      31.67,
+      36.17,
+      77.59,
+      93.33
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "IRIS44",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -5011,6 +10192,60 @@
       8.83,
       2.33
     ]
+  },
+  {
+    "measureId": "IRIS44",
+    "submissionMethod": "registry",
+    "deciles": [
+      90,
+      18.18,
+      13.33,
+      12.64,
+      11.63,
+      11.125,
+      7.14,
+      5,
+      4.05,
+      1.39
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "IRIS45",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.45,
+      1.19,
+      1.565,
+      2.33,
+      3.13,
+      3.67,
+      4.75,
+      6.48,
+      8.985,
+      13.6
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "IRIS46",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.17,
+      24.14,
+      40,
+      53.06,
+      56.52,
+      63.31,
+      66.67,
+      71.91,
+      81.58,
+      95.24
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "IRIS48",
@@ -5053,6 +10288,114 @@
     ]
   },
   {
+    "measureId": "IRIS51",
+    "submissionMethod": "registry",
+    "deciles": [
+      60,
+      84.44,
+      87.91,
+      91.3,
+      93.785,
+      95.45,
+      95.92,
+      97.26,
+      99.26,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "IRIS52",
+    "submissionMethod": "registry",
+    "deciles": [
+      59.61,
+      75.47,
+      95.34,
+      98.92,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "IRIS53",
+    "submissionMethod": "registry",
+    "deciles": [
+      53.12,
+      78.69,
+      84,
+      86.36,
+      88.24,
+      90.18,
+      92.86,
+      95.24,
+      97.78,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "IRIS54",
+    "submissionMethod": "registry",
+    "deciles": [
+      7.5,
+      3.66,
+      2.47,
+      1.9,
+      1.66,
+      1.25,
+      0.86,
+      0.43,
+      0,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "IRIS55",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.7037,
+      8.2734,
+      27.2727,
+      33.3333,
+      33.6996,
+      36.7347,
+      43.9024,
+      46.8697,
+      48.8889,
+      65.8537
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "IRIS59",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.3699,
+      16.3265,
+      23.6679,
+      28.3168,
+      32.1839,
+      35.6306,
+      42.7874,
+      49.3119,
+      56.7458,
+      67.3469
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "IRIS6",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -5071,6 +10414,186 @@
       100,
       100
     ]
+  },
+  {
+    "measureId": "IROMS11",
+    "submissionMethod": "registry",
+    "deciles": [
+      60.71,
+      56,
+      53.4,
+      51.52,
+      50,
+      48.94,
+      47.62,
+      45.65,
+      43.45,
+      40
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "IROMS12",
+    "submissionMethod": "registry",
+    "deciles": [
+      63.11,
+      57.69,
+      55.06,
+      53.79,
+      52.17,
+      50.88,
+      50,
+      48.28,
+      46.88,
+      43.75
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "IROMS13",
+    "submissionMethod": "registry",
+    "deciles": [
+      61.11,
+      53.57,
+      50,
+      48.61,
+      47.43,
+      45.67,
+      43.75,
+      41.46,
+      38.46,
+      34.78
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "IROMS14",
+    "submissionMethod": "registry",
+    "deciles": [
+      60.61,
+      55,
+      52.55,
+      50.96,
+      50,
+      48.15,
+      46.43,
+      45,
+      42.86,
+      39.13
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "IROMS15",
+    "submissionMethod": "registry",
+    "deciles": [
+      61.9,
+      56.82,
+      54.55,
+      52.2,
+      50,
+      48.94,
+      47.06,
+      44.72,
+      40,
+      33
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "IROMS16",
+    "submissionMethod": "registry",
+    "deciles": [
+      63.41,
+      55.77,
+      53.85,
+      52.24,
+      51.22,
+      50,
+      47.83,
+      45.73,
+      43.84,
+      40
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "IROMS17",
+    "submissionMethod": "registry",
+    "deciles": [
+      59.09,
+      53.33,
+      51.04,
+      49.23,
+      47.62,
+      45.71,
+      43.64,
+      41.67,
+      38.545,
+      34.29
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "IROMS18",
+    "submissionMethod": "registry",
+    "deciles": [
+      61.11,
+      55.42,
+      53.45,
+      52.05,
+      50.85,
+      49.965,
+      47.59,
+      45.45,
+      42.86,
+      39.08
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "IROMS19",
+    "submissionMethod": "registry",
+    "deciles": [
+      56.52,
+      50,
+      47.83,
+      45.36,
+      43.9,
+      42.41,
+      40.91,
+      38.71,
+      36.59,
+      33.33
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "IROMS20",
+    "submissionMethod": "registry",
+    "deciles": [
+      58.97,
+      53.66,
+      51.43,
+      50,
+      48.39,
+      47.2,
+      45.53,
+      44.23,
+      42.31,
+      39.39
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "MCC1",
@@ -5114,6 +10637,42 @@
     ]
   },
   {
+    "measureId": "MSN13",
+    "submissionMethod": "registry",
+    "deciles": [
+      26,
+      35,
+      71,
+      79,
+      87,
+      94,
+      96,
+      99,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "MSN15",
+    "submissionMethod": "registry",
+    "deciles": [
+      15,
+      76,
+      94,
+      98,
+      99,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "NHCR4",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -5132,6 +10691,24 @@
       86.44,
       90.48
     ]
+  },
+  {
+    "measureId": "NHCR4",
+    "submissionMethod": "registry",
+    "deciles": [
+      6.67,
+      24.42,
+      38.26,
+      41.38,
+      56.03,
+      61.6,
+      77.67,
+      82.09,
+      94.87,
+      98.59
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "PIMSH1",
@@ -5154,6 +10731,78 @@
     ]
   },
   {
+    "measureId": "PIMSH1",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.5,
+      2.3,
+      6.4,
+      12.8,
+      15.7,
+      20.85,
+      25,
+      35.6,
+      43.3,
+      63.2
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "PIMSH10",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.4,
+      20.8,
+      27.6,
+      35,
+      41.2,
+      47.95,
+      57.1,
+      64.5,
+      69.6,
+      85.2
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "PIMSH11",
+    "submissionMethod": "registry",
+    "deciles": [
+      33.8,
+      5.4,
+      3.3,
+      2.4,
+      1.5,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "PIMSH2",
+    "submissionMethod": "registry",
+    "deciles": [
+      67.7,
+      40,
+      36.8,
+      35.2,
+      31.4,
+      25,
+      23,
+      10.5,
+      4.8,
+      4
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "PIMSH4",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -5172,6 +10821,42 @@
       51.05,
       58.26
     ]
+  },
+  {
+    "measureId": "PIMSH4",
+    "submissionMethod": "registry",
+    "deciles": [
+      13.3,
+      28.4,
+      34.15,
+      37.5,
+      39.65,
+      42.2,
+      44.65,
+      48.2,
+      51.8,
+      57.1
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "PIMSH9",
+    "submissionMethod": "registry",
+    "deciles": [
+      25,
+      15.6,
+      12.1,
+      10,
+      8.3,
+      6.8,
+      4.8,
+      4.1,
+      3.2,
+      0
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "QUANTUM31",
@@ -5194,6 +10879,24 @@
     ]
   },
   {
+    "measureId": "QUANTUM31",
+    "submissionMethod": "registry",
+    "deciles": [
+      46.02,
+      70,
+      80,
+      85.71,
+      90.48,
+      95.55,
+      99.45,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "RCOIR10",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -5212,6 +10915,24 @@
       84.13,
       89.52
     ]
+  },
+  {
+    "measureId": "RCOIR10",
+    "submissionMethod": "registry",
+    "deciles": [
+      50,
+      65.43,
+      69.88,
+      71.59,
+      72.57,
+      76.32,
+      79.37,
+      83.18,
+      86.05,
+      89.32
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "RCOIR12",
@@ -5234,6 +10955,24 @@
     ]
   },
   {
+    "measureId": "RCOIR12",
+    "submissionMethod": "registry",
+    "deciles": [
+      52.94,
+      60.925,
+      68.815,
+      72.225,
+      76.27,
+      79.38,
+      80.86,
+      82.92,
+      86.28,
+      88.105
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "RCOIR7",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -5252,6 +10991,24 @@
       93.62,
       96.08
     ]
+  },
+  {
+    "measureId": "RCOIR7",
+    "submissionMethod": "registry",
+    "deciles": [
+      69.89,
+      75.44,
+      82.11,
+      84.8,
+      87.64,
+      88.89,
+      91.3,
+      92.72,
+      95.31,
+      96.55
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "RPAQIR13",
@@ -5274,6 +11031,24 @@
     ]
   },
   {
+    "measureId": "RPAQIR13",
+    "submissionMethod": "registry",
+    "deciles": [
+      92.36,
+      96.48,
+      97.35,
+      98.26,
+      98.63,
+      98.785,
+      99.17,
+      99.37,
+      99.65,
+      99.745
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "RPAQIR14",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -5294,6 +11069,24 @@
     ]
   },
   {
+    "measureId": "RPAQIR14",
+    "submissionMethod": "registry",
+    "deciles": [
+      69.37,
+      72.97,
+      79.29,
+      81.58,
+      83.91,
+      86.83,
+      88.57,
+      90.85,
+      91.98,
+      93.1
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
     "measureId": "RPAQIR15",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -5312,6 +11105,24 @@
       91.69,
       93.15
     ]
+  },
+  {
+    "measureId": "RPAQIR15",
+    "submissionMethod": "registry",
+    "deciles": [
+      60.47,
+      71.15,
+      74.24,
+      79.41,
+      81.48,
+      85.29,
+      86.47,
+      90.24,
+      91.24,
+      93.1
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   },
   {
     "measureId": "STS1",
@@ -5372,5 +11183,41 @@
       98.71,
       99.51
     ]
+  },
+  {
+    "measureId": "UREQA4",
+    "submissionMethod": "registry",
+    "deciles": [
+      95.82,
+      97.63,
+      98.405,
+      99.03,
+      99.385,
+      99.48,
+      99.62,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
+  },
+  {
+    "measureId": "USWR23",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.32,
+      13.28,
+      21.43,
+      41.75,
+      48.84,
+      57.38,
+      70.83,
+      75.29,
+      80.56,
+      88.37
+    ],
+    "performanceYear": 2021,
+    "benchmarkYear": 2021
   }
 ]

--- a/benchmarks/2021.json
+++ b/benchmarks/2021.json
@@ -884,7 +884,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "claims",
     "deciles": [
-      1.57,
       30.56,
       69.89,
       81.29,
@@ -923,7 +922,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "electronicHealthRecord",
     "deciles": [
-      0.19,
       5.33,
       17.7,
       27.74,
@@ -943,7 +941,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      0.51,
       18.67,
       40.36,
       57.41,
@@ -1082,7 +1079,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "claims",
     "deciles": [
-      3.64,
       38.16,
       68.98,
       80.27,
@@ -1141,7 +1137,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      0.3,
       4.555,
       18.09,
       37.7,
@@ -1441,7 +1436,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "electronicHealthRecord",
     "deciles": [
-      0.07,
       1.8,
       7.13,
       15.39,
@@ -1601,7 +1595,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      4,
       18.42,
       44.62,
       68.21,
@@ -2121,7 +2114,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      20.41,
       37.65,
       42.94,
       47.06,
@@ -2141,7 +2133,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      17.36,
       35.71,
       41.525,
       46.13,
@@ -2161,7 +2152,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      16.42,
       34,
       37.5,
       41.67,
@@ -2181,7 +2171,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      24.78,
       33.33,
       40,
       45.38,
@@ -2201,7 +2190,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      23.08,
       33.78,
       38.61,
       44.35,
@@ -2221,7 +2209,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      21.43,
       37.04,
       44.44,
       49.4,
@@ -2300,7 +2287,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "electronicHealthRecord",
     "deciles": [
-      2.05,
       13.95,
       25,
       36.11,
@@ -2320,7 +2306,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      2.88,
       17.3,
       34.62,
       53.74,
@@ -2419,7 +2404,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "electronicHealthRecord",
     "deciles": [
-      21.82,
       10.55,
       6.7,
       3.84,
@@ -2439,7 +2423,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      20,
       3.73,
       0.625,
       0.05,
@@ -2919,7 +2902,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "claims",
     "deciles": [
-      0.32,
       31.91,
       84.62,
       96.66,
@@ -2939,7 +2921,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "electronicHealthRecord",
     "deciles": [
-      0.06,
       5.78,
       13.7,
       17.68,
@@ -2959,7 +2940,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      0.05,
       12.04,
       21.49,
       28.33,
@@ -3678,7 +3658,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      6.52,
       16.81,
       21.9,
       34.78,
@@ -3938,7 +3917,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "claims",
     "deciles": [
-      0.71,
       2.08,
       6.12,
       23.81,
@@ -3958,7 +3936,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      0.51,
       3.83,
       14.5,
       50,
@@ -4078,7 +4055,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      1.06,
       4.17,
       6.82,
       14.29,
@@ -4198,7 +4174,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      0.4,
       8.91,
       31.17,
       48.93,
@@ -4298,7 +4273,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      1.96,
       0.28,
       0.07,
       0,
@@ -4358,7 +4332,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      13.89,
       53.64,
       74.07,
       81.82,
@@ -4398,7 +4371,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      30,
       39.39,
       42.405,
       50,
@@ -4538,7 +4510,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      62.56,
       86.39,
       94.17,
       96.64,
@@ -4558,7 +4529,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      22.5,
       33.61,
       40,
       44.44,
@@ -4578,7 +4548,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "administrativeClaims",
     "deciles": [
-      0.1852,
       0.1668,
       0.161,
       0.1571,
@@ -4598,7 +4567,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "administrativeClaims",
     "deciles": [
-      0.0378,
       0.0287,
       0.0263,
       0.0247,
@@ -4658,7 +4626,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      30.86,
       88.73,
       94.82,
       98.51,
@@ -4678,7 +4645,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      22.57,
       64.52,
       88.66,
       93.65,
@@ -4758,7 +4724,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      23.26,
       82.07,
       93.37,
       95.09,
@@ -4858,7 +4823,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      78.38,
       91.76,
       95.25,
       96.74,
@@ -4878,7 +4842,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      37.19,
       50.01,
       59.33,
       74.3,
@@ -4898,7 +4861,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      3.45,
       31.25,
       64.01,
       74.07,
@@ -5138,7 +5100,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      5.17,
       12.73,
       21.43,
       54.25,
@@ -5158,7 +5119,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      24.14,
       37.31,
       46.43,
       55.38,
@@ -5178,7 +5138,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      39.9,
       34.33,
       30.64,
       29.15,
@@ -5298,7 +5257,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      4.35,
       6.98,
       13.33,
       20.37,
@@ -5318,7 +5276,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      1.18,
       6.45,
       31.87,
       45.24,
@@ -5338,7 +5295,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      17.24,
       30,
       38.46,
       43.24,
@@ -5358,7 +5314,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      32.53,
       44.22,
       50.55,
       58.68,
@@ -5578,7 +5533,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      20.83,
       56.38,
       81.7,
       90.37,
@@ -5598,7 +5552,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      29.01,
       75.39,
       86.71,
       93.27,
@@ -5618,7 +5571,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      31.41,
       95.6,
       97.61,
       98.7,
@@ -5638,7 +5590,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      57.14,
       97.15,
       99.62,
       100,
@@ -5658,7 +5609,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      89.61,
       94.95,
       98.11,
       99.84,
@@ -5758,7 +5708,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      40,
       7.74,
       4,
       2.76,
@@ -5778,7 +5727,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      27.43,
       7.24,
       4.42,
       1.06,
@@ -5958,7 +5906,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      68.5,
       70.85,
       87.24,
       90.61,
@@ -5978,7 +5925,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      65.13,
       83,
       92.13,
       94.01,
@@ -5998,7 +5944,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      40.5,
       90.6,
       96.83,
       99.22,
@@ -6018,7 +5963,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      1.56,
       55.67,
       59.38,
       60,
@@ -6038,7 +5982,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      4.25,
       16.67,
       33.77,
       45.94,
@@ -6058,7 +6001,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      4,
       7.69,
       11.54,
       13.21,
@@ -6078,7 +6020,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      5.11,
       31.26,
       50.39,
       57.565,
@@ -6098,7 +6039,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      2.56,
       8.67,
       17.15,
       19.1,
@@ -6118,7 +6058,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      13.3,
       80.89,
       93.75,
       96.67,
@@ -6138,7 +6077,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      71.43,
       94.12,
       97.65,
       99.03,
@@ -6158,7 +6096,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      80.66,
       92.32,
       99.31,
       99.69,
@@ -6218,7 +6155,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      15.27,
       21.86,
       26.62,
       32.05,
@@ -6238,7 +6174,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      18.86,
       42.86,
       60,
       70.27,
@@ -6258,7 +6193,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      25,
       42.86,
       50,
       58.33,
@@ -6278,7 +6212,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      12,
       28.57,
       40.43,
       46.88,
@@ -6298,7 +6231,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      8.57,
       31.75,
       40,
       48.51,
@@ -6358,7 +6290,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      13.33,
       32.2,
       50,
       60.75,
@@ -6378,7 +6309,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      1.8,
       50.93,
       61.7,
       66.91,
@@ -6418,7 +6348,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      4.94,
       0.86,
       0,
       0,
@@ -6478,7 +6407,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      0.45,
       1.19,
       1.565,
       2.33,
@@ -6498,7 +6426,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      4.17,
       24.14,
       40,
       53.06,
@@ -6558,7 +6485,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      60,
       84.44,
       87.91,
       91.3,
@@ -6578,7 +6504,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      59.61,
       75.47,
       95.34,
       98.92,
@@ -6598,7 +6523,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      53.12,
       78.69,
       84,
       86.36,
@@ -6618,7 +6542,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      7.5,
       3.66,
       2.47,
       1.9,
@@ -6638,7 +6561,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      3.7037,
       8.2734,
       27.2727,
       33.3333,
@@ -6658,7 +6580,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      1.3699,
       16.3265,
       23.6679,
       28.3168,
@@ -6698,7 +6619,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      60.71,
       56,
       53.4,
       51.52,
@@ -6718,7 +6638,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      63.11,
       57.69,
       55.06,
       53.79,
@@ -6738,7 +6657,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      61.11,
       53.57,
       50,
       48.61,
@@ -6758,7 +6676,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      60.61,
       55,
       52.55,
       50.96,
@@ -6778,7 +6695,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      61.9,
       56.82,
       54.55,
       52.2,
@@ -6798,7 +6714,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      63.41,
       55.77,
       53.85,
       52.24,
@@ -6818,7 +6733,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      59.09,
       53.33,
       51.04,
       49.23,
@@ -6838,7 +6752,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      61.11,
       55.42,
       53.45,
       52.05,
@@ -6858,7 +6771,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      56.52,
       50,
       47.83,
       45.36,
@@ -6878,7 +6790,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      58.97,
       53.66,
       51.43,
       50,
@@ -6939,7 +6850,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      26,
       35,
       71,
       79,
@@ -6959,7 +6869,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      15,
       76,
       94,
       98,
@@ -7019,7 +6928,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      2.4,
       20.8,
       27.6,
       35,
@@ -7039,7 +6947,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      33.8,
       5.4,
       3.3,
       2.4,
@@ -7059,7 +6966,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      67.7,
       40,
       36.8,
       35.2,
@@ -7099,7 +7005,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      25,
       15.6,
       12.1,
       10,
@@ -7319,7 +7224,6 @@
     "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
-      0.32,
       13.28,
       21.43,
       41.75,

--- a/benchmarks/2021.json
+++ b/benchmarks/2021.json
@@ -40,24 +40,6 @@
   },
   {
     "measureId": "001",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      99.52,
-      93.33,
-      75,
-      57.6,
-      46.15,
-      38.165,
-      32.26,
-      27.32,
-      22.5,
-      17.07
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "001",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -75,23 +57,6 @@
       19.15,
       12.87
     ]
-  },
-  {
-    "measureId": "001",
-    "submissionMethod": "registry",
-    "deciles": [
-      90,
-      80,
-      70,
-      60,
-      50,
-      40,
-      30,
-      20,
-      10
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "005",
@@ -115,24 +80,6 @@
   },
   {
     "measureId": "005",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      24,
-      60.8,
-      68.89,
-      73.61,
-      77.43,
-      80.03,
-      82.39,
-      85.53,
-      88.14,
-      91.67
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "005",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -150,24 +97,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "005",
-    "submissionMethod": "registry",
-    "deciles": [
-      67.35,
-      88,
-      95.45,
-      98.55,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "006",
@@ -188,24 +117,6 @@
       98.94,
       100
     ]
-  },
-  {
-    "measureId": "006",
-    "submissionMethod": "registry",
-    "deciles": [
-      41.67,
-      70.83,
-      77.71,
-      83.02,
-      86.8,
-      90.4,
-      93.66,
-      97.04,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "007",
@@ -229,24 +140,6 @@
   },
   {
     "measureId": "007",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      54.55,
-      75.76,
-      80.77,
-      83.81,
-      86.26,
-      88.095,
-      90,
-      91.8,
-      93.33,
-      95.83
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "007",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -264,24 +157,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "007",
-    "submissionMethod": "registry",
-    "deciles": [
-      56.91,
-      77.92,
-      82.845,
-      86.67,
-      90,
-      93.24,
-      96.235,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "008",
@@ -305,24 +180,6 @@
   },
   {
     "measureId": "008",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      42.86,
-      80.49,
-      85.71,
-      88.52,
-      90.7,
-      92.31,
-      93.64,
-      95,
-      96.39,
-      98.15
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "008",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -340,24 +197,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "008",
-    "submissionMethod": "registry",
-    "deciles": [
-      38.46,
-      91.21,
-      96.97,
-      98.86,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "009",
@@ -380,24 +219,6 @@
     ]
   },
   {
-    "measureId": "009",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      25,
-      62.22,
-      71.33,
-      75.56,
-      77.78,
-      80.205,
-      82.26,
-      83.82,
-      85.68,
-      88.49
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "012",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -418,24 +239,6 @@
     ]
   },
   {
-    "measureId": "012",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      3.88,
-      68.62,
-      83.13,
-      88.69,
-      91.94,
-      94.165,
-      96.08,
-      97.66,
-      98.96,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "014",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -454,24 +257,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "014",
-    "submissionMethod": "claims",
-    "deciles": [
-      22.83,
-      97.515,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "014",
@@ -492,24 +277,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "014",
-    "submissionMethod": "registry",
-    "deciles": [
-      5.91,
-      74.55,
-      89.16,
-      93.79,
-      96.31,
-      98.075,
-      99.14,
-      99.77,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "019",
@@ -533,24 +300,6 @@
   },
   {
     "measureId": "019",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      6.41,
-      52.985,
-      70.175,
-      80.36,
-      86.32,
-      90.91,
-      93.75,
-      96.045,
-      98,
-      99.55
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "019",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -570,24 +319,6 @@
     ]
   },
   {
-    "measureId": "019",
-    "submissionMethod": "registry",
-    "deciles": [
-      3.33,
-      72.335,
-      91.445,
-      98.71,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "021",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -606,24 +337,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "021",
-    "submissionMethod": "claims",
-    "deciles": [
-      5.26,
-      99.62,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "021",
@@ -646,24 +359,6 @@
     ]
   },
   {
-    "measureId": "021",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.94,
-      38.3,
-      92.31,
-      98.55,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "023",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -682,24 +377,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "023",
-    "submissionMethod": "claims",
-    "deciles": [
-      2.86,
-      95.74,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "023",
@@ -720,24 +397,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "023",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.69,
-      47.12,
-      93.21,
-      98.84,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "024",
@@ -780,24 +439,6 @@
     ]
   },
   {
-    "measureId": "024",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.04,
-      1.35,
-      31.62,
-      64.15,
-      83.1,
-      98.08,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "039",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -816,24 +457,6 @@
       96.34,
       100
     ]
-  },
-  {
-    "measureId": "039",
-    "submissionMethod": "claims",
-    "deciles": [
-      1.1,
-      24.29,
-      42.64,
-      53.7,
-      68.72,
-      77.94,
-      86.025,
-      95.18,
-      99.285,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "039",
@@ -856,24 +479,6 @@
     ]
   },
   {
-    "measureId": "039",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.53,
-      7.51,
-      19.66,
-      32.59,
-      44.63,
-      57.44,
-      69.25,
-      79.69,
-      87.68,
-      97.77
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "044",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -892,24 +497,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "044",
-    "submissionMethod": "registry",
-    "deciles": [
-      68.57,
-      91.95,
-      98.63,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "047",
@@ -933,24 +520,6 @@
   },
   {
     "measureId": "047",
-    "submissionMethod": "claims",
-    "deciles": [
-      0.65,
-      43.14,
-      96.34,
-      99.83,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "047",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -968,24 +537,6 @@
       98.95,
       100
     ]
-  },
-  {
-    "measureId": "047",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.13,
-      5.4,
-      34.06,
-      60.46,
-      79.06,
-      90.86,
-      96.78,
-      99.1,
-      99.91,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "048",
@@ -1006,24 +557,6 @@
       98.54,
       100
     ]
-  },
-  {
-    "measureId": "048",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.32,
-      32.46,
-      58.07,
-      74.83,
-      85.25,
-      95.01,
-      98.39,
-      99.7,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "050",
@@ -1047,24 +580,6 @@
   },
   {
     "measureId": "050",
-    "submissionMethod": "claims",
-    "deciles": [
-      23.81,
-      96,
-      98.31,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "050",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1082,24 +597,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "050",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.7,
-      46.96,
-      68.25,
-      75.18,
-      80.62,
-      83.8,
-      88.46,
-      96.97,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "052",
@@ -1120,24 +617,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "052",
-    "submissionMethod": "registry",
-    "deciles": [
-      8.5,
-      58.44,
-      72.165,
-      88.54,
-      97.26,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "065",
@@ -1161,24 +640,6 @@
   },
   {
     "measureId": "065",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      37.1,
-      77.5,
-      86.67,
-      90.12,
-      92.8,
-      94.74,
-      96.26,
-      97.78,
-      99.25,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "065",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1196,24 +657,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "065",
-    "submissionMethod": "registry",
-    "deciles": [
-      55.99,
-      87.23,
-      93.185,
-      95.24,
-      96.715,
-      97.76,
-      98.5,
-      99.12,
-      99.55,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "066",
@@ -1237,24 +680,6 @@
   },
   {
     "measureId": "066",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.54,
-      7.41,
-      22,
-      36.8,
-      52.43,
-      63.82,
-      72.73,
-      80,
-      84.11,
-      88.42
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "066",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1272,24 +697,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "066",
-    "submissionMethod": "registry",
-    "deciles": [
-      26.09,
-      76.92,
-      86.89,
-      92,
-      95.45,
-      97.64,
-      98.9,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "067",
@@ -1312,24 +719,6 @@
     ]
   },
   {
-    "measureId": "067",
-    "submissionMethod": "registry",
-    "deciles": [
-      11.48,
-      34.48,
-      50.23,
-      54.17,
-      68,
-      98.31,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "070",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -1348,24 +737,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "070",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.61,
-      25.81,
-      57.935,
-      68.31,
-      72.83,
-      87.855,
-      95.425,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "076",
@@ -1389,24 +760,6 @@
   },
   {
     "measureId": "076",
-    "submissionMethod": "claims",
-    "deciles": [
-      6.45,
-      96.15,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "076",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1424,24 +777,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "076",
-    "submissionMethod": "registry",
-    "deciles": [
-      45.16,
-      93.06,
-      98.56,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "093",
@@ -1465,24 +800,6 @@
   },
   {
     "measureId": "093",
-    "submissionMethod": "claims",
-    "deciles": [
-      2.27,
-      58.62,
-      82.26,
-      92.78,
-      95.35,
-      96.97,
-      98.26,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "093",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1500,24 +817,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "093",
-    "submissionMethod": "registry",
-    "deciles": [
-      37.16,
-      79.31,
-      90.39,
-      93.86,
-      96.28,
-      97.8,
-      99.015,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "102",
@@ -1580,25 +879,9 @@
     ]
   },
   {
-    "measureId": "107",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.07,
-      0.68,
-      2.37,
-      7.05,
-      13.125,
-      21.045,
-      38.545,
-      55.27,
-      78.71,
-      93.7
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "110",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "claims",
     "deciles": [
       1.57,
@@ -1612,8 +895,8 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "110",
@@ -1636,6 +919,8 @@
   },
   {
     "measureId": "110",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "electronicHealthRecord",
     "deciles": [
       0.19,
@@ -1649,11 +934,13 @@
       67.23,
       82.04
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "110",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       0.51,
@@ -1667,8 +954,8 @@
       99.37,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "111",
@@ -1692,24 +979,6 @@
   },
   {
     "measureId": "111",
-    "submissionMethod": "claims",
-    "deciles": [
-      1.52,
-      53.13,
-      68.7,
-      76.21,
-      82.17,
-      87.85,
-      93.87,
-      98.43,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "111",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1727,24 +996,6 @@
       85.83,
       95
     ]
-  },
-  {
-    "measureId": "111",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.8,
-      31.24,
-      51.62,
-      62.82,
-      69.63,
-      74.7,
-      79.23,
-      83.71,
-      89.62,
-      98.23
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "112",
@@ -1765,24 +1016,6 @@
       99.03,
       100
     ]
-  },
-  {
-    "measureId": "112",
-    "submissionMethod": "claims",
-    "deciles": [
-      2.55,
-      43.62,
-      64.55,
-      75.82,
-      83.43,
-      89.12,
-      94.97,
-      98.35,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "112",
@@ -1825,24 +1058,6 @@
   },
   {
     "measureId": "112",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.27,
-      9.23,
-      27.56,
-      39.42,
-      48.18,
-      54.84,
-      60.57,
-      66.82,
-      73.31,
-      82.05
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "112",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -1862,25 +1077,9 @@
     ]
   },
   {
-    "measureId": "112",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.24,
-      15.37,
-      36.27,
-      47.83,
-      59.02,
-      68.59,
-      76.82,
-      83.9,
-      93.75,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "113",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "claims",
     "deciles": [
       3.64,
@@ -1894,8 +1093,8 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "113",
@@ -1938,24 +1137,8 @@
   },
   {
     "measureId": "113",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.18,
-      7.22,
-      22.61,
-      34.53,
-      43.9,
-      51.89,
-      59.65,
-      66.98,
-      75.51,
-      85.69
-    ],
     "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "113",
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       0.3,
@@ -1969,8 +1152,8 @@
       90.25,
       99.55
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "116",
@@ -1991,24 +1174,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "116",
-    "submissionMethod": "registry",
-    "deciles": [
-      41.84,
-      77.03,
-      87.09,
-      92.45,
-      95.83,
-      97.88,
-      98.82,
-      99.65,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "117",
@@ -2032,24 +1197,6 @@
   },
   {
     "measureId": "117",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.59,
-      5.9,
-      13.82,
-      23,
-      33.26,
-      46.04,
-      80.51,
-      97.65,
-      99.21,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "117",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -2067,24 +1214,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "117",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.3,
-      48.29,
-      95.68,
-      99.04,
-      99.74,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "118",
@@ -2105,24 +1234,6 @@
       90.48,
       96
     ]
-  },
-  {
-    "measureId": "118",
-    "submissionMethod": "registry",
-    "deciles": [
-      55.56,
-      70.69,
-      76.67,
-      79.62,
-      82.09,
-      84.96,
-      87.5,
-      90.32,
-      96.15,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "119",
@@ -2146,24 +1257,6 @@
   },
   {
     "measureId": "119",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      20.29,
-      64.23,
-      73.01,
-      78.12,
-      81.82,
-      84.75,
-      87.565,
-      90.36,
-      93.75,
-      98.32
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "119",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -2181,24 +1274,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "119",
-    "submissionMethod": "registry",
-    "deciles": [
-      3.09,
-      66.89,
-      77.04,
-      82.08,
-      87.35,
-      90.975,
-      94.15,
-      98.06,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "126",
@@ -2221,24 +1296,6 @@
     ]
   },
   {
-    "measureId": "126",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.62,
-      49.57,
-      80.13,
-      92.91,
-      98.65,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "127",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2257,24 +1314,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "127",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.84,
-      67.77,
-      89.415,
-      96.24,
-      99.635,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "128",
@@ -2298,24 +1337,6 @@
   },
   {
     "measureId": "128",
-    "submissionMethod": "claims",
-    "deciles": [
-      14.71,
-      66.67,
-      95.78,
-      99.26,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "128",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -2333,24 +1354,6 @@
       99.76,
       100
     ]
-  },
-  {
-    "measureId": "128",
-    "submissionMethod": "registry",
-    "deciles": [
-      2.28,
-      31.82,
-      64.94,
-      85.33,
-      94.62,
-      98.35,
-      99.72,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "130",
@@ -2374,24 +1377,6 @@
   },
   {
     "measureId": "130",
-    "submissionMethod": "claims",
-    "deciles": [
-      7.39,
-      98.58,
-      99.82,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "130",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "electronicHealthRecord",
@@ -2412,24 +1397,6 @@
   },
   {
     "measureId": "130",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      7.66,
-      66.25,
-      83.08,
-      89.82,
-      93.63,
-      96.12,
-      97.75,
-      98.79,
-      99.47,
-      99.87
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "130",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -2447,24 +1414,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "130",
-    "submissionMethod": "registry",
-    "deciles": [
-      2.6,
-      30.29,
-      87.26,
-      95.57,
-      98.62,
-      99.74,
-      99.99,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "134",
@@ -2488,24 +1437,8 @@
   },
   {
     "measureId": "134",
-    "submissionMethod": "claims",
-    "deciles": [
-      17.33,
-      95.875,
-      99.48,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
     "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "134",
+    "benchmarkYear": 2021,
     "submissionMethod": "electronicHealthRecord",
     "deciles": [
       0.07,
@@ -2519,8 +1452,8 @@
       72.82,
       90.515
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "134",
@@ -2543,24 +1476,6 @@
     ]
   },
   {
-    "measureId": "134",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.05,
-      27.21,
-      72.82,
-      90.13,
-      96.65,
-      98.72,
-      99.65,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "137",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2579,24 +1494,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "137",
-    "submissionMethod": "registry",
-    "deciles": [
-      15.56,
-      92.16,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "138",
@@ -2619,24 +1516,6 @@
     ]
   },
   {
-    "measureId": "138",
-    "submissionMethod": "registry",
-    "deciles": [
-      3.33,
-      60.78,
-      93.02,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "141",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -2655,24 +1534,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "141",
-    "submissionMethod": "claims",
-    "deciles": [
-      8.57,
-      95.77,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "141",
@@ -2693,24 +1554,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "141",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.39,
-      52.27,
-      75.17,
-      86.31,
-      93.41,
-      96.255,
-      98.26,
-      99.38,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "143",
@@ -2734,24 +1577,6 @@
   },
   {
     "measureId": "143",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      2.31,
-      43.535,
-      79.995,
-      90.645,
-      94.685,
-      96.89,
-      98.015,
-      98.92,
-      99.64,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "143",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -2771,25 +1596,9 @@
     ]
   },
   {
-    "measureId": "143",
-    "submissionMethod": "registry",
-    "deciles": [
-      20.27,
-      74.86,
-      94.89,
-      97.55,
-      98.72,
-      99.31,
-      99.9,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "144",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       4,
@@ -2803,8 +1612,8 @@
       99.7,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "145",
@@ -2828,24 +1637,6 @@
   },
   {
     "measureId": "145",
-    "submissionMethod": "claims",
-    "deciles": [
-      3.54,
-      65.12,
-      88.89,
-      96.15,
-      98.67,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "145",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -2863,24 +1654,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "145",
-    "submissionMethod": "registry",
-    "deciles": [
-      12.53,
-      82.16,
-      95.79,
-      98.44,
-      99.77,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "147",
@@ -2904,24 +1677,6 @@
   },
   {
     "measureId": "147",
-    "submissionMethod": "claims",
-    "deciles": [
-      10.34,
-      51.415,
-      78.685,
-      93.295,
-      97.405,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "147",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -2939,24 +1694,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "147",
-    "submissionMethod": "registry",
-    "deciles": [
-      33.94,
-      96.11,
-      99.875,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "154",
@@ -2980,24 +1717,6 @@
   },
   {
     "measureId": "154",
-    "submissionMethod": "claims",
-    "deciles": [
-      18.42,
-      94.74,
-      99.83,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "154",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -3015,24 +1734,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "154",
-    "submissionMethod": "registry",
-    "deciles": [
-      2.7,
-      92.11,
-      98.63,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "155",
@@ -3056,24 +1757,6 @@
   },
   {
     "measureId": "155",
-    "submissionMethod": "claims",
-    "deciles": [
-      3.85,
-      75,
-      97.895,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "155",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -3091,24 +1774,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "155",
-    "submissionMethod": "registry",
-    "deciles": [
-      3.07,
-      80.68,
-      97.06,
-      99.71,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "164",
@@ -3191,24 +1856,6 @@
     ]
   },
   {
-    "measureId": "176",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.35,
-      47.06,
-      66.67,
-      84.52,
-      95.33,
-      98.01,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "177",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3227,24 +1874,6 @@
       99.67,
       100
     ]
-  },
-  {
-    "measureId": "177",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.68,
-      63.035,
-      78.8,
-      89.195,
-      94.315,
-      98.755,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "178",
@@ -3267,24 +1896,6 @@
     ]
   },
   {
-    "measureId": "178",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.34,
-      74.61,
-      89.38,
-      95.11,
-      98.44,
-      99.54,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "180",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3303,24 +1914,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "180",
-    "submissionMethod": "registry",
-    "deciles": [
-      6.37,
-      97.53,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "181",
@@ -3344,24 +1937,6 @@
   },
   {
     "measureId": "181",
-    "submissionMethod": "claims",
-    "deciles": [
-      0.37,
-      94.03,
-      99.61,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "181",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -3379,24 +1954,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "181",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.08,
-      92,
-      98.64,
-      99.47,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "182",
@@ -3420,24 +1977,6 @@
   },
   {
     "measureId": "182",
-    "submissionMethod": "claims",
-    "deciles": [
-      1.09,
-      98.11,
-      99.79,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "182",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -3455,24 +1994,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "182",
-    "submissionMethod": "registry",
-    "deciles": [
-      2.06,
-      97.89,
-      99.55,
-      99.92,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "185",
@@ -3495,24 +2016,6 @@
     ]
   },
   {
-    "measureId": "185",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.35,
-      73.33,
-      95.74,
-      98.27,
-      99.74,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "187",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -3531,24 +2034,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "187",
-    "submissionMethod": "registry",
-    "deciles": [
-      53.33,
-      85.45,
-      93.875,
-      97.385,
-      99.44,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "191",
@@ -3572,24 +2057,6 @@
   },
   {
     "measureId": "191",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      17.24,
-      74.48,
-      88.08,
-      92.67,
-      95.14,
-      96.765,
-      97.86,
-      98.63,
-      99.27,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "191",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -3607,24 +2074,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "191",
-    "submissionMethod": "registry",
-    "deciles": [
-      23.55,
-      85.71,
-      92.91,
-      97.03,
-      98.36,
-      99.18,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "195",
@@ -3648,24 +2097,6 @@
   },
   {
     "measureId": "195",
-    "submissionMethod": "claims",
-    "deciles": [
-      40.86,
-      88.62,
-      97.02,
-      99.27,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "195",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -3685,25 +2116,9 @@
     ]
   },
   {
-    "measureId": "195",
-    "submissionMethod": "registry",
-    "deciles": [
-      65.35,
-      99.1,
-      99.98,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "217",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       20.41,
@@ -3717,11 +2132,13 @@
       81.2,
       96.88
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "218",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       17.36,
@@ -3735,11 +2152,13 @@
       69.225,
       95.225
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "219",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       16.42,
@@ -3753,11 +2172,13 @@
       74.07,
       95.24
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "220",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       24.78,
@@ -3771,11 +2192,13 @@
       84.47,
       95.83
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "221",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       23.08,
@@ -3789,11 +2212,13 @@
       86.67,
       97.67
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "222",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       21.43,
@@ -3807,8 +2232,8 @@
       78.57,
       87.27
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "225",
@@ -3832,24 +2257,6 @@
   },
   {
     "measureId": "225",
-    "submissionMethod": "claims",
-    "deciles": [
-      11.17,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "225",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -3867,24 +2274,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "225",
-    "submissionMethod": "registry",
-    "deciles": [
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "226",
@@ -3907,6 +2296,8 @@
   },
   {
     "measureId": "226",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "electronicHealthRecord",
     "deciles": [
       2.05,
@@ -3920,11 +2311,13 @@
       92.31,
       98.33
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "226",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       2.88,
@@ -3938,8 +2331,8 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "236",
@@ -3960,23 +2353,6 @@
       80,
       90
     ]
-  },
-  {
-    "measureId": "236",
-    "submissionMethod": "claims",
-    "deciles": [
-      10,
-      20,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "236",
@@ -4019,24 +2395,6 @@
   },
   {
     "measureId": "236",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      2.74,
-      41.96,
-      51.36,
-      56.61,
-      60.71,
-      64.235,
-      67.55,
-      71.1,
-      75.28,
-      81.35
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "236",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -4056,24 +2414,9 @@
     ]
   },
   {
-    "measureId": "236",
-    "submissionMethod": "registry",
-    "deciles": [
-      10,
-      20,
-      30,
-      40,
-      50,
-      60,
-      70,
-      80,
-      90
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "238",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "electronicHealthRecord",
     "deciles": [
       21.82,
@@ -4087,11 +2430,13 @@
       0,
       0
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "238",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       20,
@@ -4105,8 +2450,8 @@
       0,
       0
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "239",
@@ -4129,24 +2474,6 @@
     ]
   },
   {
-    "measureId": "239",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      3.25,
-      25.73,
-      29.79,
-      31.71,
-      33.13,
-      34.48,
-      37.98,
-      43.76,
-      52.67,
-      66.56
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "240",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4165,24 +2492,6 @@
       49.57,
       56.86
     ]
-  },
-  {
-    "measureId": "240",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      1.75,
-      13.1,
-      22.58,
-      31.01,
-      36.67,
-      40.48,
-      43.54,
-      49.17,
-      53.59,
-      59.96
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "243",
@@ -4205,24 +2514,6 @@
     ]
   },
   {
-    "measureId": "243",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.69,
-      5.16,
-      11.24,
-      18.09,
-      26.98,
-      32.975,
-      38.35,
-      51.92,
-      64.58,
-      95.05
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "249",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4244,24 +2535,6 @@
   },
   {
     "measureId": "249",
-    "submissionMethod": "claims",
-    "deciles": [
-      97.5,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "249",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -4279,24 +2552,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "249",
-    "submissionMethod": "registry",
-    "deciles": [
-      96.25,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "250",
@@ -4320,24 +2575,6 @@
   },
   {
     "measureId": "250",
-    "submissionMethod": "claims",
-    "deciles": [
-      36.84,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "250",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -4355,24 +2592,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "250",
-    "submissionMethod": "registry",
-    "deciles": [
-      97.78,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "254",
@@ -4395,24 +2614,6 @@
     ]
   },
   {
-    "measureId": "254",
-    "submissionMethod": "registry",
-    "deciles": [
-      72.47,
-      90.13,
-      93.33,
-      95.88,
-      97.06,
-      98.145,
-      98.93,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "265",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4431,24 +2632,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "265",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.31,
-      52.38,
-      94.12,
-      99.13,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "268",
@@ -4471,24 +2654,6 @@
     ]
   },
   {
-    "measureId": "268",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.03,
-      6.97,
-      10.94,
-      30.14,
-      40.91,
-      55.78,
-      80,
-      91.67,
-      99.38,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "277",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4507,24 +2672,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "277",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.65,
-      3.3,
-      9.17,
-      23.21,
-      52.63,
-      68.99,
-      90.32,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "279",
@@ -4547,24 +2694,6 @@
     ]
   },
   {
-    "measureId": "279",
-    "submissionMethod": "registry",
-    "deciles": [
-      2.94,
-      73.13,
-      92.105,
-      98.79,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "281",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4583,24 +2712,6 @@
       73.91,
       91.89
     ]
-  },
-  {
-    "measureId": "281",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.53,
-      4,
-      10,
-      16.67,
-      24.44,
-      34.78,
-      44.12,
-      56.02,
-      66.67,
-      84.78
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "282",
@@ -4623,24 +2734,6 @@
     ]
   },
   {
-    "measureId": "282",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.6,
-      84.62,
-      97.97,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "283",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4659,24 +2752,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "283",
-    "submissionMethod": "registry",
-    "deciles": [
-      2.94,
-      89.86,
-      98.59,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "286",
@@ -4699,24 +2774,6 @@
     ]
   },
   {
-    "measureId": "286",
-    "submissionMethod": "registry",
-    "deciles": [
-      33.33,
-      93.07,
-      99.32,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "288",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4735,24 +2792,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "288",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.19,
-      27.36,
-      76.855,
-      91.31,
-      98.615,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "290",
@@ -4775,24 +2814,6 @@
     ]
   },
   {
-    "measureId": "290",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.565,
-      26.445,
-      72.345,
-      89.475,
-      96.22,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "291",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4811,24 +2832,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "291",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.82,
-      8.6,
-      34.91,
-      76.92,
-      92.31,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "293",
@@ -4851,24 +2854,6 @@
     ]
   },
   {
-    "measureId": "293",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.79,
-      17.33,
-      36.84,
-      68.97,
-      86.36,
-      92.96,
-      98.55,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "305",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4887,24 +2872,6 @@
       2.91,
       7.65
     ]
-  },
-  {
-    "measureId": "305",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.34,
-      1.06,
-      1.65,
-      2.17,
-      2.7,
-      3.35,
-      4.23,
-      5.18,
-      6.67,
-      10.16
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "309",
@@ -4927,24 +2894,6 @@
     ]
   },
   {
-    "measureId": "309",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.44,
-      7.77,
-      15.59,
-      21.88,
-      27.955,
-      34.04,
-      40.17,
-      46.99,
-      54.55,
-      68.52
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "310",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -4965,25 +2914,9 @@
     ]
   },
   {
-    "measureId": "310",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      1.35,
-      11.11,
-      18.255,
-      25,
-      30,
-      35.48,
-      40.865,
-      45.48,
-      53.015,
-      61.9
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "317",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "claims",
     "deciles": [
       0.32,
@@ -4997,11 +2930,13 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "317",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "electronicHealthRecord",
     "deciles": [
       0.06,
@@ -5015,11 +2950,13 @@
       35.34,
       44.34
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "317",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       0.05,
@@ -5033,8 +2970,8 @@
       98.69,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "318",
@@ -5076,24 +3013,6 @@
     ]
   },
   {
-    "measureId": "318",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.14,
-      3.91,
-      16.8,
-      35.7,
-      52.47,
-      66.87,
-      79.39,
-      88.69,
-      95.37,
-      98.92
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "320",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -5112,24 +3031,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "320",
-    "submissionMethod": "claims",
-    "deciles": [
-      15.22,
-      75,
-      92.73,
-      96,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "320",
@@ -5152,24 +3053,6 @@
     ]
   },
   {
-    "measureId": "320",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.77,
-      77.38,
-      91.3,
-      96.3,
-      97.72,
-      98.7,
-      99.44,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "322",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -5190,24 +3073,6 @@
     ]
   },
   {
-    "measureId": "322",
-    "submissionMethod": "registry",
-    "deciles": [
-      48.9,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "323",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -5226,24 +3091,6 @@
       0,
       0
     ]
-  },
-  {
-    "measureId": "323",
-    "submissionMethod": "registry",
-    "deciles": [
-      48.39,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "324",
@@ -5264,24 +3111,6 @@
       0,
       0
     ]
-  },
-  {
-    "measureId": "324",
-    "submissionMethod": "registry",
-    "deciles": [
-      50,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "326",
@@ -5305,24 +3134,6 @@
   },
   {
     "measureId": "326",
-    "submissionMethod": "claims",
-    "deciles": [
-      77.22,
-      96.88,
-      99.26,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "326",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -5340,24 +3151,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "326",
-    "submissionMethod": "registry",
-    "deciles": [
-      38,
-      67.08,
-      74.32,
-      80.65,
-      86.11,
-      96.15,
-      99.69,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "331",
@@ -5380,24 +3173,6 @@
     ]
   },
   {
-    "measureId": "331",
-    "submissionMethod": "registry",
-    "deciles": [
-      96.32,
-      81.08,
-      64.645,
-      46.945,
-      32.11,
-      17.725,
-      8,
-      3.755,
-      0.39,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "332",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -5416,24 +3191,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "332",
-    "submissionMethod": "registry",
-    "deciles": [
-      10,
-      59.38,
-      66.67,
-      75,
-      80.56,
-      84.465,
-      88.89,
-      93.18,
-      96.97,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "337",
@@ -5456,24 +3213,6 @@
     ]
   },
   {
-    "measureId": "337",
-    "submissionMethod": "registry",
-    "deciles": [
-      9.23,
-      75.89,
-      93.68,
-      98.04,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "338",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -5492,24 +3231,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "338",
-    "submissionMethod": "registry",
-    "deciles": [
-      57.32,
-      81.74,
-      87.33,
-      91.32,
-      93.26,
-      94.495,
-      95.82,
-      98.98,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "340",
@@ -5532,24 +3253,6 @@
     ]
   },
   {
-    "measureId": "340",
-    "submissionMethod": "registry",
-    "deciles": [
-      27.94,
-      38.46,
-      51.22,
-      73.26,
-      79.63,
-      84.39,
-      90.68,
-      93.43,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "342",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -5568,24 +3271,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "342",
-    "submissionMethod": "registry",
-    "deciles": [
-      73.36,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "350",
@@ -5608,24 +3293,6 @@
     ]
   },
   {
-    "measureId": "350",
-    "submissionMethod": "registry",
-    "deciles": [
-      27.6,
-      93.7,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "351",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -5644,24 +3311,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "351",
-    "submissionMethod": "registry",
-    "deciles": [
-      7.62,
-      90.39,
-      96.5,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "354",
@@ -5684,24 +3333,6 @@
     ]
   },
   {
-    "measureId": "354",
-    "submissionMethod": "registry",
-    "deciles": [
-      76.12,
-      17.14,
-      8.49,
-      4.86,
-      1.05,
-      0,
-      0,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "355",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -5720,24 +3351,6 @@
       0,
       0
     ]
-  },
-  {
-    "measureId": "355",
-    "submissionMethod": "registry",
-    "deciles": [
-      40,
-      8.6,
-      2.7,
-      1.08,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "356",
@@ -5760,24 +3373,6 @@
     ]
   },
   {
-    "measureId": "356",
-    "submissionMethod": "registry",
-    "deciles": [
-      32.26,
-      8.655,
-      6.105,
-      3.39,
-      1.81,
-      0,
-      0,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "357",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -5796,24 +3391,6 @@
       0,
       0
     ]
-  },
-  {
-    "measureId": "357",
-    "submissionMethod": "registry",
-    "deciles": [
-      80.06,
-      6.34,
-      1.17,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "358",
@@ -5836,24 +3413,6 @@
     ]
   },
   {
-    "measureId": "358",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.5,
-      9.26,
-      66.01,
-      93.75,
-      98.4,
-      99.76,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "360",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -5872,24 +3431,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "360",
-    "submissionMethod": "registry",
-    "deciles": [
-      5.01,
-      56.1,
-      98.48,
-      99.85,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "364",
@@ -5912,24 +3453,6 @@
     ]
   },
   {
-    "measureId": "364",
-    "submissionMethod": "registry",
-    "deciles": [
-      13.27,
-      45.34,
-      68.35,
-      92.11,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "366",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -5950,24 +3473,6 @@
     ]
   },
   {
-    "measureId": "366",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      2.9412,
-      11.6279,
-      15.4738,
-      22.0588,
-      25.7751,
-      29.6552,
-      34.345,
-      39.1304,
-      43.8987,
-      51.938
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "370",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -5986,24 +3491,6 @@
       15,
       22.03
     ]
-  },
-  {
-    "measureId": "370",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.5181,
-      1.9231,
-      3.125,
-      4.4693,
-      5.9412,
-      8,
-      9.7288,
-      12.1951,
-      16.6667,
-      24.6637
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "374",
@@ -6027,24 +3514,6 @@
   },
   {
     "measureId": "374",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.5,
-      4.85,
-      11.36,
-      17.31,
-      23.48,
-      30.5,
-      38.83,
-      50.51,
-      66.57,
-      85.71
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "374",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -6062,24 +3531,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "374",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.9,
-      30.43,
-      66.94,
-      84.38,
-      95.12,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "375",
@@ -6102,24 +3553,6 @@
     ]
   },
   {
-    "measureId": "375",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.99,
-      1.67,
-      2.23,
-      3.48,
-      6.94,
-      7.7,
-      10.03,
-      14.71,
-      25.32,
-      46.75
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "376",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -6138,24 +3571,6 @@
       53.57,
       100
     ]
-  },
-  {
-    "measureId": "376",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.47,
-      1.995,
-      2.58,
-      3.45,
-      4.1,
-      5.955,
-      10.4,
-      15.76,
-      22.92,
-      44.045
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "378",
@@ -6178,24 +3593,6 @@
     ]
   },
   {
-    "measureId": "378",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      92.31,
-      68.29,
-      50.04,
-      34.04,
-      15.62,
-      7.565,
-      3.67,
-      1.59,
-      0.87,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "379",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -6214,24 +3611,6 @@
       7.31,
       13.67
     ]
-  },
-  {
-    "measureId": "379",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.01,
-      0.12,
-      0.25,
-      0.46,
-      0.93,
-      1.87,
-      3.02,
-      4.79,
-      7.89,
-      11.86
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "382",
@@ -6254,24 +3633,6 @@
     ]
   },
   {
-    "measureId": "382",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.62,
-      2.94,
-      7.31,
-      13.66,
-      20.79,
-      33.94,
-      43.41,
-      54.6,
-      71.205,
-      93.41
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "383",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -6290,24 +3651,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "383",
-    "submissionMethod": "registry",
-    "deciles": [
-      22.73,
-      81.45,
-      95.75,
-      99.53,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "384",
@@ -6330,25 +3673,9 @@
     ]
   },
   {
-    "measureId": "384",
-    "submissionMethod": "registry",
-    "deciles": [
-      75.76,
-      89.14,
-      95.1,
-      96.77,
-      98.26,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "385",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       6.52,
@@ -6362,8 +3689,8 @@
       77.29,
       81.48
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "389",
@@ -6386,24 +3713,6 @@
     ]
   },
   {
-    "measureId": "389",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.35,
-      14.83,
-      24.11,
-      33.08,
-      45.01,
-      64.67,
-      91.13,
-      98,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "394",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -6424,24 +3733,6 @@
     ]
   },
   {
-    "measureId": "394",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.975,
-      4.07,
-      5.98,
-      11.7,
-      16.175,
-      21.39,
-      25.075,
-      29.565,
-      36.69,
-      45.58
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "395",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -6463,24 +3754,6 @@
   },
   {
     "measureId": "395",
-    "submissionMethod": "claims",
-    "deciles": [
-      91.3,
-      95.83,
-      98.11,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "395",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -6498,24 +3771,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "395",
-    "submissionMethod": "registry",
-    "deciles": [
-      88.03,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "396",
@@ -6558,24 +3813,6 @@
     ]
   },
   {
-    "measureId": "396",
-    "submissionMethod": "registry",
-    "deciles": [
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "397",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -6597,24 +3834,6 @@
   },
   {
     "measureId": "397",
-    "submissionMethod": "claims",
-    "deciles": [
-      90.62,
-      95.16,
-      98.44,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "397",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -6632,24 +3851,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "397",
-    "submissionMethod": "registry",
-    "deciles": [
-      41.33,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "398",
@@ -6672,24 +3873,6 @@
     ]
   },
   {
-    "measureId": "398",
-    "submissionMethod": "registry",
-    "deciles": [
-      4.44,
-      41.94,
-      52.27,
-      61.29,
-      69.7,
-      85.71,
-      97.06,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "400",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -6708,24 +3891,6 @@
       43.82,
       75.53
     ]
-  },
-  {
-    "measureId": "400",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.12,
-      0.6,
-      1.18,
-      1.96,
-      3.53,
-      7.55,
-      24.34,
-      47.28,
-      65.92,
-      97.08
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "402",
@@ -6748,24 +3913,6 @@
     ]
   },
   {
-    "measureId": "402",
-    "submissionMethod": "registry",
-    "deciles": [
-      37.84,
-      84.09,
-      92.41,
-      96.67,
-      98.72,
-      99.645,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "404",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -6786,25 +3933,9 @@
     ]
   },
   {
-    "measureId": "404",
-    "submissionMethod": "registry",
-    "deciles": [
-      7.64,
-      30.97,
-      50,
-      61.67,
-      69.96,
-      76.14,
-      80.33,
-      86.44,
-      91.94,
-      97.06
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "405",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "claims",
     "deciles": [
       0.71,
@@ -6818,11 +3949,13 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "405",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       0.51,
@@ -6836,8 +3969,8 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "406",
@@ -6880,24 +4013,6 @@
     ]
   },
   {
-    "measureId": "406",
-    "submissionMethod": "registry",
-    "deciles": [
-      50,
-      13.04,
-      6.06,
-      2.43,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "410",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -6916,24 +4031,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "410",
-    "submissionMethod": "registry",
-    "deciles": [
-      4.55,
-      45.495,
-      70.135,
-      85.19,
-      93.455,
-      97.56,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "415",
@@ -6956,24 +4053,6 @@
     ]
   },
   {
-    "measureId": "415",
-    "submissionMethod": "registry",
-    "deciles": [
-      81.7,
-      93.94,
-      96.31,
-      97.54,
-      98.33,
-      98.94,
-      99.39,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "416",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -6994,25 +4073,9 @@
     ]
   },
   {
-    "measureId": "416",
-    "submissionMethod": "registry",
-    "deciles": [
-      52.38,
-      20,
-      13.51,
-      7.04,
-      3.85,
-      1.985,
-      0,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "418",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       1.06,
@@ -7026,8 +4089,8 @@
       79.76,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "419",
@@ -7050,24 +4113,6 @@
     ]
   },
   {
-    "measureId": "419",
-    "submissionMethod": "registry",
-    "deciles": [
-      68.04,
-      37.82,
-      16.48,
-      8.86,
-      6.21,
-      2.975,
-      0.59,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "424",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -7086,24 +4131,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "424",
-    "submissionMethod": "registry",
-    "deciles": [
-      88.68,
-      98.46,
-      99.64,
-      99.9,
-      99.98,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "425",
@@ -7127,24 +4154,6 @@
   },
   {
     "measureId": "425",
-    "submissionMethod": "claims",
-    "deciles": [
-      36.54,
-      96.545,
-      98.9,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "425",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -7162,24 +4171,6 @@
       99.48,
       99.95
     ]
-  },
-  {
-    "measureId": "425",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.74,
-      84.66,
-      93.74,
-      97.075,
-      98.72,
-      99.28,
-      99.55,
-      99.82,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "430",
@@ -7202,25 +4193,9 @@
     ]
   },
   {
-    "measureId": "430",
-    "submissionMethod": "registry",
-    "deciles": [
-      76.53,
-      98.39,
-      99.665,
-      99.825,
-      99.93,
-      99.99,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "431",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       0.4,
@@ -7234,8 +4209,8 @@
       99.85,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "436",
@@ -7259,24 +4234,6 @@
   },
   {
     "measureId": "436",
-    "submissionMethod": "claims",
-    "deciles": [
-      1.29,
-      88.43,
-      97.16,
-      99.05,
-      99.79,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "436",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -7294,24 +4251,6 @@
       100,
       100
     ]
-  },
-  {
-    "measureId": "436",
-    "submissionMethod": "registry",
-    "deciles": [
-      20.53,
-      98.96,
-      99.87,
-      99.99,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "438",
@@ -7335,24 +4274,6 @@
   },
   {
     "measureId": "438",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      32.98,
-      60.84,
-      66.645,
-      69.78,
-      72.385,
-      74.61,
-      76.62,
-      78.79,
-      81.415,
-      84.75
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
-    "measureId": "438",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
     "submissionMethod": "registry",
@@ -7372,25 +4293,9 @@
     ]
   },
   {
-    "measureId": "438",
-    "submissionMethod": "registry",
-    "deciles": [
-      20.5,
-      62.01,
-      70.7,
-      76.65,
-      79.88,
-      83.95,
-      87.63,
-      91.78,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "439",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       1.96,
@@ -7404,8 +4309,8 @@
       0,
       0
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "440",
@@ -7428,24 +4333,6 @@
     ]
   },
   {
-    "measureId": "440",
-    "submissionMethod": "registry",
-    "deciles": [
-      71.05,
-      96.74,
-      98.985,
-      99.735,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "441",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -7466,25 +4353,9 @@
     ]
   },
   {
-    "measureId": "441",
-    "submissionMethod": "registry",
-    "deciles": [
-      4.35,
-      18.18,
-      26.985,
-      34.19,
-      40.735,
-      44.23,
-      47.615,
-      50.89,
-      54.49,
-      59.38
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "444",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       13.89,
@@ -7498,8 +4369,8 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "445",
@@ -7523,6 +4394,8 @@
   },
   {
     "measureId": "450",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       30,
@@ -7536,8 +4409,8 @@
       95.89,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "453",
@@ -7560,24 +4433,6 @@
     ]
   },
   {
-    "measureId": "453",
-    "submissionMethod": "registry",
-    "deciles": [
-      32.56,
-      24.39,
-      19.23,
-      15.58,
-      13.19,
-      11.21,
-      9.68,
-      7.14,
-      5.22,
-      3.57
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "457",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -7596,24 +4451,6 @@
       2.22,
       0
     ]
-  },
-  {
-    "measureId": "457",
-    "submissionMethod": "registry",
-    "deciles": [
-      34.78,
-      24.14,
-      18.18,
-      15.49,
-      13.64,
-      10.855,
-      8.73,
-      7.23,
-      4.35,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "463",
@@ -7636,24 +4473,6 @@
     ]
   },
   {
-    "measureId": "463",
-    "submissionMethod": "registry",
-    "deciles": [
-      82.445,
-      97.68,
-      99.18,
-      99.785,
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "464",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -7672,24 +4491,6 @@
       97.6,
       100
     ]
-  },
-  {
-    "measureId": "464",
-    "submissionMethod": "registry",
-    "deciles": [
-      5.88,
-      70,
-      83.56,
-      88.83,
-      95.06,
-      97.075,
-      98.21,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "472",
@@ -7712,24 +4513,6 @@
     ]
   },
   {
-    "measureId": "472",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      12.5,
-      4.1,
-      1.74,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "475",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -7750,25 +4533,9 @@
     ]
   },
   {
-    "measureId": "475",
-    "submissionMethod": "electronicHealthRecord",
-    "deciles": [
-      0.13,
-      3.005,
-      5.83,
-      8.82,
-      11.8,
-      14.62,
-      17.96,
-      21.74,
-      26.425,
-      34.675
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "477",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       62.56,
@@ -7782,11 +4549,13 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "478",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       22.5,
@@ -7800,11 +4569,13 @@
       66.67,
       89.66
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "479",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "administrativeClaims",
     "deciles": [
       0.1852,
@@ -7818,11 +4589,13 @@
       0.143,
       0.1373
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "480",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "administrativeClaims",
     "deciles": [
       0.0378,
@@ -7836,8 +4609,8 @@
       0.0209,
       0.0194
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "AAAAI6",
@@ -7881,6 +4654,8 @@
   },
   {
     "measureId": "AAD6",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       30.86,
@@ -7894,11 +4669,13 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "AAD7",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       22.57,
@@ -7912,8 +4689,8 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "AAN5",
@@ -7936,24 +4713,6 @@
     ]
   },
   {
-    "measureId": "AAN5",
-    "submissionMethod": "registry",
-    "deciles": [
-      40.74,
-      50.85,
-      57.14,
-      66.84,
-      71.09,
-      77.2,
-      80.65,
-      81.82,
-      86.67,
-      95.31
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "AAN8",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -7972,24 +4731,6 @@
       96.15,
       97.92
     ]
-  },
-  {
-    "measureId": "AAN8",
-    "submissionMethod": "registry",
-    "deciles": [
-      25,
-      50.56,
-      64.885,
-      79.63,
-      82.14,
-      89.66,
-      92.195,
-      95.52,
-      97.985,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "AAN9",
@@ -8012,25 +4753,9 @@
     ]
   },
   {
-    "measureId": "AAN9",
-    "submissionMethod": "registry",
-    "deciles": [
-      9.15,
-      59.12,
-      66.67,
-      75.51,
-      82.82,
-      90.06,
-      93.96,
-      95.75,
-      96.67,
-      98
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "AAO16",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       23.26,
@@ -8044,8 +4769,8 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "AAO20",
@@ -8088,24 +4813,6 @@
     ]
   },
   {
-    "measureId": "AAO21",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.14,
-      13.73,
-      19.46,
-      35,
-      37.5,
-      51.64,
-      71.13,
-      77.27,
-      83.58,
-      91.3
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "AAO23",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -8124,24 +4831,6 @@
       80.09,
       84.44
     ]
-  },
-  {
-    "measureId": "AAO23",
-    "submissionMethod": "registry",
-    "deciles": [
-      3.98,
-      47.15,
-      59.87,
-      67.38,
-      72.36,
-      77.105,
-      80.43,
-      83.77,
-      84.91,
-      90.59
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "AAO24",
@@ -8164,25 +4853,9 @@
     ]
   },
   {
-    "measureId": "AAO24",
-    "submissionMethod": "registry",
-    "deciles": [
-      81.48,
-      88.92,
-      96.3,
-      98.48,
-      99.59,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "AAO31",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       78.38,
@@ -8196,11 +4869,13 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ABFM9",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       37.19,
@@ -8214,11 +4889,13 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ACCPIN11",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       3.45,
@@ -8232,8 +4909,8 @@
       99.2,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ACCPIN7",
@@ -8256,24 +4933,6 @@
     ]
   },
   {
-    "measureId": "ACCPIN7",
-    "submissionMethod": "registry",
-    "deciles": [
-      43.21,
-      58.82,
-      66.67,
-      71.63,
-      74.47,
-      77.92,
-      79.54,
-      81.7,
-      84.78,
-      86.92
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "ACCPIN8",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -8292,24 +4951,6 @@
       34.29,
       38.56
     ]
-  },
-  {
-    "measureId": "ACCPIN8",
-    "submissionMethod": "registry",
-    "deciles": [
-      15.81,
-      25.97,
-      30.2,
-      34.35,
-      36.96,
-      39.875,
-      43.6,
-      45.65,
-      49.45,
-      53.1
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "ACEP19",
@@ -8332,24 +4973,6 @@
     ]
   },
   {
-    "measureId": "ACEP19",
-    "submissionMethod": "registry",
-    "deciles": [
-      53.96,
-      58.89,
-      65.07,
-      72.47,
-      77.57,
-      81.87,
-      85.25,
-      87.73,
-      91.04,
-      94.09
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "ACEP21",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -8368,24 +4991,6 @@
       2.77,
       0
     ]
-  },
-  {
-    "measureId": "ACEP21",
-    "submissionMethod": "registry",
-    "deciles": [
-      23.03,
-      11.65,
-      8.44,
-      7.14,
-      5.08,
-      4.17,
-      3.36,
-      2.64,
-      2.05,
-      1.22
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "ACEP22",
@@ -8408,24 +5013,6 @@
     ]
   },
   {
-    "measureId": "ACEP22",
-    "submissionMethod": "registry",
-    "deciles": [
-      22.52,
-      28.47,
-      34.8,
-      40.73,
-      48.42,
-      54.26,
-      57.68,
-      62.63,
-      70.5,
-      79.76
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "ACEP25",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -8444,24 +5031,6 @@
       79.04,
       88.22
     ]
-  },
-  {
-    "measureId": "ACEP25",
-    "submissionMethod": "registry",
-    "deciles": [
-      15.51,
-      61.12,
-      71.64,
-      78.63,
-      81.01,
-      84.12,
-      86.74,
-      88.17,
-      92.67,
-      96.05
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "ACEP30",
@@ -8504,24 +5073,6 @@
     ]
   },
   {
-    "measureId": "ACEP31",
-    "submissionMethod": "registry",
-    "deciles": [
-      51.29,
-      60.64,
-      66.67,
-      74.19,
-      76.32,
-      79.395,
-      81.16,
-      85.12,
-      87.39,
-      88.79
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "ACEP48",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -8542,25 +5093,9 @@
     ]
   },
   {
-    "measureId": "ACEP48",
-    "submissionMethod": "registry",
-    "deciles": [
-      65.18,
-      86.49,
-      89.515,
-      91.49,
-      92.025,
-      93.1,
-      93.93,
-      96.25,
-      98.19,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "ACEP50",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       127.228,
@@ -8574,11 +5109,13 @@
       84.3452,
       49.6086
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ACEP51",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       114.921,
@@ -8592,11 +5129,13 @@
       76.1444,
       38.3893
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ACEP52",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       5.17,
@@ -8610,11 +5149,13 @@
       67.73,
       70.88
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ACEP55",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       24.14,
@@ -8628,11 +5169,13 @@
       81.43,
       84.05
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ACEP58",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       39.9,
@@ -8646,8 +5189,8 @@
       19.46,
       11.78
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ACMS2",
@@ -8750,25 +5293,9 @@
     ]
   },
   {
-    "measureId": "ACQR3",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.85,
-      0.915,
-      0.945,
-      0.96,
-      0.97,
-      0.97,
-      0.975,
-      0.985,
-      0.995,
-      1
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "ACR10",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       4.35,
@@ -8782,11 +5309,13 @@
       41.06,
       55.25
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ACR12",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       1.18,
@@ -8800,11 +5329,13 @@
       90.44,
       94.15
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ACR14",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       17.24,
@@ -8818,11 +5349,13 @@
       58.97,
       65.22
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ACR15",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       32.53,
@@ -8836,8 +5369,8 @@
       85.15,
       90.24
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ACRAD15",
@@ -8860,24 +5393,6 @@
     ]
   },
   {
-    "measureId": "ACRAD15",
-    "submissionMethod": "registry",
-    "deciles": [
-      5.24,
-      3.61,
-      2.71,
-      2.21,
-      1.77,
-      1.53,
-      1.26,
-      1.01,
-      0.72,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "ACRAD16",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -8896,24 +5411,6 @@
       1.82,
       1.07
     ]
-  },
-  {
-    "measureId": "ACRAD16",
-    "submissionMethod": "registry",
-    "deciles": [
-      10.37,
-      5.795,
-      4.11,
-      3.275,
-      2.82,
-      2.29,
-      1.8,
-      1.38,
-      0.95,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "ACRAD17",
@@ -8936,24 +5433,6 @@
     ]
   },
   {
-    "measureId": "ACRAD17",
-    "submissionMethod": "registry",
-    "deciles": [
-      21.19,
-      15.39,
-      12.8,
-      10.44,
-      8.19,
-      6.06,
-      4.4,
-      3.24,
-      2.14,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "ACRAD18",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -8972,24 +5451,6 @@
       1.63,
       1.17
     ]
-  },
-  {
-    "measureId": "ACRAD18",
-    "submissionMethod": "registry",
-    "deciles": [
-      10.11,
-      3.86,
-      2.8,
-      2.33,
-      2.01,
-      1.66,
-      1.36,
-      1.11,
-      0.78,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "ACRAD19",
@@ -9012,24 +5473,6 @@
     ]
   },
   {
-    "measureId": "ACRAD19",
-    "submissionMethod": "registry",
-    "deciles": [
-      31.9,
-      24.2,
-      19.16,
-      13.09,
-      9.96,
-      6.99,
-      4.77,
-      3.41,
-      2.54,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "ACRAD25",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -9048,24 +5491,6 @@
       3.97,
       0.83
     ]
-  },
-  {
-    "measureId": "ACRAD25",
-    "submissionMethod": "registry",
-    "deciles": [
-      46.495,
-      27.765,
-      21.2,
-      16.455,
-      11.85,
-      6.815,
-      4.165,
-      2.195,
-      0.595,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "ACRAD34",
@@ -9088,24 +5513,6 @@
     ]
   },
   {
-    "measureId": "ACRAD34",
-    "submissionMethod": "registry",
-    "deciles": [
-      36.6808,
-      78.0275,
-      83.1584,
-      84.4009,
-      90.0213,
-      93.4405,
-      94.9784,
-      96.1203,
-      96.1203,
-      96.1203
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "AQI48",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -9124,24 +5531,6 @@
       95.59,
       96.38
     ]
-  },
-  {
-    "measureId": "AQI48",
-    "submissionMethod": "registry",
-    "deciles": [
-      83.72,
-      90,
-      91.14,
-      91.84,
-      92.67,
-      93.515,
-      94.29,
-      95.49,
-      96.15,
-      97.71
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "AQI56",
@@ -9164,24 +5553,6 @@
     ]
   },
   {
-    "measureId": "AQI56",
-    "submissionMethod": "registry",
-    "deciles": [
-      66.67,
-      93.12,
-      95.53,
-      98.05,
-      99.55,
-      99.905,
-      100,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "AQI62",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -9202,25 +5573,9 @@
     ]
   },
   {
-    "measureId": "AQI62",
-    "submissionMethod": "registry",
-    "deciles": [
-      6.01,
-      93.12,
-      97.8,
-      99.25,
-      99.68,
-      99.86,
-      99.97,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "AQI65",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       20.83,
@@ -9234,11 +5589,13 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "AQI68",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       29.01,
@@ -9252,11 +5609,13 @@
       99.99,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "AQI69",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       31.41,
@@ -9270,11 +5629,13 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "AQI70",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       57.14,
@@ -9288,11 +5649,13 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "AQI72",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       89.61,
@@ -9306,8 +5669,8 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "AQUA14",
@@ -9330,24 +5693,6 @@
     ]
   },
   {
-    "measureId": "AQUA14",
-    "submissionMethod": "registry",
-    "deciles": [
-      66.1,
-      22.22,
-      15.89,
-      12,
-      9.06,
-      7.69,
-      4.6,
-      3.06,
-      2.08,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "AQUA15",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -9366,24 +5711,6 @@
       84.1,
       92.25
     ]
-  },
-  {
-    "measureId": "AQUA15",
-    "submissionMethod": "registry",
-    "deciles": [
-      4.17,
-      26.27,
-      47.22,
-      55.77,
-      65.09,
-      73.47,
-      79.31,
-      85.19,
-      87.76,
-      94.44
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "AQUA18",
@@ -9406,24 +5733,6 @@
     ]
   },
   {
-    "measureId": "AQUA18",
-    "submissionMethod": "registry",
-    "deciles": [
-      1.67,
-      15.54,
-      18.37,
-      21.62,
-      24.24,
-      27.59,
-      28.12,
-      31.25,
-      35,
-      41.43
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "AQUA26",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -9444,25 +5753,9 @@
     ]
   },
   {
-    "measureId": "AQUA26",
-    "submissionMethod": "registry",
-    "deciles": [
-      95.93,
-      0.03,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "AQUA8",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       40,
@@ -9476,11 +5769,13 @@
       0,
       0
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ASPS29",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       27.43,
@@ -9494,8 +5789,8 @@
       0,
       0
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "CAHPS_1",
@@ -9659,6 +5954,8 @@
   },
   {
     "measureId": "CAP22",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       68.5,
@@ -9672,11 +5969,13 @@
       99.47,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "CAP28",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       65.13,
@@ -9690,11 +5989,13 @@
       99.84,
       99.95
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "CAP32",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       40.5,
@@ -9708,11 +6009,13 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "CAP33",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       1.56,
@@ -9726,11 +6029,13 @@
       98.31,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "CDR1",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       4.25,
@@ -9744,11 +6049,13 @@
       92.63,
       96.3
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "CDR2",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       4,
@@ -9762,11 +6069,13 @@
       22.61,
       24.44
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "CDR5",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       5.11,
@@ -9780,11 +6089,13 @@
       84.4,
       92.475
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "CDR6",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       2.56,
@@ -9798,11 +6109,13 @@
       32.31,
       37.04
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ECPR39",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       13.3,
@@ -9816,11 +6129,13 @@
       99.67,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ECPR40",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       71.43,
@@ -9834,11 +6149,13 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "ECPR46",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       80.66,
@@ -9852,8 +6169,8 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "EPREOP30",
@@ -9897,6 +6214,8 @@
   },
   {
     "measureId": "GIQIC22",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       15.27,
@@ -9910,11 +6229,13 @@
       51.09,
       55.84
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "GIQIC23",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       18.86,
@@ -9928,11 +6249,13 @@
       97.67,
       99.27
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "HM5",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       25,
@@ -9946,11 +6269,13 @@
       86.67,
       92
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "HM6",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       12,
@@ -9964,11 +6289,13 @@
       80.925,
       89.58
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "HM8",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       8.57,
@@ -9982,8 +6309,8 @@
       77.94,
       83.9
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IRIS1",
@@ -10026,25 +6353,9 @@
     ]
   },
   {
-    "measureId": "IRIS13",
-    "submissionMethod": "registry",
-    "deciles": [
-      56.86,
-      80.44,
-      84.62,
-      86.52,
-      88.02,
-      89.415,
-      90.37,
-      92.06,
-      93.83,
-      96.36
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "IRIS17",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       13.33,
@@ -10058,11 +6369,13 @@
       82.14,
       87.18
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IRIS2",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       1.8,
@@ -10076,8 +6389,8 @@
       83.5,
       87.59
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IRIS23",
@@ -10100,25 +6413,9 @@
     ]
   },
   {
-    "measureId": "IRIS23",
-    "submissionMethod": "registry",
-    "deciles": [
-      24.29,
-      44,
-      68.55,
-      77.58,
-      81.25,
-      82.35,
-      84.21,
-      89.2,
-      94.29,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "IRIS26",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       4.94,
@@ -10132,8 +6429,8 @@
       0,
       0
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IRIS43",
@@ -10156,24 +6453,6 @@
     ]
   },
   {
-    "measureId": "IRIS43",
-    "submissionMethod": "registry",
-    "deciles": [
-      5,
-      8.7,
-      14.29,
-      17.42,
-      21.62,
-      24.35,
-      31.67,
-      36.17,
-      77.59,
-      93.33
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "IRIS44",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -10194,25 +6473,9 @@
     ]
   },
   {
-    "measureId": "IRIS44",
-    "submissionMethod": "registry",
-    "deciles": [
-      90,
-      18.18,
-      13.33,
-      12.64,
-      11.63,
-      11.125,
-      7.14,
-      5,
-      4.05,
-      1.39
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "IRIS45",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       0.45,
@@ -10226,11 +6489,13 @@
       8.985,
       13.6
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IRIS46",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       4.17,
@@ -10244,8 +6509,8 @@
       81.58,
       95.24
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IRIS48",
@@ -10289,6 +6554,8 @@
   },
   {
     "measureId": "IRIS51",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       60,
@@ -10302,11 +6569,13 @@
       99.26,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IRIS52",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       59.61,
@@ -10320,11 +6589,13 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IRIS53",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       53.12,
@@ -10338,11 +6609,13 @@
       97.78,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IRIS54",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       7.5,
@@ -10356,11 +6629,13 @@
       0,
       0
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IRIS55",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       3.7037,
@@ -10374,11 +6649,13 @@
       48.8889,
       65.8537
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IRIS59",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       1.3699,
@@ -10392,8 +6669,8 @@
       56.7458,
       67.3469
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IRIS6",
@@ -10417,6 +6694,8 @@
   },
   {
     "measureId": "IROMS11",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       60.71,
@@ -10430,11 +6709,13 @@
       43.45,
       40
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IROMS12",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       63.11,
@@ -10448,11 +6729,13 @@
       46.88,
       43.75
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IROMS13",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       61.11,
@@ -10466,11 +6749,13 @@
       38.46,
       34.78
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IROMS14",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       60.61,
@@ -10484,11 +6769,13 @@
       42.86,
       39.13
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IROMS15",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       61.9,
@@ -10502,11 +6789,13 @@
       40,
       33
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IROMS16",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       63.41,
@@ -10520,11 +6809,13 @@
       43.84,
       40
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IROMS17",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       59.09,
@@ -10538,11 +6829,13 @@
       38.545,
       34.29
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IROMS18",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       61.11,
@@ -10556,11 +6849,13 @@
       42.86,
       39.08
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IROMS19",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       56.52,
@@ -10574,11 +6869,13 @@
       36.59,
       33.33
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "IROMS20",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       58.97,
@@ -10592,8 +6889,8 @@
       42.31,
       39.39
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "MCC1",
@@ -10638,6 +6935,8 @@
   },
   {
     "measureId": "MSN13",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       26,
@@ -10651,11 +6950,13 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "MSN15",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       15,
@@ -10669,8 +6970,8 @@
       100,
       100
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "NHCR4",
@@ -10693,24 +6994,6 @@
     ]
   },
   {
-    "measureId": "NHCR4",
-    "submissionMethod": "registry",
-    "deciles": [
-      6.67,
-      24.42,
-      38.26,
-      41.38,
-      56.03,
-      61.6,
-      77.67,
-      82.09,
-      94.87,
-      98.59
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "PIMSH1",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -10731,25 +7014,9 @@
     ]
   },
   {
-    "measureId": "PIMSH1",
-    "submissionMethod": "registry",
-    "deciles": [
-      0.5,
-      2.3,
-      6.4,
-      12.8,
-      15.7,
-      20.85,
-      25,
-      35.6,
-      43.3,
-      63.2
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "PIMSH10",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       2.4,
@@ -10763,11 +7030,13 @@
       69.6,
       85.2
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "PIMSH11",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       33.8,
@@ -10781,11 +7050,13 @@
       0,
       0
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "PIMSH2",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       67.7,
@@ -10799,8 +7070,8 @@
       4.8,
       4
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "PIMSH4",
@@ -10823,25 +7094,9 @@
     ]
   },
   {
-    "measureId": "PIMSH4",
-    "submissionMethod": "registry",
-    "deciles": [
-      13.3,
-      28.4,
-      34.15,
-      37.5,
-      39.65,
-      42.2,
-      44.65,
-      48.2,
-      51.8,
-      57.1
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "PIMSH9",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       25,
@@ -10855,8 +7110,8 @@
       3.2,
       0
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   },
   {
     "measureId": "QUANTUM31",
@@ -10879,24 +7134,6 @@
     ]
   },
   {
-    "measureId": "QUANTUM31",
-    "submissionMethod": "registry",
-    "deciles": [
-      46.02,
-      70,
-      80,
-      85.71,
-      90.48,
-      95.55,
-      99.45,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "RCOIR10",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -10915,24 +7152,6 @@
       84.13,
       89.52
     ]
-  },
-  {
-    "measureId": "RCOIR10",
-    "submissionMethod": "registry",
-    "deciles": [
-      50,
-      65.43,
-      69.88,
-      71.59,
-      72.57,
-      76.32,
-      79.37,
-      83.18,
-      86.05,
-      89.32
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "RCOIR12",
@@ -10955,24 +7174,6 @@
     ]
   },
   {
-    "measureId": "RCOIR12",
-    "submissionMethod": "registry",
-    "deciles": [
-      52.94,
-      60.925,
-      68.815,
-      72.225,
-      76.27,
-      79.38,
-      80.86,
-      82.92,
-      86.28,
-      88.105
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "RCOIR7",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -10991,24 +7192,6 @@
       93.62,
       96.08
     ]
-  },
-  {
-    "measureId": "RCOIR7",
-    "submissionMethod": "registry",
-    "deciles": [
-      69.89,
-      75.44,
-      82.11,
-      84.8,
-      87.64,
-      88.89,
-      91.3,
-      92.72,
-      95.31,
-      96.55
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "RPAQIR13",
@@ -11031,24 +7214,6 @@
     ]
   },
   {
-    "measureId": "RPAQIR13",
-    "submissionMethod": "registry",
-    "deciles": [
-      92.36,
-      96.48,
-      97.35,
-      98.26,
-      98.63,
-      98.785,
-      99.17,
-      99.37,
-      99.65,
-      99.745
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "RPAQIR14",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -11069,24 +7234,6 @@
     ]
   },
   {
-    "measureId": "RPAQIR14",
-    "submissionMethod": "registry",
-    "deciles": [
-      69.37,
-      72.97,
-      79.29,
-      81.58,
-      83.91,
-      86.83,
-      88.57,
-      90.85,
-      91.98,
-      93.1
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "RPAQIR15",
     "benchmarkYear": 2019,
     "performanceYear": 2021,
@@ -11105,24 +7252,6 @@
       91.69,
       93.15
     ]
-  },
-  {
-    "measureId": "RPAQIR15",
-    "submissionMethod": "registry",
-    "deciles": [
-      60.47,
-      71.15,
-      74.24,
-      79.41,
-      81.48,
-      85.29,
-      86.47,
-      90.24,
-      91.24,
-      93.1
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
   },
   {
     "measureId": "STS1",
@@ -11185,25 +7314,9 @@
     ]
   },
   {
-    "measureId": "UREQA4",
-    "submissionMethod": "registry",
-    "deciles": [
-      95.82,
-      97.63,
-      98.405,
-      99.03,
-      99.385,
-      99.48,
-      99.62,
-      100,
-      100,
-      100
-    ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
-  },
-  {
     "measureId": "USWR23",
+    "performanceYear": 2021,
+    "benchmarkYear": 2021,
     "submissionMethod": "registry",
     "deciles": [
       0.32,
@@ -11217,7 +7330,7 @@
       80.56,
       88.37
     ],
-    "performanceYear": 2021,
-    "benchmarkYear": 2021
+    "isToppedOut": false,
+    "isToppedOutByProgram": false
   }
 ]

--- a/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js
+++ b/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js
@@ -1,5 +1,3 @@
-
-
 const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');

--- a/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js
+++ b/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js
@@ -69,7 +69,7 @@ const processPerformanceBenchmark = (benchmark) => {
   //  Fix the underlining data where proportional measures to produce 9 deciles only by default.
   const nonPropMeasures2021 = ['ACRAD18', 'ACEP50', 'ACEP51', 'ACRAD17', 'ACRAD25', 'ACRAD19', 'ACRAD16', 'ACRAD15'];
   const trimmedDeciles = () => {
-    if (nonPropMeasures2021.includes(benchmark.measureId) && benchmark.performanceYear === 2021) {
+    if (nonPropMeasures2021.includes(benchmark.measureId) || benchmark.performanceYear !== 2021) {
       return benchmark.deciles;
     } else {
       return benchmark.deciles.slice(1);

--- a/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js
+++ b/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js
@@ -65,12 +65,25 @@ const getBenchmarkKey = (benchmark) => {
  * }}
  */
 const processPerformanceBenchmark = (benchmark) => {
+  // TODO: Kyle - This was a one-off for 2021 performance benchmarks. If you run this for 2022 performance benchmarks you're in trouble.
+  //  Fix the underlining data where proportional measures to produce 9 deciles only by default.
+  const nonPropMeasures2021 = ['ACRAD18', 'ACEP50', 'ACEP51', 'ACRAD17', 'ACRAD25', 'ACRAD19', 'ACRAD16', 'ACRAD15'];
+  const trimmedDeciles = () => {
+    if (nonPropMeasures2021.includes(benchmark.measureId)) {
+      return benchmark.deciles;
+    } else {
+      return benchmark.deciles.slice(1);
+    }
+  };
+
+  const averageDeciles = trimmedDeciles().map(d => _.round(d, (benchmark.performanceYear >= 2019 ? 4 : 2)));
+
   return {
     measureId: benchmark.measureId,
     performanceYear: benchmark.performanceYear,
     benchmarkYear: benchmark.performanceYear,
     submissionMethod: benchmark.submissionMethod,
-    deciles: benchmark.deciles.map(d => _.round(d, (benchmark.performanceYear >= 2019 ? 4 : 2))),
+    deciles: averageDeciles,
     isToppedOut: false,
     isToppedOutByProgram: false
   };

--- a/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js
+++ b/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js
@@ -69,7 +69,7 @@ const processPerformanceBenchmark = (benchmark) => {
   //  Fix the underlining data where proportional measures to produce 9 deciles only by default.
   const nonPropMeasures2021 = ['ACRAD18', 'ACEP50', 'ACEP51', 'ACRAD17', 'ACRAD25', 'ACRAD19', 'ACRAD16', 'ACRAD15'];
   const trimmedDeciles = () => {
-    if (nonPropMeasures2021.includes(benchmark.measureId)) {
+    if (nonPropMeasures2021.includes(benchmark.measureId) && benchmark.performanceYear === 2021) {
       return benchmark.deciles;
     } else {
       return benchmark.deciles.slice(1);

--- a/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js
+++ b/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js
@@ -9,21 +9,34 @@ const UNIQUE_COLUMN_CONSTRAINT = [
   'submissionMethod'
 ];
 
-// Returns an alphabetically-ordered list of files in the given pat
-const getOrderedFileNames = (currentDir, relativePath) => {
-  return fs.readdirSync(path.join(currentDir, relativePath));
-};
+/**
+ * Function to get an alphabetically-ordered list of files in a given path
+ *
+ * @param {String} currentDir The path of the current directory
+ * @param {String} relativePath The relative path to the target directory
+ * @returns {[String]} a collection of files in the target directory
+ */
+const getOrderedFileNames = (currentDir, relativePath) => fs.readdirSync(path.join(currentDir, relativePath));
 
-// Generate a key in an object to store benchmarks in.
-// Benchmarks with the same key will overwrite one another base
-// which was loaded last. See mergeBenchmarkLayers for more details.
-const getBenchmarkKey = (benchmark, isPerformanceBenchmark = false) => {
+/**
+ * Generates a key in an object to store benchmarks in. Benchmarks with the same key will overwrite one another, based on which was added
+ * first. See mergeBenchmarkLayers() for more details.
+ * @param {{
+ *   measureId: String,
+ *   performanceYear: Number,
+ *   benchmarkYear: Number,
+ *   submissionMethod: String,
+ *   deciles: [Number],
+ *   isToppedOut: Boolean,
+ *   isToppedOutByProgram: Boolean
+ * }} benchmark The benchmark to get the key for
+ * @returns {String} The benchmark key based on unique column constraints
+ */
+const getBenchmarkKey = (benchmark) => {
   let benchmarkKey = '';
   UNIQUE_COLUMN_CONSTRAINT.forEach((keyName) => {
     // For performance benchmarks, the benchmark year and the performance year are the same
-    if (keyName === 'benchmarkYear' && isPerformanceBenchmark && 'performanceYear' in benchmark) {
-      benchmarkKey = `${benchmarkKey}${benchmark['performanceYear']}|`;
-    } else if (keyName in benchmark) {
+    if (keyName in benchmark) {
       benchmarkKey = `${benchmarkKey}${benchmark[keyName]}|`;
     } else {
       throw new Error('Key is missing: ' + keyName);
@@ -33,30 +46,91 @@ const getBenchmarkKey = (benchmark, isPerformanceBenchmark = false) => {
   return benchmarkKey;
 };
 
-// Accepts an array of relative file paths, loads json files,
-// returns a composite collection of benchmarks.
-// Subsequent JSON files can add but not overwrite benchmarks from previous JSON files.
-// Uniqueness is checked by the composite key in UNIQUE_COLUMN_CONSTRAINT.
-// Note: Benchmarks with the same key will raise a collective error.
-// Note: Perforamnce benchmarks are processed with data from the same year, so require special handling
-const mergeBenchmarkLayers = (benchmarkLayers, benchmarkJsonDir) => {
+/**
+ * Function to populate the missing fields on a performance benchmark
+ * @param {{
+ *   measureId: String,
+ *   performanceYear: Number,
+ *   submissionMethod: String,
+ *   deciles: [Number]
+ * }} benchmark the performance benchmark to process
+ * @returns {{
+ *   measureId: String,
+ *   performanceYear: Number,
+ *   benchmarkYear: Number,
+ *   submissionMethod: String,
+ *   deciles: [Number],
+ *   isToppedOut: Boolean,
+ *   isToppedOutByProgram: Boolean
+ * }}
+ */
+const processPerformanceBenchmark = (benchmark) => {
+  return {
+    measureId: benchmark.measureId,
+    performanceYear: benchmark.performanceYear,
+    benchmarkYear: benchmark.performanceYear,
+    submissionMethod: benchmark.submissionMethod,
+    deciles: benchmark.deciles.map(d => _.round(d, (benchmark.performanceYear >= 2019 ? 4 : 2))),
+    isToppedOut: false,
+    isToppedOutByProgram: false
+  };
+};
+
+/**
+ * Function to read a JSON file
+ * @param {String} dir The target directory
+ * @param {String} file The target file
+ * @returns {[{
+ *   measureId: String,
+ *   benchmarkYear?: Number,
+ *   performanceYear: Number,
+ *   submissionMethod: String,
+ *   deciles: [Number],
+ *   isToppedOut?: Boolean,
+ *   isToppedOutByProgram?: Boolean
+ * }]}
+ */
+const loadBenchmark = (dir, file) => JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
+
+/**
+ * Loads in each JSON from the staging directory passed in, compares them by unique column constraints, and returns a collection of
+ * formatted benchmarks.
+ *
+ * **Notes:**
+ * * Benchmarks with the same key will raise a collective error
+ * * Performance benchmarks from Final Scoring require special processing
+ * @param {[String]} benchmarkFileNames An array of relative file paths to load JSONs from
+ * @param {String} benchmarkJsonDir The directory to load JSON files from
+ * @returns {[{
+ *   measureId: String,
+ *   benchmarkYear: Number,
+ *   performanceYear: Number,
+ *   submissionMethod: String,
+ *   deciles: [Number],
+ *   isToppedOut: Boolean,
+ *   isToppedOutByProgram: Boolean
+ * }]} a composite collection of benchmarks
+ */
+const mergeBenchmarkFiles = (benchmarkFileNames, benchmarkJsonDir) => {
   const mergedBenchmarks = new Map();
   const mergeConflicts = [];
 
-  benchmarkLayers.forEach((benchmarkLayer) => {
-    const benchmarkFile = JSON.parse(fs.readFileSync(path.join(benchmarkJsonDir, benchmarkLayer), 'utf8'));
-    const isPerformanceBenchmark = benchmarkLayer.indexOf('performance-benchmarks.json') > -1;
+  benchmarkFileNames.forEach((filename) => {
+    const benchmarkFile = loadBenchmark(benchmarkJsonDir, filename);
+    const isPerformanceBenchmark = filename.indexOf('performance-benchmarks.json') > -1;
     benchmarkFile.forEach((benchmark) => {
-      const benchmarkKey = getBenchmarkKey(benchmark, isPerformanceBenchmark);
       if (isPerformanceBenchmark) {
-        benchmark.benchmarkYear = benchmark.performanceYear;
+        benchmark = processPerformanceBenchmark(benchmark);
       }
+      const benchmarkKey = getBenchmarkKey(!isPerformanceBenchmark ? benchmark : {...benchmark, benchmarkYear: benchmark.performanceYear - 2});
       if (mergedBenchmarks.has(benchmarkKey) && !_.isEqual(mergedBenchmarks.get(benchmarkKey), benchmark)) {
-        mergeConflicts.push({
-          existing: mergedBenchmarks.get(benchmarkKey),
-          conflicting: benchmark,
-          conflictingFile: benchmarkLayer
-        });
+        if (!isPerformanceBenchmark) {
+          mergeConflicts.push({
+            existing: mergedBenchmarks.get(benchmarkKey),
+            conflicting: benchmark,
+            conflictingFile: filename
+          });
+        }
       } else {
         mergedBenchmarks.set(benchmarkKey, benchmark);
       }
@@ -74,14 +148,14 @@ const mergeBenchmarkLayers = (benchmarkLayers, benchmarkJsonDir) => {
 /**
  * Function to ensure that the benchmarks are all unique according to the column constraints outlined above
  * @param {[{
-  *   measureId: String,
-  *   performanceYear: Number,
-  *   benchmarkYear: Number,
-  *   submissionMethod: String,
-  *   deciles: [Number],
-  *   isToppedOut: Boolean,
-  *   isToppedOutByProgram: Boolean
-  * }]} benchmarks - the collection of benchmarks to evaluate
+ *   measureId: String,
+ *   performanceYear: Number,
+ *   benchmarkYear: Number,
+ *   submissionMethod: String,
+ *   deciles: [Number],
+ *   isToppedOut: Boolean,
+ *   isToppedOutByProgram: Boolean
+ * }]} benchmarks - the collection of benchmarks to evaluate
  * @returns {void}
  */
 const validateUniqueConstraints = (benchmarks) => {
@@ -110,6 +184,6 @@ const validateUniqueConstraints = (benchmarks) => {
 module.exports = {
   getOrderedFileNames,
   getBenchmarkKey,
-  mergeBenchmarkLayers,
+  mergeBenchmarkFiles,
   validateUniqueConstraints
 };

--- a/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js
+++ b/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js
@@ -1,3 +1,5 @@
+
+
 const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');
@@ -9,34 +11,21 @@ const UNIQUE_COLUMN_CONSTRAINT = [
   'submissionMethod'
 ];
 
-/**
- * Function to get an alphabetically-ordered list of files in a given path
- *
- * @param {String} currentDir The path of the current directory
- * @param {String} relativePath The relative path to the target directory
- * @returns {[String]} a collection of files in the target directory
- */
-const getOrderedFileNames = (currentDir, relativePath) => fs.readdirSync(path.join(currentDir, relativePath));
+// Returns an alphabetically-ordered list of files in the given pat
+const getOrderedFileNames = (currentDir, relativePath) => {
+  return fs.readdirSync(path.join(currentDir, relativePath));
+};
 
-/**
- * Generates a key in an object to store benchmarks in. Benchmarks with the same key will overwrite one another, based on which was added
- * first. See mergeBenchmarkLayers() for more details.
- * @param {{
-  *   measureId: String,
-  *   performanceYear: Number,
-  *   benchmarkYear: Number,
-  *   submissionMethod: String,
-  *   deciles: [Number],
-  *   isToppedOut: Boolean,
-  *   isToppedOutByProgram: Boolean
-  * }} benchmark The benchmark to get the key for
-  * @returns {String} The benchmark key based on unique column constraints
- */
-const getBenchmarkKey = (benchmark) => {
+// Generate a key in an object to store benchmarks in.
+// Benchmarks with the same key will overwrite one another base
+// which was loaded last. See mergeBenchmarkLayers for more details.
+const getBenchmarkKey = (benchmark, isPerformanceBenchmark = false) => {
   let benchmarkKey = '';
   UNIQUE_COLUMN_CONSTRAINT.forEach((keyName) => {
     // For performance benchmarks, the benchmark year and the performance year are the same
-    if (keyName in benchmark) {
+    if (keyName === 'benchmarkYear' && isPerformanceBenchmark && 'performanceYear' in benchmark) {
+      benchmarkKey = `${benchmarkKey}${benchmark['performanceYear']}|`;
+    } else if (keyName in benchmark) {
       benchmarkKey = `${benchmarkKey}${benchmark[keyName]}|`;
     } else {
       throw new Error('Key is missing: ' + keyName);
@@ -46,91 +35,30 @@ const getBenchmarkKey = (benchmark) => {
   return benchmarkKey;
 };
 
-/**
- * Function to populate the missing fields on a performance benchmark
- * @param {{
- *   measureId: String,
- *   performanceYear: Number,
- *   submissionMethod: String,
- *   deciles: [Number]
- * }} benchmark the performance benchmark to process
- * @returns {{
-  *   measureId: String,
-  *   performanceYear: Number,
-  *   benchmarkYear: Number,
-  *   submissionMethod: String,
-  *   deciles: [Number],
-  *   isToppedOut: Boolean,
-  *   isToppedOutByProgram: Boolean
-  * }}
- */
-const processPerformanceBenchmark = (benchmark) => {
-  return {
-    measureId: benchmark.measureId,
-    performanceYear: benchmark.performanceYear,
-    benchmarkYear: benchmark.performanceYear,
-    submissionMethod: benchmark.submissionMethod,
-    deciles: benchmark.deciles.map(d => _.round(d, (benchmark.performanceYear >= 2019 ? 4 : 2))),
-    isToppedOut: false,
-    isToppedOutByProgram: false
-  };
-};
-
-/**
- * Function to read a JSON file
- * @param {String} dir The target directory
- * @param {String} file The target file
- * @returns {[{
- *   measureId: String,
- *   benchmarkYear?: Number,
- *   performanceYear: Number,
- *   submissionMethod: String,
- *   deciles: [Number],
- *   isToppedOut?: Boolean,
- *   isToppedOutByProgram?: Boolean
- * }]}
- */
-const loadBenchmark = (dir, file) => JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
-
-/**
- * Loads in each JSON from the staging directory passed in, compares them by unique column constraints, and returns a collection of
- * formatted benchmarks.
- *
- * **Notes:**
- * * Benchmarks with the same key will raise a collective error
- * * Performance benchmarks from Final Scoring require special processing
- * @param {[String]} benchmarkFileNames An array of relative file paths to load JSONs from
- * @param {String} benchmarkJsonDir The directory to load JSON files from
- * @returns {[{
- *   measureId: String,
- *   benchmarkYear: Number,
- *   performanceYear: Number,
- *   submissionMethod: String,
- *   deciles: [Number],
- *   isToppedOut: Boolean,
- *   isToppedOutByProgram: Boolean
- * }]} a composite collection of benchmarks
- */
-const mergeBenchmarkFiles = (benchmarkFileNames, benchmarkJsonDir) => {
+// Accepts an array of relative file paths, loads json files,
+// returns a composite collection of benchmarks.
+// Subsequent JSON files can add but not overwrite benchmarks from previous JSON files.
+// Uniqueness is checked by the composite key in UNIQUE_COLUMN_CONSTRAINT.
+// Note: Benchmarks with the same key will raise a collective error.
+// Note: Perforamnce benchmarks are processed with data from the same year, so require special handling
+const mergeBenchmarkLayers = (benchmarkLayers, benchmarkJsonDir) => {
   const mergedBenchmarks = new Map();
   const mergeConflicts = [];
 
-  benchmarkFileNames.forEach((filename) => {
-    const benchmarkFile = loadBenchmark(benchmarkJsonDir, filename);
-    const isPerformanceBenchmark = filename.indexOf('performance-benchmarks.json') > -1;
+  benchmarkLayers.forEach((benchmarkLayer) => {
+    const benchmarkFile = JSON.parse(fs.readFileSync(path.join(benchmarkJsonDir, benchmarkLayer), 'utf8'));
+    const isPerformanceBenchmark = benchmarkLayer.indexOf('performance-benchmarks.json') > -1;
     benchmarkFile.forEach((benchmark) => {
+      const benchmarkKey = getBenchmarkKey(benchmark, isPerformanceBenchmark);
       if (isPerformanceBenchmark) {
-        benchmark = processPerformanceBenchmark(benchmark);
+        benchmark.benchmarkYear = benchmark.performanceYear;
       }
-      const benchmarkKey = getBenchmarkKey(!isPerformanceBenchmark ? benchmark : {...benchmark, benchmarkYear: benchmark.performanceYear - 2});
       if (mergedBenchmarks.has(benchmarkKey) && !_.isEqual(mergedBenchmarks.get(benchmarkKey), benchmark)) {
-        if (!isPerformanceBenchmark) {
-          mergeConflicts.push({
-            existing: mergedBenchmarks.get(benchmarkKey),
-            conflicting: benchmark,
-            conflictingFile: filename
-          });
-        }
+        mergeConflicts.push({
+          existing: mergedBenchmarks.get(benchmarkKey),
+          conflicting: benchmark,
+          conflictingFile: benchmarkLayer
+        });
       } else {
         mergedBenchmarks.set(benchmarkKey, benchmark);
       }
@@ -184,6 +112,6 @@ const validateUniqueConstraints = (benchmarks) => {
 module.exports = {
   getOrderedFileNames,
   getBenchmarkKey,
-  mergeBenchmarkFiles,
+  mergeBenchmarkLayers,
   validateUniqueConstraints
 };

--- a/scripts/benchmarks/merge-benchmark-data.js
+++ b/scripts/benchmarks/merge-benchmark-data.js
@@ -1,4 +1,4 @@
-const { getOrderedFileNames, mergeBenchmarkFiles, validateUniqueConstraints } = require('./helpers/merge-benchmark-data-helpers.js');
+const { getOrderedFileNames, mergeBenchmarkLayers, validateUniqueConstraints } = require('./helpers/merge-benchmark-data-helpers.js');
 const path = require('path');
 
 const performanceYear = process.argv[2];
@@ -20,7 +20,7 @@ if (performanceYear) {
         return 0;
       }
     });
-  const formattedBenchmarks = mergeBenchmarkFiles(benchmarkLayerFiles, jsonDir);
+  const formattedBenchmarks = mergeBenchmarkLayers(benchmarkLayerFiles, jsonDir);
 
   validateUniqueConstraints(formattedBenchmarks);
 

--- a/scripts/benchmarks/merge-benchmark-data.js
+++ b/scripts/benchmarks/merge-benchmark-data.js
@@ -1,4 +1,4 @@
-const { getOrderedFileNames, mergeBenchmarkLayers, validateUniqueConstraints } = require('./helpers/merge-benchmark-data-helpers.js');
+const { getOrderedFileNames, mergeBenchmarkFiles, validateUniqueConstraints } = require('./helpers/merge-benchmark-data-helpers.js');
 const path = require('path');
 
 const performanceYear = process.argv[2];
@@ -20,7 +20,7 @@ if (performanceYear) {
         return 0;
       }
     });
-  const formattedBenchmarks = mergeBenchmarkLayers(benchmarkLayerFiles, jsonDir);
+  const formattedBenchmarks = mergeBenchmarkFiles(benchmarkLayerFiles, jsonDir);
 
   validateUniqueConstraints(formattedBenchmarks);
 

--- a/staging/2021/benchmarks/json/performance-benchmarks.json
+++ b/staging/2021/benchmarks/json/performance-benchmarks.json
@@ -1,0 +1,5524 @@
+[
+  {
+    "measureId": "112",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.27,
+      9.23,
+      27.56,
+      39.42,
+      48.18,
+      54.84,
+      60.57,
+      66.82,
+      73.31,
+      82.05
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "126",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.62,
+      49.57,
+      80.13,
+      92.91,
+      98.65,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "155",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.07,
+      80.68,
+      97.06,
+      99.71,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "226",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.88,
+      17.3,
+      34.62,
+      53.74,
+      72,
+      84.85,
+      92.86,
+      97.78,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "305",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.34,
+      1.06,
+      1.65,
+      2.17,
+      2.7,
+      3.35,
+      4.23,
+      5.18,
+      6.67,
+      10.16
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "318",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.14,
+      3.91,
+      16.8,
+      35.7,
+      52.47,
+      66.87,
+      79.39,
+      88.69,
+      95.37,
+      98.92
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "331",
+    "submissionMethod": "registry",
+    "deciles": [
+      96.32,
+      81.08,
+      64.645,
+      46.945,
+      32.11,
+      17.725,
+      8,
+      3.755,
+      0.39,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "374",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.5,
+      4.85,
+      11.36,
+      17.31,
+      23.48,
+      30.5,
+      38.83,
+      50.51,
+      66.57,
+      85.71
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "404",
+    "submissionMethod": "registry",
+    "deciles": [
+      7.64,
+      30.97,
+      50,
+      61.67,
+      69.96,
+      76.14,
+      80.33,
+      86.44,
+      91.94,
+      97.06
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "450",
+    "submissionMethod": "registry",
+    "deciles": [
+      30,
+      39.39,
+      42.405,
+      50,
+      54.42,
+      63.3,
+      78.18,
+      87.8,
+      95.89,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "464",
+    "submissionMethod": "registry",
+    "deciles": [
+      5.88,
+      70,
+      83.56,
+      88.83,
+      95.06,
+      97.075,
+      98.21,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AAO31",
+    "submissionMethod": "registry",
+    "deciles": [
+      78.38,
+      91.76,
+      95.25,
+      96.74,
+      97.92,
+      98.495,
+      98.65,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "GIQIC22",
+    "submissionMethod": "registry",
+    "deciles": [
+      15.27,
+      21.86,
+      26.62,
+      32.05,
+      37.81,
+      41.3,
+      44.87,
+      46.67,
+      51.09,
+      55.84
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IRIS45",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.45,
+      1.19,
+      1.565,
+      2.33,
+      3.13,
+      3.67,
+      4.75,
+      6.48,
+      8.985,
+      13.6
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "066",
+    "submissionMethod": "registry",
+    "deciles": [
+      26.09,
+      76.92,
+      86.89,
+      92,
+      95.45,
+      97.64,
+      98.9,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "110",
+    "submissionMethod": "claims",
+    "deciles": [
+      1.57,
+      30.56,
+      69.89,
+      81.29,
+      90.18,
+      96.83,
+      99.33,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "143",
+    "submissionMethod": "registry",
+    "deciles": [
+      20.27,
+      74.86,
+      94.89,
+      97.55,
+      98.72,
+      99.31,
+      99.9,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "217",
+    "submissionMethod": "registry",
+    "deciles": [
+      20.41,
+      37.65,
+      42.94,
+      47.06,
+      52.7,
+      56.67,
+      61.05,
+      65.31,
+      81.2,
+      96.88
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "NHCR4",
+    "submissionMethod": "registry",
+    "deciles": [
+      6.67,
+      24.42,
+      38.26,
+      41.38,
+      56.03,
+      61.6,
+      77.67,
+      82.09,
+      94.87,
+      98.59
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "PIMSH2",
+    "submissionMethod": "registry",
+    "deciles": [
+      67.7,
+      40,
+      36.8,
+      35.2,
+      31.4,
+      25,
+      23,
+      10.5,
+      4.8,
+      4
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "RPAQIR14",
+    "submissionMethod": "registry",
+    "deciles": [
+      69.37,
+      72.97,
+      79.29,
+      81.58,
+      83.91,
+      86.83,
+      88.57,
+      90.85,
+      91.98,
+      93.1
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "007",
+    "submissionMethod": "registry",
+    "deciles": [
+      56.91,
+      77.92,
+      82.845,
+      86.67,
+      90,
+      93.24,
+      96.235,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "093",
+    "submissionMethod": "registry",
+    "deciles": [
+      37.16,
+      79.31,
+      90.39,
+      93.86,
+      96.28,
+      97.8,
+      99.015,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "143",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      2.31,
+      43.535,
+      79.995,
+      90.645,
+      94.685,
+      96.89,
+      98.015,
+      98.92,
+      99.64,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "195",
+    "submissionMethod": "claims",
+    "deciles": [
+      40.86,
+      88.62,
+      97.02,
+      99.27,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACRAD19",
+    "submissionMethod": "registry",
+    "deciles": [
+      31.9,
+      24.2,
+      19.16,
+      13.09,
+      9.96,
+      6.99,
+      4.77,
+      3.41,
+      2.54,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AQUA8",
+    "submissionMethod": "registry",
+    "deciles": [
+      40,
+      7.74,
+      4,
+      2.76,
+      2.27,
+      1.615,
+      0.62,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "144",
+    "submissionMethod": "registry",
+    "deciles": [
+      4,
+      18.42,
+      44.62,
+      68.21,
+      80.88,
+      90.435,
+      94.6,
+      97.63,
+      99.7,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "181",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.08,
+      92,
+      98.64,
+      99.47,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "310",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      1.35,
+      11.11,
+      18.255,
+      25,
+      30,
+      35.48,
+      40.865,
+      45.48,
+      53.015,
+      61.9
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "358",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.5,
+      9.26,
+      66.01,
+      93.75,
+      98.4,
+      99.76,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "384",
+    "submissionMethod": "registry",
+    "deciles": [
+      75.76,
+      89.14,
+      95.1,
+      96.77,
+      98.26,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "385",
+    "submissionMethod": "registry",
+    "deciles": [
+      6.52,
+      16.81,
+      21.9,
+      34.78,
+      38.78,
+      56.94,
+      62.28,
+      64.71,
+      77.29,
+      81.48
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "453",
+    "submissionMethod": "registry",
+    "deciles": [
+      32.56,
+      24.39,
+      19.23,
+      15.58,
+      13.19,
+      11.21,
+      9.68,
+      7.14,
+      5.22,
+      3.57
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "475",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.13,
+      3.005,
+      5.83,
+      8.82,
+      11.8,
+      14.62,
+      17.96,
+      21.74,
+      26.425,
+      34.675
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AAN5",
+    "submissionMethod": "registry",
+    "deciles": [
+      40.74,
+      50.85,
+      57.14,
+      66.84,
+      71.09,
+      77.2,
+      80.65,
+      81.82,
+      86.67,
+      95.31
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACRAD25",
+    "submissionMethod": "registry",
+    "deciles": [
+      46.495,
+      27.765,
+      21.2,
+      16.455,
+      11.85,
+      6.815,
+      4.165,
+      2.195,
+      0.595,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AQI69",
+    "submissionMethod": "registry",
+    "deciles": [
+      31.41,
+      95.6,
+      97.61,
+      98.7,
+      99.21,
+      99.62,
+      99.97,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IROMS20",
+    "submissionMethod": "registry",
+    "deciles": [
+      58.97,
+      53.66,
+      51.43,
+      50,
+      48.39,
+      47.2,
+      45.53,
+      44.23,
+      42.31,
+      39.39
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "RCOIR7",
+    "submissionMethod": "registry",
+    "deciles": [
+      69.89,
+      75.44,
+      82.11,
+      84.8,
+      87.64,
+      88.89,
+      91.3,
+      92.72,
+      95.31,
+      96.55
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "USWR23",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.32,
+      13.28,
+      21.43,
+      41.75,
+      48.84,
+      57.38,
+      70.83,
+      75.29,
+      80.56,
+      88.37
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "001",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      99.52,
+      93.33,
+      75,
+      57.6,
+      46.15,
+      38.165,
+      32.26,
+      27.32,
+      22.5,
+      17.07
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "006",
+    "submissionMethod": "registry",
+    "deciles": [
+      41.67,
+      70.83,
+      77.71,
+      83.02,
+      86.8,
+      90.4,
+      93.66,
+      97.04,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "007",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      54.55,
+      75.76,
+      80.77,
+      83.81,
+      86.26,
+      88.095,
+      90,
+      91.8,
+      93.33,
+      95.83
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "052",
+    "submissionMethod": "registry",
+    "deciles": [
+      8.5,
+      58.44,
+      72.165,
+      88.54,
+      97.26,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "238",
+    "submissionMethod": "registry",
+    "deciles": [
+      20,
+      3.73,
+      0.625,
+      0.05,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "405",
+    "submissionMethod": "claims",
+    "deciles": [
+      0.71,
+      2.08,
+      6.12,
+      23.81,
+      46.07,
+      70.46,
+      96.3,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "410",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.55,
+      45.495,
+      70.135,
+      85.19,
+      93.455,
+      97.56,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "438",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      32.98,
+      60.84,
+      66.645,
+      69.78,
+      72.385,
+      74.61,
+      76.62,
+      78.79,
+      81.415,
+      84.75
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "440",
+    "submissionMethod": "registry",
+    "deciles": [
+      71.05,
+      96.74,
+      98.985,
+      99.735,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACEP50",
+    "submissionMethod": "registry",
+    "deciles": [
+      127.228,
+      117.9865,
+      111.896,
+      106.929,
+      103.0555,
+      98.8234,
+      94.6961,
+      90.0213,
+      84.3452,
+      49.6086
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "RPAQIR13",
+    "submissionMethod": "registry",
+    "deciles": [
+      92.36,
+      96.48,
+      97.35,
+      98.26,
+      98.63,
+      98.785,
+      99.17,
+      99.37,
+      99.65,
+      99.745
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "005",
+    "submissionMethod": "registry",
+    "deciles": [
+      67.35,
+      88,
+      95.45,
+      98.55,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "138",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.33,
+      60.78,
+      93.02,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "322",
+    "submissionMethod": "registry",
+    "deciles": [
+      48.9,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACEP21",
+    "submissionMethod": "registry",
+    "deciles": [
+      23.03,
+      11.65,
+      8.44,
+      7.14,
+      5.08,
+      4.17,
+      3.36,
+      2.64,
+      2.05,
+      1.22
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACRAD15",
+    "submissionMethod": "registry",
+    "deciles": [
+      5.24,
+      3.61,
+      2.71,
+      2.21,
+      1.77,
+      1.53,
+      1.26,
+      1.01,
+      0.72,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IRIS44",
+    "submissionMethod": "registry",
+    "deciles": [
+      90,
+      18.18,
+      13.33,
+      12.64,
+      11.63,
+      11.125,
+      7.14,
+      5,
+      4.05,
+      1.39
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "RCOIR10",
+    "submissionMethod": "registry",
+    "deciles": [
+      50,
+      65.43,
+      69.88,
+      71.59,
+      72.57,
+      76.32,
+      79.37,
+      83.18,
+      86.05,
+      89.32
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "021",
+    "submissionMethod": "claims",
+    "deciles": [
+      5.26,
+      99.62,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "067",
+    "submissionMethod": "registry",
+    "deciles": [
+      11.48,
+      34.48,
+      50.23,
+      54.17,
+      68,
+      98.31,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "119",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.09,
+      66.89,
+      77.04,
+      82.08,
+      87.35,
+      90.975,
+      94.15,
+      98.06,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "182",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.06,
+      97.89,
+      99.55,
+      99.92,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "286",
+    "submissionMethod": "registry",
+    "deciles": [
+      33.33,
+      93.07,
+      99.32,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "351",
+    "submissionMethod": "registry",
+    "deciles": [
+      7.62,
+      90.39,
+      96.5,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "383",
+    "submissionMethod": "registry",
+    "deciles": [
+      22.73,
+      81.45,
+      95.75,
+      99.53,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AAO16",
+    "submissionMethod": "registry",
+    "deciles": [
+      23.26,
+      82.07,
+      93.37,
+      95.09,
+      97.41,
+      98.35,
+      99.82,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "021",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.94,
+      38.3,
+      92.31,
+      98.55,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "024",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.04,
+      1.35,
+      31.62,
+      64.15,
+      83.1,
+      98.08,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "113",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.18,
+      7.22,
+      22.61,
+      34.53,
+      43.9,
+      51.89,
+      59.65,
+      66.98,
+      75.51,
+      85.69
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "250",
+    "submissionMethod": "registry",
+    "deciles": [
+      97.78,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "282",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.6,
+      84.62,
+      97.97,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "357",
+    "submissionMethod": "registry",
+    "deciles": [
+      80.06,
+      6.34,
+      1.17,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AQI48",
+    "submissionMethod": "registry",
+    "deciles": [
+      83.72,
+      90,
+      91.14,
+      91.84,
+      92.67,
+      93.515,
+      94.29,
+      95.49,
+      96.15,
+      97.71
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ECPR39",
+    "submissionMethod": "registry",
+    "deciles": [
+      13.3,
+      80.89,
+      93.75,
+      96.67,
+      97.65,
+      98.355,
+      98.9,
+      99.25,
+      99.67,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IRIS2",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.8,
+      50.93,
+      61.7,
+      66.91,
+      71.09,
+      74.29,
+      77.61,
+      80.13,
+      83.5,
+      87.59
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "PIMSH4",
+    "submissionMethod": "registry",
+    "deciles": [
+      13.3,
+      28.4,
+      34.15,
+      37.5,
+      39.65,
+      42.2,
+      44.65,
+      48.2,
+      51.8,
+      57.1
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IRIS53",
+    "submissionMethod": "registry",
+    "deciles": [
+      53.12,
+      78.69,
+      84,
+      86.36,
+      88.24,
+      90.18,
+      92.86,
+      95.24,
+      97.78,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "005",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      24,
+      60.8,
+      68.89,
+      73.61,
+      77.43,
+      80.03,
+      82.39,
+      85.53,
+      88.14,
+      91.67
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "050",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.7,
+      46.96,
+      68.25,
+      75.18,
+      80.62,
+      83.8,
+      88.46,
+      96.97,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "191",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      17.24,
+      74.48,
+      88.08,
+      92.67,
+      95.14,
+      96.765,
+      97.86,
+      98.63,
+      99.27,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "398",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.44,
+      41.94,
+      52.27,
+      61.29,
+      69.7,
+      85.71,
+      97.06,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "439",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.96,
+      0.28,
+      0.07,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACRAD18",
+    "submissionMethod": "registry",
+    "deciles": [
+      10.11,
+      3.86,
+      2.8,
+      2.33,
+      2.01,
+      1.66,
+      1.36,
+      1.11,
+      0.78,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "HM8",
+    "submissionMethod": "registry",
+    "deciles": [
+      8.57,
+      31.75,
+      40,
+      48.51,
+      53.52,
+      61.29,
+      65.99,
+      70,
+      77.94,
+      83.9
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IRIS43",
+    "submissionMethod": "registry",
+    "deciles": [
+      5,
+      8.7,
+      14.29,
+      17.42,
+      21.62,
+      24.35,
+      31.67,
+      36.17,
+      77.59,
+      93.33
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "396",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "019",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      6.41,
+      52.985,
+      70.175,
+      80.36,
+      86.32,
+      90.91,
+      93.75,
+      96.045,
+      98,
+      99.55
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "181",
+    "submissionMethod": "claims",
+    "deciles": [
+      0.37,
+      94.03,
+      99.61,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "225",
+    "submissionMethod": "registry",
+    "deciles": [
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "236",
+    "submissionMethod": "claims",
+    "deciles": [
+      10,
+      20,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "236",
+    "submissionMethod": "registry",
+    "deciles": [
+      10,
+      20,
+      30,
+      40,
+      50,
+      60,
+      70,
+      80,
+      90
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACEP52",
+    "submissionMethod": "registry",
+    "deciles": [
+      5.17,
+      12.73,
+      21.43,
+      54.25,
+      59.18,
+      62.99,
+      64.35,
+      66.58,
+      67.73,
+      70.88
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACRAD17",
+    "submissionMethod": "registry",
+    "deciles": [
+      21.19,
+      15.39,
+      12.8,
+      10.44,
+      8.19,
+      6.06,
+      4.4,
+      3.24,
+      2.14,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AQUA14",
+    "submissionMethod": "registry",
+    "deciles": [
+      66.1,
+      22.22,
+      15.89,
+      12,
+      9.06,
+      7.69,
+      4.6,
+      3.06,
+      2.08,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AQUA26",
+    "submissionMethod": "registry",
+    "deciles": [
+      95.93,
+      0.03,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "CDR2",
+    "submissionMethod": "registry",
+    "deciles": [
+      4,
+      7.69,
+      11.54,
+      13.21,
+      14.77,
+      16.89,
+      19.05,
+      19.7,
+      22.61,
+      24.44
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "112",
+    "submissionMethod": "claims",
+    "deciles": [
+      2.55,
+      43.62,
+      64.55,
+      75.82,
+      83.43,
+      89.12,
+      94.97,
+      98.35,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "147",
+    "submissionMethod": "registry",
+    "deciles": [
+      33.94,
+      96.11,
+      99.875,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "293",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.79,
+      17.33,
+      36.84,
+      68.97,
+      86.36,
+      92.96,
+      98.55,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACR14",
+    "submissionMethod": "registry",
+    "deciles": [
+      17.24,
+      30,
+      38.46,
+      43.24,
+      45.21,
+      46.58,
+      50,
+      52.38,
+      58.97,
+      65.22
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "RCOIR12",
+    "submissionMethod": "registry",
+    "deciles": [
+      52.94,
+      60.925,
+      68.815,
+      72.225,
+      76.27,
+      79.38,
+      80.86,
+      82.92,
+      86.28,
+      88.105
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "050",
+    "submissionMethod": "claims",
+    "deciles": [
+      23.81,
+      96,
+      98.31,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "093",
+    "submissionMethod": "claims",
+    "deciles": [
+      2.27,
+      58.62,
+      82.26,
+      92.78,
+      95.35,
+      96.97,
+      98.26,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IRIS46",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.17,
+      24.14,
+      40,
+      53.06,
+      56.52,
+      63.31,
+      66.67,
+      71.91,
+      81.58,
+      95.24
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "076",
+    "submissionMethod": "claims",
+    "deciles": [
+      6.45,
+      96.15,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "117",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.59,
+      5.9,
+      13.82,
+      23,
+      33.26,
+      46.04,
+      80.51,
+      97.65,
+      99.21,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "226",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      2.05,
+      13.95,
+      25,
+      36.11,
+      48,
+      60.36,
+      72.5,
+      84,
+      92.31,
+      98.33
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "337",
+    "submissionMethod": "registry",
+    "deciles": [
+      9.23,
+      75.89,
+      93.68,
+      98.04,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "342",
+    "submissionMethod": "registry",
+    "deciles": [
+      73.36,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "375",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.99,
+      1.67,
+      2.23,
+      3.48,
+      6.94,
+      7.7,
+      10.03,
+      14.71,
+      25.32,
+      46.75
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "397",
+    "submissionMethod": "claims",
+    "deciles": [
+      90.62,
+      95.16,
+      98.44,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "424",
+    "submissionMethod": "registry",
+    "deciles": [
+      88.68,
+      98.46,
+      99.64,
+      99.9,
+      99.98,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AAD6",
+    "submissionMethod": "registry",
+    "deciles": [
+      30.86,
+      88.73,
+      94.82,
+      98.51,
+      99.46,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACEP55",
+    "submissionMethod": "registry",
+    "deciles": [
+      24.14,
+      37.31,
+      46.43,
+      55.38,
+      60,
+      69.88,
+      73.77,
+      77.03,
+      81.43,
+      84.05
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ECPR40",
+    "submissionMethod": "registry",
+    "deciles": [
+      71.43,
+      94.12,
+      97.65,
+      99.03,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IRIS59",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.3699,
+      16.3265,
+      23.6679,
+      28.3168,
+      32.1839,
+      35.6306,
+      42.7874,
+      49.3119,
+      56.7458,
+      67.3469
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "110",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.19,
+      5.33,
+      17.7,
+      27.74,
+      36.15,
+      43.91,
+      51.19,
+      58.14,
+      67.23,
+      82.04
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "111",
+    "submissionMethod": "claims",
+    "deciles": [
+      1.52,
+      53.13,
+      68.7,
+      76.21,
+      82.17,
+      87.85,
+      93.87,
+      98.43,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "243",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.69,
+      5.16,
+      11.24,
+      18.09,
+      26.98,
+      32.975,
+      38.35,
+      51.92,
+      64.58,
+      95.05
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "364",
+    "submissionMethod": "registry",
+    "deciles": [
+      13.27,
+      45.34,
+      68.35,
+      92.11,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACEP48",
+    "submissionMethod": "registry",
+    "deciles": [
+      65.18,
+      86.49,
+      89.515,
+      91.49,
+      92.025,
+      93.1,
+      93.93,
+      96.25,
+      98.19,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "048",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.32,
+      32.46,
+      58.07,
+      74.83,
+      85.25,
+      95.01,
+      98.39,
+      99.7,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "128",
+    "submissionMethod": "claims",
+    "deciles": [
+      14.71,
+      66.67,
+      95.78,
+      99.26,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "178",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.34,
+      74.61,
+      89.38,
+      95.11,
+      98.44,
+      99.54,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "324",
+    "submissionMethod": "registry",
+    "deciles": [
+      50,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "360",
+    "submissionMethod": "registry",
+    "deciles": [
+      5.01,
+      56.1,
+      98.48,
+      99.85,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "463",
+    "submissionMethod": "registry",
+    "deciles": [
+      82.445,
+      97.68,
+      99.18,
+      99.785,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACEP31",
+    "submissionMethod": "registry",
+    "deciles": [
+      51.29,
+      60.64,
+      66.67,
+      74.19,
+      76.32,
+      79.395,
+      81.16,
+      85.12,
+      87.39,
+      88.79
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "CDR1",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.25,
+      16.67,
+      33.77,
+      45.94,
+      58.97,
+      68.46,
+      74.73,
+      82.59,
+      92.63,
+      96.3
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "GIQIC23",
+    "submissionMethod": "registry",
+    "deciles": [
+      18.86,
+      42.86,
+      60,
+      70.27,
+      76.29,
+      87.225,
+      89.13,
+      94.69,
+      97.67,
+      99.27
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "112",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.24,
+      15.37,
+      36.27,
+      47.83,
+      59.02,
+      68.59,
+      76.82,
+      83.9,
+      93.75,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "134",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.05,
+      27.21,
+      72.82,
+      90.13,
+      96.65,
+      98.72,
+      99.65,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "154",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.7,
+      92.11,
+      98.63,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "323",
+    "submissionMethod": "registry",
+    "deciles": [
+      48.39,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "378",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      92.31,
+      68.29,
+      50.04,
+      34.04,
+      15.62,
+      7.565,
+      3.67,
+      1.59,
+      0.87,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "395",
+    "submissionMethod": "claims",
+    "deciles": [
+      91.3,
+      95.83,
+      98.11,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACEP51",
+    "submissionMethod": "registry",
+    "deciles": [
+      114.921,
+      107.823,
+      104.667,
+      99.7479,
+      95.5479,
+      91.5498,
+      86.6811,
+      83.3691,
+      76.1444,
+      38.3893
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AQI68",
+    "submissionMethod": "registry",
+    "deciles": [
+      29.01,
+      75.39,
+      86.71,
+      93.27,
+      96.2,
+      98.52,
+      99.35,
+      99.79,
+      99.99,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IROMS18",
+    "submissionMethod": "registry",
+    "deciles": [
+      61.11,
+      55.42,
+      53.45,
+      52.05,
+      50.85,
+      49.965,
+      47.59,
+      45.45,
+      42.86,
+      39.08
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "CAP22",
+    "submissionMethod": "registry",
+    "deciles": [
+      68.5,
+      70.85,
+      87.24,
+      90.61,
+      93.5,
+      94.41,
+      95.68,
+      96.07,
+      99.47,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AQI65",
+    "submissionMethod": "registry",
+    "deciles": [
+      20.83,
+      56.38,
+      81.7,
+      90.37,
+      97.2,
+      98.32,
+      99.22,
+      99.84,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "070",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.61,
+      25.81,
+      57.935,
+      68.31,
+      72.83,
+      87.855,
+      95.425,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "076",
+    "submissionMethod": "registry",
+    "deciles": [
+      45.16,
+      93.06,
+      98.56,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "117",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.3,
+      48.29,
+      95.68,
+      99.04,
+      99.74,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "281",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.53,
+      4,
+      10,
+      16.67,
+      24.44,
+      34.78,
+      44.12,
+      56.02,
+      66.67,
+      84.78
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "332",
+    "submissionMethod": "registry",
+    "deciles": [
+      10,
+      59.38,
+      66.67,
+      75,
+      80.56,
+      84.465,
+      88.89,
+      93.18,
+      96.97,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "406",
+    "submissionMethod": "registry",
+    "deciles": [
+      50,
+      13.04,
+      6.06,
+      2.43,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IRIS55",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.7037,
+      8.2734,
+      27.2727,
+      33.3333,
+      33.6996,
+      36.7347,
+      43.9024,
+      46.8697,
+      48.8889,
+      65.8537
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IROMS14",
+    "submissionMethod": "registry",
+    "deciles": [
+      60.61,
+      55,
+      52.55,
+      50.96,
+      50,
+      48.15,
+      46.43,
+      45,
+      42.86,
+      39.13
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "317",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.05,
+      12.04,
+      21.49,
+      28.33,
+      35.87,
+      50.25,
+      71.53,
+      91.76,
+      98.69,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "416",
+    "submissionMethod": "registry",
+    "deciles": [
+      52.38,
+      20,
+      13.51,
+      7.04,
+      3.85,
+      1.985,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "MSN13",
+    "submissionMethod": "registry",
+    "deciles": [
+      26,
+      35,
+      71,
+      79,
+      87,
+      94,
+      96,
+      99,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "MSN15",
+    "submissionMethod": "registry",
+    "deciles": [
+      15,
+      76,
+      94,
+      98,
+      99,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "444",
+    "submissionMethod": "registry",
+    "deciles": [
+      13.89,
+      53.64,
+      74.07,
+      81.82,
+      98.57,
+      99.79,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACR10",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.35,
+      6.98,
+      13.33,
+      20.37,
+      23.62,
+      30.35,
+      34.38,
+      36.01,
+      41.06,
+      55.25
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "191",
+    "submissionMethod": "registry",
+    "deciles": [
+      23.55,
+      85.71,
+      92.91,
+      97.03,
+      98.36,
+      99.18,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "277",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.65,
+      3.3,
+      9.17,
+      23.21,
+      52.63,
+      68.99,
+      90.32,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "356",
+    "submissionMethod": "registry",
+    "deciles": [
+      32.26,
+      8.655,
+      6.105,
+      3.39,
+      1.81,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "415",
+    "submissionMethod": "registry",
+    "deciles": [
+      81.7,
+      93.94,
+      96.31,
+      97.54,
+      98.33,
+      98.94,
+      99.39,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "457",
+    "submissionMethod": "registry",
+    "deciles": [
+      34.78,
+      24.14,
+      18.18,
+      15.49,
+      13.64,
+      10.855,
+      8.73,
+      7.23,
+      4.35,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IRIS17",
+    "submissionMethod": "registry",
+    "deciles": [
+      13.33,
+      32.2,
+      50,
+      60.75,
+      67.86,
+      71.37,
+      74.02,
+      77.78,
+      82.14,
+      87.18
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IROMS15",
+    "submissionMethod": "registry",
+    "deciles": [
+      61.9,
+      56.82,
+      54.55,
+      52.2,
+      50,
+      48.94,
+      47.06,
+      44.72,
+      40,
+      33
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "PIMSH9",
+    "submissionMethod": "registry",
+    "deciles": [
+      25,
+      15.6,
+      12.1,
+      10,
+      8.3,
+      6.8,
+      4.8,
+      4.1,
+      3.2,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ASPS29",
+    "submissionMethod": "registry",
+    "deciles": [
+      27.43,
+      7.24,
+      4.42,
+      1.06,
+      0.74,
+      0.395,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IRIS23",
+    "submissionMethod": "registry",
+    "deciles": [
+      24.29,
+      44,
+      68.55,
+      77.58,
+      81.25,
+      82.35,
+      84.21,
+      89.2,
+      94.29,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "001",
+    "submissionMethod": "registry",
+    "deciles": [
+      90,
+      80,
+      70,
+      60,
+      50,
+      40,
+      30,
+      20,
+      10
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "047",
+    "submissionMethod": "claims",
+    "deciles": [
+      0.65,
+      43.14,
+      96.34,
+      99.83,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "113",
+    "submissionMethod": "claims",
+    "deciles": [
+      3.64,
+      38.16,
+      68.98,
+      80.27,
+      88.17,
+      95.67,
+      98.73,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "145",
+    "submissionMethod": "claims",
+    "deciles": [
+      3.54,
+      65.12,
+      88.89,
+      96.15,
+      98.67,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "147",
+    "submissionMethod": "claims",
+    "deciles": [
+      10.34,
+      51.415,
+      78.685,
+      93.295,
+      97.405,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "219",
+    "submissionMethod": "registry",
+    "deciles": [
+      16.42,
+      34,
+      37.5,
+      41.67,
+      47.56,
+      51.465,
+      56.49,
+      60.67,
+      74.07,
+      95.24
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "249",
+    "submissionMethod": "claims",
+    "deciles": [
+      97.5,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "317",
+    "submissionMethod": "claims",
+    "deciles": [
+      0.32,
+      31.91,
+      84.62,
+      96.66,
+      99.04,
+      99.73,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "395",
+    "submissionMethod": "registry",
+    "deciles": [
+      88.03,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "397",
+    "submissionMethod": "registry",
+    "deciles": [
+      41.33,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "430",
+    "submissionMethod": "registry",
+    "deciles": [
+      76.53,
+      98.39,
+      99.665,
+      99.825,
+      99.93,
+      99.99,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AQI72",
+    "submissionMethod": "registry",
+    "deciles": [
+      89.61,
+      94.95,
+      98.11,
+      99.84,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "RPAQIR15",
+    "submissionMethod": "registry",
+    "deciles": [
+      60.47,
+      71.15,
+      74.24,
+      79.41,
+      81.48,
+      85.29,
+      86.47,
+      90.24,
+      91.24,
+      93.1
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "023",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.69,
+      47.12,
+      93.21,
+      98.84,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "110",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.51,
+      18.67,
+      40.36,
+      57.41,
+      68.37,
+      81.415,
+      90.6,
+      96.17,
+      99.37,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "116",
+    "submissionMethod": "registry",
+    "deciles": [
+      41.84,
+      77.03,
+      87.09,
+      92.45,
+      95.83,
+      97.88,
+      98.82,
+      99.65,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "154",
+    "submissionMethod": "claims",
+    "deciles": [
+      18.42,
+      94.74,
+      99.83,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "355",
+    "submissionMethod": "registry",
+    "deciles": [
+      40,
+      8.6,
+      2.7,
+      1.08,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "419",
+    "submissionMethod": "registry",
+    "deciles": [
+      68.04,
+      37.82,
+      16.48,
+      8.86,
+      6.21,
+      2.975,
+      0.59,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "477",
+    "submissionMethod": "registry",
+    "deciles": [
+      62.56,
+      86.39,
+      94.17,
+      96.64,
+      97.96,
+      98.77,
+      99.49,
+      99.99,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACCPIN8",
+    "submissionMethod": "registry",
+    "deciles": [
+      15.81,
+      25.97,
+      30.2,
+      34.35,
+      36.96,
+      39.875,
+      43.6,
+      45.65,
+      49.45,
+      53.1
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "141",
+    "submissionMethod": "claims",
+    "deciles": [
+      8.57,
+      95.77,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "141",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.39,
+      52.27,
+      75.17,
+      86.31,
+      93.41,
+      96.255,
+      98.26,
+      99.38,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "155",
+    "submissionMethod": "claims",
+    "deciles": [
+      3.85,
+      75,
+      97.895,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "180",
+    "submissionMethod": "registry",
+    "deciles": [
+      6.37,
+      97.53,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "182",
+    "submissionMethod": "claims",
+    "deciles": [
+      1.09,
+      98.11,
+      99.79,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "185",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.35,
+      73.33,
+      95.74,
+      98.27,
+      99.74,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "195",
+    "submissionMethod": "registry",
+    "deciles": [
+      65.35,
+      99.1,
+      99.98,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "238",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      21.82,
+      10.55,
+      6.7,
+      3.84,
+      1.79,
+      0.64,
+      0.16,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "317",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.06,
+      5.78,
+      13.7,
+      17.68,
+      21.05,
+      23.96,
+      27.1,
+      30.59,
+      35.34,
+      44.34
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "HM5",
+    "submissionMethod": "registry",
+    "deciles": [
+      25,
+      42.86,
+      50,
+      58.33,
+      61.76,
+      65.22,
+      66.67,
+      69.57,
+      86.67,
+      92
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IRIS54",
+    "submissionMethod": "registry",
+    "deciles": [
+      7.5,
+      3.66,
+      2.47,
+      1.9,
+      1.66,
+      1.25,
+      0.86,
+      0.43,
+      0,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IROMS11",
+    "submissionMethod": "registry",
+    "deciles": [
+      60.71,
+      56,
+      53.4,
+      51.52,
+      50,
+      48.94,
+      47.62,
+      45.65,
+      43.45,
+      40
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IROMS12",
+    "submissionMethod": "registry",
+    "deciles": [
+      63.11,
+      57.69,
+      55.06,
+      53.79,
+      52.17,
+      50.88,
+      50,
+      48.28,
+      46.88,
+      43.75
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IROMS17",
+    "submissionMethod": "registry",
+    "deciles": [
+      59.09,
+      53.33,
+      51.04,
+      49.23,
+      47.62,
+      45.71,
+      43.64,
+      41.67,
+      38.545,
+      34.29
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "376",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.47,
+      1.995,
+      2.58,
+      3.45,
+      4.1,
+      5.955,
+      10.4,
+      15.76,
+      22.92,
+      44.045
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "008",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      42.86,
+      80.49,
+      85.71,
+      88.52,
+      90.7,
+      92.31,
+      93.64,
+      95,
+      96.39,
+      98.15
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "014",
+    "submissionMethod": "claims",
+    "deciles": [
+      22.83,
+      97.515,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "239",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      3.25,
+      25.73,
+      29.79,
+      31.71,
+      33.13,
+      34.48,
+      37.98,
+      43.76,
+      52.67,
+      66.56
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "405",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.51,
+      3.83,
+      14.5,
+      50,
+      87.225,
+      99.49,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "436",
+    "submissionMethod": "claims",
+    "deciles": [
+      1.29,
+      88.43,
+      97.16,
+      99.05,
+      99.79,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "436",
+    "submissionMethod": "registry",
+    "deciles": [
+      20.53,
+      98.96,
+      99.87,
+      99.99,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "478",
+    "submissionMethod": "registry",
+    "deciles": [
+      22.5,
+      33.61,
+      40,
+      44.44,
+      50,
+      53.33,
+      57.45,
+      61.97,
+      66.67,
+      89.66
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AAD7",
+    "submissionMethod": "registry",
+    "deciles": [
+      22.57,
+      64.52,
+      88.66,
+      93.65,
+      95.58,
+      96.94,
+      98.68,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACEP58",
+    "submissionMethod": "registry",
+    "deciles": [
+      39.9,
+      34.33,
+      30.64,
+      29.15,
+      27.92,
+      26.265,
+      23.8,
+      23.1,
+      19.46,
+      11.78
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "047",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.13,
+      5.4,
+      34.06,
+      60.46,
+      79.06,
+      90.86,
+      96.78,
+      99.1,
+      99.91,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "065",
+    "submissionMethod": "registry",
+    "deciles": [
+      55.99,
+      87.23,
+      93.185,
+      95.24,
+      96.715,
+      97.76,
+      98.5,
+      99.12,
+      99.55,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "107",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.07,
+      0.68,
+      2.37,
+      7.05,
+      13.125,
+      21.045,
+      38.545,
+      55.27,
+      78.71,
+      93.7
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "130",
+    "submissionMethod": "claims",
+    "deciles": [
+      7.39,
+      98.58,
+      99.82,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "379",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.01,
+      0.12,
+      0.25,
+      0.46,
+      0.93,
+      1.87,
+      3.02,
+      4.79,
+      7.89,
+      11.86
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AAN8",
+    "submissionMethod": "registry",
+    "deciles": [
+      25,
+      50.56,
+      64.885,
+      79.63,
+      82.14,
+      89.66,
+      92.195,
+      95.52,
+      97.985,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AAO24",
+    "submissionMethod": "registry",
+    "deciles": [
+      81.48,
+      88.92,
+      96.3,
+      98.48,
+      99.59,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IRIS13",
+    "submissionMethod": "registry",
+    "deciles": [
+      56.86,
+      80.44,
+      84.62,
+      86.52,
+      88.02,
+      89.415,
+      90.37,
+      92.06,
+      93.83,
+      96.36
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "023",
+    "submissionMethod": "claims",
+    "deciles": [
+      2.86,
+      95.74,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "039",
+    "submissionMethod": "claims",
+    "deciles": [
+      1.1,
+      24.29,
+      42.64,
+      53.7,
+      68.72,
+      77.94,
+      86.025,
+      95.18,
+      99.285,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "113",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.3,
+      4.555,
+      18.09,
+      37.7,
+      52.67,
+      63.665,
+      72.415,
+      80.945,
+      90.25,
+      99.55
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "320",
+    "submissionMethod": "claims",
+    "deciles": [
+      15.22,
+      75,
+      92.73,
+      96,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACRAD16",
+    "submissionMethod": "registry",
+    "deciles": [
+      10.37,
+      5.795,
+      4.11,
+      3.275,
+      2.82,
+      2.29,
+      1.8,
+      1.38,
+      0.95,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AQI56",
+    "submissionMethod": "registry",
+    "deciles": [
+      66.67,
+      93.12,
+      95.53,
+      98.05,
+      99.55,
+      99.905,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ECPR46",
+    "submissionMethod": "registry",
+    "deciles": [
+      80.66,
+      92.32,
+      99.31,
+      99.69,
+      99.9,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AAO21",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.14,
+      13.73,
+      19.46,
+      35,
+      37.5,
+      51.64,
+      71.13,
+      77.27,
+      83.58,
+      91.3
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "PIMSH10",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.4,
+      20.8,
+      27.6,
+      35,
+      41.2,
+      47.95,
+      57.1,
+      64.5,
+      69.6,
+      85.2
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "118",
+    "submissionMethod": "registry",
+    "deciles": [
+      55.56,
+      70.69,
+      76.67,
+      79.62,
+      82.09,
+      84.96,
+      87.5,
+      90.32,
+      96.15,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "130",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      7.66,
+      66.25,
+      83.08,
+      89.82,
+      93.63,
+      96.12,
+      97.75,
+      98.79,
+      99.47,
+      99.87
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "218",
+    "submissionMethod": "registry",
+    "deciles": [
+      17.36,
+      35.71,
+      41.525,
+      46.13,
+      49.395,
+      53.375,
+      56.64,
+      59.98,
+      69.225,
+      95.225
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "236",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      2.74,
+      41.96,
+      51.36,
+      56.61,
+      60.71,
+      64.235,
+      67.55,
+      71.1,
+      75.28,
+      81.35
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "249",
+    "submissionMethod": "registry",
+    "deciles": [
+      96.25,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "254",
+    "submissionMethod": "registry",
+    "deciles": [
+      72.47,
+      90.13,
+      93.33,
+      95.88,
+      97.06,
+      98.145,
+      98.93,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "374",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.9,
+      30.43,
+      66.94,
+      84.38,
+      95.12,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACCPIN7",
+    "submissionMethod": "registry",
+    "deciles": [
+      43.21,
+      58.82,
+      66.67,
+      71.63,
+      74.47,
+      77.92,
+      79.54,
+      81.7,
+      84.78,
+      86.92
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "CAP33",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.56,
+      55.67,
+      59.38,
+      60,
+      62.59,
+      75.65,
+      79.12,
+      93.77,
+      98.31,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IROMS19",
+    "submissionMethod": "registry",
+    "deciles": [
+      56.52,
+      50,
+      47.83,
+      45.36,
+      43.9,
+      42.41,
+      40.91,
+      38.71,
+      36.59,
+      33.33
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "066",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.54,
+      7.41,
+      22,
+      36.8,
+      52.43,
+      63.82,
+      72.73,
+      80,
+      84.11,
+      88.42
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "221",
+    "submissionMethod": "registry",
+    "deciles": [
+      23.08,
+      33.78,
+      38.61,
+      44.35,
+      50,
+      55.115,
+      61.18,
+      71.43,
+      86.67,
+      97.67
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "288",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.19,
+      27.36,
+      76.855,
+      91.31,
+      98.615,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "350",
+    "submissionMethod": "registry",
+    "deciles": [
+      27.6,
+      93.7,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "394",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.975,
+      4.07,
+      5.98,
+      11.7,
+      16.175,
+      21.39,
+      25.075,
+      29.565,
+      36.69,
+      45.58
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "402",
+    "submissionMethod": "registry",
+    "deciles": [
+      37.84,
+      84.09,
+      92.41,
+      96.67,
+      98.72,
+      99.645,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACEP22",
+    "submissionMethod": "registry",
+    "deciles": [
+      22.52,
+      28.47,
+      34.8,
+      40.73,
+      48.42,
+      54.26,
+      57.68,
+      62.63,
+      70.5,
+      79.76
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IRIS51",
+    "submissionMethod": "registry",
+    "deciles": [
+      60,
+      84.44,
+      87.91,
+      91.3,
+      93.785,
+      95.45,
+      95.92,
+      97.26,
+      99.26,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "QUANTUM31",
+    "submissionMethod": "registry",
+    "deciles": [
+      46.02,
+      70,
+      80,
+      85.71,
+      90.48,
+      95.55,
+      99.45,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "340",
+    "submissionMethod": "registry",
+    "deciles": [
+      27.94,
+      38.46,
+      51.22,
+      73.26,
+      79.63,
+      84.39,
+      90.68,
+      93.43,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "014",
+    "submissionMethod": "registry",
+    "deciles": [
+      5.91,
+      74.55,
+      89.16,
+      93.79,
+      96.31,
+      98.075,
+      99.14,
+      99.77,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "065",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      37.1,
+      77.5,
+      86.67,
+      90.12,
+      92.8,
+      94.74,
+      96.26,
+      97.78,
+      99.25,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "119",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      20.29,
+      64.23,
+      73.01,
+      78.12,
+      81.82,
+      84.75,
+      87.565,
+      90.36,
+      93.75,
+      98.32
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "130",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.6,
+      30.29,
+      87.26,
+      95.57,
+      98.62,
+      99.74,
+      99.99,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "177",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.68,
+      63.035,
+      78.8,
+      89.195,
+      94.315,
+      98.755,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "220",
+    "submissionMethod": "registry",
+    "deciles": [
+      24.78,
+      33.33,
+      40,
+      45.38,
+      49.54,
+      55.89,
+      60.24,
+      67.5,
+      84.47,
+      95.83
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "222",
+    "submissionMethod": "registry",
+    "deciles": [
+      21.43,
+      37.04,
+      44.44,
+      49.4,
+      53.48,
+      60.34,
+      67.27,
+      72,
+      78.57,
+      87.27
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "291",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.82,
+      8.6,
+      34.91,
+      76.92,
+      92.31,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "326",
+    "submissionMethod": "registry",
+    "deciles": [
+      38,
+      67.08,
+      74.32,
+      80.65,
+      86.11,
+      96.15,
+      99.69,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "382",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.62,
+      2.94,
+      7.31,
+      13.66,
+      20.79,
+      33.94,
+      43.41,
+      54.6,
+      71.205,
+      93.41
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AAO23",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.98,
+      47.15,
+      59.87,
+      67.38,
+      72.36,
+      77.105,
+      80.43,
+      83.77,
+      84.91,
+      90.59
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACCPIN11",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.45,
+      31.25,
+      64.01,
+      74.07,
+      83.87,
+      89.18,
+      94.14,
+      97.06,
+      99.2,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACRAD34",
+    "submissionMethod": "registry",
+    "deciles": [
+      36.6808,
+      78.0275,
+      83.1584,
+      84.4009,
+      90.0213,
+      93.4405,
+      94.9784,
+      96.1203,
+      96.1203,
+      96.1203
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "CAP32",
+    "submissionMethod": "registry",
+    "deciles": [
+      40.5,
+      90.6,
+      96.83,
+      99.22,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "PIMSH1",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.5,
+      2.3,
+      6.4,
+      12.8,
+      15.7,
+      20.85,
+      25,
+      35.6,
+      43.3,
+      63.2
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "008",
+    "submissionMethod": "registry",
+    "deciles": [
+      38.46,
+      91.21,
+      96.97,
+      98.86,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "127",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.84,
+      67.77,
+      89.415,
+      96.24,
+      99.635,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "128",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.28,
+      31.82,
+      64.94,
+      85.33,
+      94.62,
+      98.35,
+      99.72,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "134",
+    "submissionMethod": "claims",
+    "deciles": [
+      17.33,
+      95.875,
+      99.48,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "225",
+    "submissionMethod": "claims",
+    "deciles": [
+      11.17,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "240",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      1.75,
+      13.1,
+      22.58,
+      31.01,
+      36.67,
+      40.48,
+      43.54,
+      49.17,
+      53.59,
+      59.96
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "309",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.44,
+      7.77,
+      15.59,
+      21.88,
+      27.955,
+      34.04,
+      40.17,
+      46.99,
+      54.55,
+      68.52
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "366",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      2.9412,
+      11.6279,
+      15.4738,
+      22.0588,
+      25.7751,
+      29.6552,
+      34.345,
+      39.1304,
+      43.8987,
+      51.938
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "438",
+    "submissionMethod": "registry",
+    "deciles": [
+      20.5,
+      62.01,
+      70.7,
+      76.65,
+      79.88,
+      83.95,
+      87.63,
+      91.78,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACR15",
+    "submissionMethod": "registry",
+    "deciles": [
+      32.53,
+      44.22,
+      50.55,
+      58.68,
+      68.86,
+      70.89,
+      75.07,
+      80.22,
+      85.15,
+      90.24
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AQI70",
+    "submissionMethod": "registry",
+    "deciles": [
+      57.14,
+      97.15,
+      99.62,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "354",
+    "submissionMethod": "registry",
+    "deciles": [
+      76.12,
+      17.14,
+      8.49,
+      4.86,
+      1.05,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACEP25",
+    "submissionMethod": "registry",
+    "deciles": [
+      15.51,
+      61.12,
+      71.64,
+      78.63,
+      81.01,
+      84.12,
+      86.74,
+      88.17,
+      92.67,
+      96.05
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "CDR5",
+    "submissionMethod": "registry",
+    "deciles": [
+      5.11,
+      31.26,
+      50.39,
+      57.565,
+      65.4,
+      68.14,
+      72.265,
+      76.7,
+      84.4,
+      92.475
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "UREQA4",
+    "submissionMethod": "registry",
+    "deciles": [
+      95.82,
+      97.63,
+      98.405,
+      99.03,
+      99.385,
+      99.48,
+      99.62,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "044",
+    "submissionMethod": "registry",
+    "deciles": [
+      68.57,
+      91.95,
+      98.63,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "176",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.35,
+      47.06,
+      66.67,
+      84.52,
+      95.33,
+      98.01,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "187",
+    "submissionMethod": "registry",
+    "deciles": [
+      53.33,
+      85.45,
+      93.875,
+      97.385,
+      99.44,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AQUA15",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.17,
+      26.27,
+      47.22,
+      55.77,
+      65.09,
+      73.47,
+      79.31,
+      85.19,
+      87.76,
+      94.44
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "HM6",
+    "submissionMethod": "registry",
+    "deciles": [
+      12,
+      28.57,
+      40.43,
+      46.88,
+      52.475,
+      61.54,
+      65.74,
+      72.97,
+      80.925,
+      89.58
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IRIS52",
+    "submissionMethod": "registry",
+    "deciles": [
+      59.61,
+      75.47,
+      95.34,
+      98.92,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IROMS16",
+    "submissionMethod": "registry",
+    "deciles": [
+      63.41,
+      55.77,
+      53.85,
+      52.24,
+      51.22,
+      50,
+      47.83,
+      45.73,
+      43.84,
+      40
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "PIMSH11",
+    "submissionMethod": "registry",
+    "deciles": [
+      33.8,
+      5.4,
+      3.3,
+      2.4,
+      1.5,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "338",
+    "submissionMethod": "registry",
+    "deciles": [
+      57.32,
+      81.74,
+      87.33,
+      91.32,
+      93.26,
+      94.495,
+      95.82,
+      98.98,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "009",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      25,
+      62.22,
+      71.33,
+      75.56,
+      77.78,
+      80.205,
+      82.26,
+      83.82,
+      85.68,
+      88.49
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "137",
+    "submissionMethod": "registry",
+    "deciles": [
+      15.56,
+      92.16,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "145",
+    "submissionMethod": "registry",
+    "deciles": [
+      12.53,
+      82.16,
+      95.79,
+      98.44,
+      99.77,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "279",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.94,
+      73.13,
+      92.105,
+      98.79,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "283",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.94,
+      89.86,
+      98.59,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "290",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.565,
+      26.445,
+      72.345,
+      89.475,
+      96.22,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "326",
+    "submissionMethod": "claims",
+    "deciles": [
+      77.22,
+      96.88,
+      99.26,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "370",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.5181,
+      1.9231,
+      3.125,
+      4.4693,
+      5.9412,
+      8,
+      9.7288,
+      12.1951,
+      16.6667,
+      24.6637
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "400",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.12,
+      0.6,
+      1.18,
+      1.96,
+      3.53,
+      7.55,
+      24.34,
+      47.28,
+      65.92,
+      97.08
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "441",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.35,
+      18.18,
+      26.985,
+      34.19,
+      40.735,
+      44.23,
+      47.615,
+      50.89,
+      54.49,
+      59.38
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ABFM9",
+    "submissionMethod": "registry",
+    "deciles": [
+      37.19,
+      50.01,
+      59.33,
+      74.3,
+      92.75,
+      99.92,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACEP19",
+    "submissionMethod": "registry",
+    "deciles": [
+      53.96,
+      58.89,
+      65.07,
+      72.47,
+      77.57,
+      81.87,
+      85.25,
+      87.73,
+      91.04,
+      94.09
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "CAP28",
+    "submissionMethod": "registry",
+    "deciles": [
+      65.13,
+      83,
+      92.13,
+      94.01,
+      95.77,
+      97.275,
+      98.91,
+      99.3,
+      99.84,
+      99.95
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IRIS26",
+    "submissionMethod": "registry",
+    "deciles": [
+      4.94,
+      0.86,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "019",
+    "submissionMethod": "registry",
+    "deciles": [
+      3.33,
+      72.335,
+      91.445,
+      98.71,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "039",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.53,
+      7.51,
+      19.66,
+      32.59,
+      44.63,
+      57.44,
+      69.25,
+      79.69,
+      87.68,
+      97.77
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "111",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.8,
+      31.24,
+      51.62,
+      62.82,
+      69.63,
+      74.7,
+      79.23,
+      83.71,
+      89.62,
+      98.23
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "250",
+    "submissionMethod": "claims",
+    "deciles": [
+      36.84,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "320",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.77,
+      77.38,
+      91.3,
+      96.3,
+      97.72,
+      98.7,
+      99.44,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "389",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.35,
+      14.83,
+      24.11,
+      33.08,
+      45.01,
+      64.67,
+      91.13,
+      98,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "425",
+    "submissionMethod": "claims",
+    "deciles": [
+      36.54,
+      96.545,
+      98.9,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "425",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.74,
+      84.66,
+      93.74,
+      97.075,
+      98.72,
+      99.28,
+      99.55,
+      99.82,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AQI62",
+    "submissionMethod": "registry",
+    "deciles": [
+      6.01,
+      93.12,
+      97.8,
+      99.25,
+      99.68,
+      99.86,
+      99.97,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AQUA18",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.67,
+      15.54,
+      18.37,
+      21.62,
+      24.24,
+      27.59,
+      28.12,
+      31.25,
+      35,
+      41.43
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "CDR6",
+    "submissionMethod": "registry",
+    "deciles": [
+      2.56,
+      8.67,
+      17.15,
+      19.1,
+      20.78,
+      21.73,
+      23.39,
+      27.58,
+      32.31,
+      37.04
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "IROMS13",
+    "submissionMethod": "registry",
+    "deciles": [
+      61.11,
+      53.57,
+      50,
+      48.61,
+      47.43,
+      45.67,
+      43.75,
+      41.46,
+      38.46,
+      34.78
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "012",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      3.88,
+      68.62,
+      83.13,
+      88.69,
+      91.94,
+      94.165,
+      96.08,
+      97.66,
+      98.96,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "134",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      0.07,
+      1.8,
+      7.13,
+      15.39,
+      24.395,
+      33.79,
+      45.425,
+      58.935,
+      72.82,
+      90.515
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "265",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.31,
+      52.38,
+      94.12,
+      99.13,
+      100,
+      100,
+      100,
+      100,
+      100,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "268",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.03,
+      6.97,
+      10.94,
+      30.14,
+      40.91,
+      55.78,
+      80,
+      91.67,
+      99.38,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "418",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.06,
+      4.17,
+      6.82,
+      14.29,
+      20.65,
+      29.755,
+      38.21,
+      49.21,
+      79.76,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "431",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.4,
+      8.91,
+      31.17,
+      48.93,
+      64.66,
+      77.545,
+      89.76,
+      96.58,
+      99.85,
+      100
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "472",
+    "submissionMethod": "electronicHealthRecord",
+    "deciles": [
+      12.5,
+      4.1,
+      1.74,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACQR3",
+    "submissionMethod": "registry",
+    "deciles": [
+      0.85,
+      0.915,
+      0.945,
+      0.96,
+      0.97,
+      0.97,
+      0.975,
+      0.985,
+      0.995,
+      1
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "ACR12",
+    "submissionMethod": "registry",
+    "deciles": [
+      1.18,
+      6.45,
+      31.87,
+      45.24,
+      63.16,
+      67.11,
+      79.31,
+      85.23,
+      90.44,
+      94.15
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "AAN9",
+    "submissionMethod": "registry",
+    "deciles": [
+      9.15,
+      59.12,
+      66.67,
+      75.51,
+      82.82,
+      90.06,
+      93.96,
+      95.75,
+      96.67,
+      98
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "479",
+    "submissionMethod": "administrativeClaims",
+    "deciles": [
+      0.1852,
+      0.1668,
+      0.161,
+      0.1571,
+      0.1539,
+      0.1517,
+      0.1496,
+      0.1468,
+      0.143,
+      0.1373
+    ],
+    "performanceYear": 2021
+  },
+  {
+    "measureId": "480",
+    "submissionMethod": "administrativeClaims",
+    "deciles": [
+      0.0378,
+      0.0287,
+      0.0263,
+      0.0247,
+      0.0234,
+      0.023,
+      0.0225,
+      0.0219,
+      0.0209,
+      0.0194
+    ],
+    "performanceYear": 2021
+  }
+]

--- a/staging/2021/benchmarks/json/performance-benchmarks.json
+++ b/staging/2021/benchmarks/json/performance-benchmarks.json
@@ -428,6 +428,7 @@
     "measureId": "ACRAD19",
     "submissionMethod": "registry",
     "deciles": [
+      66.65,
       31.9,
       24.2,
       19.16,
@@ -436,8 +437,7 @@
       6.99,
       4.77,
       3.41,
-      2.54,
-      0
+      2.54
     ],
     "performanceYear": 2021
   },
@@ -615,6 +615,7 @@
     "measureId": "ACRAD25",
     "submissionMethod": "registry",
     "deciles": [
+      154.68,
       46.495,
       27.765,
       21.2,
@@ -623,8 +624,7 @@
       6.815,
       4.165,
       2.195,
-      0.595,
-      0
+      0.595
     ],
     "performanceYear": 2021
   },
@@ -853,6 +853,7 @@
     "measureId": "ACEP50",
     "submissionMethod": "registry",
     "deciles": [
+      155.995,
       127.228,
       117.9865,
       111.896,
@@ -861,8 +862,7 @@
       98.8234,
       94.6961,
       90.0213,
-      84.3452,
-      49.6086
+      84.3452
     ],
     "performanceYear": 2021
   },
@@ -955,6 +955,7 @@
     "measureId": "ACRAD15",
     "submissionMethod": "registry",
     "deciles": [
+      33.72,
       5.24,
       3.61,
       2.71,
@@ -963,8 +964,7 @@
       1.53,
       1.26,
       1.01,
-      0.72,
-      0
+      0.72
     ],
     "performanceYear": 2021
   },
@@ -1414,6 +1414,7 @@
     "measureId": "ACRAD18",
     "submissionMethod": "registry",
     "deciles": [
+      41.65,
       10.11,
       3.86,
       2.8,
@@ -1422,8 +1423,7 @@
       1.66,
       1.36,
       1.11,
-      0.78,
-      0
+      0.78
     ],
     "performanceYear": 2021
   },
@@ -1582,6 +1582,7 @@
     "measureId": "ACRAD17",
     "submissionMethod": "registry",
     "deciles": [
+      46.09,
       21.19,
       15.39,
       12.8,
@@ -1590,8 +1591,7 @@
       6.06,
       4.4,
       3.24,
-      2.14,
-      0
+      2.14
     ],
     "performanceYear": 2021
   },
@@ -2330,6 +2330,7 @@
     "measureId": "ACEP51",
     "submissionMethod": "registry",
     "deciles": [
+      147.395,
       114.921,
       107.823,
       104.667,
@@ -2338,8 +2339,7 @@
       91.5498,
       86.6811,
       83.3691,
-      76.1444,
-      38.3893
+      76.1444
     ],
     "performanceYear": 2021
   },
@@ -3791,6 +3791,7 @@
     "measureId": "ACRAD16",
     "submissionMethod": "registry",
     "deciles": [
+      37.38,
       10.37,
       5.795,
       4.11,
@@ -3799,8 +3800,7 @@
       2.29,
       1.8,
       1.38,
-      0.95,
-      0
+      0.95
     ],
     "performanceYear": 2021
   },


### PR DESCRIPTION
Adding in PY21 Performance Benchmarks from the FS Run Id # 2442.

#### Motivation for change

Adding in PY21 Performance Benchmarks from the FS Run Id # 2442. What is odd is when I looked at the `merge-benchmark-data-helpers.js` file the performance benchmark logic had been stripped out, but the git history is vague and seems to be missing. I had to go to an old commit when it was previously added (and fixed) via [this commit.](https://github.com/CMSgov/qpp-measures-data/blob/d2e578dfa3c61ad865da05ada6b52f07151ecec9/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js). Maybe a git rebase gone wrong or otherwise refactoring.

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [ ] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [ ] Unit tests added/passing
* [ ] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPSF-9970
