### PR TITLE
QPPA-6448: remove 047 PCF requirement PY22

### DIFF
--- a/measures/2022/measures-data.json
+++ b/measures/2022/measures-data.json
@@ -2169,9 +2169,6 @@
       "mips",
       "pcf"
     ],
-    "requiredForPrograms": [
-      "pcf"
-    ],
     "submissionMethods": [
       "claims",
       "registry"

--- a/staging/2022/measures-data-quality.json
+++ b/staging/2022/measures-data-quality.json
@@ -448,9 +448,6 @@
       "mips",
       "pcf"
     ],
-    "requiredForPrograms": [
-      "pcf"
-    ],
     "submissionMethods": [
       "claims",
       "registry"

--- a/util/measures/2022/enriched-measures-data-quality.json
+++ b/util/measures/2022/enriched-measures-data-quality.json
@@ -479,9 +479,6 @@
       "mips",
       "pcf"
     ],
-    "requiredForPrograms": [
-      "pcf"
-    ],
     "submissionMethods": [
       "claims",
       "registry"

--- a/util/measures/2022/quality-measures.csv
+++ b/util/measures/2022/quality-measures.csv
@@ -1,6 +1,6 @@
 ﻿title,eMeasureId,nqfEMeasureId,nqfId,measureId,description,nationalQualityStrategyDomain,measureType,measureArea,isHighPriority,appropriateUse,primarySteward,firstPerformanceYear,lastPerformanceYear,methodsClaims,methodsCertifiedSurveyVendor,methodsElectronicHealthRecord,methodsCmsWebInterface,methodsAdministrativeClaims,methodsRegistry,allergyImmunology,anesthesiology,audiology,cardiology,certifiedNurseMidwife,chiropracticMedicine,clinicalSocialWork,dentistry,dermatology,diagnosticRadiology,electrophysiologyCardiacSpecialist,emergencyMedicine,endocrinology,familyMedicine,gastroenterology,generalSurgery,geriatrics,hospitalists,infectiousDisease,internalMedicine,interventionalRadiology,mentalBehavioralHealth,nephrology,neurology,neurosurgical,nutritionDietician,obstetricsGynecology,oncology,ophthalmology,orthopedicSurgery,otolaryngology,pathology,pediatrics,physicalMedicine,physicalTherapyOccupationalTherapy,plasticSurgery,podiatry,preventiveMedicine,pulmonology,radiationOncology,rheumatology,skilledNursingFacility,speechLanguagePathology,thoracicSurgery,urgentCare,urology,vascularSurgery,"additionalGuidence
 ",telehealthModifiers,isInverse,nonCoveredDenominator,numStrataRegistry,overallAlgorithm,perFrateDescriptions,isNonProportional,,,,,,,,,suppressionReason,,,,,,,,removalReason,,,,,,,,,truncationReason,,,,,,,,flatReason,programMIPS,programPCF,programAPP1,requiredPCF,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),CMS122v10,N/A,0059,001,Percentage of patients 18-75 years of age with diabetes who had hemoglobin A1c > 9.0% during the measurement period.,Effective Clinical Care, Intermediate Outcome,Management of Chronic Conditions,X,-,National Committee for Quality Assurance,2017,Measure is still in program,X,-,X,X,-,X,-,-,-,-,-,-,-,-,-,-,-,-,"X
+Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),CMS122v10,N/A,0059,001,Percentage of patients 18-75 years of age with diabetes who had hemoglobin A1c > 9.0% during the measurement period.,Effective Clinical Care," Intermediate Outcome",Management of Chronic Conditions,X,-,National Committee for Quality Assurance,2017,Measure is still in program,X,-,X,X,-,X,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2020
 2021
 2022","X
@@ -88,7 +88,7 @@ Coronary Artery Disease (CAD): Antiplatelet Therapy,N/A,N/A,0067,006,Percentage 
 2019
 2020
 2021
-2022",-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Coronary Artery Disease (CAD): Beta-Blocker Therapy – Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF < 40%),CMS145v10,0070e,0070,007,Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease seen within a 12-month period who also have a prior MI or a current or prior LVEF < 40% who were prescribed beta-blocker therapy.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Heart Association,2017,Measure is still in program,-,-,X,-,-,X,-,-,-,"X
 2017
 2018
@@ -174,23 +174,23 @@ Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation,CMS143v10,0086e,N/A,0
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Age-Related Macular Degeneration (AMD): Dilated Macular Examination,N/A,N/A,0087,014,Percentage of patients aged 50 years and older with a diagnosis of age-related macular degeneration (AMD) who had a dilated macular examination performed which included documentation of the presence or absence of macular thickening or geographic atrophy or hemorrhage AND the level of macular degeneration severity during one or more office visits within the 12 month performance period.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Academy of Ophthalmology,2017,Measure is still in program ,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Age-Related Macular Degeneration (AMD): Dilated Macular Examination,N/A,N/A,0087,014,Percentage of patients aged 50 years and older with a diagnosis of age-related macular degeneration (AMD) who had a dilated macular examination performed which included documentation of the presence or absence of macular thickening or geographic atrophy or hemorrhage AND the level of macular degeneration severity during one or more office visits within the 12 month performance period.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Academy of Ophthalmology,2017,"Measure is still in program ",-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Diabetic Retinopathy: Documentation of Presence or Absence of Macular Edema and Level of Severity of Retinopathy,CMS167v6,N/A,0088,018,Percentage of patients aged 18 years and older with a diagnosis of diabetic retinopathy who had a dilated macular or fundus exam performed which included documentation of the level of severity of retinopathy and the presence or absence of macular edema during one or more office visits within 12 months,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,Physician Consortium for Performance Improvement,2017,2019,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
-2018",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,,N,N,1,N/A, ,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care,CMS142v10,N/A,N/A,019,Percentage of patients aged 18 years and older with a diagnosis of diabetic retinopathy who had a dilated macular or fundus exam performed with documented communication to the physician who manages the ongoing care of the patient with diabetes mellitus regarding the findings of the macular or fundus exam at least once within 12 months.,Communication and Care Coordination ,Process,Transfer of Health Information and Interoperability,X,-,American Academy of Ophthalmology,2017,Measure is still in program ,-,-,X,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
+2018",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",,N,N,1,N/A, ,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care,CMS142v10,N/A,N/A,019,Percentage of patients aged 18 years and older with a diagnosis of diabetic retinopathy who had a dilated macular or fundus exam performed with documented communication to the physician who manages the ongoing care of the patient with diabetes mellitus regarding the findings of the macular or fundus exam at least once within 12 months.,"Communication and Care Coordination ",Process,Transfer of Health Information and Interoperability,X,-,American Academy of Ophthalmology,2017,"Measure is still in program ",-,-,X,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Perioperative Care: Selection of Prophylactic Antibiotic – First OR Second-Generation Cephalosporin,N/A,N/A,0268,021,Percentage of surgical patients aged 18 years and older undergoing procedures with the indications for a first OR second-generation cephalosporin prophylactic antibiotic who had an order for a first OR second-generation cephalosporin for antimicrobial prophylaxis.,Patient Safety,Process,Healthcare-associated Infections,X,X,American Society of Plastic Surgeons,2017,2022,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
 2019
@@ -217,7 +217,7 @@ Perioperative Care: Selection of Prophylactic Antibiotic – First OR Second-Gen
 2021",-,-,"2018
 2019
 2020
-2021",N/A,-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2021","N/A",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Perioperative Care: Venous Thromboembolism (VTE) Prophylaxis (When Indicated in ALL Patients),N/A,N/A,N/A,023,"Percentage of surgical patients aged 18 years and older undergoing procedures for which venous thromboembolism (VTE) prophylaxis is indicated in all patients, who had an order for Low Molecular Weight Heparin (LMWH), Low- Dose Unfractionated Heparin (LDUH), adjusted-dose warfarin, fondaparinux or mechanical prophylaxis to be given within 24 hours prior to incision time or within 24 hours after surgery end time.",Patient Safety,Process,Preventive Care,X,-,American Society of Plastic Surgeons,2017,2022,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
 2019
@@ -247,7 +247,7 @@ Perioperative Care: Venous Thromboembolism (VTE) Prophylaxis (When Indicated in 
 2021","2018
 2019
 2020
-2021",N/A,-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2021","N/A",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Communication with the Physician or Other Clinician Managing On-Going Care Post-Fracture for Men and Women Aged 50 Years and Older,N/A,N/A,N/A,024,"Percentage of patients aged 50 years and older treated for a fracture with documentation of communication, between the physician treating the fracture and the physician or other clinician managing the patient’s on-going care, that a fracture occurred and that the patient was or should be considered for osteoporosis treatment or testing. This measure is submitted by the physician who treats the fracture and who therefore is held accountable for the communication.",Communication and Care Coordination,Process,Transfer of Health Information and Interoperability,X,-,National Committee for Quality Assurance,2017,Measure is still in program,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2018
 2019
@@ -281,7 +281,7 @@ Communication with the Physician or Other Clinician Managing On-Going Care Post-
 • Use the most favorable instance of reporting for performance rates if multiple conflicting QDCs exist on a qualifying episode
 • The QDC must exist on the claim with the qualifying denominator episode (overarching rule for all measures)
 This measure has multiple denominator options based on care setting (outpatient vs. procedure).  This measure requires the reporting of only one data completeness and performance rate.  ",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Stroke and Stroke Rehabilitation: Discharged on Antithrombotic Therapy,N/A,N/A,0325,032,Percentage of patients aged 18 years and older with a diagnosis of ischemic stroke or transient ischemic attack (TIA) who were prescribed antithrombotic therapy at discharge,Effective Clinical Care,Process,-,-,-,American Academy of Neurology,2017,2018,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2017,-,-,-,-,-,2017,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,Claims: Each time a discharge code 99238 or 99239 is included on a claim a quality-data code is to be reported. Utilize Visit logic for this measure. ,,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Stroke and Stroke Rehabilitation: Discharged on Antithrombotic Therapy,N/A,N/A,0325,032,Percentage of patients aged 18 years and older with a diagnosis of ischemic stroke or transient ischemic attack (TIA) who were prescribed antithrombotic therapy at discharge,Effective Clinical Care,Process,-,-,-,American Academy of Neurology,2017,2018,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2017,-,-,-,-,-,2017,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"Claims: Each time a discharge code 99238 or 99239 is included on a claim a quality-data code is to be reported. Utilize Visit logic for this measure. ",,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Screening for Osteoporosis for Women Aged 65-85 Years of Age,N/A,N/A,0046,039,Percentage of female patients aged 65-85 years of age who ever had a central dual-energy X-ray absorptiometry (DXA) to check for osteoporosis.,Effective Clinical Care,Process,Preventive Care,-,-,National Committee for Quality Assurance,2017,Measure is still in program,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2020
 2021
@@ -312,12 +312,12 @@ Screening for Osteoporosis for Women Aged 65-85 Years of Age,N/A,N/A,0046,039,Pe
 2021
 2022",-,-,-,-,-,-,"Diagnosis of osteoporosis on the date of service is not considered denominator eligible. 
 ",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Coronary Artery Bypass Graft (CABG): Use of Internal Mammary Artery (IMA) in Patients with Isolated CABG Surgery ,N/A,N/A,0134,043,Percentage of patients aged 18 years and older undergoing isolated CABG surgery who received an IMA graft,Effective Clinical Care,Process,Appropriate Use of Healthcare,-,-,Society of Thoracic Surgeons,2017,2019,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2018,-,-,-,N/A,,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+"Coronary Artery Bypass Graft (CABG): Use of Internal Mammary Artery (IMA) in Patients with Isolated CABG Surgery ",N/A,N/A,0134,043,Percentage of patients aged 18 years and older undergoing isolated CABG surgery who received an IMA graft,Effective Clinical Care,Process,Appropriate Use of Healthcare,-,-,Society of Thoracic Surgeons,2017,2019,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2018,-,-,-,"N/A",,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Coronary Artery Bypass Graft (CABG): Preoperative Beta-Blocker in Patients with Isolated CABG Surgery,N/A,N/A,0236,044,Percentage of isolated Coronary Artery Bypass Graft (CABG) surgeries for patients aged 18 years and older who received a beta-blocker within 24 hours prior to surgical incision.,Effective Clinical Care,Process,Medication Management,-,-,Centers for Medicare & Medicaid Services,2017,2022,-,-,-,-,-,X,-,"2017
 2018
 2019
 2020
-2021",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2021,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2021",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2021,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Medication Reconciliation Post-Discharge,N/A,N/A,0097,046,"The percentage of discharges from any inpatient facility (e.g. hospital, skilled nursing facility, or rehabilitation facility) for patients 18 years of age and older seen within 30 days following discharge in the office by the physician, prescribing practitioner, registered nurse, or clinical pharmacist providing on-going care for whom the discharge medication list was reconciled with the current medication list in the outpatient medical record
 This measure is submitted as three rates stratified by age group:
 • Submission Criteria 1: 18-64 years of age.
@@ -457,7 +457,7 @@ Advance Care Plan,N/A,N/A,0326,047,Percentage of patients aged 65 years and olde
 2020
 2021
 2022","Claims: Exclude line items from the denominator when CPT codes are seen with a Place of Service for emergency department (POS) = 23. MIPS eligible clinicians indicating the Place of Service as the emergency department will not be included in this measure.
-",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Urinary Incontinence: Assessment of Presence or Absence of Urinary Incontinence in Women Aged 65 Years and Older,N/A,N/A,N/A,048,Percentage of female patients aged 65 years and older who were assessed for the presence or absence of urinary incontinence within 12 months.,Effective Clinical Care,Process,Preventive Care,-,-,National Committee for Quality Assurance,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2018
 2019
@@ -489,8 +489,8 @@ Urinary Incontinence: Assessment of Presence or Absence of Urinary Incontinence 
 2019
 2020
 2021
-2022",-,N/A,-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Years and Older,N/A,N/A,N/A,050,Percentage of female patients aged 65 years and older with a diagnosis of urinary incontinence with a documented plan of care for urinary incontinence at least once within 12 months.,Person and Caregiver-Centered Experience and Outcomes,Process,Management of Chronic Conditions,X,-,National Committee for Quality Assurance,2017,Measure is still in Program ,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
+2022",-,"N/A",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Years and Older,N/A,N/A,N/A,050,Percentage of female patients aged 65 years and older with a diagnosis of urinary incontinence with a documented plan of care for urinary incontinence at least once within 12 months.,Person and Caregiver-Centered Experience and Outcomes,Process,Management of Chronic Conditions,X,-,National Committee for Quality Assurance,2017,"Measure is still in Program ",-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
@@ -519,12 +519,12 @@ Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Yea
 2019
 2020
 2021
-2022",-,N/A,-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Chronic Obstructive Pulmonary Disease (COPD): Spirometry Evaluation,N/A,N/A,0091,051,Percentage of patients aged 18 years and older with a diagnosis of COPD who had spirometry results documented.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Thoracic Society,2017,2020,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,"N/A",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Chronic Obstructive Pulmonary Disease (COPD): Spirometry Evaluation,N/A,N/A,0091,051,Percentage of patients aged 18 years and older with a diagnosis of COPD who had spirometry results documented.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Thoracic Society,2017,2020,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Chronic Obstructive Pulmonary Disease (COPD): Long-Acting Inhaled Bronchodilator Therapy,N/A,N/A,0102,052,Percentage of patients aged 18 years and older with a diagnosis of COPD (FEV1/FVC < 70%) and who have an FEV1 less than 60% predicted and have symptoms who were prescribed a long-acting inhaled bronchodilator.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Thoracic Society,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2020
 2021
-2022",-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Appropriate Treatment for Upper Respiratory Infection (URI),CMS154v10,N/A,0069,065,Percentage of episodes for patients 3 months of age and older with a diagnosis of upper respiratory infection (URI) that did not result in an antibiotic dispensing event.,Efficiency and Cost Reduction,Process,Appropriate Use of Healthcare,X,X,National Committee for Quality Assurance,2017,Measure is still in program,-,-,X,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
@@ -546,7 +546,7 @@ Appropriate Treatment for Upper Respiratory Infection (URI),CMS154v10,N/A,0069,0
 2019
 2020
 2021
-2022",-,-,N/A,-,N,Y,1,"N/A
+2022",-,-,"N/A",-,N,Y,1,"N/A
 ",N/A,N,,,,,,,,,,N,N,N,N,N,Y (2022),2022,Measure is being updated to assess the correct patient population and align with intent.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Appropriate Testing for Pharyngitis,CMS146v10,N/A,N/A,066,The percentage of episodes for patients 3 years and older with a diagnosis of pharyngitis that resulted in an antibiotic dispensing event and a group A streptococcus (strep) test.,Efficiency and Cost Reduction,Process,Appropriate Use of Healthcare,X,X,National Committee for Quality Assurance,2017,Measure is still in program,-,-,X,-,-,X,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
@@ -570,17 +570,17 @@ Appropriate Testing for Pharyngitis,CMS146v10,N/A,N/A,066,The percentage of epis
 2019
 2020
 2021
-2022",-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
- Hematology: Myelodysplastic Syndrome (MDS) and Acute Leukemias: Baseline Cytogenetic Testing Performed on Bone Marrow,N/A,N/A,N/A,067,Percentage of patients aged 18 years and older with a diagnosis of myelodysplastic syndrome (MDS) or an acute leukemia who had baseline cytogenetic testing performed on bone marrow.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Society of Hematology,2017,2022,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2020
-2021",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
- Hematology: Myelodysplastic Syndrome (MDS): Documentation of Iron Stores in Patients Receiving Erythropoietin Therapy,N/A,N/A,N/A,068,Percentage of patients aged 18 years and older with a diagnosis of myelodysplastic syndrome (MDS) who are receiving erythropoietin therapy with documentation of iron stores within 60 days prior to initiating erythropoietin therapy.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Society of Hematology,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
- Hematology: Multiple Myeloma: Treatment with Bisphosphonates,N/A,N/A,N/A,069,"Percentage of patients aged 18 years and older with a diagnosis of multiple myeloma, not in remission, who were prescribed or received intravenous bisphosphonate therapy within the 12-month reporting period.",Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Society of Hematology,2017,2021,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2020,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,Y,1,N/A,N/A,N,N,N,N,N,N,"(Y) 2019
-(Y) 2020",Suppression ,"2019
+2022",-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+" Hematology: Myelodysplastic Syndrome (MDS) and Acute Leukemias: Baseline Cytogenetic Testing Performed on Bone Marrow",N/A,N/A,N/A,067,Percentage of patients aged 18 years and older with a diagnosis of myelodysplastic syndrome (MDS) or an acute leukemia who had baseline cytogenetic testing performed on bone marrow.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Society of Hematology,2017,2022,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2020
+2021",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+" Hematology: Myelodysplastic Syndrome (MDS): Documentation of Iron Stores in Patients Receiving Erythropoietin Therapy",N/A,N/A,N/A,068,Percentage of patients aged 18 years and older with a diagnosis of myelodysplastic syndrome (MDS) who are receiving erythropoietin therapy with documentation of iron stores within 60 days prior to initiating erythropoietin therapy.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Society of Hematology,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+" Hematology: Multiple Myeloma: Treatment with Bisphosphonates",N/A,N/A,N/A,069,"Percentage of patients aged 18 years and older with a diagnosis of multiple myeloma, not in remission, who were prescribed or received intravenous bisphosphonate therapy within the 12-month reporting period.",Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Society of Hematology,2017,2021,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2020,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,Y,1,N/A,N/A,N,N,N,N,N,N,"(Y) 2019
+(Y) 2020","Suppression ","2019
 2020","2019: Update to guidelines. For 2019 and 2020, utilized the denominator exception for use of denosumab.
 ",,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Hematology: Chronic Lymphocytic Leukemia (CLL): Baseline Flow Cytometry,N/A,N/A,N/A,070,"Percentage of patients aged 18 years and older, seen within a 12-month reporting period, with a diagnosis of chronic lymphocytic leukemia (CLL) made at any time during or prior to the reporting period who had baseline flow cytometry studies performed and documented in the chart.",Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Society of Hematology,2017,2022,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2020
-2021",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
- Prevention of Central Venous Catheter (CVC) - Related Bloodstream Infections,N/A,N/A,2726,076,"Percentage of patients, regardless of age, who undergo central venous catheter (CVC) insertion for whom CVC was inserted with all elements of maximal sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound techniques followed.",Patient Safety,Process,Healthcare-associated Infections,X,-,American Society of Anesthesiologists,2017,Measure is still in program,X,-,-,-,-,X,-,"X
+2021",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+" Prevention of Central Venous Catheter (CVC) - Related Bloodstream Infections",N/A,N/A,2726,076,"Percentage of patients, regardless of age, who undergo central venous catheter (CVC) insertion for whom CVC was inserted with all elements of maximal sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound techniques followed.",Patient Safety,Process,Healthcare-associated Infections,X,-,American Society of Anesthesiologists,2017,Measure is still in program,X,-,-,-,-,X,-,"X
 2017
 2018
 2019
@@ -597,7 +597,7 @@ Hematology: Chronic Lymphocytic Leukemia (CLL): Baseline Flow Cytometry,N/A,N/A,
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Acute Otitis Externa (AOE): Topical Therapy,N/A,N/A,0653,091,Percentage of patients aged 2 years and older with a diagnosis of AOE who were prescribed topical preparations.,Effective Clinical Care,Process,Appropriate Use of Healthcare,X,X,American Academy of Otolaryngology – Head and Neck Surgery,2017,2020,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
 2019",-,"2018
@@ -645,10 +645,10 @@ Acute Otitis Externa (AOE): Systemic Antimicrobial Therapy – Avoidance of Inap
 2022",-,-,"Claims: Approved to count an episode as any claims for the TIN/NPI/Bene that qualify for the measure within a 30-day timeframe. Use the last expense date corresponding to qualifying line items (denominator diagnosis or encounter codes) on the first claim to start the 30-day episode.  The 30-day continues forward to include any subsequent claim(s) where the 1st expense date on qualifying line items (denominator diagnosis or procedure codes) is within 30-days of the last expense date on that 1st claim. The first claim with a QDC within the episode is the QDC to use when calculating performance.  
 
 ",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Breast Cancer Resection Pathology Reporting: pT Category (Primary Tumor) and pN Category (Regional Lymph Nodes) with Histologic Grade ,N/A,N/A,0391,099,"Percentage of breast cancer resection pathology reports that include the pT category (primary tumor), the pN category (regional lymph nodes), and the histologic grade",Effective Clinical Care,Process,Transfer of Health Information and Interoperability,-,-,College of American Pathologists,2017,2019,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,#VALUE!,-,-,-,-,-,-,-,-,-,-,-,-,"2017
-2018",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,Claims: Only one QDC per date of service for a patient is required. ,,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+"Breast Cancer Resection Pathology Reporting: pT Category (Primary Tumor) and pN Category (Regional Lymph Nodes) with Histologic Grade ",N/A,N/A,0391,099,"Percentage of breast cancer resection pathology reports that include the pT category (primary tumor), the pN category (regional lymph nodes), and the histologic grade",Effective Clinical Care,Process,Transfer of Health Information and Interoperability,-,-,College of American Pathologists,2017,2019,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,#VALUE!,-,-,-,-,-,-,-,-,-,-,-,-,"2017
+2018",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"Claims: Only one QDC per date of service for a patient is required. ",,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Colorectal Cancer Resection Pathology Reporting: pT Category (Primary Tumor) and pN Category (Regional Lymph Nodes) with Histologic Grade,N/A,N/A,0392,100,"Percentage of colon and rectum cancer resection pathology reports that include the pT category (primary tumor), the pN category (regional lymph nodes) and the histologic grade",Effective Clinical Care,Process,Transfer of Health Information and Interoperability,-,-,College of American Pathologists,2017,2019,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
-2018",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,Claims: Only one QDC per date of service for a patient is required. ,,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2018",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"Claims: Only one QDC per date of service for a patient is required. ",,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients,CMS129v11,0389e,0389,102,"Percentage of patients, regardless of age, with a diagnosis of prostate cancer at low (or very low) risk of recurrence receiving interstitial prostate brachytherapy, OR external beam radiotherapy to the prostate, OR radical prostatectomy who did not have a bone scan performed at any time since diagnosis of prostate cancer.",Efficiency and Cost Reduction,Process,Appropriate Use of Healthcare,X,X,Centers for Medicare & Medicaid Services,2017,Measure is still in program,-,-,X,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
@@ -667,14 +667,14 @@ Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate
 2019
 2020
 2021
-2022",-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Prostate Cancer: Combination Androgen Deprivation Therapy for High Risk or Very High Risk Prostate Cancer,N/A,N/A,0390,104,"Percentage of patients, regardless of age, with a diagnosis of prostate cancer at high or very high risk of recurrence receiving external beam radiotherapy to the prostate who were prescribed androgen deprivation therapy in combination with external beam radiotherapy to the prostate.",Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Urological Association Education and Research,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Adult Major Depressive Disorder (MDD): Suicide Risk Assessment,CMS161v10,0104e,N/A,107,All patient visits during which a new diagnosis of MDD or a new diagnosis of recurrent MDD was identified for patients aged 18 years and older with a suicide risk assessment completed during the visit.,Effective Clinical Care,Process,"Prevention, Treatment, and Management of Mental Health",-,-,Mathematica,2017,Measure is still in program,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2018
 2019
@@ -692,15 +692,15 @@ Adult Major Depressive Disorder (MDD): Suicide Risk Assessment,CMS161v10,0104e,N
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Osteoarthritis (OA): Function and Pain Assessment,N/A,N/A,N/A,109,Percentage of patient visits for patients aged 21 years and older with a diagnosis of osteoarthritis (OA) with assessment for function and pain.,Person and Caregiver-Centered Experience and Outcomes,Process,Patient's Experience of Care ,X,-,American Academy of Orthopedic Surgeons,2017,2020,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,"2018
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Osteoarthritis (OA): Function and Pain Assessment,N/A,N/A,N/A,109,Percentage of patient visits for patients aged 21 years and older with a diagnosis of osteoarthritis (OA) with assessment for function and pain.,Person and Caregiver-Centered Experience and Outcomes,Process,"Patient's Experience of Care ",X,-,American Academy of Orthopedic Surgeons,2017,2020,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,"2018
 2019",-,-,-,-,-,2017,-,-,-,-,-,-,-,-,-,"2017
 2018
 2019",-,-,-,"2017
 2018
 2019",-,-,-,"2017
 2018
-2019",-,-,-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019",-,-,-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Preventive Care and Screening: Influenza Immunization,CMS147v11,0041e,0041,110,Percentage of patients aged 6 months and older seen for a visit between October 1 and March 31 who received an influenza immunization OR who reported previous receipt of an influenza immunization.,Community/Population Health,Process,Preventive Care,-,-,National Committee for Quality Assurance,2017,Measure is still in program,X,-,X,X,-,X,"X
 2017
 2018
@@ -777,7 +777,7 @@ Preventive Care and Screening: Influenza Immunization,CMS147v11,0041e,0041,110,P
 2021
 2022",-,-,-,-,-,"For claims and CQM collection types: Report a minimum of once for visits occurring between January 1, 2021 and March 31, 2021 for the 2020-2021 influenza season and a minimum of once for visits occurring between October 1, 2021 and December 31, 2021 for the 2021-2022 influenza season. For example, if there is a visit in January 2021 and a visit in November 2021, both of these visits would count in the denominator (a count of 2). However, if there are two visits which occur in January 2021 and one in February 2021, only one of these needs to be reported to account for the 2020-2021 influenza season.  
 
-",-,N,Y,1,N/A,N/A,N,(Y) 2019,N,(Y) 2019,(Y) 2019,N,(Y) 2019,Suppression ,2019,CDC guidelines indicated that the Live virus formulation was acceptable. The 2018-2019 flu season has already passed. MIPS eligible clinicians would have likely submitted a performance not met due to the instructions within the measure specification. ,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+",-,N,Y,1,N/A,N/A,N,(Y) 2019,N,(Y) 2019,(Y) 2019,N,(Y) 2019,"Suppression ",2019,"CDC guidelines indicated that the Live virus formulation was acceptable. The 2018-2019 flu season has already passed. MIPS eligible clinicians would have likely submitted a performance not met due to the instructions within the measure specification. ",,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Pneumococcal Vaccination Status for Older Adults,CMS127v10,N/A,N/A,111,Percentage of patients 66 years of age and older who have ever received a pneumococcal vaccine.,Community/Population Health,Process,Preventive Care,-,-,National Committee for Quality Assurance,2017,Measure is still in program,X,-,X,-,-,X,"X
 2017
 2018
@@ -839,7 +839,7 @@ Pneumococcal Vaccination Status for Older Adults,CMS127v10,N/A,N/A,111,Percentag
 2021
 2022","X
 2021
-2022",-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,Y (2021),N,Y (2021),N,N,Y (2021),First,2021,ACIP guideline recommendations were revised in October 2021 and no longer aligned with the current posted measure specification.,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,Y (2021),N,Y (2021),N,N,Y (2021),First,2021,ACIP guideline recommendations were revised in October 2021 and no longer aligned with the current posted measure specification.,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Breast Cancer Screening,CMS125v10,N/A,2372,112,Percentage of women 50 - 74 years of age who had a mammogram to screen for breast cancer in the 27 months prior to the end of the measurement period.,Effective Clinical Care,Process,Preventive Care,-,-,National Committee for Quality Assurance,2017,Measure is still in program,X,-,X,X,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
@@ -871,8 +871,8 @@ Colorectal Cancer Screening,CMS130v10,N/A,0034,113,Percentage of patients 50-75 
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,Y (2020) ,N,N,N,N,Y (2020) ,2020,"Updated numerator guidance finalized for 2020: For Medicare Part B Claims Measure Specification and MIPS CQMs Specifications collection types: Do not count DRE, FOBT tests performed in an office setting or performed on a sample collected via DRE. 7/12:  Remove benchmark for 2020.",,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Avoidance of Antibiotic Treatment for Acute Bronchitis/Bronchiolitis,N/A,N/A,0058,116,The percentage of episodes for patients ages 3 months and older with a diagnosis of acute bronchitis/bronchiolitis that did not result in an antibiotic dispensing event.,Efficiency and Cost Reduction,Process,Appropriate Use of Healthcare ,X,X,National Committee for Quality Assurance,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,"X
+2022",-,-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,"Y (2020) ",N,N,N,N,"Y (2020) ",2020,"Updated numerator guidance finalized for 2020: For Medicare Part B Claims Measure Specification and MIPS CQMs Specifications collection types: Do not count DRE, FOBT tests performed in an office setting or performed on a sample collected via DRE. 7/12:  Remove benchmark for 2020.",,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Avoidance of Antibiotic Treatment for Acute Bronchitis/Bronchiolitis,N/A,N/A,0058,116,The percentage of episodes for patients ages 3 months and older with a diagnosis of acute bronchitis/bronchiolitis that did not result in an antibiotic dispensing event.,Efficiency and Cost Reduction,Process,"Appropriate Use of Healthcare ",X,X,National Committee for Quality Assurance,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
@@ -900,7 +900,7 @@ Avoidance of Antibiotic Treatment for Acute Bronchitis/Bronchiolitis,N/A,N/A,005
 2019
 2020
 2021
-2022",-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2022),2022,Measure is being updated to assess the correct patient population and align with intent.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2022),2022,Measure is being updated to assess the correct patient population and align with intent.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Diabetes: Eye Exam,CMS131v10,N/A,0055,117,Percentage of patients 18-75 years of age with diabetes and an active diagnosis of retinopathy in any part of the measurement period who had a retinal or dilated eye exam by an eye care professional during the measurement period or diabetics with no diagnosis of retinopathy in any part of the measurement period who had a retinal or dilated eye exam by an eye care professional during the measurement period or in the 12 months prior to the measurement period.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,National Committee for Quality Assurance,2017,Measure is still in program,X,-,X,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2020
 2021
@@ -921,7 +921,7 @@ Diabetes: Eye Exam,CMS131v10,N/A,0055,117,Percentage of patients 18-75 years of 
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,(Y) 2021,N,N,N,N,N,Suppression,2021,2021 CPTII codes were inactivated for 6 months of the performance period.,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,(Y) 2021,N,N,N,N,N,Suppression,2021,2021 CPTII codes were inactivated for 6 months of the performance period.,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Coronary Artery Disease (CAD): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy - Diabetes or Left Ventricular Systolic Dysfunction (LVEF < 40%),N/A,N/A,0066,118,Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease seen within a 12 month period who also have diabetes OR a current or prior Left Ventricular Ejection Fraction (LVEF) < 40% who were prescribed ACE inhibitor or ARB therapy.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Heart Association,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,"X
 2017
 2018
@@ -968,8 +968,8 @@ Diabetes: Medical Attention for Nephropathy,CMS134v10,N/A,0062,119,The percentag
 2019
 2020
 2021
-2022",-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Adult Kidney Disease: Blood Pressure Management ,N/A,N/A,N/A,122,"Percentage of patient visits for those patients aged 18 years and older with a diagnosis of chronic kidney disease (CKD) (stage 3, 4, or 5, not receiving Renal Replacement Therapy [RRT]) with a blood pressure < 140/90 mmHg OR ≥ 140/90 mmHg with a documented plan of care",Effective Clinical Care,Intermediate Outcome,Management of Chronic Conditions,X,-,Renal Physicians Association,2017,2019,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2018,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"This measure has multiple denominator options.  This measure requires the reporting of three performance rates. The third performance rate outlined in the measure specification should be utilized for an overall data completeness and performance rate for this measure.  
+2022",-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+"Adult Kidney Disease: Blood Pressure Management ",N/A,N/A,N/A,122,"Percentage of patient visits for those patients aged 18 years and older with a diagnosis of chronic kidney disease (CKD) (stage 3, 4, or 5, not receiving Renal Replacement Therapy [RRT]) with a blood pressure < 140/90 mmHg OR ≥ 140/90 mmHg with a documented plan of care",Effective Clinical Care,Intermediate Outcome,Management of Chronic Conditions,X,-,Renal Physicians Association,2017,2019,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2018,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"This measure has multiple denominator options.  This measure requires the reporting of three performance rates. The third performance rate outlined in the measure specification should be utilized for an overall data completeness and performance rate for this measure.  
 
 This measure will be calculated with 3 performance rates:
 1) Percentage of patient visits with blood pressure results < 140/90 mmHg
