### PR TITLE
QPPSF-10172: Remove proportional decile trimming

### DIFF
--- a/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js
+++ b/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js
@@ -65,18 +65,8 @@ const getBenchmarkKey = (benchmark) => {
  * }}
  */
 const processPerformanceBenchmark = (benchmark) => {
-  // TODO: Kyle - This was a one-off for 2021 performance benchmarks. If you run this for 2022 performance benchmarks you're in trouble.
-  //  Fix the underlining data where proportional measures to produce 9 deciles only by default.
-  const nonPropMeasures2021 = ['ACRAD18', 'ACEP50', 'ACEP51', 'ACRAD17', 'ACRAD25', 'ACRAD19', 'ACRAD16', 'ACRAD15'];
-  const acMeasures2021 = ['479', '480'];
-  const trimmedDeciles = () => {
-    if (nonPropMeasures2021.includes(benchmark.measureId) || acMeasures2021.includes(benchmark.measureId) || benchmark.performanceYear !== 2021) {
-      return benchmark.deciles;
-    } else {
-      return benchmark.deciles.slice(1);
-    }
-  };
   // Determines how to round Performance Benchmarks should be rounded per circumstance and business rules. Should mostly be 2.
+  const acMeasures2021 = ['479', '480'];
   const decimalPlaces = () => {
     if (acMeasures2021.includes(benchmark.measureId) && benchmark.performanceYear >= 2021) {
       return 4;
@@ -87,7 +77,7 @@ const processPerformanceBenchmark = (benchmark) => {
     }
   };
 
-  const averageDeciles = trimmedDeciles()
+  const averageDeciles = benchmark.deciles
     .map(d => _.round(d, decimalPlaces()));
 
   return {


### PR DESCRIPTION
#### Motivation for change

Trimming the first decile for proportional measures was added as a quick fix. This should be done in the Final Scoring engine that computes the deciles. The PR for that is [here](https://github.cms.gov/qpp/qppar-final-scoring/pull/1334).

#### What is being changed

This PR just removes the decile trimming.

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [ ] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [x] Unit tests added/passing
* [x] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPSF-10172