@@ -1005,7 +1005,7 @@ This measure will be calculated with 3 performance rates:
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 "Diabetes Mellitus: Diabetic Foot and Ankle Care, Ulcer Prevention – Evaluation of Footwear",N/A,N/A,0416,127,Percentage of patients aged 18 years and older with a diagnosis of diabetes mellitus who were evaluated for proper footwear and sizing.,Effective Clinical Care,Process,Preventive Care,-,-,American Podiatric Medical Association,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2022",-,-,-,-,-,-,-,-,"X
 2020
@@ -1015,7 +1015,7 @@ This measure will be calculated with 3 performance rates:
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan,CMS69v10,N/A,N/A,128,Percentage of patients aged 18 years and older with a BMI documented during the current encounter or within the previous twelve months AND who had a follow-up plan documented if most recent BMI was outside of normal parameters.,Community/Population Health,Process,Preventive Care,-,-,Centers for Medicare & Medicaid Services,2017,Measure is still in program,X,-,X,-,-,X,-,-,-,"X
 2017
 2018
@@ -1301,8 +1301,8 @@ Documentation of Current Medications in the Medical Record,CMS68v11,N/A,N/A,130,
 2019
 2020
 2021
-2022",N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Pain Assessment and Follow-Up,N/A,N/A,0420,131,Percentage of visits for patients aged 18 years and older with documentation of a pain assessment using a standardized tool(s) on each visit AND documentation of a follow-up plan when pain is present.,Communication and Care Coordination,Process,Patient's Experience of Care ,X,-,Centers for Medicare & Medicaid Services,2017,2020,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2019,-,-,-,-,-,-,-,-,-,-,-,-,"2017
+2022","N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Pain Assessment and Follow-Up,N/A,N/A,0420,131,Percentage of visits for patients aged 18 years and older with documentation of a pain assessment using a standardized tool(s) on each visit AND documentation of a follow-up plan when pain is present.,Communication and Care Coordination,Process,"Patient's Experience of Care ",X,-,Centers for Medicare & Medicaid Services,2017,2020,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2019,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
 2019",-,-,-,"2017
 2018
@@ -1363,11 +1363,11 @@ Preventive Care and Screening: Screening for Depression and Follow-Up Plan,CMS2v
 2021
 2022",-,-,-,-,"X
 2021
-2022",-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,N,N,(Y) 2019,"(Y) 2019
+2022",-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,N,N,(Y) 2019,"(Y) 2019
 (Y) 2020
 (Y) 2021",N,N,Suppression,"2019
 2020
-2021",Inconsistency resulting with the removal of SNOMED coding related to appropriate follow up not reflected in the narrative measure specifications which resulted in misalignment of measure intent. ,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2021","Inconsistency resulting with the removal of SNOMED coding related to appropriate follow up not reflected in the narrative measure specifications which resulted in misalignment of measure intent. ",,,,,,,,,,,,,,,,,,,,,,,,,,X,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Melanoma: Continuity of Care – Recall System,N/A,N/A,N/A,137,"Percentage of patients, regardless of age, with a current diagnosis of melanoma or a history of melanoma whose information was entered, at least once within a 12 month period, into a recall system that includes:
 • A target date for the next complete physical skin exam, AND
 • A process to follow up with patients who either did not make an appointment within the specified timeframe or who missed a scheduled appointment.
@@ -1377,7 +1377,7 @@ Melanoma: Continuity of Care – Recall System,N/A,N/A,N/A,137,"Percentage of pa
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,Y (2018),First,2018,Annual analysis of ICD10 codes indicated greater than 10 percent impacted,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,Y (2018),First,2018,Annual analysis of ICD10 codes indicated greater than 10 percent impacted,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Melanoma: Coordination of Care,N/A,N/A,N/A,138,"Percentage of patient visits, regardless of age, with a new occurrence of melanoma that have a treatment plan documented in the chart that was communicated to the physician(s) providing continuing care within one month of diagnosis.",Communication and Care Coordination,Process,Transfer of Health Information and Interoperability,X,-,American Academy of Dermatology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,"X
 2017
 2018
@@ -1386,7 +1386,7 @@ Melanoma: Coordination of Care,N/A,N/A,N/A,138,"Percentage of patient visits, re
 2021
 2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"This measure has multiple denominator options. This measure requires the reporting of only one data completeness and performance rate. 
 ",X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,Y (2018),First,2018,Annual analysis of ICD10 codes indicated greater than 10 percent impacted,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Age-Related Macular Degeneration (AMD): Counseling on Antioxidant Supplement ,N/A,N/A,0566,140,Percentage of patients aged 50 years and older with a diagnosis of age-related macular degeneration (AMD) or their caregiver(s) who were counseled within 12 months on the benefits and/or risks of the Age-Related Eye Disease Study (AREDS) 2 formulation for preventing progression of AMD,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Academy of Ophthalmology,2017,2019,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
+"Age-Related Macular Degeneration (AMD): Counseling on Antioxidant Supplement ",N/A,N/A,0566,140,Percentage of patients aged 50 years and older with a diagnosis of age-related macular degeneration (AMD) or their caregiver(s) who were counseled within 12 months on the benefits and/or risks of the Age-Related Eye Disease Study (AREDS) 2 formulation for preventing progression of AMD,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Academy of Ophthalmology,2017,2019,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-," For denominator criteria, encounter codes with Telehealth modifiers GQ, GT, 95 and POS 02 would not be considered encounter (eligible cases).",,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care,N/A,N/A,0563,141,"Percentage of patients aged 18 years and older with a diagnosis of primary open-angle glaucoma (POAG) whose glaucoma treatment has not failed (the most recent IOP was reduced by at least 15% from the pre-intervention level) OR if the most recent IOP was not reduced by at least 15% from the pre-intervention level, a plan of care was documented within the 12 month performance period.",Communication and Care Coordination,Outcome,Management of Chronic Conditions,X,-,American Academy of Ophthalmology,2017,Measure is still in program,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
@@ -1394,7 +1394,7 @@ Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 1
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"-",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Oncology: Medical and Radiation – Pain Intensity Quantified,CMS157v10,0384e,0384,143,"Percentage of patient visits, regardless of patient age, with a diagnosis of cancer currently receiving chemotherapy or radiation therapy in which pain intensity is quantified.",Person and Caregiver-Centered Experience and Outcomes,Process,Management of Chronic Conditions,X,-,American Society of Clinical Oncology,2017,Measure is still in program,-,-,X,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
@@ -1407,7 +1407,7 @@ Oncology: Medical and Radiation – Pain Intensity Quantified,CMS157v10,0384e,03
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Oncology: Medical and Radiation - Plan of Care for Pain,N/A,N/A,0383,144,"Percentage of visits for patients, regardless of age, with a diagnosis of cancer currently receiving chemotherapy or radiation therapy who report having pain with a documented plan of care to address pain.",Person and Caregiver-Centered Experience and Outcomes,Process,Patient Focused Episode of Care,X,-,American Society of Clinical Oncology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2018
 2019
@@ -1419,7 +1419,7 @@ Oncology: Medical and Radiation - Plan of Care for Pain,N/A,N/A,0383,144,"Percen
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,N/A,N,,,,,,,,,,Y (2019),N,N,N,N,Y (2019),2019,The 2019 measure would need to be benchmarked on current year performance data. ,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,N/A,N,,,,,,,,,,Y (2019),N,N,N,N,Y (2019),2019,"The 2019 measure would need to be benchmarked on current year performance data. ",,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Radiology: Exposure Dose Indices or Exposure Time and Number of Images Reported for Procedures Using Fluoroscopy,N/A,N/A,N/A,145,"Final reports for procedures using fluoroscopy that document radiation exposure indices, or exposure time and number of fluorographic images (if radiation exposure indices are not available).",Patient Safety,Process,Appropriate Use of Healthcare,X,-,American College of Radiology,2017,Measure is still in program,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
@@ -1431,18 +1431,18 @@ Radiology: Exposure Dose Indices or Exposure Time and Number of Images Reported 
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Radiology: Inappropriate Use of “Probably Benign” Assessment Category in Screening Mammograms,N/A,N/A,0508,146,Percentage of final reports for screening mammograms that are classified as “probably benign”.,Efficiency and Cost Reduction,Process,Transfer of Health Information and Interoperability,X,-,American College of Radiology,2017,2021,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,"2017
 2018
 2019
-2020",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,Performance hierarchy is reversed to determine the most favorable instance of reporting for performance rate calculations (fails performance then meets performance) - used when multiple QDCs are reported on the same claim/day.                                                                                           ,-,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2020",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"Performance hierarchy is reversed to determine the most favorable instance of reporting for performance rate calculations (fails performance then meets performance) - used when multiple QDCs are reported on the same claim/day.                                                                                           ",-,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Nuclear Medicine: Correlation with Existing Imaging Studies for All Patients Undergoing Bone Scintigraphy,N/A,N/A,N/A,147,"Percentage of final reports for all patients, regardless of age, undergoing bone scintigraphy that include physician documentation of correlation with existing relevant imaging studies (e.g., x-ray, Magnetic Resonance Imaging (MRI), Computed Tomography (CT), etc.) that were performed.",Communication and Care Coordination,Process,Transfer of Health Information and Interoperability,X,-,Society of Nuclear Medicine and Molecular Imaging,2017,Measure is still in program,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Falls: Risk Assessment,N/A,N/A,0101,154,Percentage of patients aged 65 years and older with a history of falls that had a risk assessment for falls completed within 12 months.,Patient Safety,Process,Preventable Healthcare Harm,X,-,National Committee for Quality Assurance,2017,2022,X,-,-,-,-,X,-,-,"2020
 2021",-,-,-,-,-,-,-,-,-,-,"2017
 2018
@@ -1475,7 +1475,7 @@ Falls: Risk Assessment,N/A,N/A,0101,154,Percentage of patients aged 65 years and
 2020
 2021",-,-,-,"2019
 2020
-2021",-,-,-,-,-,No requirement exists to report both measures (154 and 155) when paired.  Any paired measure reported would count as an individual measure.  The system should not require that an eligible clinician report both of the paired measures. The system should consider each of these measures as an individually reportable measure.  An eligible clinician may report both or only one of the paired measures as part of the measures threshold required for data completeness.  ,-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2021",-,-,-,-,-,"No requirement exists to report both measures (154 and 155) when paired.  Any paired measure reported would count as an individual measure.  The system should not require that an eligible clinician report both of the paired measures. The system should consider each of these measures as an individually reportable measure.  An eligible clinician may report both or only one of the paired measures as part of the measures threshold required for data completeness.  ",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Falls: Plan of Care,N/A,N/A,0101,155,Percentage of patients aged 65 years and older with a history of falls that had a plan of care for falls documented within 12 months.,Communication and Care Coordination,Process,Preventable Healthcare Harm,X,-,National Committee for Quality Assurance,2017,Measure is still in program,X,-,-,-,-,X,-,-,"X
 2020
 2021
@@ -1537,7 +1537,7 @@ Falls: Plan of Care,N/A,N/A,0101,155,Percentage of patients aged 65 years and ol
 No requirement exists to report both measures (154 and 155)  when paired.  Any paired measure reported would count as an individual measure.  The system should not require that an eligible clinician report both of the paired measures. The system should consider each of these measures as an individually reportable measure.  An eligible clinician may report both or only one of the paired measures as part of the measures threshold required for data completeness.
 ",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Oncology: Radiation Dose Limits to Normal Tissues,N/A,N/A,0382,156,"Percentage of patients, regardless of age, with a diagnosis of breast, rectal, pancreatic or lung cancer receiving 3D conformal radiation therapy who had documentation in medical record that radiation dose limits to normal tissues were established prior to the initiation of a course of 3D conformal radiation for a minimum of two tissues",Patient Safety,Process,Appropriate Use of Healthcare,X,X,American Society for Radiation Oncology,2017,2019,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
-2018",-,-,-,-,-,-,-,N/A,,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2018",-,-,-,-,-,-,-,"N/A",,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 HIV/AIDS: Pneumocystis Jiroveci Pneumonia (PCP) Prophylaxis,CMS52v8,N/A,N/A,160,Percentage of patients aged 6 weeks and older with a diagnosis of HIV/AIDS who were prescribed Pneumocystis jiroveci pneumonia (PCP) prophylaxis.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,National Committee for Quality Assurance,2017,2020,-,-,X,-,-,-,"2017
 2018
 2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
@@ -1546,34 +1546,34 @@ HIV/AIDS: Pneumocystis Jiroveci Pneumonia (PCP) Prophylaxis,CMS52v8,N/A,N/A,160,
 ",-,N,N/A,3,Weighted Average,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Diabetes: Foot Exam,CMS123v6,N/A,0056,163,The percentage of patients 18-75 years of age with diabetes (type 1 and type 2) who received a foot exam (visual inspection and sensory exam with mono filament and a pulse exam) during the measurement year,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,National Committee for Quality Assurance,2017,2019,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018",-,-,-,-,-,"2017
-2018",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2018",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Coronary Artery Bypass Graft (CABG): Prolonged Intubation,N/A,N/A,0129,164,Percentage of patients aged 18 years and older undergoing isolated CABG surgery who require postoperative intubation > 24 hours.,Effective Clinical Care,Outcome,Preventable Healthcare Harm,X,-,Society of Thoracic Surgeons,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,N/A,X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,"N/A",X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Coronary Artery Bypass Graft (CABG): Deep Sternal Wound Infection Rate,N/A,N/A,0130,165,"Percentage of patients aged 18 years and older undergoing isolated CABG surgery who, within 30 days postoperatively, develop deep sternal wound infection involving muscle, bone, and/or mediastinum requiring operative intervention.",Effective Clinical Care,Outcome,Healthcare-associated Infections,X,-,Society of Thoracic Surgeons,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
-2019",-,-,-,N/A,-,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019",-,-,-,"N/A",-,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Coronary Artery Bypass Graft (CABG): Stroke,N/A,N/A,0131,166,"Percentage of patients aged 18 years and older undergoing isolated CABG surgery who have a postoperative stroke (i.e., any confirmed neurological deficit of abrupt onset caused by a disturbance in blood supply to the brain) that did not resolve within 24 hours.",Effective Clinical Care,Outcome,Preventable Healthcare Harm,X,-,Society of Thoracic Surgeons,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
-2019",-,-,-,N/A,-,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019",-,-,-,"N/A",-,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Coronary Artery Bypass Graft (CABG): Postoperative Renal Failure,N/A,N/A,0114,167,Percentage of patients aged 18 years and older undergoing isolated CABG surgery (without pre-existing renal failure) who develop postoperative renal failure or require dialysis.,Effective Clinical Care,Outcome,Preventable Healthcare Harm,X,-,Society of Thoracic Surgeons,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,N/A,X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,"N/A",X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Coronary Artery Bypass Graft (CABG): Surgical Re-Exploration,N/A,N/A,0115,168,"Percentage of patients aged 18 years and older undergoing isolated CABG surgery who require a return to the operating room (OR) during the current hospitalization for mediastinal bleeding with or without tamponade, graft occlusion, valve dysfunction, or other cardiac reason.",Effective Clinical Care,Outcome,Preventable Healthcare Harm,X,-,Society of Thoracic Surgeons,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,N/A,X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,"N/A",X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Tuberculosis Screening Prior to First Course Biologic Therapy,N/A,N/A,N/A,176,"If a patient has been newly prescribed a biologic disease-modifying anti-rheumatic drug (DMARD) therapy, then the medical record should indicate TB testing in the preceding 12-month period.
 ",Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American College of Rheumatology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,"X
 2022",-,-,-,-,-,-,-,-,-,2018,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
@@ -1582,16 +1582,16 @@ Tuberculosis Screening Prior to First Course Biologic Therapy,N/A,N/A,N/A,176,"I
 2019
 2020
 2021
-2022",-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Rheumatoid Arthritis (RA): Periodic Assessment of Disease Activity,N/A,N/A,2523,177,Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have an assessment of disease activity using an ACR-preferred RA disease activity assessment tool at ≥50% of encounters for RA for each patient during the measurement year.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American College of Rheumatology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,N/A,X,N,Y,1,N/A,N/A,N,0,,,,,,,,,N,N,N,N,N,Y (2019),2019,"ACRheumatology confirmed the change may impact the performance data - Offered to establish new benchmark
+2022",-,-,-,-,-,-,"N/A",X,N,Y,1,N/A,N/A,N,0,,,,,,,,,N,N,N,N,N,Y (2019),2019,"ACRheumatology confirmed the change may impact the performance data - Offered to establish new benchmark
 ",,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Rheumatoid Arthritis (RA): Functional Status Assessment,N/A,N/A,N/A,178,Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) for whom a functional status assessment was performed at least once within 12 months.,Effective Clinical Care,Process,Patient's Experience of Care ,-,-,American College of Rheumatology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
+Rheumatoid Arthritis (RA): Functional Status Assessment,N/A,N/A,N/A,178,Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) for whom a functional status assessment was performed at least once within 12 months.,Effective Clinical Care,Process,"Patient's Experience of Care ",-,-,American College of Rheumatology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
@@ -1603,12 +1603,12 @@ Rheumatoid Arthritis (RA): Functional Status Assessment,N/A,N/A,N/A,178,Percenta
 2019
 2020
 2021
-2022",-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Rheumatoid Arthritis (RA): Assessment and Classification of Disease Prognosis,N/A,N/A,N/A,179,Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have an assessment and classification of disease prognosis at least once within 12 months.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American College of Rheumatology,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
 2019",-,-,-,-,-,-,-,-,-,-,"2017
 2018
-2019",-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019",-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Rheumatoid Arthritis (RA): Glucocorticoid Management,N/A,N/A,N/A,180,"Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have been assessed for glucocorticoid use and, for those on prolonged doses of prednisone > 5 mg daily (or equivalent) with improvement or no change in disease activity, documentation of glucocorticoid management plan within 12 months.",Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American College of Rheumatology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
@@ -1621,7 +1621,7 @@ Rheumatoid Arthritis (RA): Glucocorticoid Management,N/A,N/A,N/A,180,"Percentage
 2019
 2020
 2021
-2022",-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Elder Maltreatment Screen and Follow-Up Plan,N/A,N/A,N/A,181,Percentage of patients aged 65 years and older with a documented elder maltreatment screen using an Elder Maltreatment Screening tool on the date of encounter AND a documented follow-up plan on the date of the positive screen.,Patient Safety,Process,Preventive Care,X,-,Centers for Medicare & Medicaid Services,2017,Measure is still in program,X,-,-,-,-,X,-,-,"X
 2020
 2021
@@ -1667,7 +1667,7 @@ Elder Maltreatment Screen and Follow-Up Plan,N/A,N/A,N/A,181,Percentage of patie
 2022","X
 2020
 2021
-2022",-,-,-,-,N/A,X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,"N/A",X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Functional Outcome Assessment,N/A,N/A,N/A,182,Percentage of visits for patients aged 18 years and older with documentation of a current functional outcome assessment using a standardized functional outcome assessment tool on the date of the encounter AND documentation of a care plan based on identified functional outcome deficiencies on the date of the identified deficiencies.,Communication and Care Coordination,Process,Functional Outcomes,X,-,Centers for Medicare & Medicaid Services,2017,Measure is still in program,-,-,-,-,-,X,-,-,"X
 2020
 2021
@@ -1701,14 +1701,14 @@ Functional Outcome Assessment,N/A,N/A,N/A,182,Percentage of visits for patients 
 2022",-,-,-,-,"X
 2020
 2021
-2022",-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Colonoscopy Interval for Patients with a History of Adenomatous Polyps – Avoidance of Inappropriate Use,N/A,N/A,N/A,185,"Percentage of patients aged 18 years and older receiving a surveillance colonoscopy, with a history of prior adenomatous polyp(s) in previous colonoscopy findings, which had an interval of 3 or more years since their last colonoscopy.",Communication and Care Coordination,Process,Appropriate Use of Healthcare,X,X,American Gastroenterological Association,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Stroke and Stroke Rehabilitation: Thrombolytic Therapy,N/A,N/A,N/A,187,Percentage of patients aged 18 years and older with a diagnosis of acute ischemic stroke who arrive at the hospital within two hours of time last known well and for whom IV alteplase was initiated within three hours of time last known well.,Effective Clinical Care,Process,Medication Management,-,-,American Heart Association,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,"X
 2018
 2019
@@ -1719,27 +1719,27 @@ Stroke and Stroke Rehabilitation: Thrombolytic Therapy,N/A,N/A,N/A,187,Percentag
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Cataracts: 20/40 or Better Visual Acuity within 90 Days Following Cataract Surgery,CMS133v10,0565e,0565,191,Percentage of cataract surgeries for patients aged 18 years and older with a diagnosis of uncomplicated cataract and no significant ocular conditions impacting the visual outcome of surgery and had best-corrected visual acuity of 20/40 or better (distance or near) achieved in the operative eye within 90 days following the cataract surgery.,Effective Clinical Care,Outcome,Functional Outcomes,X,-,American Academy of Ophthalmology,2017,Measure is still in program,-,-,X,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Cataracts: Complications within 30 Days Following Cataract Surgery Requiring Additional Surgical Procedures,CMS132v8,0564e,0564,192,"Percentage of patients aged 18 years and older with a diagnosis of uncomplicated cataract who had cataract surgery and had any of a specified list of surgical procedures in the 30 days following cataract surgery which would indicate the occurrence of any of the following major complications: retained nuclear fragments, endophthalmitis, dislocated or wrong power IOL, retinal detachment, or wound dehiscence.",Patient Safety,Outcome,Management of Chronic Conditions,X,-,Physician Consortium for Performance Improvement Foundation (PCPI®),2017,2020,-,-,X,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
-2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Radiology: Stenosis Measurement in Carotid Imaging Reports,N/A,N/A,0507,195,"Percentage of final reports for carotid imaging studies (neck magnetic resonance angiography [MRA], neck computed tomography angiography [CTA], neck duplex ultrasound, carotid angiogram) performed that include direct or indirect reference to measurements of distal internal carotid diameter as the denominator for stenosis measurement.",Effective Clinical Care,Process,Preventable Healthcare Harm,-,-,American College of Radiology,2017,2022,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,"2017
 2018
 2019
 2020
-2021",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2021",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 "Ischemic Vascular Disease (IVD): Use of Aspirin or Another Antithrombotic
 ",CMS164v6,N/A,0068,204,"Percentage of patients 18 years of age and older who were diagnosed with acute myocardial infarction (AMI), coronary artery bypass graft (CABG) or percutaneous coronary interventions (PCI) in the 12 months prior to the measurement period, or who had an active diagnosis of ischemic vascular disease (IVD) during the measurement period, and who had documentation of use of aspirin or another antiplatelet during the measurement period",Effective Clinical Care,Process,Management of Chronic Conditions,-,-,National Committee for Quality Assurance,2017,2019,X,-,X,X,-,X,-,-,-,"2017
 2018",-,-,-,-,-,-,-,-,-,"2017
 2018",-,-,-,-,-,"2017
-2018",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2018",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 "HIV/AIDS: Sexually Transmitted Disease Screening for Chlamydia, Gonorrhea, and Syphilis",N/A,N/A,0409,205,"Percentage of patients aged 13 years and older with a diagnosis of HIV/AIDS for whom chlamydia, gonorrhea, and syphilis screenings were performed at least once since the diagnosis of HIV infection.",Effective Clinical Care,Process,Management of Chronic Conditions,-,-,Health Resources and Services Administration,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2018
 2019
@@ -1751,7 +1751,7 @@ Radiology: Stenosis Measurement in Carotid Imaging Reports,N/A,N/A,0507,195,"Per
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Functional Status Change for Patients with Knee Impairments,N/A,N/A,N/A,217,"A patient-reported outcome measure of risk-adjusted change in functional status for patients 14 years+ with knee impairments. The change in functional status (FS) is assessed using the FOTO Lower Extremity Physical Function (LEPF) patient-reported outcome measure (PROM). The measure is adjusted to patient characteristics known to be associated with FS outcomes (risk-adjusted) and used as a performance measure at the patient level, at the individual clinician level, and at the clinic level to assess quality. The measure is available as a computer adaptive test, for reduced patient burden, or a short form (static measure).",Communication and Care Coordination,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,"Focus on Therapeutic Outcomes, Inc.",2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,"X
 2020
 2021
@@ -1762,7 +1762,7 @@ Functional Status Change for Patients with Knee Impairments,N/A,N/A,N/A,217,"A p
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,N,Y,1,N/A,N/A,N,N,N,N,N,N,N,,,"This measure may produce variation in the method to determine denominator eligibility as some clinicians, groups, and virtual groups may map based on the expanded set of ICD-10 codes. ",N,N,N,N,N,Y (2020) ,2020,The substantive changes finalized for the 2020 performance period would require the benchmark be removed for the 2020 Benchmarking File.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,"-",-,N,Y,1,N/A,N/A,N,N,N,N,N,N,N,,,"This measure may produce variation in the method to determine denominator eligibility as some clinicians, groups, and virtual groups may map based on the expanded set of ICD-10 codes. ",N,N,N,N,N,"Y (2020) ",2020,The substantive changes finalized for the 2020 performance period would require the benchmark be removed for the 2020 Benchmarking File.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Functional Status Change for Patients with Hip Impairments,N/A,N/A,N/A,218,"A patient-reported outcome measure of risk-adjusted change in functional status for patients 14 years+ with hip impairments. The change in functional status (FS) is assessed using the FOTO Lower Extremity Physical Function (LEPF) patient-reported outcome measure (PROM). The measure is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician level, and at the clinic level to assess quality. The measure is available as a computer adaptive test, for reduced patient burden, or a short form (static measure). ",Communication and Care Coordination,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,"Focus on Therapeutic Outcomes, Inc.",2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,"X
 2020
 2021
@@ -1773,7 +1773,7 @@ Functional Status Change for Patients with Hip Impairments,N/A,N/A,N/A,218,"A pa
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,N,Y,1,N/A,N/A,N,N,N,N,N,N,N,,,"This measure may produce variation in the method to determine denominator eligibility as some clinicians, groups, and virtual groups may map based on the expanded set of ICD-10 codes. ",N,N,N,N,N,Y (2020) ,2020,The substantive changes finalized for the 2020 performance period would require the benchmark be removed for the 2020 Benchmarking File.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,"-",-,N,Y,1,N/A,N/A,N,N,N,N,N,N,N,,,"This measure may produce variation in the method to determine denominator eligibility as some clinicians, groups, and virtual groups may map based on the expanded set of ICD-10 codes. ",N,N,N,N,N,"Y (2020) ",2020,The substantive changes finalized for the 2020 performance period would require the benchmark be removed for the 2020 Benchmarking File.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 "Functional Status Change for Patients with Lower Leg, Foot or Ankle Impairments",N/A,N/A,N/A,219,"A patient-reported outcome measure of risk-adjusted change in functional status for patients 14 years+ with foot, ankle or lower leg impairments. The change in functional status (FS) is assessed using the FOTO Lower Extremity Physical Function (LEPF) patient- reported outcome measure (PROM). The measure is adjusted to patient characteristics known to be associated with FS outcomes (risk-adjusted) and used as a performance measure at the patient level, at the individual clinician level, and at the clinic level to assess quality. The measure is available as a computer adaptive test, for reduced patient burden, or a short form (static measure).",Communication and Care Coordination,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,"Focus on Therapeutic Outcomes, Inc.",2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,"X
 2020
 2021
@@ -1784,7 +1784,7 @@ Functional Status Change for Patients with Hip Impairments,N/A,N/A,N/A,218,"A pa
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,N,Y,1,N/A,N/A,N,N,N,N,N,N,N,,,"This measure may produce variation in the method to determine denominator eligibility as some clinicians, groups, and virtual groups may map based on the expanded set of ICD-10 codes. ",N,N,N,N,N,Y (2020) ,2020,The substantive changes finalized for the 2020 performance period would require the benchmark be removed for the 2020 Benchmarking File.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,"-",-,N,Y,1,N/A,N/A,N,N,N,N,N,N,N,,,"This measure may produce variation in the method to determine denominator eligibility as some clinicians, groups, and virtual groups may map based on the expanded set of ICD-10 codes. ",N,N,N,N,N,"Y (2020) ",2020,The substantive changes finalized for the 2020 performance period would require the benchmark be removed for the 2020 Benchmarking File.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Functional Status Change for Patients with Low Back Impairments,N/A,N/A,N/A,220,"A patient-reported outcome measure of risk-adjusted change in functional status for patients 14 years+ with low back impairments. The change in functional status (FS) is assessed using the FOTO Low Back FS patient-reported outcome measure (PROM). The measure is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician level, and at the clinic level to assess quality. The measure is available as a computer adaptive test, for reduced patient burden, or a short form (static measure).",Communication and Care Coordination,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,"Focus on Therapeutic Outcomes, Inc.",2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,"X
 2020
 2021
@@ -1795,7 +1795,7 @@ Functional Status Change for Patients with Low Back Impairments,N/A,N/A,N/A,220,
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,N,Y,1,N/A,N/A,N,N,N,N,N,N,N,,,"This measure may produce variation in the method to determine denominator eligibility as some clinicians, groups, and virtual groups may map based on the expanded set of ICD-10 codes. ",N,N,N,N,N,Y (2020) ,2020,The substantive changes finalized for the 2020 performance period would require the benchmark be removed for the 2020 Benchmarking File.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,"-",-,N,Y,1,N/A,N/A,N,N,N,N,N,N,N,,,"This measure may produce variation in the method to determine denominator eligibility as some clinicians, groups, and virtual groups may map based on the expanded set of ICD-10 codes. ",N,N,N,N,N,"Y (2020) ",2020,The substantive changes finalized for the 2020 performance period would require the benchmark be removed for the 2020 Benchmarking File.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Functional Status Change for Patients with Shoulder Impairments,N/A,N/A,N/A,221,"A patient-reported outcome measure of risk-adjusted change in functional status for patients 14 years+ with shoulder impairments. The change in functional status (FS) is assessed using the FOTO Shoulder FS patient-reported outcome measure (PROM). The measure is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician level, and at the clinic level to assess quality. The measure is available as a computer adaptive test, for reduced patient burden, or a short form (static measure).",Communication and Care Coordination,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,"Focus on Therapeutic Outcomes, Inc.",2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,"X
 2020
 2021
@@ -1806,7 +1806,7 @@ Functional Status Change for Patients with Shoulder Impairments,N/A,N/A,N/A,221,
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,N,Y,1,N/A,N/A,N,N,N,N,N,N,N,,,"This measure may produce variation in the method to determine denominator eligibility as some clinicians, groups, and virtual groups may map based on the expanded set of ICD-10 codes. ",N,N,N,N,N,Y (2020) ,2020,The substantive changes finalized for the 2020 performance period would require the benchmark be removed for the 2020 Benchmarking File.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,"-",-,N,Y,1,N/A,N/A,N,N,N,N,N,N,N,,,"This measure may produce variation in the method to determine denominator eligibility as some clinicians, groups, and virtual groups may map based on the expanded set of ICD-10 codes. ",N,N,N,N,N,"Y (2020) ",2020,The substantive changes finalized for the 2020 performance period would require the benchmark be removed for the 2020 Benchmarking File.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 "Functional Status Change for Patients with Elbow, Wrist or Hand Impairments",N/A,N/A,N/A,222,"A patient-reported outcome measure of risk-adjusted change in functional status for patients 14 years+ with elbow, wrist, or hand impairments. The change in functional status (FS) is assessed using the FOTO Elbow/Wrist/Hand FS patient-reported outcome measure (PROM). The measure is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician level, and at the clinic level to assess quality. The measure is available as a computer adaptive test, for reduced patient burden, or a short form (static measure).",Communication and Care Coordination,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,"Focus on Therapeutic Outcomes, Inc.",2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,"X
 2020
 2021
@@ -1817,9 +1817,9 @@ Functional Status Change for Patients with Shoulder Impairments,N/A,N/A,N/A,221,
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,N,Y,1,N/A,N/A,N,N,N,N,N,N,N,,,"This measure may produce variation in the method to determine denominator eligibility as some clinicians, groups, and virtual groups may map based on the expanded set of ICD-10 codes. ",N,N,N,N,N,Y (2020) ,2020,The substantive changes finalized for the 2020 performance period would require the benchmark be removed for the 2020 Benchmarking File.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Functional Status Change for Patients with General Orthopedic Impairments,N/A,N/A,0428,223,"A patient-reported outcome measure of risk-adjusted change in functional status (FS) for patients aged 14 years+ with general orthopedic impairments (neck, cranium, mandible, thoracic spine, ribs or other general orthopedic impairment). The change in FS is assessed using the General Orthopedic FS PROM (patient reported outcome measure) (©Focus on Therapeutic Outcomes, Inc.). The measure is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality. The measure is available as a computer adaptive test, for reduced patient burden, or a short form (static survey).",Communication and Care Coordination,Patient Reported Outcome,Functional Outcomes,X,-,"Focus on Therapeutic Outcomes, Inc.",2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2019,-,-,-,-,-,-,-,-,-,-,-,-,There are four submission criteria for this measure and one performance rate.,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Melanoma: Avoidance of Overutilization of Imaging Studies,N/A,N/A,N/A,224,"Percentage of patients, regardless of age, with a current diagnosis of Stage 0 through IIC melanoma or a history of melanoma of any stage, without signs or symptoms suggesting systemic spread, seen for an office visit during the one-year measurement period, for whom no diagnostic imaging studies were ordered",Efficiency and Cost Reduction,Process,Appropriate Use of Healthcare ,X,X,American Academy of Dermatology,2017,2019,-,-,-,-,-,X,-,-,-,-,-,-,-,-,"2017
+2022",-,-,-,-,-,-,-,-,-,-,-,-,"-",-,N,Y,1,N/A,N/A,N,N,N,N,N,N,N,,,"This measure may produce variation in the method to determine denominator eligibility as some clinicians, groups, and virtual groups may map based on the expanded set of ICD-10 codes. ",N,N,N,N,N,"Y (2020) ",2020,The substantive changes finalized for the 2020 performance period would require the benchmark be removed for the 2020 Benchmarking File.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Functional Status Change for Patients with General Orthopedic Impairments,N/A,N/A,0428,223,"A patient-reported outcome measure of risk-adjusted change in functional status (FS) for patients aged 14 years+ with general orthopedic impairments (neck, cranium, mandible, thoracic spine, ribs or other general orthopedic impairment). The change in FS is assessed using the General Orthopedic FS PROM (patient reported outcome measure) (©Focus on Therapeutic Outcomes, Inc.). The measure is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality. The measure is available as a computer adaptive test, for reduced patient burden, or a short form (static survey).",Communication and Care Coordination,Patient Reported Outcome,Functional Outcomes,X,-,"Focus on Therapeutic Outcomes, Inc.",2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2019,-,-,-,-,-,-,-,-,-,-,-,-,"There are four submission criteria for this measure and one performance rate.",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Melanoma: Avoidance of Overutilization of Imaging Studies,N/A,N/A,N/A,224,"Percentage of patients, regardless of age, with a current diagnosis of Stage 0 through IIC melanoma or a history of melanoma of any stage, without signs or symptoms suggesting systemic spread, seen for an office visit during the one-year measurement period, for whom no diagnostic imaging studies were ordered",Efficiency and Cost Reduction,Process,"Appropriate Use of Healthcare ",X,X,American Academy of Dermatology,2017,2019,-,-,-,-,-,X,-,-,-,-,-,-,-,-,"2017
 2018",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"The measure has multiple denominator options. This measure requires the reporting of only one reporting and performance rate. 
 
  For denominator criteria, encounter codes with Telehealth modifiers GQ, GT, 95 and POS 02 would not be considered encounter (eligible cases).",,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,Y (2018),First,2018,Annual analysis of ICD10 codes indicated greater than 10 percent impacted,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
@@ -1827,7 +1827,7 @@ Radiology: Reminder System for Screening Mammograms,N/A,N/A,0509,225,Percentage 
 2018
 2019
 2020
-2021",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2021",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,CMS138v10,0028e,0028,226,"Percentage of patients aged 18 years and older who were screened for tobacco use one or more times within the measurement period AND who received tobacco cessation intervention on the date of the encounter or within the previous 12 months if identified as a tobacco user.
 Three rates are reported:
 a. Percentage of patients aged 18 years and older who were screened for tobacco use one or more times within the measurement period.
@@ -2023,7 +2023,7 @@ Y (2021)","2018
 2021: This measure is being revised to every 12 months from every 24 months.
 
 2018: This measure was revised to be a multi-strata measure. The benchmarked rate is not limited to patient that assess positive and receive cessation. ",,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Controlling High Blood Pressure,CMS165v10,N/A,N/A,236,"Percentage of patients 18-85 years of age who had a diagnosis of essential hypertension starting before and continuing into, or starting during the first six months of the measurement period, and whose most recent blood pressure was adequately controlled (<140/90mmHg) during the measurement period.",Effective Clinical Care, Intermediate Outcome,Management of Chronic Conditions,X,-,National Committee for Quality Assurance,2017,Measure is still in program,X,-,X,X,-,X,-,-,-,"X
+Controlling High Blood Pressure,CMS165v10,N/A,N/A,236,"Percentage of patients 18-85 years of age who had a diagnosis of essential hypertension starting before and continuing into, or starting during the first six months of the measurement period, and whose most recent blood pressure was adequately controlled (<140/90mmHg) during the measurement period.",Effective Clinical Care," Intermediate Outcome",Management of Chronic Conditions,X,-,National Committee for Quality Assurance,2017,Measure is still in program,X,-,X,X,-,X,-,-,-,"X
 2017
 2018
 2019
@@ -2077,7 +2077,7 @@ Y (2022)","2020
 2021
 2022","May lead to overtreatment/inappropriate care
 **2022 information pending the performance data",X,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Use of High-Risk Medications in Older Adults,CMS156v10,N/A,0022,238,Percentage of patients 65 years of age and older who were ordered at least two high-risk medications from the same drug class.,Patient Safety,Process,Medication Management ,X,-,National Committee for Quality Assurance,2017,Measure is still in program,-,-,X,-,-,X,"X
+Use of High-Risk Medications in Older Adults,CMS156v10,N/A,0022,238,Percentage of patients 65 years of age and older who were ordered at least two high-risk medications from the same drug class.,Patient Safety,Process,"Medication Management ",X,-,National Committee for Quality Assurance,2017,Measure is still in program,-,-,X,-,-,X,"X
 2018
 2019
 2020
@@ -2143,8 +2143,8 @@ Childhood Immunization Status,CMS117v10,N/A,N/A,240,"Percentage of children 2 ye
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
- Cardiac Rehabilitation Patient Referral from an Outpatient Setting,N/A,N/A,0643,243,"Percentage of patients evaluated in an outpatient setting who within the previous 12 months have experienced an acute myocardial infarction (MI), coronary artery bypass graft (CABG) surgery, a percutaneous coronary intervention (PCI), cardiac valve surgery, or cardiac transplantation, or who have chronic stable angina (CSA) and have not already participated in an early outpatient cardiac rehabilitation/secondary prevention (CR) program for the qualifying event/diagnosis who were referred to a CR program.",Communication and Care Coordination,Process,Preventive Care,X,-,American Heart Association,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,"X
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+" Cardiac Rehabilitation Patient Referral from an Outpatient Setting",N/A,N/A,0643,243,"Percentage of patients evaluated in an outpatient setting who within the previous 12 months have experienced an acute myocardial infarction (MI), coronary artery bypass graft (CABG) surgery, a percutaneous coronary intervention (PCI), cardiac valve surgery, or cardiac transplantation, or who have chronic stable angina (CSA) and have not already participated in an early outpatient cardiac rehabilitation/secondary prevention (CR) program for the qualifying event/diagnosis who were referred to a CR program.",Communication and Care Coordination,Process,Preventive Care,X,-,American Heart Association,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,"X
 2018
 2019
 2020
@@ -2159,14 +2159,14 @@ Childhood Immunization Status,CMS117v10,N/A,N/A,240,"Percentage of children 2 ye
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Barrett’s Esophagus,N/A,N/A,N/A,249,Percentage of esophageal biopsy reports that document the presence of Barrett’s mucosa that also include a statement about dysplasia.,Effective Clinical Care,Process,Transfer of Health Information and Interoperability,-,-,College of American Pathologists,2017,Measure is still in program,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,Claims: Only one QDC per date of service for a patient is required. ,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"Claims: Only one QDC per date of service for a patient is required. ",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Radical Prostatectomy Pathology Reporting,N/A,N/A,N/A,250,"Percentage of radical prostatectomy pathology reports that include the pT category, the pN category, the Gleason score and a statement about margin status.",Effective Clinical Care,Process,Transfer of Health Information and Interoperability,-,-,College of American Pathologists,2017,Measure is still in program,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
@@ -2179,7 +2179,7 @@ Radical Prostatectomy Pathology Reporting,N/A,N/A,N/A,250,"Percentage of radical
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,Claims: Only one QDC per date of service for a patient is required. ,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"Claims: Only one QDC per date of service for a patient is required. ",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Quantitative Immunohistochemical (IHC) Evaluation of Human Epidermal Growth Factor Receptor 2 Testing (HER2) for Breast Cancer Patients,N/A,N/A,1855,251,This is a measure based on whether quantitative evaluation of Human Epidermal Growth Factor Receptor 2 Testing (HER2) by immunohistochemistry (IHC) uses the system recommended in the current ASCO/CAP Guidelines for Human Epidermal Growth Factor Receptor 2 Testing in breast cancer,Effective Clinical Care,Process,Appropriate Use of Healthcare,-,-,College of American Pathologists,2017,2019,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"Claims: The measure should be reported each time a quantitative HER2 IHC pathology examination is performed during the performance period for patients with breast cancer; however, only one QDC per date of service for a patient is required.",,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Ultrasound Determination of Pregnancy Location for Pregnant Patients with Abdominal Pain,N/A,N/A,N/A,254,Percentage of pregnant female patients aged 14 to 50 who present to the emergency department (ED) with a chief complaint of abdominal pain or vaginal bleeding who receive a trans-abdominal or trans-vaginal ultrasound to determine pregnancy location.,Effective Clinical Care,Process,Preventive Care,-,-,American College of Emergency Physicians,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,"X
@@ -2198,21 +2198,21 @@ Rh Immunoglobulin (Rhogam) for Rh-Negative Pregnant Women at Risk of Fetal Blood
 Counted once per claim for each TIN/NPI/Bene
 •  Multiple ICD10 codes on a single claim count once.           
 •  These will be treated as episode measures with no special coding required.                                                                                                                               •  Line items with CPT I coding require a place of service code ""23"" to be included in the denominator.",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Statin Therapy at Discharge after Lower Extremity Bypass (LEB) ,N/A,N/A,1519,257,Percentage of patients aged 18 years and older undergoing infra-inguinal lower extremity bypass who are prescribed a statin medication at discharge,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,Society for Vascular Surgeons,2017,2019,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2018,N/A,,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+"Statin Therapy at Discharge after Lower Extremity Bypass (LEB) ",N/A,N/A,1519,257,Percentage of patients aged 18 years and older undergoing infra-inguinal lower extremity bypass who are prescribed a statin medication at discharge,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,Society for Vascular Surgeons,2017,2019,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2018,"N/A",,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Rate of Open Repair of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post-Operative Day #7),N/A,N/A,N/A,258,Percent of patients undergoing open repair of small or moderate sized non-ruptured infrarenal abdominal aortic aneurysms (AAA) who do not experience a major complication (discharge to home no later than post-operative day #7).,Patient Safety,Outcome,Appropriate Use of Healthcare,X,-,Society for Vascular Surgeons,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022","N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post-Operative Day #2),N/A,N/A,N/A,259,Percent of patients undergoing endovascular repair of small or moderate non-ruptured infrarenal abdominal aortic aneurysms (AAA) that do not experience a major complication (discharged to home no later than post-operative day #2).,Patient Safety,Outcome,Appropriate Use of Healthcare,X,-,Society for Vascular Surgeons,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2017,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022","N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 "Rate of Carotid Endarterectomy (CEA) for Asymptomatic Patients, without Major Complications (Discharged to Home by Post-Operative Day #2)",N/A,N/A,N/A,260,Percent of asymptomatic patients undergoing Carotid Endarterectomy (CEA) who are discharged to home no later than post-operative day #2.,Patient Safety,Outcome,Appropriate Use of Healthcare,X,-,Society for Vascular Surgeons,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2021
 2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
@@ -2221,18 +2221,18 @@ Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured In
 2019
 2020
 2021
-2022",N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022","N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Referral for Otologic Evaluation for Patients with Acute or Chronic Dizziness,N/A,N/A,N/A,261,Percentage of patients aged birth and older referred to a physician (preferably a physician specially trained in disorders of the ear) for an otologic evaluation subsequent to an audiologic evaluation after presenting with acute or chronic dizziness.,Communication and Care Coordination,Process,Transfer of Health Information and Interoperability,X,-,Audiology Quality Consortium,2017,Measure is still in program,X,-,-,-,-,X,-,-,"X
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Image Confirmation of Successful Excision of Image-Localized Breast Lesion,N/A,N/A,N/A,262,"Image confirmation of lesion(s) targeted for image guided excisional biopsy or image guided partial mastectomy in patients with nonpalpable, image-detected breast lesion(s). Lesions may include: microcalcifications, mammographic or sonographic mass or architectural distortion, focal suspicious abnormalities on magnetic resonance imaging (MRI) or other breast imaging amenable to localization such as positron emission tomography (PET) mammography, or a biopsy marker demarcating site of confirmed pathology as established by previous core biopsy.",Patient Safety,Process,Preventable Healthcare Harm,X,-,American Society of Breast Surgeons,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Preoperative Diagnosis of Breast Cancer,N/A,N/A,N/A,263,The percent of patients undergoing breast cancer operations who obtained the diagnosis of breast cancer preoperatively by a minimally invasive biopsy method,Effective Clinical Care,Process,Preventable Healthcare Harm,-,-,American Society of Breast Surgeons,2017,2019,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Image Confirmation of Successful Excision of Image-Localized Breast Lesion,N/A,N/A,N/A,262,"Image confirmation of lesion(s) targeted for image guided excisional biopsy or image guided partial mastectomy in patients with nonpalpable, image-detected breast lesion(s). Lesions may include: microcalcifications, mammographic or sonographic mass or architectural distortion, focal suspicious abnormalities on magnetic resonance imaging (MRI) or other breast imaging amenable to localization such as positron emission tomography (PET) mammography, or a biopsy marker demarcating site of confirmed pathology as established by previous core biopsy.",Patient Safety,Process,Preventable Healthcare Harm,X,-,American Society of Breast Surgeons,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Preoperative Diagnosis of Breast Cancer,N/A,N/A,N/A,263,The percent of patients undergoing breast cancer operations who obtained the diagnosis of breast cancer preoperatively by a minimally invasive biopsy method,Effective Clinical Care,Process,Preventable Healthcare Harm,-,-,American Society of Breast Surgeons,2017,2019,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Sentinel Lymph Node Biopsy for Invasive Breast Cancer,N/A,N/A,N/A,264,"The percentage of clinically node negative (clinical stage T1N0M0 or T2N0M0) breast cancer patients before or after neoadjuvant systemic therapy, who undergo a sentinel lymph node (SLN) procedure.",Effective Clinical Care,Process,Appropriate Use of Healthcare,-,-,American Society of Breast Surgeons,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Biopsy Follow-Up,N/A,N/A,N/A,265,Percentage of new patients whose biopsy results have been reviewed and communicated to the primary care/referring physician and patient.,Communication and Care Coordination,Process,Transfer of Health Information and Interoperability,X,-,American Academy of Dermatology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,"X
 2017
 2018
@@ -2256,7 +2256,7 @@ Biopsy Follow-Up,N/A,N/A,N/A,265,Percentage of new patients whose biopsy results
 2019
 2020
 2021
-2022",-,N/A,X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,"N/A",X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Epilepsy: Counseling for Women of Childbearing Potential with Epilepsy,N/A,N/A,N/A,268,Percentage of all patients of childbearing potential (12 years and older) diagnosed with epilepsy who were counseled at least once a year about how epilepsy and its treatment may affect contraception and pregnancy.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Academy of Neurology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
@@ -2267,14 +2267,14 @@ Epilepsy: Counseling for Women of Childbearing Potential with Epilepsy,N/A,N/A,N
 Inflammatory Bowel Disease (IBD): Preventive Care: Corticosteroid Related Iatrogenic Injury – Bone Loss Assessment,N/A,N/A,N/A,271,"Percentage of patients regardless of age with an inflammatory bowel disease encounter who were prescribed prednisone equivalents greater than or equal to 10 mg/day for 60 or greater consecutive days or a single prescription equating to 600 mg prednisone or greater for all fills and were documented for risk of bone loss once during the reporting year or the previous calendar year. Individuals who received an assessment for bone loss during the year prior and current year are considered adequately screened to prevent overuse of X-ray assessment.
 ",Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Gastroenterological Association,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
-2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Inflammatory Bowel Disease (IBD): Assessment of Hepatitis B Virus (HBV) Status Before Initiating Anti-TNF (Tumor Necrosis Factor) Therapy,N/A,N/A,N/A,275,Percentage of patients with a diagnosis of inflammatory bowel disease (IBD) who had Hepatitis B Virus (HBV) status assessed and results interpreted prior to initiating anti-TNF (tumor necrosis factor) therapy.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Gastroenterological Association,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,2018,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,2018,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Sleep Apnea: Assessment of Sleep Symptoms,N/A,N/A,N/A,276,"Percentage of visits for patients aged 18 years and older with a diagnosis of obstructive sleep apnea that includes documentation of an assessment of sleep symptoms, including presence or absence of snoring and daytime sleepiness",Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Academy of Sleep Medicine,2017,2019,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2018,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-," For denominator criteria, encounter codes with Telehealth modifiers GQ, GT, 95 and POS 02 would not be considered encounter (eligible cases).",,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Sleep Apnea: Severity Assessment at Initial Diagnosis,N/A,N/A,N/A,277,Percentage of patients aged 18 years and older with a diagnosis of obstructive sleep apnea who had an apnea hypopnea index (AHI) or a respiratory disturbance index (RDI) measured at the time of initial diagnosis.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Academy of Sleep Medicine,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2019
@@ -2290,8 +2290,8 @@ Sleep Apnea: Severity Assessment at Initial Diagnosis,N/A,N/A,N/A,277,Percentage
 2022",-,-,-,-,-,-,-,"X
 2020
 2021
-2022",-,-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Sleep Apnea: Positive Airway Pressure Therapy Prescribed,N/A,N/A,N/A,278,Percentage of patients aged 18 years and older with a diagnosis of moderate or severe obstructive sleep apnea who were prescribed positive airway pressure therapy,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Academy of Sleep Medicine,2017,2019,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2018,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-," For denominator criteria, encounter codes with Telehealth modifiers GQ, GT, 95 and POS 02 would not be considered encounter (eligible cases).",, N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Sleep Apnea: Positive Airway Pressure Therapy Prescribed,N/A,N/A,N/A,278,Percentage of patients aged 18 years and older with a diagnosis of moderate or severe obstructive sleep apnea who were prescribed positive airway pressure therapy,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Academy of Sleep Medicine,2017,2019,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2018,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-," For denominator criteria, encounter codes with Telehealth modifiers GQ, GT, 95 and POS 02 would not be considered encounter (eligible cases).",," N",N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Sleep Apnea: Assessment of Adherence to Positive Airway Pressure Therapy,N/A,N/A,N/A,279,Percentage of visits for patients aged 18 years and older with a diagnosis of obstructive sleep apnea who were prescribed positive airway pressure therapy who had documentation that adherence to positive airway pressure therapy was objectively measured.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Academy of Sleep Medicine,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2019
 2020
@@ -2306,7 +2306,7 @@ Sleep Apnea: Assessment of Adherence to Positive Airway Pressure Therapy,N/A,N/A
 2022",-,-,-,-,-,-,-,"X
 2020
 2021
-2022",-,-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Dementia: Cognitive Assessment,CMS149v10,2872e,N/A,281,"Percentage of patients, regardless of age, with a diagnosis of dementia for whom an assessment of cognition is performed and the results reviewed at least once within a 12-month period.",Effective Clinical Care,Process,"Prevention, Treatment, and Management of Mental Health",-,-,American Academy of Neurology,2017,Measure is still in program,-,-,X,-,-,-,-,-,-,-,-,-,"X
 2020
 2021
@@ -2329,7 +2329,7 @@ Dementia: Cognitive Assessment,CMS149v10,2872e,N/A,281,"Percentage of patients, 
 2022",-,-,-,-,-,-,-,-,-,-,"X
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Dementia: Functional Status Assessment,N/A,N/A,N/A,282,Percentage of patients with dementia for whom an assessment of functional status was performed at least once in the last 12 months.,Effective Clinical Care,Process,"Prevention, Treatment, and Management of Mental Health",-,-,American Academy of Neurology/American Psychiatric Association,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,"X
 2020
 2021
@@ -2349,7 +2349,7 @@ Dementia: Functional Status Assessment,N/A,N/A,N/A,282,Percentage of patients wi
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,2020,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,2020,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 "Dementia Associated Behavioral and Psychiatric Symptoms Screening and Management
 ",N/A,N/A,N/A,283,"Percentage of patients with dementia for whom there was a documented screening for behavioral and psychiatric symptoms, including depression, and for whom, if symptoms screening was positive, there was also documentation of recommendations for management in the last 12 months.",Effective Clinical Care,Process,"Prevention, Treatment, and Management of Mental Health",-,-,American Academy of Neurology/American Psychiatric Association,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,"X
 2020
@@ -2372,8 +2372,8 @@ Dementia: Functional Status Assessment,N/A,N/A,N/A,282,Percentage of patients wi
 2021
 2022",-,-,-,-,-,-,-,-,-,-,"X
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Dementia: Management of Neuropsychiatric Symptoms ,N/A,N/A,N/A,284,"Percentage of patients, regardless of age, with a diagnosis of dementia who have one or more neuropsychiatric symptoms who received or were recommended to receive an intervention for neuropsychiatric symptoms within a 12 month period",Effective Clinical Care,Process,"Prevention, Treatment, and Management of Mental Health",-,-,American Academy of Neurology,2017,2018,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2017,-,2017,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+"Dementia: Management of Neuropsychiatric Symptoms ",N/A,N/A,N/A,284,"Percentage of patients, regardless of age, with a diagnosis of dementia who have one or more neuropsychiatric symptoms who received or were recommended to receive an intervention for neuropsychiatric symptoms within a 12 month period",Effective Clinical Care,Process,"Prevention, Treatment, and Management of Mental Health",-,-,American Academy of Neurology,2017,2018,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2017,-,2017,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Dementia: Safety Concern Screening and Follow-Up for Patients with Dementia,N/A,N/A,N/A,286,"Percentage of patients with dementia or their caregiver(s) for whom there was a documented safety concerns screening in two domains of risk: 1) dangerousness to self or others and 2) environmental risks; and if safety concerns screening was positive in the last 12 months, there was documentation of mitigation recommendations, including but not limited to referral to other resources.
 ",Patient Safety,Process,"Prevention, Treatment, and Management of Mental Health",X,-,American Academy of Neurology/American Psychiatric Association,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,"X
 2020
@@ -2396,7 +2396,7 @@ Dementia: Safety Concern Screening and Follow-Up for Patients with Dementia,N/A,
 2021
 2022",-,-,-,-,-,-,-,-,-,-,"X
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Dementia: Education and Support of Caregivers for Patients with Dementia,N/A,N/A,N/A,288,Percentage of patients with dementia whose caregiver(s) were provided with education on dementia disease management and health behavior changes AND were referred to additional resources for support in the last 12 months.,Communication and Care Coordination,Process,"Prevention, Treatment, and Management of Mental Health",X,-,American Academy of Neurology/American Psychiatric Association,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,"X
 2020
 2021
@@ -2419,41 +2419,41 @@ Dementia: Education and Support of Caregivers for Patients with Dementia,N/A,N/A
 2022",-,-,-,-,-,-,-,-,-,-,"X
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Assessment of Mood Disorders and Psychosis for Patients with Parkinson’s Disease,N/A,N/A,N/A,290,"Percentage of all patients with a diagnosis of Parkinson’s Disease [PD] who were assessed for depression, anxiety, apathy, AND psychosis once during the measurement period.",Effective Clinical Care,Process,"Prevention, Treatment, and Management of Mental Health",-,-,American Academy of Neurology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Assessment of Cognitive Impairment or Dysfunction for Patients with Parkinson’s Disease,N/A,N/A,N/A,291,Percentage of all patients with a diagnosis of Parkinson’s Disease [PD] who were assessed for cognitive impairment or dysfunction once during the measurement period.,Effective Clinical Care,Process,"Prevention, Treatment, and Management of Mental Health",-,-,American Academy of Neurology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Rehabilitative Therapy Referral for Patients with Parkinson’s Disease,N/A,N/A,N/A,293,"Percentage of all patients with a diagnosis of Parkinson’s Disease  who were referred to physical, occupational, speech, or recreational therapy once during the measurement period.",Communication and Care Coordination,Process,Management of Chronic Conditions,X,-,American Academy of Neurology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Parkinson’s Disease: Parkinson’s Disease Medical and Surgical Treatment Options Reviewed ,N/A,N/A,N/A,294,"All patients with a diagnosis of Parkinson’s disease (or caregiver(s), as appropriate) who had the Parkinson’s disease treatment options (e.g., non-pharmacological treatment, pharmacological treatment, or surgical treatment) reviewed at least annually",Communication and Care Coordination,Process,-,X,-,American Academy of Neurology,2017,2018,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2017,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+"Parkinson’s Disease: Parkinson’s Disease Medical and Surgical Treatment Options Reviewed ",N/A,N/A,N/A,294,"All patients with a diagnosis of Parkinson’s disease (or caregiver(s), as appropriate) who had the Parkinson’s disease treatment options (e.g., non-pharmacological treatment, pharmacological treatment, or surgical treatment) reviewed at least annually",Communication and Care Coordination,Process,-,X,-,American Academy of Neurology,2017,2018,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2017,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Cataracts: Improvement in Patient’s Visual Function within 90 Days Following Cataract Surgery,N/A,N/A,N/A,303,"Percentage of patients aged 18 years and older who had cataract surgery and had improvement in visual function achieved within 90 days following the cataract surgery, based on completing a pre-operative and post-operative visual function survey.",Person and Caregiver-Centered Experience and Outcomes,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,American Academy of Ophthalmology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Cataracts: Patient Satisfaction within 90 Days Following Cataract Surgery,N/A,N/A,N/A,304,"Percentage of patients aged 18 years and older who had cataract surgery and were satisfied with their care within 90 days following the cataract surgery, based on completion of the Consumer Assessment of Healthcare Providers and Systems Surgical Care Survey.",Person and Caregiver-Centered Experience and Outcomes,Patient Engagement/Experience,Functional Outcomes,X,-,American Academy of Ophthalmology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Initiation and Engagement of Alcohol and Other Drug Dependence Treatment,CMS137v10,N/A,N/A,305,"Percentage of patients 13 years of age and older with a new episode of alcohol or other drug abuse or (AOD) dependence who received the following. Two rates are reported.
 
 a. Percentage of patients who initiated treatment including either an intervention or medication for the treatment of AOD abuse or dependence within 14 days of the diagnosis.
@@ -2473,7 +2473,7 @@ b. Percentage of patients who engaged in ongoing treatment including two additio
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,The eCQM measure requires the reporting of two performance rates. An overall performance rate needs to be calculated for this measure for benchmarking. A simple average of the performance rates will be determined to calculate the overall performance rate.,-,N,N/A,2,Simple Average,"Rate 1: Percentage of patients who initiated treatment including either an intervention or medication for the treatment of AOD abuse or dependence within 14 days of the diagnosis 
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,"The eCQM measure requires the reporting of two performance rates. An overall performance rate needs to be calculated for this measure for benchmarking. A simple average of the performance rates will be determined to calculate the overall performance rate.",-,N,N/A,2,Simple Average,"Rate 1: Percentage of patients who initiated treatment including either an intervention or medication for the treatment of AOD abuse or dependence within 14 days of the diagnosis 
 Rate 2: Percentage of patients who engaged in ongoing treatment including two additional interventions or a medication for the treatment of AOD abuse or dependence within 34 days of the initiation visit. For patients who initiated treatment with a medication, at least one of the two engagement events must be a treatment intervention.",N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Cervical Cancer Screening,CMS124v10,N/A,N/A,309,"Percentage of women 21-64 years of age who were screened for cervical cancer using either of the following criteria:
 *  Women age 21-64 who had cervical cytology performed within the last 3 years
@@ -2494,7 +2494,7 @@ Cervical Cancer Screening,CMS124v10,N/A,N/A,309,"Percentage of women 21-64 years
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Chlamydia Screening for Women,CMS153v10,N/A,N/A,310,Percentage of women 16-24 years of age who were identified as sexually active and who had at least one test for chlamydia during the measurement period.,Community/Population Health,Process,Preventive Care,-,-,National Committee for Quality Assurance,2017,Measure is still in program,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
@@ -2507,8 +2507,8 @@ Chlamydia Screening for Women,CMS153v10,N/A,N/A,310,Percentage of women 16-24 ye
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Use of Imaging Studies for Low Back Pain,CMS166v6,N/A,0052,312,"Percentage of patients 18-50 years of age with a diagnosis of low back pain who did not have an imaging study (plain X-ray, MRI, CT scan) within 28 days of the diagnosis.",Efficiency and Cost Reduction,Process,-,X,X,National Committee for Quality Assurance,2017,2018,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2017,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2017,-,-,-,2017,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Use of Imaging Studies for Low Back Pain,CMS166v6,N/A,0052,312,"Percentage of patients 18-50 years of age with a diagnosis of low back pain who did not have an imaging study (plain X-ray, MRI, CT scan) within 28 days of the diagnosis.",Efficiency and Cost Reduction,Process,-,X,X,National Committee for Quality Assurance,2017,2018,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2017,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2017,-,-,-,2017,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented,CMS22v10,N/A,N/A,317,"Percentage of patient visits for patients aged 18 years and older seen during the measurement period who were screened for high blood pressure AND a recommended follow-up plan is documented, as indicated, if blood pressure is elevated or hypertensive.",Community/Population Health,Process,Preventive Care,-,-,Centers for Medicare & Medicaid Services,2017,Measure is still in program,X,-,X,-,-,X,"X
 2017
 2018
@@ -2647,7 +2647,7 @@ Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up D
 2019
 2020
 2021
-2022",N/A,X,N,Y,1,N/A,N/A,N,,,,,,,,,,Y (2021),N,Y (2021),N,N,Y (2021),2021,2021: The frequency is being changed to every visit.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022","N/A",X,N,Y,1,N/A,N/A,N,,,,,,,,,,Y (2021),N,Y (2021),N,N,Y (2021),2021,2021: The frequency is being changed to every visit.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Falls: Screening for Future Fall Risk,CMS139v10,N/A,0101,318,Percentage of patients 65 years of age and older who were screened for future fall risk during the measurement period.,Patient Safety,Process,Preventable Healthcare Harm,X,-,National Committee for Quality Assurance,2017,Measure is still in program,-,-,X,X,-,-,-,-,"X
 2020
 2021
@@ -2679,7 +2679,7 @@ Falls: Screening for Future Fall Risk,CMS139v10,N/A,0101,318,Percentage of patie
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,N/A,-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients,N/A,N/A,0658,320,Percentage of patients aged 50 to 75 years of age receiving a screening colonoscopy without biopsy or polypectomy who had a recommended follow-up interval of at least 10 years for repeat colonoscopy documented in their colonoscopy report.,Communication and Care Coordination,Process,Appropriate Use of Healthcare,X,X,American Gastroenterological Association,2017,Measure is still in program,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
@@ -2709,31 +2709,31 @@ CAHPS for MIPs Clinician/Group Survey,N/A,N/A,0005,321,"The Consumer Assessment 
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N,N/A,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low-Risk Surgery Patients,N/A,N/A,N/A,322,"Percentage of stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), or cardiac magnetic resonance (CMR) performed in low-risk surgery patients 18 years or older for preoperative evaluation during the 12-month submission period.",Efficiency and Cost Reduction,Efficiency,Appropriate Use of Healthcare ,X,X,American College of Cardiology Foundation,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,"X
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N,N/A,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low-Risk Surgery Patients,N/A,N/A,N/A,322,"Percentage of stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), or cardiac magnetic resonance (CMR) performed in low-risk surgery patients 18 years or older for preoperative evaluation during the 12-month submission period.",Efficiency and Cost Reduction,Efficiency,"Appropriate Use of Healthcare ",X,X,American College of Cardiology Foundation,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Routine Testing After Percutaneous Coronary Intervention (PCI),N/A,N/A,N/A,323,"Percentage of all stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), and cardiovascular magnetic resonance (CMR) performed in patients aged 18 years and older routinely after percutaneous coronary intervention (PCI), with reference to timing of test after PCI and symptom status.",Efficiency and Cost Reduction,Efficiency,Appropriate Use of Healthcare ,X,X,American College of Cardiology Foundation,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,"X
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Routine Testing After Percutaneous Coronary Intervention (PCI),N/A,N/A,N/A,323,"Percentage of all stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), and cardiovascular magnetic resonance (CMR) performed in patients aged 18 years and older routinely after percutaneous coronary intervention (PCI), with reference to timing of test after PCI and symptom status.",Efficiency and Cost Reduction,Efficiency,"Appropriate Use of Healthcare ",X,X,American College of Cardiology Foundation,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-"Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Testing in Asymptomatic, Low-Risk Patients",N/A,N/A,N/A,324,"Percentage of all stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), and cardiovascular magnetic resonance (CMR) performed in asymptomatic, low coronary heart disease (CHD) risk patients 18 years and older for initial detection and risk assessment.",Efficiency and Cost Reduction,Efficiency,Appropriate Use of Healthcare ,X,X,American College of Cardiology Foundation,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,"X
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+"Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Testing in Asymptomatic, Low-Risk Patients",N/A,N/A,N/A,324,"Percentage of all stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), and cardiovascular magnetic resonance (CMR) performed in asymptomatic, low coronary heart disease (CHD) risk patients 18 years and older for initial detection and risk assessment.",Efficiency and Cost Reduction,Efficiency,"Appropriate Use of Healthcare ",X,X,American College of Cardiology Foundation,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Adult Major Depressive Disorder (MDD): Coordination of Care of Patients with Specific Comorbid Conditions,N/A,N/A,N/A,325,"Percentage of medical records of patients aged 18 years and older with a diagnosis of major depressive disorder (MDD) and a specific diagnosed comorbid condition (diabetes, coronary artery disease, ischemic stroke, intracranial hemorrhage, chronic kidney disease [stages 4 or 5], End Stage Renal Disease [ESRD] or congestive heart failure) being treated by another clinician with communication to the clinician treating the comorbid condition.",Communication and Care Coordination,Process,"Prevention, Treatment, and Management of Mental Health",X,-,American Psychiatric Association,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
-2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Atrial Fibrillation and Atrial Flutter: Chronic Anticoagulation Therapy,N/A,N/A,1525,326,Percentage of patients aged 18 years and older with atrial fibrillation (AF) or atrial flutter who were prescribed an FDA-approved oral anticoagulant drug for the prevention of thromboembolism during the measurement period.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,American Heart Association,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,"X
 2017
 2018
@@ -2756,14 +2756,14 @@ Atrial Fibrillation and Atrial Flutter: Chronic Anticoagulation Therapy,N/A,N/A,
 2019
 2020
 2021
-2022",-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,Y (2019),,,,,Y (2019),First,2019,Annual analysis of ICD10 codes indicated greater than 10 percent impacted,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,Y (2019),,,,,Y (2019),First,2019,Annual analysis of ICD10 codes indicated greater than 10 percent impacted,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Pediatric Kidney Disease: Adequacy of Volume Management,N/A,N/A,N/A,327,Percentage of calendar months within a 12-month period during which patients aged 17 years and younger with a diagnosis of End Stage Renal Disease (ESRD) undergoing maintenance hemodialysis in an outpatient dialysis facility have an assessment of the adequacy of volume management from a nephrologist,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,Renal Physicians Association,2017,2019,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2018,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-," For denominator criteria, encounter codes with Telehealth modifiers GQ, GT, 95 and POS 02 would not be considered encounter (eligible cases).",,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Pediatric Kidney Disease: ESRD Patients Receiving Dialysis: Hemoglobin Level < 10 g/dL,N/A,N/A,1667,328,Percentage of calendar months within a 12-month period during which patients aged 17 years and younger with a diagnosis of End Stage Renal Disease (ESRD) receiving hemodialysis or peritoneal dialysis have a hemoglobin level < 10 g/dL.,Effective Clinical Care, Intermediate Outcome,Management of Chronic Conditions,X,-,Renal Physicians Association,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2018
-2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,Y,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Adult Kidney Disease: Catheter Use at Initiation of Hemodialysis,N/A,N/A,N/A,329,"Percentage of patients aged 18 years and older with a diagnosis of End Stage Renal Disease (ESRD) who initiate maintenance hemodialysis during the measurement period, whose mode of vascular access is a catheter at the time maintenance hemodialysis is initiated.",Effective Clinical Care,Outcome,Appropriate Use of Healthcare ,X,-,Renal Physicians Association,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,Y,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Adult Kidney Disease: Catheter Use for Greater Than or Equal to 90 Days,N/A,N/A,N/A,330,Percentage of patients aged 18 years and older with a diagnosis of End Stage Renal Disease (ESRD) receiving maintenance hemodialysis for greater than or equal to 90 days whose mode of vascular access is a catheter.,Patient Safety,Outcome,Appropriate Use of Healthcare ,X,X,Renal Physicians Association,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2018
-2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,Y,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Adult Sinusitis: Antibiotic Prescribed for Acute Viral Sinusitis (Overuse),N/A,N/A,N/A,331,"Percentage of patients, aged 18 years and older, with a diagnosis of acute viral sinusitis who were prescribed an antibiotic within 10 days after onset of symptoms.",Efficiency and Cost Reduction,Process,Appropriate Use of Healthcare ,X,X,American Academy of Otolaryngology – Head and Neck Surgery Foundation,2017,Measure is still in program,-,-,-,-,-,X,"X
+Pediatric Kidney Disease: ESRD Patients Receiving Dialysis: Hemoglobin Level < 10 g/dL,N/A,N/A,1667,328,Percentage of calendar months within a 12-month period during which patients aged 17 years and younger with a diagnosis of End Stage Renal Disease (ESRD) receiving hemodialysis or peritoneal dialysis have a hemoglobin level < 10 g/dL.,Effective Clinical Care," Intermediate Outcome",Management of Chronic Conditions,X,-,Renal Physicians Association,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2018
+2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,Y,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Adult Kidney Disease: Catheter Use at Initiation of Hemodialysis,N/A,N/A,N/A,329,"Percentage of patients aged 18 years and older with a diagnosis of End Stage Renal Disease (ESRD) who initiate maintenance hemodialysis during the measurement period, whose mode of vascular access is a catheter at the time maintenance hemodialysis is initiated.",Effective Clinical Care,Outcome,"Appropriate Use of Healthcare ",X,-,Renal Physicians Association,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,Y,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Adult Kidney Disease: Catheter Use for Greater Than or Equal to 90 Days,N/A,N/A,N/A,330,Percentage of patients aged 18 years and older with a diagnosis of End Stage Renal Disease (ESRD) receiving maintenance hemodialysis for greater than or equal to 90 days whose mode of vascular access is a catheter.,Patient Safety,Outcome,"Appropriate Use of Healthcare ",X,X,Renal Physicians Association,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2018
+2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,Y,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Adult Sinusitis: Antibiotic Prescribed for Acute Viral Sinusitis (Overuse),N/A,N/A,N/A,331,"Percentage of patients, aged 18 years and older, with a diagnosis of acute viral sinusitis who were prescribed an antibiotic within 10 days after onset of symptoms.",Efficiency and Cost Reduction,Process,"Appropriate Use of Healthcare ",X,X,American Academy of Otolaryngology – Head and Neck Surgery Foundation,2017,Measure is still in program,-,-,-,-,-,X,"X
 2017
 2021
 2022",-,-,-,-,-,-,-,-,-,-,"X
@@ -2793,8 +2793,8 @@ Adult Sinusitis: Antibiotic Prescribed for Acute Viral Sinusitis (Overuse),N/A,N
 2019
 2020
 2021
-2022",-,-,N/A,-,Y,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Adult Sinusitis: Appropriate Choice of Antibiotic: Amoxicillin With or Without Clavulanate Prescribed for Patients with Acute Bacterial Sinusitis (Appropriate Use),N/A,N/A,N/A,332,"Percentage of patients aged 18 years and older with a diagnosis of acute bacterial sinusitis that were prescribed amoxicillin, with or without clavulanate, as a first line antibiotic at the time of diagnosis.",Efficiency and Cost Reduction,Process,Appropriate Use of Healthcare ,X,X,American Academy of Otolaryngology – Head and Neck Surgery Foundation,2017,Measure is still in program,-,-,-,-,-,X,"X
+2022",-,-,"N/A",-,Y,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Adult Sinusitis: Appropriate Choice of Antibiotic: Amoxicillin With or Without Clavulanate Prescribed for Patients with Acute Bacterial Sinusitis (Appropriate Use),N/A,N/A,N/A,332,"Percentage of patients aged 18 years and older with a diagnosis of acute bacterial sinusitis that were prescribed amoxicillin, with or without clavulanate, as a first line antibiotic at the time of diagnosis.",Efficiency and Cost Reduction,Process,"Appropriate Use of Healthcare ",X,X,American Academy of Otolaryngology – Head and Neck Surgery Foundation,2017,Measure is still in program,-,-,-,-,-,X,"X
 2017
 2021
 2022",-,-,-,-,-,-,-,-,-,-,"X
@@ -2824,8 +2824,8 @@ Adult Sinusitis: Appropriate Choice of Antibiotic: Amoxicillin With or Without C
 2019
 2020
 2021
-2022",-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Adult Sinusitis: Computerized Tomography (CT) for Acute Sinusitis (Overuse),N/A,N/A,N/A,333,"Percentage of patients aged 18 years and older, with a diagnosis of acute sinusitis who had a computerized tomography (CT) scan of the paranasal sinuses ordered at the time of diagnosis or received within 28 days after date of diagnosis.",Efficiency and Cost Reduction,Efficiency,Appropriate Use of Healthcare ,X,X,American Academy of Otolaryngology – Head and Neck Surgery Foundation,2017,2021,-,-,-,-,-,X,2017,-,-,-,-,-,-,-,-,-,-,"2018
+2022",-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Adult Sinusitis: Computerized Tomography (CT) for Acute Sinusitis (Overuse),N/A,N/A,N/A,333,"Percentage of patients aged 18 years and older, with a diagnosis of acute sinusitis who had a computerized tomography (CT) scan of the paranasal sinuses ordered at the time of diagnosis or received within 28 days after date of diagnosis.",Efficiency and Cost Reduction,Efficiency,"Appropriate Use of Healthcare ",X,X,American Academy of Otolaryngology – Head and Neck Surgery Foundation,2017,2021,-,-,-,-,-,X,2017,-,-,-,-,-,-,-,-,-,-,"2018
 2019
 2020",-,"2017
 2018
@@ -2838,21 +2838,21 @@ Adult Sinusitis: Computerized Tomography (CT) for Acute Sinusitis (Overuse),N/A,
 2019
 2020",-,-,-,-,-,-,-,-,-,-,-,-,-,"2019
 2020
-",-,-,N/A,-,Y,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Adult Sinusitis: More than One Computerized Tomography (CT) Scan Within 90 Days for Chronic Sinusitis (Overuse),N/A,N/A,N/A,334,Percentage of patients aged 18 years and older with a diagnosis of chronic sinusitis who had more than one CT scan of the paranasal sinuses ordered or received within 90 days after date of diagnosis,Efficiency and Cost Reduction,Efficiency,Appropriate Use of Healthcare ,X,X,American Academy of Otolaryngology – Head and Neck Surgery,2017,2019,-,-,-,-,-,X,2017,-,-,-,-,-,-,-,-,-,-,-,-,"2017
+",-,-,"N/A",-,Y,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Adult Sinusitis: More than One Computerized Tomography (CT) Scan Within 90 Days for Chronic Sinusitis (Overuse),N/A,N/A,N/A,334,Percentage of patients aged 18 years and older with a diagnosis of chronic sinusitis who had more than one CT scan of the paranasal sinuses ordered or received within 90 days after date of diagnosis,Efficiency and Cost Reduction,Efficiency,"Appropriate Use of Healthcare ",X,X,American Academy of Otolaryngology – Head and Neck Surgery,2017,2019,-,-,-,-,-,X,2017,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018",-,-,-,-,2018,"2017
 2018",-,-,-,-,-,-,-,-,-,-,"2017
 2018",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-," For denominator criteria, encounter codes with Telehealth modifiers GQ, GT, 95 and POS 02 would not be considered encounter (eligible cases).",-,Y,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Maternity Care: Elective Delivery (Without Medical Indication) at < 39 Weeks (Overuse),N/A,N/A,N/A,335,"Percentage of patients, regardless of age, who gave birth during a 12-month period, delivered a live singleton at < 39 weeks of gestation, and had elective deliveries (without medical indication) by cesarean birth or induction of labor.",Patient Safety,Outcome,Appropriate Use of Healthcare ,X,X,Centers for Medicare & Medicaid Services,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,"X
+Maternity Care: Elective Delivery (Without Medical Indication) at < 39 Weeks (Overuse),N/A,N/A,N/A,335,"Percentage of patients, regardless of age, who gave birth during a 12-month period, delivered a live singleton at < 39 weeks of gestation, and had elective deliveries (without medical indication) by cesarean birth or induction of labor.",Patient Safety,Outcome,"Appropriate Use of Healthcare ",X,X,Centers for Medicare & Medicaid Services,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,"X
 2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,Y,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2022),2022,Measure analytics updated to be inverse.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,Y,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2022),2022,Measure analytics updated to be inverse.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Maternity Care: Postpartum Follow-up and Care Coordination,N/A,N/A,N/A,336,"Percentage of patients, regardless of age, who gave birth during a 12-month period who were seen for postpartum care before or at 12 weeks of giving birth and received the following at a postpartum visit: breast-feeding evaluation and education, postpartum depression screening, postpartum glucose screening for gestational diabetes patients, family and contraceptive planning counseling, tobacco use screening and cessation education, healthy lifestyle behavioral advice, and an immunization review and update.",Communication and Care Coordination,Process,"Prevention, Treatment, and Management of Mental Health",X,-,Centers for Medicare & Medicaid Services,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,"X
 2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 "Psoriasis: Tuberculosis (TB) Prevention for Patients with Psoriasis, Psoriatic Arthritis and Rheumatoid Arthritis on a Biological Immune Response Modifier",N/A,N/A,N/A,337,"Percentage of patients, regardless of age, with psoriasis, psoriatic arthritis and/or rheumatoid arthritis on a biological immune response modifier whose providers are ensuring active tuberculosis prevention either through negative standard tuberculosis screening tests or are reviewing the patient’s history to determine if they have had appropriate management for a recent or prior positive test.
 ",Effective Clinical Care,Process,Preventive Care,-,-,American Academy of Dermatology,2017,2022,-,-,-,-,-,X,-,-,-,-,-,-,-,-,"2017
 2018
@@ -2865,7 +2865,7 @@ Maternity Care: Postpartum Follow-up and Care Coordination,N/A,N/A,N/A,336,"Perc
 2021",-,-,-,-,2018,"2018
 2019
 2020
-2021",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2017,-,-,-,-,-,-,N/A,X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2021",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2017,-,-,-,-,-,-,"N/A",X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 HIV Viral Load Suppression,N/A,N/A,2082,338,"The percentage of patients, regardless of age, with a diagnosis of HIV with a HIV viral load less than 200 copies/mL at last HIV viral load test during the measurement year.",Effective Clinical Care,Outcome,Management of Chronic Conditions,X,-,Health Resources and Services Administration,2017,Measure is still in program,-,-,-,-,-,X,"X
 2018
 2019
@@ -2887,7 +2887,7 @@ HIV Viral Load Suppression,N/A,N/A,2082,338,"The percentage of patients, regardl
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 HIV Medical Visit Frequency,N/A,N/A,2079,340,"Percentage of patients, regardless of age with a diagnosis of HIV who had at least one medical visit in each 6 month period of the 24 month measurement period, with a minimum of 60 days between medical visits.",Efficiency and Cost Reduction,Process,Management of Chronic Conditions,X,-,Health Resources and Services Administration,2017,Measure is still in program,-,-,-,-,-,X,"X
 2018
 2019
@@ -2898,7 +2898,7 @@ HIV Medical Visit Frequency,N/A,N/A,2079,340,"Percentage of patients, regardless
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Pain Brought Under Control Within 48 Hours,N/A,N/A,0209,342,Patients aged 18 and older who report being uncomfortable because of pain at the initial assessment (after admission to palliative care services) who report pain was brought to a comfortable level within 48 hours.,Person and Caregiver-Centered Experience and Outcomes,Outcome,End of Life Care According to Preferences,X,-,National Hospice and Palliative Care Organization,2017,2022,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
 2019
@@ -2906,10 +2906,10 @@ Pain Brought Under Control Within 48 Hours,N/A,N/A,0209,342,Patients aged 18 and
 2021",-,-,-,-,-,"2018
 2019
 2020
-2021",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2021",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Screening Colonoscopy Adenoma Detection Rate,N/A,N/A,N/A,343,The percentage of patients age 50 years or older with at least one conventional adenoma or colorectal cancer detected during screening colonoscopy.,Effective Clinical Care,Outcome,Preventive Care,X,-,American Society for Gastrointestinal Endoscopy,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
-2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,,N,,,,,,,,,,N,N,N,N,N,"Y (2018)
+2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,,N,,,,,,,,,,N,N,N,N,N,"Y (2018)
 Y (2019)","2018;
 2019",This measure was previously discussed in PY2018 and determined that the scoring logic did not align with the methodology used for MIPS.  The measure is being scored in the 2019 Benchmarking File as a traditional measure. 1/23/2019: Dr. Nilasena confirmed to remove benchmark for 2018 and 2019.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 "Rate of Carotid Artery Stenting (CAS) for Asymptomatic Patients, Without Major Complications (Discharged to Home by Post-Operative Day #2)",N/A,N/A,N/A,344,Percent of asymptomatic patients undergoing CAS who are discharged to home no later than post-operative day #2.,Effective Clinical Care,Outcome,Appropriate Use of Healthcare,X,-,Society for Vascular Surgeons,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,"X
@@ -2925,47 +2925,47 @@ Y (2019)","2018;
 2019
 2020
 2021
-2022",N/A,X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022","N/A",X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Rate of Asymptomatic Patients Undergoing Carotid Artery Stenting (CAS) Who Are Stroke Free or Discharged Alive,N/A,N/A,1543,345,Percent of asymptomatic patients undergoing CAS who are stroke free while in the hospital or discharged alive following surgery.,Effective Clinical Care,Outcome,Appropriate Use of Healthcare,X,-,Society for Vascular Surgeons,2017,2020,-,-,-,-,-,X,-,-,-,"2018
 2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2017,-,-,-,"2018
 2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
-2019",N/A,-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019","N/A",-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Rate of Asymptomatic Patients Undergoing Carotid Endarterectomy (CEA) Who Are Stroke Free or Discharged Alive,N/A,N/A,1540,346,Percent of asymptomatic patients undergoing CEA who are stroke free or discharged alive following surgery.,Effective Clinical Care,Outcome,Appropriate Use of Healthcare,X,-,Society for Vascular Surgeons,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2018
 2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2018
-2019",N/A,-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019","N/A",-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) Who Are Discharged Alive,N/A,N/A,1534,347,Percent of patients undergoing endovascular repair of small or moderate non-ruptured infrarenal abdominal aortic aneurysms (AAA) who are discharged alive.,Patient Safety,Outcome,Appropriate Use of Healthcare,X,-,Society for Vascular Surgeons,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
-2019",N/A,-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019","N/A",-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Implantable Cardioverter-Defibrillator (ICD) Complications Rate,N/A,N/A,N/A,348,Patients with physician-specific risk-standardized rates of procedural complications following the first time implantation of an ICD.,Patient Safety,Outcome,Preventable Healthcare Harm,X,-,American College of Cardiology Foundation,2017,2021,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,"2017
 2018
 2019
-2020",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,An overall data completeness and performance rate needs to be calculated for this measure. A weighted average will be determined at the numerator and denominator count level. ,-,Y,N,2,Weighted Average,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2020",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"An overall data completeness and performance rate needs to be calculated for this measure. A weighted average will be determined at the numerator and denominator count level. ",-,Y,N,2,Weighted Average,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Total Knee or Hip Replacement: Shared Decision-Making: Trial of Conservative (Non-surgical) Therapy,N/A,N/A,N/A,350,"Percentage of patients regardless of age undergoing a total knee or total hip replacement with documented shared decision- making with discussion of conservative (non-surgical) therapy (e.g., non-steroidal anti-inflammatory drug (NSAIDs), analgesics, weight loss, exercise, injections) prior to the procedure.",Communication and Care Coordination,Process,Care is Personalized and Aligned with Patient’s Goals,X,-,American Association of Hip and Knee Surgeons,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2022),2022,Measure updated to include total hip replacement.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2022),2022,Measure updated to include total hip replacement.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Total Knee or Hip Replacement: Venous Thromboembolic and Cardiovascular Risk Evaluation,N/A,N/A,N/A,351,"Percentage of patients regardless of age undergoing a total knee or total hip replacement who are evaluated for the presence or absence of venous thromboembolic and cardiovascular risk factors within 30 days prior to the procedure (e.g., History of Deep Vein Thrombosis (DVT), Pulmonary Embolism (PE), Myocardial Infarction (MI), Arrhythmia and Stroke).",Patient Safety,Process,Preventive Care,X,-,American Association of Hip and Knee Surgeons,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2022),2022,Measure updated to include total hip replacement.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2022),2022,Measure updated to include total hip replacement.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Total Knee Replacement: Preoperative Antibiotic Infusion with Proximal Tourniquet,N/A,N/A,N/A,352,Percentage of patients regardless of age undergoing a total knee replacement who had the prophylactic antibiotic completely infused prior to the inflation of the proximal tourniquet.,Patient Safety,Process,Healthcare-associated Infections,X,-,American Association of Hip and Knee Surgeons,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
-2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Total Knee Replacement: Identification of Implanted Prosthesis in Operative Report,N/A,N/A,N/A,353,"Percentage of patients regardless of age undergoing a total knee replacement whose operative report identifies the prosthetic implant specifications including the prosthetic implant manufacturer, the brand name of the prosthetic implant and the size of each prosthetic implant.",Patient Safety,Process,Transfer of Health Information and Interoperability,X,-,American Association of Hip and Knee Surgeons,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
-2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Anastomotic Leak Intervention,N/A,N/A,N/A,354,Percentage of patients aged 18 years and older who required an anastomotic leak intervention following gastric bypass or colectomy surgery.,Patient Safety,Outcome,Preventable Healthcare Harm,X,-,American College of Surgeons,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Unplanned Reoperation within the 30 Day Postoperative Period,N/A,N/A,N/A,355,Percentage of patients aged 18 years and older who had any unplanned reoperation within the 30 day postoperative period.,Patient Safety,Outcome,Admissions and Readmissions to Hospitals,X,-,American College of Surgeons,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
@@ -2977,7 +2977,7 @@ Unplanned Reoperation within the 30 Day Postoperative Period,N/A,N/A,N/A,355,Per
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,N/A,X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,"N/A",X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Unplanned Hospital Readmission within 30 Days of Principal Procedure,N/A,N/A,N/A,356,Percentage of patients aged 18 years and older who had an unplanned hospital readmission within 30 days of principal procedure.,Effective Clinical Care,Outcome,Admissions and Readmissions to Hospitals,X,-,American College of Surgeons,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
@@ -2989,7 +2989,7 @@ Unplanned Hospital Readmission within 30 Days of Principal Procedure,N/A,N/A,N/A
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,N/A,X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,"N/A",X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Surgical Site Infection (SSI),N/A,N/A,N/A,357,Percentage of patients aged 18 years and older who had a surgical site infection (SSI).,Effective Clinical Care,Outcome,Healthcare-associated Infections,X,-,American College of Surgeons,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
@@ -3014,7 +3014,7 @@ Surgical Site Infection (SSI),N/A,N/A,N/A,357,Percentage of patients aged 18 yea
 2019
 2020
 2021
-2022",N/A,X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022","N/A",X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Patient-Centered Surgical Risk Assessment and Communication,N/A,N/A,N/A,358,"Percentage of patients who underwent a non-emergency surgery who had their personalized risks of postoperative complications assessed by their surgical team prior to surgery using a clinical data-based, patient-specific risk calculator and who received personal discussion of those risks with the surgeon.",Person and Caregiver-Centered Experience and Outcomes,Process,Care is Personalized and Aligned with Patient’s Goals,X,-,American College of Surgeons,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
@@ -3056,31 +3056,31 @@ Patient-Centered Surgical Risk Assessment and Communication,N/A,N/A,N/A,358,"Per
 2019
 2020
 2021
-2022",N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022","N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Optimizing Patient Exposure to Ionizing Radiation: Utilization of a Standardized Nomenclature for Computed Tomography (CT) Imaging Description,N/A,N/A,N/A,359,"Percentage of computed tomography (CT) imaging reports for all patients, regardless of age, with the imaging study named according to a standardized nomenclature and the standardized nomenclature is used in institution’s computer systems",Communication and Care Coordination,Process,Transfer of Health Information and Interoperability,X,-,American College of Radiology,2017,2019,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,"2017
-2018",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2018",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Optimizing Patient Exposure to Ionizing Radiation: Count of Potential High Dose Radiation Imaging Studies: Computed Tomography (CT) and Cardiac Nuclear Medicine Studies,N/A,N/A,N/A,360,"Percentage of computed tomography (CT) and cardiac nuclear medicine (myocardial perfusion studies) imaging reports for all patients, regardless of age, that document a count of known previous CT (any type of CT) and cardiac nuclear medicine (myocardial perfusion) studies that the patient has received in the 12-month period prior to the current study.",Patient Safety,Process,Transfer of Health Information and Interoperability,X,X,American College of Radiology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Optimizing Patient Exposure to Ionizing Radiation: Reporting to a Radiation Dose Index Registry,N/A,N/A,N/A,361,"Percentage of total computed tomography (CT) studies performed for all patients, regardless of age, that are submitted to a radiation dose index registry that is capable of collecting at a minimum selected data elements.",Patient Safety,Structure,Transfer of Health Information and Interoperability,X,-,American College of Radiology,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,"2017
 2018
-2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Optimizing Patient Exposure to Ionizing Radiation: Computed Tomography (CT) Images Available for Patient Follow-up and Comparison Purposes,N/A,N/A,N/A,362,"Percentage of final reports for computed tomography (CT) studies performed for all patients, regardless of age, which document that Digital Imaging and Communications in Medicine (DICOM) format image data are available to non-affiliated external healthcare facilities or entities on a secure, media free, reciprocally searchable basis with patient authorization for at least a 12 month period after the study.",Communication and Care Coordination,Structure,Transfer of Health Information and Interoperability,X,-,American College of Radiology,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,"2017
 2018
-2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 "Optimizing Patient Exposure to Ionizing Radiation: Search for Prior Computed Tomography (CT) Studies Through a Secure, Authorized, Media-Free, Shared Archive ",N/A,N/A,N/A,363,"Percentage of final reports of computed tomography (CT) studies performed for all patients, regardless of age, which document that a search for Digital Imaging and Communications in Medicine (DICOM) format images was conducted for prior patient CT imaging studies completed at non-affiliated external healthcare facilities or entities within the past 12-months and are available through a secure, authorized, media-free, shared archive prior to an imaging study being performed",Communication and Care Coordination,Structure,Transfer of Health Information and Interoperability,X,-,American College of Radiology,2017,2019,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,"2017
-2018",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2018",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Optimizing Patient Exposure to Ionizing Radiation: Appropriateness: Follow-up CT Imaging for Incidentally Detected Pulmonary Nodules According to Recommended Guidelines,N/A,N/A,N/A,364,"Percentage of final reports for CT imaging studies with a finding of an incidental pulmonary nodule for patients aged 35 years and older that contain an impression or conclusion that includes a recommended interval and modality for follow-up (e.g., type of imaging or biopsy) or for no follow-up, and source of recommendations (e.g., guidelines such as Fleischner Society, American Lung Association, American College of Chest Physicians).",Communication and Care Coordination,Process,Transfer of Health Information and Interoperability,X,X,American College of Radiology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Follow-Up Care for Children Prescribed ADHD Medication (ADD),CMS136v11,N/A,N/A,366,"Percentage of children 6-12 years of age and newly dispensed a medication for attention-deficit/hyperactivity disorder (ADHD) who had appropriate follow-up care. Two rates are reported.  
 a) Percentage of children who had one follow-up visit with a practitioner with prescribing authority during the 30-Day Initiation Phase.
 b) Percentage of children who remained on ADHD medication for at least 210 days and who, in addition to the visit in the Initiation Phase, had at least two additional follow-up visits with a practitioner within 270 days (9 months) after the Initiation Phase ended.
@@ -3098,9 +3098,9 @@ b) Percentage of children who remained on ADHD medication for at least 210 days 
 2021
 2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,"The eCQM measure requires the submission of two performance rates (Intake & Continuation and Maintenance Phase). While the eCQM calculates 2 rates, only performance rate 2 will be utilized for benchmarking purposes.",-,N,N/A,2,2,"Rate 1: Percentage of children who had one follow-up visit with a practitioner with prescribing authority during the 30-Day Initiation Phase.
 Rate 2:  Percentage of children who remained on ADHD medication for at least 210 days and who, in addition to the visit in the Initiation Phase, had at least two additional follow-up visits with a practitioner within 270 days (9 months) after the Initiation Phase ended.",N,,,,,,,,,,N,N,Y (2022),N,N,N,2022,Measure updated to utilize Performance Rate 2 for the benchmark.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Bipolar Disorder and Major Depression: Appraisal for alcohol or chemical substance use,CMS169v6,N/A,N/A,367,Percentage of patients with depression or bipolar disorder with evidence of an initial assessment that includes an appraisal for alcohol or chemical substance use,Effective Clinical Care,Process,"Prevention, Treatment, and Management of Mental Health",-,-,Center for Quality Assessment and Improvement in Mental Health,2017,2019,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2018,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Bipolar Disorder and Major Depression: Appraisal for alcohol or chemical substance use,CMS169v6,N/A,N/A,367,Percentage of patients with depression or bipolar disorder with evidence of an initial assessment that includes an appraisal for alcohol or chemical substance use,Effective Clinical Care,Process,"Prevention, Treatment, and Management of Mental Health",-,-,Center for Quality Assessment and Improvement in Mental Health,2017,2019,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2018,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 "Pregnant women that had HBsAg testing
-",CMS158v6,N/A,N/A,369,This measure identifies pregnant women who had a HBsAg (hepatitis B) test during their pregnancy,Effective Clinical Care,Process,Preventive Care,-,-,OptumInsight,2017,2019,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2018,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+",CMS158v6,N/A,N/A,369,This measure identifies pregnant women who had a HBsAg (hepatitis B) test during their pregnancy,Effective Clinical Care,Process,Preventive Care,-,-,OptumInsight,2017,2019,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2018,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Depression Remission at Twelve Months,CMS159v10,0710e,0710,370,The percentage of adolescent patients 12 to 17 years of age and adult patients 18 years of age or older with major depression or dysthymia who reached remission 12 months (+/- 60 days) after an index event date.,Effective Clinical Care,Outcome,"Prevention, Treatment, and Management of Mental Health",X,-,Minnesota Community Measurement,2017,Measure is still in program,-,-,X,X,-,X,-,-,-,-,-,-,"X
 2020
 2021
@@ -3128,17 +3128,17 @@ Depression Remission at Twelve Months,CMS159v10,0710e,0710,370,The percentage of
 2022",-,-,-,-,-,-,-,-,-,-,"X
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N,2,Weighted Average,"Rate 1: Percentage of adolescent patients (aged 12-17 years) with a diagnosis of major depression or dysthymia and an initial PHQ-9 or PHQ-9M score greater than nine during the index event who reached remission at twelve months as demonstrated by a twelve month (+/-60 days) PHQ-9 or PHQ-9M score of less than 5
-Rate 2: Percentage of adult patients (aged 18 years or older) with a diagnosis of major depression or dysthymia and an initial PHQ-9 or PHQ-9M score greater than nine during the index event who reached remission at twelve months as demonstrated by a twelve month (+/-60 days) PHQ-9 or PHQ-9M score of less than 5",N,,,,This measure is not scored for the WI ,,,,,"This measure does not have a MSSP Benchmark. 
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N,2,Weighted Average,"Rate 1: Percentage of adolescent patients (aged 12-17 years) with a diagnosis of major depression or dysthymia and an initial PHQ-9 or PHQ-9M score greater than nine during the index event who reached remission at twelve months as demonstrated by a twelve month (+/-60 days) PHQ-9 or PHQ-9M score of less than 5
+Rate 2: Percentage of adult patients (aged 18 years or older) with a diagnosis of major depression or dysthymia and an initial PHQ-9 or PHQ-9M score greater than nine during the index event who reached remission at twelve months as demonstrated by a twelve month (+/-60 days) PHQ-9 or PHQ-9M score of less than 5",N,,,,"This measure is not scored for the WI ",,,,,"This measure does not have a MSSP Benchmark. 
 Unlike other collection types, we will not attempt to calculate a performance period benchmark if there isn’t an existing benchmark or if the measure is classified as pay-for-reporting. CMS Web Interface measures without an existing benchmark or classified as pay-for-reporting do not count toward Quality performance category score, as long as data completeness requirements are met.
-",,,,This measure is not scored for the WI ,,,,,,,,,,,,,,,,,X,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+",,,,"This measure is not scored for the WI ",,,,,,,,,,,,,,,,,X,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Depression Utilization of the PHQ-9 Tool,CMS160v8,0712e,N/A,371,The percentage of adolescent patients 12 to 17 years of age and adult patients age 18 and older with the diagnosis of major depression or dysthymia who have a completed PHQ-9 during each applicable 4 month period in which there was a qualifying depression encounter.,Effective Clinical Care,Process,"Prevention, Treatment, and Management of Mental Health",-,-,Minnesota Community Measurement,2017,2020,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2018
 2019",-,-,-,-,-,"2018
 2019",-,"2017
 2018
-2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,The eCQM measure requires the reporting of three performance rates. An overall performance rate needs to be calculated for this measure. A weighted average will be determined at the numerator and denominator count level.,-,N,N/A,3,Weighted Average,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Maternal Depression Screening,CMS82v7,N/A,N/A,372,"The percentage of children who turned 6 months of age during the measurement year, who had a face-to-face visit between the clinician and the child during child's first 6 months, and who had a maternal depression screening for the mother at least once between 0 and 6 months of life.",Community/Population Health,Process,"Prevention, Treatment, and Management of Mental Health",-,-,National Committee for Quality Assurance,2017,2020,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N/A,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Hypertension: Improvement in Blood Pressure,CMS65v7,N/A,N/A,373,Percentage of patients aged 18-85 years of age with a diagnosis of hypertension whose blood pressure improved during the measurement period,Effective Clinical Care,Intermediate Outcome,Management of Chronic Conditions,X,-,Centers for Medicare & Medicaid Services,2017,2019,-,-,X,-,-,-,-,-,-,2018,-,-,-,-,-,-,-,-,-,2018,-,-,-,-,-,2018,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"The eCQM measure requires the reporting of three performance rates. An overall performance rate needs to be calculated for this measure. A weighted average will be determined at the numerator and denominator count level.",-,N,N/A,3,Weighted Average,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Maternal Depression Screening,CMS82v7,N/A,N/A,372,"The percentage of children who turned 6 months of age during the measurement year, who had a face-to-face visit between the clinician and the child during child's first 6 months, and who had a maternal depression screening for the mother at least once between 0 and 6 months of life.",Community/Population Health,Process,"Prevention, Treatment, and Management of Mental Health",-,-,National Committee for Quality Assurance,2017,2020,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N/A,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Hypertension: Improvement in Blood Pressure,CMS65v7,N/A,N/A,373,Percentage of patients aged 18-85 years of age with a diagnosis of hypertension whose blood pressure improved during the measurement period,Effective Clinical Care,Intermediate Outcome,Management of Chronic Conditions,X,-,Centers for Medicare & Medicaid Services,2017,2019,-,-,X,-,-,-,-,-,-,2018,-,-,-,-,-,-,-,-,-,2018,-,-,-,-,-,2018,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Closing the Referral Loop: Receipt of Specialist Report,CMS50v10,N/A,N/A,374,"Percentage of patients with referrals, regardless of age, for which the referring provider receives a report from the provider to whom the patient was referred.",Communication and Care Coordination,Process,Transfer of Health Information and Interoperability,X,-,Centers for Medicare & Medicaid Services,2017,Measure is still in program,-,-,X,-,-,X,"X
 2017
 2018
@@ -3267,21 +3267,21 @@ Closing the Referral Loop: Receipt of Specialist Report,CMS50v10,N/A,N/A,374,"Pe
 2019
 2020
 2021
-2022",N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022","N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Functional Status Assessment for Total Knee Replacement,CMS66v10,N/A,N/A,375,Percentage of patients 18 years of age and older who received an elective primary total knee arthroplasty (TKA) and completed a functional status assessment within 90 days prior to the surgery and in the 270-365 days after the surgery.,Person and Caregiver-Centered Experience and Outcomes,Process,Functional Outcomes,X,-,Centers for Medicare & Medicaid Services,2017,Measure is still in program,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Functional Status Assessment for Total Hip Replacement,CMS56v10,N/A,N/A,376,Percentage of patients 18 years of age and older who received an elective primary total hip arthroplasty (THA) and completed a functional status assessment within 90 days prior to the surgery and in the 270-365 days after the surgery.,Person and Caregiver-Centered Experience and Outcomes,Process,Functional Outcomes,X,-,Centers for Medicare & Medicaid Services,2017,Measure is still in program,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Functional Status Assessments for Heart Failure,CMS90v11,N/A,N/A,377,Percentage of patients 18 years of age and older with heart failure who completed initial and follow-up patient-reported functional status assessments.,Person and Caregiver-Centered Experience and Outcomes,Process,Functional Outcomes,X,-,Centers for Medicare & Medicaid Services,2017,Measure is still in program,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2018
 2019
@@ -3292,13 +3292,13 @@ Functional Status Assessments for Heart Failure,CMS90v11,N/A,N/A,377,Percentage 
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Children Who Have Dental Decay or Cavities,CMS75v10,N/A,N/A,378,"Percentage of children, 6 months - 20 years of age at the start of the measurement period, who have had tooth decay or cavities during the measurement period.",Community/Population Health,Outcome,Preventive Care,X,-,Centers for Medicare & Medicaid Services,2017,Measure is still in program,-,-,X,-,-,-,-,-,-,-,-,-,-,"X
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,Telehealth is not allowed for denominator.,X,Y,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"Telehealth is not allowed for denominator.",X,Y,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 "Primary Caries Prevention Intervention as Offered by Primary Care Providers, including Dentists",CMS74v11,N/A,N/A,379,"Percentage of children, 6 months - 20 years of age, who received a fluoride varnish application during the measurement period.",Effective Clinical Care,Process,Preventive Care,-,-,Centers for Medicare & Medicaid Services,2017,Measure is still in program,-,-,X,-,-,-,-,-,-,-,-,-,-,"X
 2018
 2019
@@ -3310,7 +3310,7 @@ Children Who Have Dental Decay or Cavities,CMS75v10,N/A,N/A,378,"Percentage of c
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Child and Adolescent Major Depressive Disorder (MDD): Suicide Risk Assessment,CMS177v10,1365e,N/A,382,Percentage of patient visits for those patients aged 6 through 17 years with a diagnosis of major depressive disorder with an assessment for suicide risk.,Patient Safety,Process,"Prevention, Treatment, and Management of Mental Health",X,-,Mathematica,2017,Measure is still in program,-,-,X,-,-,-,-,-,-,-,-,-,"X
 2020
 2021
@@ -3326,8 +3326,8 @@ Child and Adolescent Major Depressive Disorder (MDD): Suicide Risk Assessment,CM
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Adherence to Antipsychotic Medications For Individuals with Schizophrenia,N/A,N/A,1879,383,Percentage of individuals at least 18 years of age as of the beginning of the performance period with schizophrenia or schizoaffective disorder who had at least two prescriptions filled for any antipsychotic medication and who had a Proportion of Days Covered (PDC) of at least 0.8 for antipsychotic medications during the performance period.,Patient Safety,Intermediate Outcome,"Prevention, Treatment, and Management of Mental Health ",X,-,Centers for Medicare & Medicaid Services ,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,"X
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Adherence to Antipsychotic Medications For Individuals with Schizophrenia,N/A,N/A,1879,383,Percentage of individuals at least 18 years of age as of the beginning of the performance period with schizophrenia or schizoaffective disorder who had at least two prescriptions filled for any antipsychotic medication and who had a Proportion of Days Covered (PDC) of at least 0.8 for antipsychotic medications during the performance period.,Patient Safety,Intermediate Outcome,"Prevention, Treatment, and Management of Mental Health ",X,-,"Centers for Medicare & Medicaid Services ",2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,"X
 2020
 2021
 2022",-,-,-,-,-,-,"X
@@ -3346,28 +3346,28 @@ Adherence to Antipsychotic Medications For Individuals with Schizophrenia,N/A,N/
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Adult Primary Rhegmatogenous Retinal Detachment Surgery: No Return to the Operating Room Within 90 Days of Surgery,N/A,N/A,N/A,384,Patients aged 18 years and older who had surgery for primary rhegmatogenous retinal detachment who did not require a return to the operating room within 90 days of surgery.,Effective Clinical Care,Outcome,Preventable Healthcare Harm,X,-,American Academy of Ophthalmology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Adult Primary Rhegmatogenous Retinal Detachment Surgery: Visual Acuity Improvement Within 90 Days of Surgery,N/A,N/A,N/A,385,"Patients aged 18 years and older who had surgery for primary rhegmatogenous retinal detachment and achieved an improvement in their visual acuity, from their preoperative level, within 90 days of surgery in the operative eye.",Effective Clinical Care,Outcome,Functional Outcomes,X,-,American Academy of Ophthalmology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2020) ,2020,"7/12:  Remove benchmark for 2020. The measure was revised  to include a denominator exclusion to account for patients with a pre-operative visual acuity better than 20/40, as these patients would not be expected to show an improvement in visual acuity following surgical intervention. We believe these patients should be excluded based upon expected visual acuity outcomes.",,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,"Y (2020) ",2020,"7/12:  Remove benchmark for 2020. The measure was revised  to include a denominator exclusion to account for patients with a pre-operative visual acuity better than 20/40, as these patients would not be expected to show an improvement in visual acuity following surgical intervention. We believe these patients should be excluded based upon expected visual acuity outcomes.",,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Amyotrophic Lateral Sclerosis (ALS) Patient Care Preferences,N/A,N/A,N/A,386,"Percentage of patients diagnosed with Amyotrophic Lateral Sclerosis (ALS) who were offered assistance in planning for end of life issues (e.g., advance directives, invasive ventilation, hospice) at least once annually.",Person and Caregiver-Centered Experience and Outcomes,Process,End of Life Care According to Preferences,X,-,American Academy of Neurology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Annual Hepatitis C Virus (HCV) Screening for Patients who are Active Injection Drug Users,N/A,N/A,N/A,387,"Percentage of patients, regardless of age, who are active injection drug users who received screening for HCV infection within the 12-month reporting period.",Effective Clinical Care,Process,Preventive Care,-,-,American Gastroenterological Association,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
@@ -3380,21 +3380,21 @@ Annual Hepatitis C Virus (HCV) Screening for Patients who are Active Injection D
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Cataract Surgery with Intra-Operative Complications (Unplanned Rupture of Posterior Capsule Requiring Unplanned Vitrectomy),N/A,N/A,N/A,388,Percentage of patients aged 18 years and older who had cataract surgery performed and had an unplanned rupture of the posterior capsule requiring vitrectomy.,Patient Safety,Outcome,Preventable Healthcare Harm,X,-,American Academy of Ophthalmology,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
-2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,Y,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,Y,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Cataract Surgery: Difference Between Planned and Final Refraction,N/A,N/A,N/A,389,Percentage of patients aged 18 years and older who had cataract surgery performed and who achieved a final refraction within +/- 1.0 diopters of their planned (target) refraction.,Effective Clinical Care,Outcome,Functional Outcomes,X,-,American Academy of Ophthalmology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Hepatitis C: Discussion and Shared Decision Making Surrounding Treatment Options,N/A,N/A,N/A,390,"Percentage of patients aged 18 years and older with a diagnosis of hepatitis C with whom a physician or other qualified healthcare professional reviewed the range of treatment options appropriate to their genotype and demonstrated a shared decision making approach with the patient. To meet the measure, there must be documentation in the patient record of a discussion between the physician or other qualified healthcare professional and the patient that includes all of the following: treatment choices appropriate to genotype, risks and benefits, evidence of effectiveness, and patient preferences toward treatment.",Person and Caregiver-Centered Experience and Outcomes,Process,Care is Personalized and Aligned with Patient’s Goals,X,-,American Gastroenterological Association,2017,2021,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
 2019
-2020",-,-,-,2018,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2020",-,-,-,2018,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Follow-Up After Hospitalization for Mental Illness (FUH),N/A,N/A,0576,391,"The percentage of discharges for patients 6 years of age and older who were hospitalized for treatment of selected mental illness or intentional self-harm diagnoses and who had a follow-up visit with a mental health provider. Two rates are submitted:
 • The percentage of discharges for which the patient received follow-up within 30 days after discharge
 • The percentage of discharges for which the patient received follow-up within 7 days after discharge",Communication and Care Coordination,Process,"Prevention, Treatment, and Management of Mental Health ",X,-,National Committee for Quality Assurance,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
@@ -3425,7 +3425,7 @@ Cardiac Tamponade and/or Pericardiocentesis Following Atrial Fibrillation Ablati
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,This measure has multiple denominator options. This measure requires the reporting of five performance rates but only one data completeness is required. The fifth performance rate (Overall percentage of patients with cardiac tamponade and/or pericardiocentesis occurring within 30 days)should be utilized for an overall data completeness and performance rate for this measure.,X,Y,N,5,5th Performance Rate,"Rate 1: Females 18-64 years of age
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"This measure has multiple denominator options. This measure requires the reporting of five performance rates but only one data completeness is required. The fifth performance rate (Overall percentage of patients with cardiac tamponade and/or pericardiocentesis occurring within 30 days)should be utilized for an overall data completeness and performance rate for this measure.",X,Y,N,5,5th Performance Rate,"Rate 1: Females 18-64 years of age
 Rate 2: Males 18-64 years of age
 Rate 3: Females 65 years of age and older
 Rate 4: Males 65 years of age and older
@@ -3436,7 +3436,7 @@ Rate 5: Overall percentage of patients with cardiac tamponade and/or pericardioc
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,This measure has multiple denominator options based on care setting (new CIED vs. replaced or revised CIED).  This measure requires the reporting of only one data completeness and performance rate. ,X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"This measure has multiple denominator options based on care setting (new CIED vs. replaced or revised CIED).  This measure requires the reporting of only one data completeness and performance rate. ",X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Immunizations for Adolescents,N/A,N/A,N/A,394,"The percentage of adolescents 13 years of age who had one dose of meningococcal vaccine (serogroups A, C, W, Y), one tetanus, diphtheria toxoids and acellular pertussis (Tdap) vaccine, and have completed the human papillomavirus (HPV) vaccine series by their 13th birthday.",Community/Population Health,Process,Preventive Care,-,-,National Committee for Quality Assurance,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
@@ -3530,7 +3530,7 @@ One-Time Screening for Hepatitis C Virus (HCV) for all Patients,N/A,N/A,N/A,400,
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2022),2022,"Measure updated to remove requirement for 'at risk' patients, includes all patients.",,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2022),2022,"Measure updated to remove requirement for 'at risk' patients, includes all patients.",,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Hepatitis C: Screening for Hepatocellular Carcinoma (HCC) in Patients with Cirrhosis,N/A,N/A,N/A,401,"Percentage of patients aged 18 years and older with a diagnosis of chronic hepatitis C cirrhosis who underwent imaging with either ultrasound, contrast enhanced CT or MRI for hepatocellular carcinoma (HCC) at least once within the 12-month submission period.",Effective Clinical Care,Process,Preventive Care,-,-,American Gastroenterological Association,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
@@ -3549,7 +3549,7 @@ Hepatitis C: Screening for Hepatocellular Carcinoma (HCC) in Patients with Cirrh
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Tobacco Use and Help with Quitting Among Adolescents,N/A,N/A,N/A,402,The percentage of adolescents 12 to 20 years of age with a primary care visit during the measurement year for whom tobacco use status was documented and received help with quitting if identified as a tobacco user.,Community/Population Health,Process,Prevention and Treatment of Opioid and Substance Use Disorders,-,-,National Committee for Quality Assurance,2017,Measure is still in program,-,-,-,-,-,X,"X
 2017
 2018
@@ -3670,34 +3670,34 @@ Tobacco Use and Help with Quitting Among Adolescents,N/A,N/A,N/A,402,The percent
 2019
 2020
 2021
-2022",N/A,-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022","N/A",-,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Adult Kidney Disease: Referral to Hospice,N/A,N/A,N/A,403,Percentage of patients aged 18 years and older with a diagnosis of ESRD who withdraw from hemodialysis or peritoneal dialysis who are referred to hospice care,Person and Caregiver-Centered Experience and Outcomes,Process,End of Life Care According to Preferences,X,-,Renal Physicians Association,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2018
-2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Anesthesiology Smoking Abstinence,N/A,N/A,N/A,404,The percentage of current smokers who abstain from cigarettes prior to anesthesia on the day of elective surgery or procedure.,Effective Clinical Care,Intermediate Outcome,Prevention and Treatment of Opioid and Substance Use Disorders,X,-,American Society of Anesthesiologists,2017,Measure is still in program,-,-,-,-,-,X,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Appropriate Follow-up Imaging for Incidental Abdominal Lesions,N/A,N/A,N/A,405," Percentage of final reports for imaging studies for patients aged 18 years and older with one or more of the following noted incidentally with a specific recommendation for no follow‐up imaging recommended based on radiological findings:
 • Cystic renal lesion that is simple appearing* (Bosniak I or II)
 • Adrenal lesion less than or equal to 1.0 cm
 • Adrenal lesion greater than 1.0 cm but less than or equal to 4.0 cm classified as likely benign or diagnostic benign by unenhanced CT or washout protocol CT, or MRI with in- and opposed-phase sequences or other equivalent institutional imaging protocols
-",Effective Clinical Care,Process,Appropriate Use of Healthcare ,X,X,American College of Radiology,2017,Measure is still in program,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,"X
+",Effective Clinical Care,Process,"Appropriate Use of Healthcare ",X,X,American College of Radiology,2017,Measure is still in program,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,Y (2020) ,N,N,N,N,Y (2020) ,2020,The substantive changes proposed for the 2020 performance period would require the benchmark be removed for the 2020 Benchmarking File. The measure was previous specified as an inverse measure and will be updated to be non-inverse.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Appropriate Follow-up Imaging for Incidental Thyroid Nodules in Patients,N/A,N/A,N/A,406,"Percentage of final reports for computed tomography (CT), CT angiography (CTA) or magnetic resonance imaging (MRI) or magnetic resonance angiogram (MRA) studies of the chest or neck for patients aged 18 years and older with no known thyroid disease with a thyroid nodule < 1.0 cm noted incidentally with follow-up imaging recommended.",Effective Clinical Care,Process,Appropriate Use of Healthcare ,X,X,American College of Radiology,2017,Measure is still in program,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,"X
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,"Y (2020) ",N,N,N,N,"Y (2020) ",2020,The substantive changes proposed for the 2020 performance period would require the benchmark be removed for the 2020 Benchmarking File. The measure was previous specified as an inverse measure and will be updated to be non-inverse.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Appropriate Follow-up Imaging for Incidental Thyroid Nodules in Patients,N/A,N/A,N/A,406,"Percentage of final reports for computed tomography (CT), CT angiography (CTA) or magnetic resonance imaging (MRI) or magnetic resonance angiogram (MRA) studies of the chest or neck for patients aged 18 years and older with no known thyroid disease with a thyroid nodule < 1.0 cm noted incidentally with follow-up imaging recommended.",Effective Clinical Care,Process,"Appropriate Use of Healthcare ",X,X,American College of Radiology,2017,Measure is still in program,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Appropriate Treatment of Methicillin-Susceptible Staphylococcus Aureus (MSSA) Bacteremia,N/A,N/A,N/A,407,"Percentage of patients with sepsis due to MSSA bacteremia who received beta-lactam antibiotic (e.g. Nafcillin, Oxacillin or Cefazolin) as definitive therapy.",Effective Clinical Care,Process,Healthcare-associated Infections,X,X,Infectious Diseases Society of America,2017,2020,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2018
 2019","2018
 2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"Claims: Utilize Part B Claims. Correlate eligible cases with inpatient ""hidden"" codes at the bene-level regardless of TIN/NPI to determine the length of hospital stay (episode). ""Hidden"" inpatient code line items that are denied or include modifier 80, 81 or 82 should be included in this analysis.  
@@ -3724,8 +3724,8 @@ Opioid Therapy Follow-up Evaluation,N/A,N/A,N/A,408,All patients 18 and older pr
 2018
 2019
 2020
-",-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Clinical Outcome Post Endovascular Stroke Treatment,N/A,N/A,N/A,409,Percentage of patients with a Modified Rankin Score (mRS) score of 0 to 2 at 90 days following endovascular stroke intervention.,Effective Clinical Care,Outcome,Management of Chronic Conditions,X,-,Society of Interventional Radiology ,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
+",-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Clinical Outcome Post Endovascular Stroke Treatment,N/A,N/A,N/A,409,Percentage of patients with a Modified Rankin Score (mRS) score of 0 to 2 at 90 days following endovascular stroke intervention.,Effective Clinical Care,Outcome,Management of Chronic Conditions,X,-,"Society of Interventional Radiology ",2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2018
 2019
 2020
@@ -3735,17 +3735,17 @@ Clinical Outcome Post Endovascular Stroke Treatment,N/A,N/A,N/A,409,Percentage o
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2022),2022,Measure stratified into multiple submission criteria with Submission Criteria 2 being used for benchmarking.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2022),2022,Measure stratified into multiple submission criteria with Submission Criteria 2 being used for benchmarking.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Psoriasis: Clinical Response to Systemic Medications,N/A,N/A,N/A,410,Percentage of psoriasis vulgaris patients receiving systemic medication who meet minimal physician-or patient- reported disease activity levels. It is implied that establishment and maintenance of an established minimum level of disease control as measured by physician-and/or patient-reported outcomes will increase patient satisfaction with and adherence to treatment.,Person and Caregiver-Centered Experience and Outcomes,Outcome,Management of Chronic Conditions,X,-,American Academy of Dermatology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Depression Remission at Six Months,N/A,N/A,0711,411,The percentage of adolescent patients 12 to 17 years of age and adult patients 18 years of age or older with major depression or dysthymia who reached remission six months (+/- 60 days) after an index event date.,Effective Clinical Care,Outcome,"Prevention, Treatment, and Management of Mental Health ",X,-,Minnesota Community Measurement,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
-2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N,2,Weighted Average,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N,2,Weighted Average,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Documentation of Signed Opioid Treatment Agreement,N/A,N/A,N/A,412,All patients 18 and older prescribed opiates for longer than six weeks duration who signed an opioid treatment agreement at least once during Opioid Therapy documented in the medical record.,Effective Clinical Care,Process,Prevention and Treatment of Opioid and Substance Use Disorders,X,-,American Academy of Neurology,2017,2021,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
 2019
@@ -3763,8 +3763,8 @@ Documentation of Signed Opioid Treatment Agreement,N/A,N/A,N/A,412,All patients 
 2018
 2019
 2020
-",-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Door to Puncture Time for Endovascular Stroke Treatment,N/A,N/A,N/A,413,Percentage of patients undergoing endovascular stroke treatment who have a door to puncture time of 90 minutes or less.,Effective Clinical Care,Intermediate Outcome,Patient Focused Episode of Care ,X,-,Society of Interventional Radiology ,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
+",-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Door to Puncture Time for Endovascular Stroke Treatment,N/A,N/A,N/A,413,Percentage of patients undergoing endovascular stroke treatment who have a door to puncture time of 90 minutes or less.,Effective Clinical Care,Intermediate Outcome,"Patient Focused Episode of Care ",X,-,"Society of Interventional Radiology ",2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2018
 2019
 2020
@@ -3774,7 +3774,7 @@ Door to Puncture Time for Endovascular Stroke Treatment,N/A,N/A,N/A,413,Percenta
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Evaluation or Interview for Risk of Opioid Misuse,N/A,N/A,N/A,414,"All patients 18 and older prescribed opiates for longer than six weeks duration evaluated for risk of opioid misuse using a brief validated instrument (e.g. Opioid Risk Tool, Screener and Opioid Assessment for Patients with Pain, revised (SOAPP-R)) or patient interview documented at least once during Opioid Therapy in the medical record.",Effective Clinical Care,Process,Prevention and Treatment of Opioid and Substance Use Disorders,X,-,American Academy of Neurology,2017,2021,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
 2019
@@ -3792,8 +3792,8 @@ Evaluation or Interview for Risk of Opioid Misuse,N/A,N/A,N/A,414,"All patients 
 2018
 2019
 2020
-",-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older,N/A,N/A,N/A,415,Percentage of emergency department visits for patients aged 18 years and older who presented with a minor blunt head trauma who had a head CT for trauma ordered by an emergency care provider who have an indication for a head CT.,Efficiency and Cost Reduction,Efficiency,Appropriate Use of Healthcare ,X,-,American College of Emergency Physicians,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,"X
+",-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older,N/A,N/A,N/A,415,Percentage of emergency department visits for patients aged 18 years and older who presented with a minor blunt head trauma who had a head CT for trauma ordered by an emergency care provider who have an indication for a head CT.,Efficiency and Cost Reduction,Efficiency,"Appropriate Use of Healthcare ",X,-,American College of Emergency Physicians,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
@@ -3801,7 +3801,7 @@ Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head 
 2021
 2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"Claims: The patient should have CPT 70450 (regardless of TIN/NPI) on the same date of service as the denominator eligible encounter in order to be included in the denominator. 
 ",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
- Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years,N/A,N/A,N/A,416,Percentage of emergency department visits for patients aged 2 through 17 years who presented with a minor blunt head trauma who had a head CT for trauma ordered by an emergency care provider who are classified as low risk according to the Pediatric Emergency Care Applied Research Network (PECARN) prediction rules for traumatic brain injury.,Efficiency and Cost Reduction,Efficiency,Appropriate Use of Healthcare ,X,X,American College of Emergency Physicians,2017,Measure is still in program,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,"X
+" Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years",N/A,N/A,N/A,416,Percentage of emergency department visits for patients aged 2 through 17 years who presented with a minor blunt head trauma who had a head CT for trauma ordered by an emergency care provider who are classified as low risk according to the Pediatric Emergency Care Applied Research Network (PECARN) prediction rules for traumatic brain injury.,Efficiency and Cost Reduction,Efficiency,"Appropriate Use of Healthcare ",X,X,American College of Emergency Physicians,2017,Measure is still in program,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
@@ -3810,7 +3810,7 @@ Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head 
 2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"Claims: The patient should have CPT 70450 (regardless of TIN/NPI) on the same date of service as the denominator eligible encounter in order to be included in the denominator. 
 ",X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Rate of Open Repair of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) Where Patients Are Discharged Alive,N/A,N/A,1523,417,Percentage of patients undergoing open repair of small or moderate non-ruptured infrarenal abdominal aortic aneurysms (AAA) who are discharged alive.,Patient Safety,Outcome,Appropriate Use of Healthcare,X,-,Society for Vascular Surgery,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2018
-2019",N/A,-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019","N/A",-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Osteoporosis Management in Women Who Had a Fracture,N/A,N/A,0053,418,The percentage of women 50–85 years of age who suffered a fracture and who had either a bone mineral density (BMD) test or prescription for a drug to treat osteoporosis in the six months after the fracture.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,National Committee for Quality Assurance,2017,Measure is still in program,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2020
 2021
@@ -3843,14 +3843,14 @@ Osteoporosis Management in Women Who Had a Fracture,N/A,N/A,0053,418,The percent
 • Use the most favorable instance of reporting for performance rates if multiple conflicting QDCs exist on a qualifying episode.
 • The QDC must exist on the claim with the qualifying denominator episode (overarching rule for all measures).
 ",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Overuse of Imaging for the Evaluation of Primary Headache,N/A,N/A,N/A,419,Percentage of patients for whom imaging of the head (CT or MRI) is obtained for the evaluation of primary headache when clinical indications are not present.,Efficiency and Cost Reduction,Process,Appropriate Use of Healthcare ,X,X,American Academy of Neurology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
+Overuse of Imaging for the Evaluation of Primary Headache,N/A,N/A,N/A,419,Percentage of patients for whom imaging of the head (CT or MRI) is obtained for the evaluation of primary headache when clinical indications are not present.,Efficiency and Cost Reduction,Process,"Appropriate Use of Healthcare ",X,X,American Academy of Neurology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
 2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,,-,Y,Y,1,N/A,N/A,N,(Y) 2020,N,N,N,N,N,Suppression,2020,The 2020 Medicare Part B Claims measure specification includes a quality data code (M1030) that was inadvertently indicated to be inactivated during the Healthcare Common Procedure Coding System (HCPCS) update process.,Y (2019),N,N,N,N,Y (2019),2019,"This measure was previously an not inverse measure. In 2019, the measure steward revised the measure to be inverse. Measure should be re-benchmarked with inverse logic if data meets requirements.",,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Varicose Vein Treatment with Saphenous Ablation: Outcome Survey,N/A,N/A,N/A,420,Percentage of patients treated for varicose veins (CEAP C2-S) who are treated with saphenous ablation (with or without adjunctive tributary treatment) that report an improvement on a disease specific patient reported outcome survey instrument after treatment.,Effective Clinical Care,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,Society of Interventional Radiology ,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
+Varicose Vein Treatment with Saphenous Ablation: Outcome Survey,N/A,N/A,N/A,420,Percentage of patients treated for varicose veins (CEAP C2-S) who are treated with saphenous ablation (with or without adjunctive tributary treatment) that report an improvement on a disease specific patient reported outcome survey instrument after treatment.,Effective Clinical Care,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,"Society of Interventional Radiology ",2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2018
 2019
 2020
@@ -3860,28 +3860,28 @@ Varicose Vein Treatment with Saphenous Ablation: Outcome Survey,N/A,N/A,N/A,420,
 2019
 2020
 2021
-2022",N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Appropriate Assessment of Retrievable Inferior Vena Cava (IVC) Filters for Removal,N/A,N/A,N/A,421,"Percentage of patients in whom a retrievable IVC filter is placed who, within 3 months post-placement, have a documented assessment for the appropriateness of continued filtration, device removal or the inability to contact the patient with at least two attempts.",Effective Clinical Care,Process,Preventable Healthcare Harm,-,-,Society of Interventional Radiology ,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
+2022","N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Appropriate Assessment of Retrievable Inferior Vena Cava (IVC) Filters for Removal,N/A,N/A,N/A,421,"Percentage of patients in whom a retrievable IVC filter is placed who, within 3 months post-placement, have a documented assessment for the appropriateness of continued filtration, device removal or the inability to contact the patient with at least two attempts.",Effective Clinical Care,Process,Preventable Healthcare Harm,-,-,"Society of Interventional Radiology ",2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Performing Cystoscopy at the Time of Hysterectomy for Pelvic Organ Prolapse to Detect Lower Urinary Tract Injury,N/A,N/A,2063,422,Percentage of patients who undergo cystoscopy to evaluate for lower urinary tract injury at the time of hysterectomy for pelvic organ prolapse.,Patient Safety,Process,Preventable Healthcare Harm,X,-,American Urogynecologic Society,2017,Measure is still in program,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Perioperative Anti-platelet Therapy for Patients Undergoing Carotid Endarterectomy,N/A,N/A,0465,423,Percentage of patients undergoing carotid endarterectomy (CEA) who are taking an anti-platelet agent within 48 hours prior to surgery and are prescribed this medication at hospital discharge following surgery,Effective Clinical Care,Process,Risk Adjusted Mortality,-,-,Society for Vascular Surgeons,2017,2019,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2018,N/A,,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Perioperative Anti-platelet Therapy for Patients Undergoing Carotid Endarterectomy,N/A,N/A,0465,423,Percentage of patients undergoing carotid endarterectomy (CEA) who are taking an anti-platelet agent within 48 hours prior to surgery and are prescribed this medication at hospital discharge following surgery,Effective Clinical Care,Process,Risk Adjusted Mortality,-,-,Society for Vascular Surgeons,2017,2019,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,2018,"N/A",,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Perioperative Temperature Management,N/A,N/A,N/A,424,"Percentage of patients, regardless of age, who undergo surgical or therapeutic procedures under general or neuraxial anesthesia of 60 minutes duration or longer for whom at least one body temperature greater than or equal to 35.5 degrees Celsius (or 95.9 degrees Fahrenheit) was achieved within the 30 minutes immediately before or the 15 minutes immediately after anesthesia end time.",Patient Safety,Outcome,Preventable Healthcare Harm,X,-,American Society of Anesthesiologists,2017,Measure is still in program,-,-,-,-,-,X,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Photodocumentation of Cecal Intubation,N/A,N/A,N/A,425,The rate of screening and surveillance colonoscopies for which photodocumentation of at least two landmarks of cecal intubation is performed to establish a complete examination.,Effective Clinical Care,Process,Transfer of Health Information and Interoperability,-,-,American Society for Gastrointestinal Endoscopy,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2018
 2019
@@ -3893,27 +3893,27 @@ If QDCs are submitted on the same claim for multiple measures, exclude only the 
 ",X,N,N,1,N/A,N/A,N,,,,,,,,,,Y (2019),N,N,N,N,Y (2019),2019,"This measure was revised to required 2 landmarks or cecal intubation. It previously only required one landmarks, this revision would impact performance. Measure Steward has raised this concern as well",,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Post-Anesthetic Transfer of Care Measure: Procedure Room to a Post Anesthesia Care Unit (PACU),N/A,N/A,N/A,426,"Percentage of patients, regardless of age, who are under the care of an anesthesia practitioner and are admitted to a PACU in which a post-anesthetic formal transfer of care protocol or checklist which includes the key transfer of care elements is utilized",Communication and Care Coordination,Process,Transfer of Health Information and Interoperability,X,-,American Society of Anesthesiologists,2017,2019,-,-,-,-,-,X,-,"2017
 2018
-2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Post-Anesthetic Transfer of Care: Use of Checklist or Protocol for Direct Transfer of Care from Procedure Room to Intensive Care Unit (ICU) ,N/A,N/A,N/A,427,"Percentage of patients, regardless of age, who undergo a procedure under anesthesia and are admitted to an Intensive Care Unit (ICU) directly from the anesthetizing location, who have a documented use of a checklist or protocol for the transfer of care from the responsible anesthesia practitioner to the responsible ICU team or team member",Communication and Care Coordination,Process,Transfer of Health Information and Interoperability,X,-,American Society of Anesthesiologists,2017,2019,-,-,-,-,-,X,-,"2017
+2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+"Post-Anesthetic Transfer of Care: Use of Checklist or Protocol for Direct Transfer of Care from Procedure Room to Intensive Care Unit (ICU) ",N/A,N/A,N/A,427,"Percentage of patients, regardless of age, who undergo a procedure under anesthesia and are admitted to an Intensive Care Unit (ICU) directly from the anesthetizing location, who have a documented use of a checklist or protocol for the transfer of care from the responsible anesthesia practitioner to the responsible ICU team or team member",Communication and Care Coordination,Process,Transfer of Health Information and Interoperability,X,-,American Society of Anesthesiologists,2017,2019,-,-,-,-,-,X,-,"2017
 2018
-2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Pelvic Organ Prolapse: Preoperative Assessment of Occult Stress Urinary Incontinence,N/A,N/A,N/A,428,Percentage of patients undergoing appropriate preoperative evaluation of stress urinary incontinence prior to pelvic organ prolapse surgery per ACOG/AUGS/AUA guidelines.,Effective Clinical Care,Process,Preventable Healthcare Harm,-,-,American Urogynecologic Society,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2018
 2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2018
-2019",-,N/A,-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019",-,"N/A",-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Pelvic Organ Prolapse: Preoperative Screening for Uterine Malignancy,N/A,N/A,N/A,429,Percentage of patients who are screened for uterine malignancy prior to vaginal closure or obliterative surgery for pelvic organ prolapse.,Patient Safety,Process,Preventive Care,X,-,American Urogynecologic Society,2017,2022,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2018
 2019
 2020
 2021",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2018
 2019
 2020
-2021",-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2021",-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Prevention of Post-Operative Nausea and Vomiting (PONV) – Combination Therapy,N/A,N/A,N/A,430,"Percentage of patients, aged 18 years and older, who undergo a procedure under an inhalational general anesthetic, AND who have three or more risk factors for post-operative nausea and vomiting (PONV), who receive combination therapy consisting of at least two prophylactic pharmacologic antiemetic agents of different classes preoperatively and/or intraoperatively.",Patient Safety,Process,Preventive Care,X,-,American Society of Anesthesiologists,2017,Measure is still in program,-,-,-,-,-,X,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Preventive Care and Screening: Unhealthy Alcohol Use: Screening & Brief Counseling,N/A,N/A,2152,431,Percentage of patients aged 18 years and older who were screened for unhealthy alcohol use using a systematic screening method at least once within the last 12 months AND who received brief counseling if identified as an unhealthy alcohol user.,Community/Population Health,Process,Prevention and Treatment of Opioid and Substance Use Disorders,-,-,National Committee for Quality Assurance,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,"X
 2017
 2018
@@ -3999,7 +3999,7 @@ Preventive Care and Screening: Unhealthy Alcohol Use: Screening & Brief Counseli
 2019
 2020
 2021
-2022",-,N/A,-,N,Y,3,2nd Performance Rate,"Rate 1: Percentage of patients aged 18 years and older who were screened for unhealthy alcohol use using a systematic screening method at least once within the last 12 months
+2022",-,"N/A",-,N,Y,3,2nd Performance Rate,"Rate 1: Percentage of patients aged 18 years and older who were screened for unhealthy alcohol use using a systematic screening method at least once within the last 12 months
 Rate 2: Percentage of patients aged 18 years and older who were identified as unhealthy alcohol users who received brief counseling
 Rate 3: Percentage of patients aged 18 years and older who were screened for unhealthy alcohol use using a systematic screening method at least once within the last 12 months AND who received brief counseling if identified as unhealthy alcohol users",N,,,,,,,,,,N,N,N,N,N,Y (2021),2021,2021: The measure is being updated to include 3 submission criteria (similar to Q226). The second performance rate will be used for benchmarking.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Proportion of Patients Sustaining a Bladder Injury at the Time of any Pelvic Organ Prolapse Repair,N/A,N/A,N/A,432,Percentage of patients undergoing pelvic organ prolapse repairs who sustain an injury to the bladder recognized either during or within 30 days after surgery.,Patient Safety,Outcome,Preventable Healthcare Harm,X,-,American Urogynecologic Society,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
@@ -4013,7 +4013,7 @@ Proportion of Patients Sustaining a Bladder Injury at the Time of any Pelvic Org
 2019
 2020
 2021
-2022",-,N/A,X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,"N/A",X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Proportion of Patients Sustaining a Bowel Injury at the time of any Pelvic Organ Prolapse Repair,N/A,N/A,N/A,433,Percentage of patients undergoing surgical repair of pelvic organ prolapse that is complicated by a bowel injury at the time of index surgery that is recognized intraoperatively or within 30 days after surgery.,Patient Safety,Outcome,Preventable Healthcare Harm,X,-,American Urogynecologic Society,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
@@ -4025,7 +4025,7 @@ Proportion of Patients Sustaining a Bowel Injury at the time of any Pelvic Organ
 2019
 2020
 2021
-2022",-,N/A,X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,"N/A",X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Proportion of Patients Sustaining a Ureter Injury at the Time of Pelvic Organ Prolapse Repair,N/A,N/A,N/A,434,Percentage of patients undergoing pelvic organ prolapse repairs who sustain an injury to the ureter recognized either during or within 30 days after surgery.,Patient Safety,Outcome,Preventable Healthcare Harm,X,-,American Urogynecologic Society,2017,2022,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
 2019
@@ -4033,7 +4033,7 @@ Proportion of Patients Sustaining a Ureter Injury at the Time of Pelvic Organ Pr
 2021",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2018
 2019
 2020
-2021",-,N/A,X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2021",-,"N/A",X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Quality of Life Assessment For Patients With Primary Headache Disorders,N/A,N/A,N/A,435,Percentage of patients with a diagnosis of primary headache disorder whose health related quality of life (HRQoL) was assessed with a tool(s) during at least two visits during the 12 month measurement period AND whose health related quality of life score stayed the same or improved.,Effective Clinical Care,Patient Reported Outcome,Functional Outcomes,X,-,American Academy of Neurology,2017,2021,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
 2019
@@ -4046,14 +4046,14 @@ Radiation Consideration for Adult CT: Utilization of Dose Lowering Techniques,N/
 • Automated exposure control.
 • Adjustment of the mA and/or kV according to patient size.
 • Use of iterative reconstruction technique.
-",Effective Clinical Care,Process,Appropriate Use of Healthcare ,-,-,American College of Radiology/ American Medical Association/ National Committee for Quality Assurance,2017,Measure is still in program,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,"X
+",Effective Clinical Care,Process,"Appropriate Use of Healthcare ",-,-,American College of Radiology/ American Medical Association/ National Committee for Quality Assurance,2017,Measure is still in program,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Rate of Surgical Conversion from Lower Extremity Endovascular Revascularization Procedure,N/A,N/A,N/A,437,"Inpatients assigned to endovascular treatment for obstructive arterial disease, the percent of patients who undergo unplanned major amputation or surgical bypass within 48 hours of the index procedure.",Patient Safety,Outcome,Preventable Healthcare Harm,X,-,Society of Interventional Radiology ,2017,2021,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2018
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Rate of Surgical Conversion from Lower Extremity Endovascular Revascularization Procedure,N/A,N/A,N/A,437,"Inpatients assigned to endovascular treatment for obstructive arterial disease, the percent of patients who undergo unplanned major amputation or surgical bypass within 48 hours of the index procedure.",Patient Safety,Outcome,Preventable Healthcare Harm,X,-,"Society of Interventional Radiology ",2017,2021,X,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2018
 2019
 2020",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"Include only patients undergoing an endovascular lower extremity revascularization procedure through December 29 of the performance period. This will allow the evaluation of at least 48 hours of the procedure within the reporting year.
 ",-,Y,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
@@ -4088,16 +4088,16 @@ Statin Therapy for the Prevention and Treatment of Cardiovascular Disease,CMS347
 2021
 2022",-,-,-,-,-,-,-,-,-,"The measure has multiple submission criteria. This measure requires the submission of only one performance rate and data completeness.  
 
-",-,N,Y,1,N/A,N/A,N,,,,This measure is not scored for the WI ,,,,,"This measure does not have a MSSP Benchmark. 
+",-,N,Y,1,N/A,N/A,N,,,,"This measure is not scored for the WI ",,,,,"This measure does not have a MSSP Benchmark. 
 Unlike other collection types, we will not attempt to calculate a performance period benchmark if there isn’t an existing benchmark or if the measure is classified as pay-for-reporting. CMS Web Interface measures without an existing benchmark or classified as pay-for-reporting do not count toward Quality performance category score, as long as data completeness requirements are met.
-",,,,This measure is not scored for the WI ,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+",,,,"This measure is not scored for the WI ",,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Age Appropriate Screening Colonoscopy,N/A,N/A,N/A,439,The percentage of screening colonoscopies performed in patients greater than or equal to 86 years of age from January 1 to December 31.,Efficiency and Cost Reduction,Efficiency,Appropriate Use of Healthcare,X,X,American Gastroenterological Association,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,Y,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2021),2021,The measure is being updated to include patients 50+ in the denominator. The numerator options were updated to reflect the change in denominator.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,Y,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2021),2021,The measure is being updated to include patients 50+ in the denominator. The numerator options were updated to reflect the change in denominator.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Skin Cancer: Biopsy Reporting Time – Pathologist to Clinician,N/A,N/A,N/A,440,"Percentage of biopsies with a diagnosis of cutaneous Basal Cell Carcinoma (BCC) and Squamous Cell Carcinoma (SCC), or melanoma (including in situ disease) in which the pathologist communicates results to the clinician within 7 days from the time when the tissue specimen was received by the pathologist.",Communication and Care Coordination,Process,Transfer of Health Information and Interoperability,X,-,American Academy of Dermatology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,"X
 2018
 2019
@@ -4106,7 +4106,7 @@ Skin Cancer: Biopsy Reporting Time – Pathologist to Clinician,N/A,N/A,N/A,440,
 2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,Y (2018),First,2018,Annual analysis of ICD10 codes indicated greater than 10 percent impacted,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,Y (2018),First,2018,Annual analysis of ICD10 codes indicated greater than 10 percent impacted,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Ischemic Vascular Disease (IVD) All or None Outcome Measure (Optimal Control),N/A,N/A,N/A,441,"The IVD All-or-None Measure is one outcome measure (optimal control). The measure contains four goals. All four goals within a measure must be reached in order to meet that measure. The numerator for the all-or-none measure should be collected from the organization's total IVD denominator. All-or-None Outcome Measure (Optimal Control) - Using the IVD denominator optimal results include:
 
 •  Most recent blood pressure (BP) measurement is less than or equal to 140/90 mm Hg -- AND
@@ -4135,13 +4135,13 @@ Ischemic Vascular Disease (IVD) All or None Outcome Measure (Optimal Control),N/
 2019
 2020
 2021
-2022",N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022","N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Persistence of Beta-Blocker Treatment After a Heart Attack,N/A,N/A,0071,442,The percentage of patients 18 years of age and older during the measurement year who were hospitalized and discharged from July 1 of the year prior to the measurement year to June 30 of the measurement year with a diagnosis of acute myocardial infarction (AMI) and who were prescribed persistent beta-blocker treatment for six months after discharge.,Effective Clinical Care,Process,Management of Chronic Conditions,-,-,National Committee for Quality Assurance,2017,2020,-,-,-,-,-,X,-,-,-,"2018
 2019",-,-,-,-,-,-,-,-,-,"2017
 2018
 2019",-,-,-,-,-,"2018
-2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Non-Recommended Cervical Cancer Screening in Adolescent Females,N/A,N/A,N/A,443,The percentage of adolescent females 16–20 years of age who were screened unnecessarily for cervical cancer.,Patient Safety,Process,Appropriate Use of Healthcare ,X,X,National Committee for Quality Assurance,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
+2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Non-Recommended Cervical Cancer Screening in Adolescent Females,N/A,N/A,N/A,443,The percentage of adolescent females 16–20 years of age who were screened unnecessarily for cervical cancer.,Patient Safety,Process,"Appropriate Use of Healthcare ",X,X,National Committee for Quality Assurance,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
@@ -4158,8 +4158,8 @@ Non-Recommended Cervical Cancer Screening in Adolescent Females,N/A,N/A,N/A,443,
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Medication Management for People with Asthma,N/A,N/A,N/A,444,The percentage of patients 5-64 years of age during the performance period who were identified as having persistent asthma and were dispensed appropriate medications that they remained on for at least 75% of their treatment period.,Efficiency and Cost Reduction,Process,Medication Management ,X,-,National Committee for Quality Assurance,2017,2022,-,-,-,-,-,X,"2017
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Medication Management for People with Asthma,N/A,N/A,N/A,444,The percentage of patients 5-64 years of age during the performance period who were identified as having persistent asthma and were dispensed appropriate medications that they remained on for at least 75% of their treatment period.,Efficiency and Cost Reduction,Process,"Medication Management ",X,-,National Committee for Quality Assurance,2017,2022,-,-,-,-,-,X,"2017
 2021",-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
 2019
@@ -4172,58 +4172,58 @@ Medication Management for People with Asthma,N/A,N/A,N/A,444,The percentage of p
 2019
 2020
 2021",-,-,-,-,-,"2020
-2021",-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2021",-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Risk-Adjusted Operative Mortality for Coronary Artery Bypass Graft (CABG),N/A,N/A,0119,445,"Percent of patients aged 18 years and older undergoing isolated CABG who die, including both all deaths occurring during the hospitalization in which the CABG was performed, even if after 30 days, and those deaths occurring after discharge from the hospital, but within 30 days of the procedure.",Effective Clinical Care,Outcome,Risk Adjusted Mortality,X,-,Society of Thoracic Surgeons,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2018
 2019
 2020
 2021
-2022",-,-,-,N/A,X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Operative Mortality Stratified by the Five STS-EACTS Mortality Categories,N/A,N/A,0733,446,"Percent of patients undergoing index pediatric and/or congenital heart surgery who die, including both 1) all deaths occurring during the hospitalization in which the procedure was performed, even if after 30 days (including patients transferred to other acute care facilities), and 2) those deaths occurring after discharge from the hospital, but within 30 days of the procedure, stratified by the five STAT Mortality Levels, a multi-institutional validated complexity stratification tool.",Patient Safety,Outcome,Risk Adjusted Mortality,X,-,Society of Thoracic Surgeons,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,There are two submission criteria for this measure and one performance rate.,-,Y,Y,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,"N/A",X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Operative Mortality Stratified by the Five STS-EACTS Mortality Categories,N/A,N/A,0733,446,"Percent of patients undergoing index pediatric and/or congenital heart surgery who die, including both 1) all deaths occurring during the hospitalization in which the procedure was performed, even if after 30 days (including patients transferred to other acute care facilities), and 2) those deaths occurring after discharge from the hospital, but within 30 days of the procedure, stratified by the five STAT Mortality Levels, a multi-institutional validated complexity stratification tool.",Patient Safety,Outcome,Risk Adjusted Mortality,X,-,Society of Thoracic Surgeons,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"There are two submission criteria for this measure and one performance rate.",-,Y,Y,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Chlamydia Screening and Follow Up,N/A,N/A,N/A,447,The percentage of female adolescents 16 years of age who had a chlamydia screening test with proper follow-up during the measurement period,Community/Population Health,Process,Preventive Care,-,-,National Committee for Quality Assurance,2017,2019,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,2018,-,-,-,-,2018,2018,-,-,-,-,-,-,"2017
-2018",-,-,-,-,-,2018,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,,N,Y,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Appropriate Workup Prior to Endometrial Ablation,N/A,N/A,N/A,448,"Percentage of patients, aged 18 years and older, who undergo endometrial sampling or hysteroscopy with biopsy and results are documented before undergoing an endometrial ablation.",Communication and Care Coordination,Process,Appropriate Use of Healthcare ,X,-,Centers for Medicare & Medicaid Services,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
+2018",-,-,-,-,-,2018,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",,N,Y,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Appropriate Workup Prior to Endometrial Ablation,N/A,N/A,N/A,448,"Percentage of patients, aged 18 years and older, who undergo endometrial sampling or hysteroscopy with biopsy and results are documented before undergoing an endometrial ablation.",Communication and Care Coordination,Process,"Appropriate Use of Healthcare ",X,-,Centers for Medicare & Medicaid Services,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 HER2 Negative or Undocumented Breast Cancer Patients Spared Treatment with HER2-Targeted Therapies,N/A,N/A,1857,449,Percentage of female patients (aged 18 years and older) with breast cancer who are human epidermal growth factor receptor 2 (HER2)/neu negative who are not administered HER2-targeted therapies.,Efficiency and Cost Reduction,Process,Preventable Healthcare Harm,X,X,American Society of Clinical Oncology,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
-2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Appropriate Treatment for Patients with Stage I (T1c) - III HER2 Positive Breast Cancer,N/A,N/A,1858,450,Percentage of female patients aged 18 to 70 with stage I (T1c) - III HER2 positive breast cancer for whom appropriate treatment is initiated.,Effective Clinical Care,Process,Appropriate Use of Healthcare,X,X,American Society of Clinical Oncology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,N,N,N,N,N,(Y) 2019,Suppression,2019,"In January of 2019, the FDA approved biosimilar drugs. ASCO approved it as a performance met. CMS/PIMMS agreed to allow denominator exception for 2019. This was communicated to Qualified Registries QCDRs 1/21. (Late guidance consideration)",N,N,N,N,N,Y (2021),2021,The measure is being updated to assess if adjuvant treatment includes both chemotherapy and HER2-targeted therapy for all female patients aged 18 - 70 with stage I (T1c) - III HER2 positive breast cancer.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,N,N,N,N,N,(Y) 2019,Suppression,2019,"In January of 2019, the FDA approved biosimilar drugs. ASCO approved it as a performance met. CMS/PIMMS agreed to allow denominator exception for 2019. This was communicated to Qualified Registries QCDRs 1/21. (Late guidance consideration)",N,N,N,N,N,Y (2021),2021,The measure is being updated to assess if adjuvant treatment includes both chemotherapy and HER2-targeted therapy for all female patients aged 18 - 70 with stage I (T1c) - III HER2 positive breast cancer.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 RAS (KRAS and NRAS) Gene Mutation Testing Performed for Patients with Metastatic Colorectal Cancer who receive Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibody Therapy,N/A,N/A,1859,451,Percentage of adult patients (aged 18 or over) with metastatic colorectal cancer who receive anti-epidermal growth factor receptor monoclonal antibody therapy for whom RAS (KRAS and NRAS) gene mutation testing was performed.,Effective Clinical Care,Process,Appropriate Use of Healthcare,-,-,American Society of Clinical Oncology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Patients with Metastatic Colorectal Cancer and RAS (KRAS or NRAS) Gene Mutation Spared Treatment with Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibodies,N/A,N/A,1860,452,Percentage of adult patients (aged 18 or over) with metastatic colorectal cancer and RAS (KRAS or NRAS) gene mutation spared treatment with anti-EGFR monoclonal antibodies.,Patient Safety,Process,Appropriate Use of Healthcare,X,X,American Society of Clinical Oncology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Percentage of Patients Who Died from Cancer Receiving Chemotherapy in the Last 14 Days of Life (lower score – better),N/A,N/A,0210,453,Percentage of patients who died from cancer receiving chemotherapy in the last 14 days of life.,Effective Clinical Care,Process,Appropriate Use of Healthcare ,X,X,American Society of Clinical Oncology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Percentage of Patients Who Died from Cancer Receiving Chemotherapy in the Last 14 Days of Life (lower score – better),N/A,N/A,0210,453,Percentage of patients who died from cancer receiving chemotherapy in the last 14 days of life.,Effective Clinical Care,Process,"Appropriate Use of Healthcare ",X,X,American Society of Clinical Oncology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Percentage of Patients who Died from Cancer with More than One Emergency Department Visit in the Last 30 Days of Life (lower score – better),N/A,N/A,N/A,454,Percentage of patients who died from cancer with more than one emergency department visit in the last 30 days of life.,Effective Clinical Care,Outcome,Appropriate Use of Healthcare ,X,X,American Society of Clinical Oncology,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Percentage of Patients who Died from Cancer with More than One Emergency Department Visit in the Last 30 Days of Life (lower score – better),N/A,N/A,N/A,454,Percentage of patients who died from cancer with more than one emergency department visit in the last 30 days of life.,Effective Clinical Care,Outcome,"Appropriate Use of Healthcare ",X,X,American Society of Clinical Oncology,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
-2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,Y,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Percentage of Patients Who Died from Cancer Admitted to the Intensive Care Unit (ICU) in the Last 30 Days of Life (lower score – better),N/A,N/A,0213,455,Percentage of patients who died from cancer admitted to the ICU in the last 30 days of life.,Effective Clinical Care,Outcome,Appropriate Use of Healthcare ,X,X,American Society of Clinical Oncology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
+2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,Y,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Percentage of Patients Who Died from Cancer Admitted to the Intensive Care Unit (ICU) in the Last 30 Days of Life (lower score – better),N/A,N/A,0213,455,Percentage of patients who died from cancer admitted to the ICU in the last 30 days of life.,Effective Clinical Care,Outcome,"Appropriate Use of Healthcare ",X,X,American Society of Clinical Oncology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2019
 2020
 2021
@@ -4233,19 +4233,19 @@ Percentage of Patients Who Died from Cancer Admitted to the Intensive Care Unit 
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Percentage of Patients Who Died From Cancer Not Admitted To Hospice (lower score – better),N/A,N/A,0215,456,Percentage of patients who died from cancer not admitted to hospice.,Effective Clinical Care,Process,Appropriate Use of Healthcare ,X,X,American Society of Clinical Oncology,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Percentage of Patients Who Died From Cancer Not Admitted To Hospice (lower score – better),N/A,N/A,0215,456,Percentage of patients who died from cancer not admitted to hospice.,Effective Clinical Care,Process,"Appropriate Use of Healthcare ",X,X,American Society of Clinical Oncology,2017,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2017
 2018
-2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,Y,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,Y,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Percentage of Patients Who Died from Cancer Admitted to Hospice for Less than 3 days (lower score – better),N/A,N/A,0216,457,"Percentage of patients who died from cancer, and admitted to hospice and spent less than 3 days there.",Effective Clinical Care,Outcome,End of Life Care According to Preferences,X,X,American Society of Clinical Oncology,2017,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2017
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-All-cause Hospital Readmission,N/A,N/A,1789,458,The 30-day All-Cause Hospital Readmission measure is a risk-standardized readmission rate for beneficiaries age 65 or older who were hospitalized at a short-stay acute care hospital and experienced an unplanned readmission for any cause to an acute care hospital within 30 days of discharge.,Communication and Care Coordination ,Outcome,Admissions and Readmissions to Hospitals,X,-,Yale University,2017,2021,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,Y,N,1,N/A,,N,N,N,N,N,(Y) 2020,N,,2020,"Due to public health emergency, there is geographical variance in the claims data which impacts performance calculations for this administrative claims measure and will likely produce misleading results.",,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Back Pain After Lumbar Discectomy/Laminectomy,N/A,N/A,N/A,459,"For patients 18 years of age or older who had a lumbar discectomy/laminectomy procedure, back pain is rated by the patients as less than or equal to 3.0 OR an improvement of 5.0 points or greater on the Visual Analog Scale (VAS) Pain scale at three months (6 to 20 weeks) postoperatively.",Person and Caregiver-Centered Experience and Outcomes,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,Minnesota Community Measurement ,2018,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,Y,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+All-cause Hospital Readmission,N/A,N/A,1789,458,The 30-day All-Cause Hospital Readmission measure is a risk-standardized readmission rate for beneficiaries age 65 or older who were hospitalized at a short-stay acute care hospital and experienced an unplanned readmission for any cause to an acute care hospital within 30 days of discharge.,"Communication and Care Coordination ",Outcome,Admissions and Readmissions to Hospitals,X,-,Yale University,2017,2021,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,Y,N,1,N/A,,N,N,N,N,N,(Y) 2020,N,,2020,"Due to public health emergency, there is geographical variance in the claims data which impacts performance calculations for this administrative claims measure and will likely produce misleading results.",,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Back Pain After Lumbar Discectomy/Laminectomy,N/A,N/A,N/A,459,"For patients 18 years of age or older who had a lumbar discectomy/laminectomy procedure, back pain is rated by the patients as less than or equal to 3.0 OR an improvement of 5.0 points or greater on the Visual Analog Scale (VAS) Pain scale at three months (6 to 20 weeks) postoperatively.",Person and Caregiver-Centered Experience and Outcomes,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,"Minnesota Community Measurement ",2018,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2018
 2019
 2020
@@ -4255,7 +4255,7 @@ Back Pain After Lumbar Discectomy/Laminectomy,N/A,N/A,N/A,459,"For patients 18 y
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,Y,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2020) ,2020,This measure was revised from a continuous variable to a proportional analytic for the 2020 performance period.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,Y,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,"Y (2020) ",2020,This measure was revised from a continuous variable to a proportional analytic for the 2020 performance period.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Back Pain After Lumbar Fusion,N/A,N/A,N/A,460,"For patients 18 years of age or older who had a lumbar fusion procedure, back pain is rated by the patient as less than or equal to 3.0 OR an improvement of 5.0 points or greater on the Visual Analog Scale (VAS) Pain scale at one year (9 to 15 months) postoperatively.
 ",Person and Caregiver-Centered Experience and Outcomes,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,Minnesota Community Measurement,2018,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2018
@@ -4267,8 +4267,8 @@ Back Pain After Lumbar Fusion,N/A,N/A,N/A,460,"For patients 18 years of age or o
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2020) ,2020,This measure was revised from a continuous variable to a proportional analytic for the 2020 performance period.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Leg Pain After Lumbar Discectomy/Laminectomy,N/A,N/A,N/A,461,"For patients 18 years of age or older who had a lumbar discectomy/laminectomy procedure, leg pain is rated by the patient as less than or equal to 3.0 OR an improvement of 5.0 points or greater on the VAS Pain scale at three months (6 to 20 weeks) postoperatively.",Person and Caregiver-Centered Experience and Outcomes,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,Minnesota Community Measurement ,2018,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,"Y (2020) ",2020,This measure was revised from a continuous variable to a proportional analytic for the 2020 performance period.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Leg Pain After Lumbar Discectomy/Laminectomy,N/A,N/A,N/A,461,"For patients 18 years of age or older who had a lumbar discectomy/laminectomy procedure, leg pain is rated by the patient as less than or equal to 3.0 OR an improvement of 5.0 points or greater on the VAS Pain scale at three months (6 to 20 weeks) postoperatively.",Person and Caregiver-Centered Experience and Outcomes,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,"Minnesota Community Measurement ",2018,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2018
 2019
 2020
@@ -4278,8 +4278,8 @@ Leg Pain After Lumbar Discectomy/Laminectomy,N/A,N/A,N/A,461,"For patients 18 ye
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2020) ,2020,This measure was revised from a continuous variable to a proportional analytic for the 2020 performance period.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Bone Density Evaluation for Patients with Prostate Cancer and Receiving Androgen Deprivation Therapy,CMS645v5,N/A,N/A,462,"Patients determined as having prostate cancer who are currently starting or undergoing androgen deprivation therapy (ADT), for an anticipated period of 12 months or greater and who receive an initial bone density evaluation. The bone density evaluation must be prior to the start of ADT or within 3 months of the start of ADT.",Effective Clinical Care,Process,Management of Chronic Conditions,-,-,Oregon Urology Institute ,2018,Measure is still in program,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,"Y (2020) ",2020,This measure was revised from a continuous variable to a proportional analytic for the 2020 performance period.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Bone Density Evaluation for Patients with Prostate Cancer and Receiving Androgen Deprivation Therapy,CMS645v5,N/A,N/A,462,"Patients determined as having prostate cancer who are currently starting or undergoing androgen deprivation therapy (ADT), for an anticipated period of 12 months or greater and who receive an initial bone density evaluation. The bone density evaluation must be prior to the start of ADT or within 3 months of the start of ADT.",Effective Clinical Care,Process,Management of Chronic Conditions,-,-,"Oregon Urology Institute ",2018,Measure is still in program,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2020
 2021
 2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
@@ -4292,13 +4292,13 @@ Bone Density Evaluation for Patients with Prostate Cancer and Receiving Androgen
 2019
 2020
 2021
-2022",-,N/A,-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,"N/A",-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Prevention of Post-Operative Vomiting (POV) – Combination Therapy (Pediatrics),N/A,N/A,N/A,463,"Percentage of patients aged 3 through 17 years, who undergo a procedure under general anesthesia in which an inhalational anesthetic is used for maintenance AND who have two or more risk factors for post-operative vomiting (POV), who receive combination therapy consisting of at least two prophylactic pharmacologic anti-emetic agents of different classes preoperatively and/or intraoperatively.",Patient Safety,Process,Preventive Care,X,-,American Society of Anesthesiologists,2018,Measure is still in program,-,-,-,-,-,X,-,"X
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Otitis Media with Effusion: Systemic Antimicrobials - Avoidance of Inappropriate Use,N/A,N/A,0657,464,Percentage of patients aged 2 months through 12 years with a diagnosis of OME who were not prescribed systemic antimicrobials.,Effective Clinical Care,Process,Appropriate Use of Healthcare,X,X,American Academy of Otolaryngology – Head and Neck Surgery Foundation,2018,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2018
 2019
@@ -4319,13 +4319,13 @@ Otitis Media with Effusion: Systemic Antimicrobials - Avoidance of Inappropriate
 2019
 2020
 2021
-2022",-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Uterine Artery Embolization Technique: Documentation of Angiographic Endpoints and Interrogation of Ovarian Arteries,N/A,N/A,N/A,465,The percentage of patients with documentation of angiographic endpoints of embolization AND the documentation of embolization strategies in the presence of unilateral or bilateral absent uterine arteries.,Patient Safety,Process,Transfer of Health Information and Interoperability,X,-,Society of Interventional Radiology,2018,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2018
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Developmental Screening in the First Three Years of Life,N/A,N/A,N/A,467,"The percentage of children screened for risk of developmental, behavioral and social delays using a standardized screening tool in the 12 months preceding or on their first, second, or third birthday. This is a composite measure of screening in the first three years of life that includes three, age-specific indicators assessing whether children are screened in the 12 months preceding or on their first, second or third birthday.",Community/Population Health,Process,Preventive Care,-,-,Oregon Health & Science University,2018,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"2018
 2019",-,-,-,-,-,-,-,-,-,-,-,-,-,-,"There are four submission criteria for this measure. The fourth performance rate (Percentage of children who turned 1, 2, or 3 during the performance period who were screened for risk of developmental, behavioral and social delays using a standardized tool with interpretation and report within 12 months preceding or on their birthday) should be utilized for an overall data completeness and performance rate for this measure. 
 4. The total performance rate is calculated  as the sum of Performance for criteria 1, 2 and 3.
@@ -4346,7 +4346,7 @@ Continuity of Pharmacotherapy for Opioid Use Disorder (OUD),N/A,N/A,N/A,468,Perc
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,N,1,N/A,N/A,N,N,N,N,N,N,N,,,"The Denominator Identification Period does not align within the measure specification. It specifies 18 months although the Denominator Identification Period is limited to 12 months. Due to this lack of clarity within the measure specification surrounding determination of the Denominator Identification Period, this measure will likely produce misleading results by assessing the differing patient populations. ",,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,N,1,N/A,N/A,N,N,N,N,N,N,N,,,"The Denominator Identification Period does not align within the measure specification. It specifies 18 months although the Denominator Identification Period is limited to 12 months. Due to this lack of clarity within the measure specification surrounding determination of the Denominator Identification Period, this measure will likely produce misleading results by assessing the differing patient populations. ",,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Functional Status After Lumbar Fusion,N/A,N/A,N/A,469,"For patients 18 years of age and older who had a lumbar fusion procedure, functional status is rated by the patient as less than or equal to 22 OR an improvement of 30 points or greater on the Oswestry Disability Index (ODI version 2.1a) at one year (9 to 15 months) postoperatively.",Person and Caregiver-Centered Experience and Outcomes,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,Minnesota Community Measurement,2019,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2019
 2020
@@ -4355,13 +4355,13 @@ Functional Status After Lumbar Fusion,N/A,N/A,N/A,469,"For patients 18 years of 
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2020) ,2020,This measure was revised from a continuous variable to a proportional analytic for the 2020 performance period.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
- Functional Status After Primary Total Knee Replacement,N/A,N/A,N/A,470,"For patients age 18 and older who had a primary total knee replacement procedure, functional status is rated by the patient as greater than or equal to 37 on the Oxford Knee Score (OKS) or a 71 or greater on the KOOS, JR tool at one year (9 to 15 months) postoperatively.",Person and Caregiver-Centered Experience and Outcomes,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,Minnesota Community Measurement,2019,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,"Y (2020) ",2020,This measure was revised from a continuous variable to a proportional analytic for the 2020 performance period.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+" Functional Status After Primary Total Knee Replacement",N/A,N/A,N/A,470,"For patients age 18 and older who had a primary total knee replacement procedure, functional status is rated by the patient as greater than or equal to 37 on the Oxford Knee Score (OKS) or a 71 or greater on the KOOS, JR tool at one year (9 to 15 months) postoperatively.",Person and Caregiver-Centered Experience and Outcomes,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,Minnesota Community Measurement,2019,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2020) ,2020,This measure was revised from a continuous variable to a proportional analytic for the 2020 performance period.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
- Functional Status After Lumbar Discectomy/Laminectomy,N/A,N/A,N/A,471,"For patients age 18 and older who had lumbar discectomy/laminectomy procedure, functional status is rated by the patient as less than or equal to 22 OR an improvement of 30 points or greater on the Oswestry Disability Index (ODI version 2.1a) at three months (6 to 20 weeks) postoperatively.",Person and Caregiver-Centered Experience and Outcomes,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,Minnesota Community Measurement,2019,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,"Y (2020) ",2020,This measure was revised from a continuous variable to a proportional analytic for the 2020 performance period.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+" Functional Status After Lumbar Discectomy/Laminectomy",N/A,N/A,N/A,471,"For patients age 18 and older who had lumbar discectomy/laminectomy procedure, functional status is rated by the patient as less than or equal to 22 OR an improvement of 30 points or greater on the Oswestry Disability Index (ODI version 2.1a) at three months (6 to 20 weeks) postoperatively.",Person and Caregiver-Centered Experience and Outcomes,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,Minnesota Community Measurement,2019,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2019
 2020
 2021
@@ -4369,7 +4369,7 @@ Functional Status After Lumbar Fusion,N/A,N/A,N/A,469,"For patients 18 years of 
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2020) ,2020,This measure was revised from a continuous variable to a proportional analytic for the 2020 performance period.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,"Y (2020) ",2020,This measure was revised from a continuous variable to a proportional analytic for the 2020 performance period.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Appropriate Use of DXA Scans in Women Under 65 Years Who Do Not Meet the Risk Factor Profile for Osteoporotic Fracture,CMS249v4,3475e,N/A,472,Percentage of female patients 50 to 64 years of age without select risk factors for osteoporotic fracture who received an order for a dual-energy x-ray absorptiometry (DXA) scan during the measurement period.,Efficiency and Cost Reduction,Process,Appropriate Use of Healthcare,X,X,Centers for Medicare & Medicaid Services,2019,Measure is still in program,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2019
 2020
@@ -4382,7 +4382,7 @@ Appropriate Use of DXA Scans in Women Under 65 Years Who Do Not Meet the Risk Fa
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,Y,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,Y,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Leg Pain After Lumbar Fusion,N/A,N/A,N/A,473,"For patients 18 years of age or older who had a lumbar fusion procedure, leg pain is rated by the patient as less than or equal to 3.0 OR an improvement of 5.0 points or greater on the Visual Analog Scale (VAS) Pain scale at one year (9 to 15 months) postoperatively. ",Person and Caregiver-Centered Experience and Outcomes,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,Minnesota Community Measurement,2019,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2019
 2020
@@ -4391,8 +4391,8 @@ Leg Pain After Lumbar Fusion,N/A,N/A,N/A,473,"For patients 18 years of age or ol
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2020) ,2020,This measure was revised from a continuous variable to a proportional analytic for the 2020 performance period.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Zoster (Shingles) Vaccination,N/A,N/A,N/A,474,The percentage of patients aged 50 years and older who have had the Shingrix zoster (shingles) vaccination.,Community/Population Health,Process,Preventive Care,-,-,PPRNet,2019,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,2019,-,-,2019,-,2019,2019,-,-,2019,-,-,-,-,2019,-,-,-,-,-,-,-,-,-,2019,-,-,-,2019,-,-,-,-,-,N/A,X,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,"Y (2020) ",2020,This measure was revised from a continuous variable to a proportional analytic for the 2020 performance period.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Zoster (Shingles) Vaccination,N/A,N/A,N/A,474,The percentage of patients aged 50 years and older who have had the Shingrix zoster (shingles) vaccination.,Community/Population Health,Process,Preventive Care,-,-,PPRNet,2019,2020,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,2019,-,-,2019,-,2019,2019,-,-,2019,-,-,-,-,2019,-,-,-,-,-,-,-,-,-,2019,-,-,-,2019,-,-,-,-,-,"N/A",X,N,N,1,N/A,,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 HIV Screening,CMS349v4,N/A,N/A,475,Percentage of patients aged 15-65 at the start of the measurement period who were between 15-65 years old when tested for HIV.,Community/Population Health,Process,Preventive Care,-,-,Centers for Disease Control and Prevention,2019,Measure is still in program,-,-,X,-,-,-,-,-,-,-,"X
 2022",-,-,-,-,-,-,-,-,"X
 2019
@@ -4414,18 +4414,18 @@ HIV Screening,CMS349v4,N/A,N/A,475,Percentage of patients aged 15-65 at the star
 2019
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,N/A,-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Urinary Symptom Score Change 6-12 Months After Diagnosis of Benign Prostatic Hyperplasia,CMS771v3,N/A,N/A,476,Percentage of patients with an office visit within the measurement period and with a new diagnosis of clinically significant Benign Prostatic Hyperplasia who have International Prostate Symptoms Score (IPSS) or American Urological Association (AUA) Symptom Index (SI) documented at time of diagnosis and again 6-12 months later with an improvement of 3 points.,Person and Caregiver-centered Experience and Outcomes ,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,Large Urology Group Practice Association and Oregon Urology Institute,2020,Measure is still in program,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
+2022",-,-,-,-,-,-,-,-,-,"N/A",-,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Urinary Symptom Score Change 6-12 Months After Diagnosis of Benign Prostatic Hyperplasia,CMS771v3,N/A,N/A,476,Percentage of patients with an office visit within the measurement period and with a new diagnosis of clinically significant Benign Prostatic Hyperplasia who have International Prostate Symptoms Score (IPSS) or American Urological Association (AUA) Symptom Index (SI) documented at time of diagnosis and again 6-12 months later with an improvement of 3 points.,"Person and Caregiver-centered Experience and Outcomes ",Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,Large Urology Group Practice Association and Oregon Urology Institute,2020,Measure is still in program,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2020
 2021
 2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2020
 2021
-2022",-,N/A,X,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Multimodal Pain Management,N/A,N/A,N/A,477,"Percentage of patients, aged 18 years and older, undergoing selected surgical procedures that were managed with multimodal pain medicine.",Effective Clinical Care ,Process,Prevention and Treatment of Opioid and Substance Use Disorders,X,-,American Society of Anesthesiologists,2020,Measure is still in program,-,-,-,-,-,X,-,"X
+2022",-,"N/A",X,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Multimodal Pain Management,N/A,N/A,N/A,477,"Percentage of patients, aged 18 years and older, undergoing selected surgical procedures that were managed with multimodal pain medicine.","Effective Clinical Care ",Process,Prevention and Treatment of Opioid and Substance Use Disorders,X,-,American Society of Anesthesiologists,2020,Measure is still in program,-,-,-,-,-,X,-,"X
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",X,N,N,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Functional Status Change for Patients with Neck Impairments,N/A,N/A,N/A,478,"A patient-reported outcome measure of risk-adjusted change in functional status for patients 14 years+ with neck impairments. The change in functional status (FS) is assessed using the FOTO Neck FS patient-reported outcome measure (PROM). The measure is adjusted to patient characteristics known to be associated with FS outcomes (risk-adjusted) and  used as a performance measure at the patient level, at the individual clinician level, and at the clinic level to assess quality. The measure is available as a computer adaptive test, for reduced patient burden, or a short form (static/paper-pencil).",Person and Caregiver-centered Experience and Outcomes,Patient-Reported Outcome-Based Performance Measure,Functional Outcomes,X,-,"Focus on Therapeutic Outcomes, Inc.",2020,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,"X
 2020
 2021
@@ -4435,14 +4435,14 @@ Functional Status Change for Patients with Neck Impairments,N/A,N/A,N/A,478,"A p
 2022",-,-,-,-,"X
 2020
 2021
-2022",-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,N,Y,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2021),2021,This measure is being updated to align with the other FOTO measures.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,N,Y,1,N/A,N/A,N,,,,,,,,,,N,N,N,N,N,Y (2021),2021,This measure is being updated to align with the other FOTO measures.,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 "Hospital-Wide, 30-Day, All-Cause Unplanned Readmission (HWR) Rate for the Merit-Based Incentive Payment System (MIPS) Groups",N/A,N/A,N/A,479,"This measure is a re-specified version of the measure, “Risk-adjusted readmission rate (RARR) of unplanned readmission within 30 days of hospital discharge for any condition” (NQF 1789), which was developed for patients 65 years and older using Medicare claims. This re-specified measure attributes outcomes to MIPS participating clinician groups and assesses each group’s readmission rate. The measure comprises a single summary score, derived from the results of five models, one for each of the following specialty cohorts (groups of discharge condition categories or procedure categories): medicine, surgery/gynecology, cardio-respiratory, cardiovascular, and neurology.",Communication and Care Coordination,Outcome,Admissions and readmissions to hospitals,X,-,Centers for Medicare & Medicaid Services,2021,Measure is still in program,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"The measure comprises a single summary score, derived from the results of five models, one for each of the following specialty cohorts (groups of discharge condition categories or procedure categories): medicine, surgery/gynecology, cardio-respiratory, cardiovascular, and neurology",-,Y,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Risk-standardized complication rate (RSCR) following elective primary total hip arthroplasty (THA) and/or total knee arthroplasty (TKA) for Merit-based Incentive Payment System (MIPS),N/A,N/A,3493,480,"This measure is a re-specified version of the measure, “Hospital-level Risk-standardized Complication rate (RSCR) following Elective Primary Total Hip Arthroplasty (THA) and/or Total Knee Arthroplasty (TKA)” (National Quality Forum 1550), which was developed for patients 65 years and older using Medicare claims. This re-specified measure attributes outcomes to Merit-based Incentive Payment System participating clinicians and/or clinician groups (“provider”) and assesses each provider’s complication rate, defined as any one of the specified complications occurring from the date of index admission to up to 90 days post date of the index procedure.",Patient Safety,Outcome,Preventable healthcare harm,X,-,Centers for Medicare & Medicaid Services,2021,Measure is still in program,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,N/A,-,Y,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Risk-standardized complication rate (RSCR) following elective primary total hip arthroplasty (THA) and/or total knee arthroplasty (TKA) for Merit-based Incentive Payment System (MIPS),N/A,N/A,3493,480,"This measure is a re-specified version of the measure, “Hospital-level Risk-standardized Complication rate (RSCR) following Elective Primary Total Hip Arthroplasty (THA) and/or Total Knee Arthroplasty (TKA)” (National Quality Forum 1550), which was developed for patients 65 years and older using Medicare claims. This re-specified measure attributes outcomes to Merit-based Incentive Payment System participating clinicians and/or clinician groups (“provider”) and assesses each provider’s complication rate, defined as any one of the specified complications occurring from the date of index admission to up to 90 days post date of the index procedure.",Patient Safety,Outcome,Preventable healthcare harm,X,-,Centers for Medicare & Medicaid Services,2021,Measure is still in program,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"N/A",-,Y,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Intravesical Bacillus-Calmette Guerin for Non-muscle Invasive Bladder Cancer,CMS646v2,-,N/A,481,Percentage of patients initially diagnosed with non-muscle invasive bladder cancer and who received intravesical Bacillus-Calmette-Guerin (BCG) within 6 months of bladder cancer staging.,Effective Clinical Care,Process,Appropriate Use of Healthcare,X,X,Oregon Urology,2022,Measure is still in program,-,-,X,-,-,-,-,-,-,-,,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
-2022",-,N/A,X,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2022",-,"N/A",X,N,N/A,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Hemodialysis Vascular Access: Practitioner Level Long-term Catheter Rate,-,-,N/A,482,Percentage of adult hemodialysis patient-months using a catheter continuously for three months or longer for vascular access attributable to an individual practitioner or group practice.,Effective Clinical Care,Intermediate Outcome,Management of chronic conditions,X,-,Centers for Medicare & Medicaid Services,2022,Measure is still in program,-,-,-,-,-,X,-,-,-,-,,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,,,,,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Person-Centered Primary Care Measure Patient Reported Outcome Performance Measure (PCPCM PRO-PM),-,-,-,483,"The Person-Centered Primary Care Measure Patient Reported Outcome Performance Measure (PCPCM PRO-PM) uses the PCPCM PROM (a comprehensive and parsimonious set of 11 patient-reported items) to assess the broad scope of primary care. Unlike other primary care measures, the PCPCM PRO-PM measures the high value aspects of primary care based on a patient’s relationship with the clinician or practice. Patients identify the PCPCM PROM as meaningful and able to communicate the quality of their care to their clinicians and/or care team. The items within the PCPCM PROM are based on extensive stakeholder engagement and comprehensive reviews of the literature.",Person and Caregiver-centered Experience and Outcomes,Patient-Reported Outcome-Based Performance Measure,Patient's Experience of Care,X,-,The American Board of Family Medicine,2022,Measure is still in program,-,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,"X
 2022",-,-,-,-,-,"X
 2022",-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,,,N,,1,N/A,N/A,Y,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
- Clinician and Clinician Group Risk-standardized Hospital Admission Rates for Patients with Multiple Chronic Conditions,N/A,N/A,N/A,484,"Annual risk-standardized rate of acute, unplanned hospital admissions among Medicare Fee-for-Service (FFS) patients aged 65 years and older with multiple chronic conditions (MCCs).",Effective Clinical Care,Outcome,Management of chronic conditions,X,-,Centers for Medicare & Medicaid Services,2022,Measure is still in program,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,,,,,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+" Clinician and Clinician Group Risk-standardized Hospital Admission Rates for Patients with Multiple Chronic Conditions",N/A,N/A,N/A,484,"Annual risk-standardized rate of acute, unplanned hospital admissions among Medicare Fee-for-Service (FFS) patients aged 65 years and older with multiple chronic conditions (MCCs).",Effective Clinical Care,Outcome,Management of chronic conditions,X,-,Centers for Medicare & Medicaid Services,2022,Measure is still in program,-,-,-,-,X,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,,,,,1,N/A,N/A,N,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,X,X,X,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
As part of Y6 requirements, measureId 047 should no longer be required for PCF measurementSets.

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-6448
