### PR TITLE
QPPA-6517, QPPA-6772: changed benchmarks field to historic_benchmarks, add PY23 Repo

### DIFF
--- a/measures/2022/measures-data.json
+++ b/measures/2022/measures-data.json
@@ -2361,7 +2361,7 @@
       "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms154v10",
       "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_065_MIPSCQM.pdf"
     },
-    "benchmarks": {
+    "historic_benchmarks": {
       "registry": "removed"
     }
   },
@@ -2841,7 +2841,7 @@
     "measureSpecification": {
       "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_116_MIPSCQM.pdf"
     },
-    "benchmarks": {
+    "historic_benchmarks": {
       "registry": "removed"
     }
   },
@@ -4357,7 +4357,7 @@
         "description": "Percentage of patients aged 18 years and older who were screened for tobacco use one or more times within the measurement period AND who received tobacco cessation intervention if identified as a tobacco user on the date of the encounter or within the previous 12 months"
       }
     ],
-    "benchmarks": {
+    "historic_benchmarks": {
       "cmsWebInterface": "removed"
     }
   },
@@ -5915,7 +5915,7 @@
     "measureSpecification": {
       "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_326_MIPSCQM.pdf"
     },
-    "benchmarks": {}
+    "historic_benchmarks": {}
   },
   {
     "title": "Adult Sinusitis: Antibiotic Prescribed for Acute Viral Sinusitis (Overuse)",
@@ -6035,7 +6035,7 @@
     "measureSpecification": {
       "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_335_MIPSCQM.pdf"
     },
-    "benchmarks": {
+    "historic_benchmarks": {
       "registry": "removed"
     }
   },
@@ -6225,7 +6225,7 @@
     "measureSpecification": {
       "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_350_MIPSCQM.pdf"
     },
-    "benchmarks": {
+    "historic_benchmarks": {
       "registry": "removed"
     }
   },
@@ -6264,7 +6264,7 @@
     "measureSpecification": {
       "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_351_MIPSCQM.pdf"
     },
-    "benchmarks": {
+    "historic_benchmarks": {
       "registry": "removed"
     }
   },
@@ -6578,7 +6578,7 @@
         "description": "Percentage of children who remained on ADHD medication for at least 210 days and who, in addition to the visit in the Initiation Phase, had at least two additional follow-up visits with a practitioner within 270 days (9 months) after the Initiation Phase ended."
       }
     ],
-    "benchmarks": {
+    "historic_benchmarks": {
       "electronicHealthRecord": "removed"
     }
   },
@@ -7560,7 +7560,7 @@
     "measureSpecification": {
       "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_400_MIPSCQM.pdf"
     },
-    "benchmarks": {
+    "historic_benchmarks": {
       "registry": "removed"
     }
   },
@@ -7806,7 +7806,7 @@
     "measureSpecification": {
       "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_409_MIPSCQM.pdf"
     },
-    "benchmarks": {
+    "historic_benchmarks": {
       "registry": "removed"
     }
   },
@@ -17402,7 +17402,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "benchmarks": {
+    "historic_benchmarks": {
       "registry": "removed"
     }
   },
@@ -17467,7 +17467,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "benchmarks": {
+    "historic_benchmarks": {
       "registry": "removed"
     }
   },
@@ -17532,7 +17532,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "benchmarks": {
+    "historic_benchmarks": {
       "registry": "removed"
     }
   },
@@ -17597,7 +17597,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "benchmarks": {
+    "historic_benchmarks": {
       "registry": "removed"
     }
   },
@@ -17662,7 +17662,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "benchmarks": {
+    "historic_benchmarks": {
       "registry": "removed"
     }
   },
@@ -17727,7 +17727,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "benchmarks": {
+    "historic_benchmarks": {
       "registry": "removed"
     }
   },
@@ -17792,7 +17792,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "benchmarks": {
+    "historic_benchmarks": {
       "registry": "removed"
     }
   },
@@ -17857,7 +17857,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "benchmarks": {
+    "historic_benchmarks": {
       "registry": "removed"
     }
   },
@@ -17922,7 +17922,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "benchmarks": {
+    "historic_benchmarks": {
       "registry": "removed"
     }
   },

--- a/measures/2022/measures-schema.yaml
+++ b/measures/2022/measures-schema.yaml
@@ -216,7 +216,7 @@ definitions:
             type: array
             description: List of submissionMethods where ICD 10 codes for the measure changed during the submission year. Used to indicate that submissions data should be truncated to only the first nine months of the performance year when the ICD 10 codes were unchanged. Typically impacts claims submissionMethod. Does not impact registry submissionMethod.
             items: { $ref: #/definitions/methods }
-          benchmarks:
+          historic_benchmarks:
             type: object
             description: The submissionMethods of the measure which have had their benchmarks removed or flattened for the current year. A benchmark is marked as flat if the measure is determined to have the potential to result in inappropriate treatment of patients if the top decile is higher than 90%, or if inverse less than 10%. 
             propertyNames: { $ref: #/definitions/methods }

--- a/measures/2023/measures-data.json
+++ b/measures/2023/measures-data.json
@@ -1,0 +1,20988 @@
+[
+  {
+    "category": "ia",
+    "title": "Provide 24/7 Access to MIPS Eligible Clinicians or Groups Who Have Real-Time Access to Patient's Medical Record",
+    "description": "Provide 24/7 access to MIPS eligible clinicians, groups, or care teams for advice about urgent care (e.g., MIPS eligible clinician and care team access to medical record, cross-coverage with access to medical record, or protocol-driven nurse line with access to medical record) that could include one or more of the following:•\tExpanded hours in evenings and weekends with access to the patient medical record (e.g., coordinate with small practices to provide alternate hour office visits and urgent care);•\tUse of alternatives to increase access to care team by MIPS eligible clinicians and groups, such as e-visits, phone visits, group visits, home visits and alternate locations (e.g., senior centers and assisted living centers); and/or•\tProvision of same-day or next-day access to a MIPS eligible clinician, group or care team when needed for urgent care or transition management.",
+    "measureId": "IA_EPA_1",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "expandedPracticeAccess"
+  },
+  {
+    "category": "ia",
+    "title": "Use of telehealth services that expand practice access",
+    "description": "Create and implement a standardized process for providing telehealth services to expand access to care.",
+    "measureId": "IA_EPA_2",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "expandedPracticeAccess"
+  },
+  {
+    "category": "ia",
+    "title": "Collection and use of patient experience and satisfaction data on access",
+    "description": "Collection of patient experience and satisfaction data on access to care and development of an improvement plan, such as outlining steps for improving communications with patients to help understanding of urgent access needs.",
+    "measureId": "IA_EPA_3",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "expandedPracticeAccess"
+  },
+  {
+    "category": "ia",
+    "title": "Additional improvements in access as a result of QIN/QIO TA",
+    "description": "As a result of Quality Innovation Network-Quality Improvement Organization technical assistance, performance of additional activities that improve access to services or improve care coordination (for example, investment of on-site diabetes educator).",
+    "measureId": "IA_EPA_4",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "expandedPracticeAccess"
+  },
+  {
+    "category": "ia",
+    "title": "Participation in User Testing of the Quality Payment Program Website (https://qpp.cms.gov/)",
+    "description": "User participation in the Quality Payment Program website testing is an activity for eligible clinicians who have worked with CMS to provide substantive, timely, and responsive input to improve the CMS Quality Payment Program website through product user-testing that enhances system and program accessibility, readability and responsiveness as well as providing feedback for developing tools and guidance thereby allowing for a more user-friendly and accessible clinician and practice Quality Payment Program website experience.",
+    "measureId": "IA_EPA_5",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "expandedPracticeAccess"
+  },
+  {
+    "category": "ia",
+    "title": "Anticoagulant Management Improvements",
+    "description": "Individual MIPS eligible clinicians and groups who prescribe anti-coagulation medications (including, but not limited to oral Vitamin K antagonist therapy, including warfarin or other coagulation cascade inhibitors) must attest that for 75 percent of their ambulatory care patients receiving these medications are being managed with support from one or more of the following improvement activities:• Participation in a systematic anticoagulation program (coagulation clinic, patient self-reporting program, or patient self-management program);• Patients are being managed by an anticoagulant management service, that involves systematic and coordinated care, incorporating comprehensive patient education, systematic prothrombin time (PT-INR) testing, tracking, follow-up, and patient communication of results and dosing decisions;• Patients are being managed according to validated electronic decision support and clinical management tools that involve systematic and coordinated care, incorporating comprehensive patient education, systematic PT-INR testing, tracking, follow-up, and patient communication of results and dosing decisions;• For rural or remote patients, patients are managed using remote monitoring or telehealth options that involve systematic and coordinated care, incorporating comprehensive patient education, systematic PT-INR testing, tracking, follow-up, and patient communication of results and dosing decisions; or• For patients who demonstrate motivation, competency, and adherence, patients are managed using either a patient self-testing (PST) or patient-self-management (PSM) program.",
+    "measureId": "IA_PM_2",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "populationManagement"
+  },
+  {
+    "category": "ia",
+    "title": "RHC, IHS or FQHC quality improvement activities",
+    "description": "Participating in a Rural Health Clinic (RHC), Indian Health Service Medium Management (IHS), or Federally Qualified Health Center in ongoing engagement activities that contribute to more formal quality reporting, and that include receiving quality data back for broader quality improvement and benchmarking improvement which will ultimately benefit patients. Participation in Indian Health Service, as an improvement activity, requires MIPS eligible clinicians and groups to deliver care to federally recognized American Indian and Alaska Native populations in the U.S. and in the course of that care implement continuous clinical practice improvement including reporting data on quality of services being provided and receiving feedback to make improvements over time.",
+    "measureId": "IA_PM_3",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "populationManagement"
+  },
+  {
+    "category": "ia",
+    "title": "Glycemic management services",
+    "description": "For outpatient Medicare beneficiaries with diabetes and who are prescribed antidiabetic agents (e.g., insulin, sulfonylureas), MIPS eligible clinicians and groups must attest to having: For the first performance year, at least 60 percent of medical records with documentation of an individualized glycemic treatment goal that: a) Takes into account patient-specific factors, including, at least 1) age, 2) comorbidities, and 3) risk for hypoglycemia, andb) Is reassessed at least annually.The performance threshold will increase to 75 percent for the second performance year and onward.Clinician would attest that, 60 percent for first year, or 75 percent for the second year, of their medical records that document individualized glycemic treatment represent patients who are being treated for at least 90 days during the performance period.",
+    "measureId": "IA_PM_4",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "populationManagement"
+  },
+  {
+    "category": "ia",
+    "title": "Engagement of community for health status improvement",
+    "description": "Take steps to improve health status of communities, such as collaborating with key partners and stakeholders to implement evidenced-based practices to improve a specific chronic condition. Refer to the local Quality Improvement Organization (QIO) for additional steps to take for improving health status of communities as there are many steps to select from for satisfying this activity. QIOs work under the direction of CMS to assist MIPS eligible clinicians and groups with quality improvement, and review quality concerns for the protection of beneficiaries and the Medicare Trust Fund.",
+    "measureId": "IA_PM_5",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "populationManagement"
+  },
+  {
+    "category": "ia",
+    "title": "Use of Toolsets or Other Resources to Close Health and Health Care Inequities Across Communities",
+    "description": "Address inequities in health outcomes by using population health data analysis tools to identify health inequities in the community and practice and assess options for effective and relevant interventions such as Population Health Toolkit or other resources identified by the clinician, practice, or by CMS. Based on this information, create, refine, and implement an action plan to address and close inequities in health outcomes and/or health care access, quality, and safety.",
+    "measureId": "IA_PM_6",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "populationManagement"
+  },
+  {
+    "category": "ia",
+    "title": "Use of QCDR for feedback reports that incorporate population health",
+    "description": "Use of a QCDR to generate regular feedback reports that summarize local practice patterns and treatment outcomes, including for vulnerable populations.",
+    "measureId": "IA_PM_7",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "populationManagement"
+  },
+  {
+    "category": "ia",
+    "title": "Regular review practices in place on targeted patient population needs",
+    "description": "Implement regular reviews of targeted patient population needs, such as structured clinical case reviews, which include access to reports that show unique characteristics of MIPS eligible clinician's patient population, identification of underserved patients, and how clinical treatment needs are being tailored, if necessary, to address unique needs and what resources in the community have been identified as additional resources. The review should consider how structural inequities, such as racism, are influencing patterns of care and consider changes to acknowledge and address them. Reviews should stratify patient data by demographic characteristics and health related social needs to appropriately identify differences among unique populations and assess the drivers of gaps and disparities and identify interventions appropriate for the needs of the sub-populations.",
+    "measureId": "IA_PM_11",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "populationManagement"
+  },
+  {
+    "category": "ia",
+    "title": "Population empanelment",
+    "description": "Empanel (assign responsibility for) the total population, linking each patient to a MIPS eligible clinician or group or care team.Empanelment is a series of processes that assign each active patient to a MIPS eligible clinician or group and/or care team, confirm assignment with patients and clinicians, and use the resultant patient panels as a foundation for individual patient and population health management. Empanelment identifies the patients and population for whom the MIPS eligible clinician or group and/or care team is responsible and is the foundation for the relationship continuity between patient and MIPS eligible clinician or group /care team that is at the heart of comprehensive primary care. Effective empanelment requires identification of the “active population” of the practice: those patients who identify and use your practice as a source for primary care. There are many ways to define “active patients” operationally, but generally, the definition of “active patients” includes patients who have sought care within the last 24 to 36 months, allowing inclusion of younger patients who have minimal acute or preventive health care.",
+    "measureId": "IA_PM_12",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "populationManagement"
+  },
+  {
+    "category": "ia",
+    "title": "Chronic Care and Preventative Care Management for Empaneled Patients",
+    "description": "In order to receive credit for this activity, a MIPS eligible clinician must manage chronic and preventive care for empaneled patients (that is, patients assigned to care teams for the purpose of population health management), which could include one or more of the following actions:• Provide patients annually with an opportunity for development and/or adjustment of an individualized plan of care as appropriate to age and health status, including health risk appraisal; gender, age and condition-specific preventive care services; and plan of care for chronic conditions;• Use evidence based, condition-specific pathways for care of chronic conditions (for example, hypertension, diabetes, depression, asthma, and heart failure). These might include, but are not limited to, the NCQA Diabetes Recognition Program (DRP) and the NCQA Heart/Stroke Recognition Program (HSRP);• Use pre-visit planning, that is, preparations for conversations or actions to propose with patient before an in-office visit to optimize preventive care and team management of patients with chronic conditions;• Use panel support tools, (that is, registry functionality) or other technology that can use clinical data to identify trends or data points in patient records to identify services due;• Use predictive analytical models to predict risk, onset and progression of chronic diseases; and/or• Use reminders and outreach (e.g., phone calls, emails, postcards, patient portals, and community health workers where available) to alert and educate patients about services due; and/or routine medication reconciliation.",
+    "measureId": "IA_PM_13",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "populationManagement"
+  },
+  {
+    "category": "ia",
+    "title": "Implementation of methodologies for improvements in longitudinal care management for high risk patients",
+    "description": "Provide longitudinal care management to patients at high risk for adverse health outcome or harm that could include one or more of the following: • Use a consistent method to assign and adjust global risk status for all empaneled patients to allow risk stratification into actionable risk cohorts. Monitor the risk-stratification method and refine as necessary to improve accuracy of risk status identification; • Use a personalized plan of care for patients at high risk for adverse health outcome or harm, integrating patient goals, values and priorities; and/or• Use on-site practice-based or shared care managers to proactively monitor and coordinate care for the highest risk cohort of patients.",
+    "measureId": "IA_PM_14",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "populationManagement"
+  },
+  {
+    "category": "ia",
+    "title": "Implementation of episodic care management practice improvements",
+    "description": "Provide episodic care management, including management across transitions and referrals that could include one or more of the following:• Routine and timely follow-up to hospitalizations, ED visits and stays in other institutional settings, including symptom and disease management, and medication reconciliation and management; and/or• Managing care intensively through new diagnoses, injuries and exacerbations of illness.",
+    "measureId": "IA_PM_15",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "populationManagement"
+  },
+  {
+    "category": "ia",
+    "title": "Implementation of medication management practice improvements",
+    "description": "Manage medications to maximize efficiency, effectiveness and safety that could include one or more of the following: • Reconcile and coordinate medications and provide medication management across transitions of care settings and eligible clinicians or groups; • Integrate a pharmacist into the care team; and/or• Conduct periodic, structured medication reviews.",
+    "measureId": "IA_PM_16",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "populationManagement"
+  },
+  {
+    "category": "ia",
+    "title": "Participation in Population Health Research",
+    "description": "Participation in federally and/or privately funded research that identifies interventions, tools, or processes that can improve a targeted patient population.",
+    "measureId": "IA_PM_17",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "populationManagement"
+  },
+  {
+    "category": "ia",
+    "title": "Provide Clinical-Community Linkages",
+    "description": "Engaging community health workers to provide a comprehensive link to community resources through family-based services focusing on success in health, education, and self-sufficiency. This activity supports individual MIPS eligible clinicians or groups that coordinate with primary care and other clinicians, engage and support patients, use of health information technology, and employ quality measurement and improvement processes. An example of this community based program is the NCQA Patient-Centered Connected Care (PCCC) Recognition Program or other such programs that meet these criteria.",
+    "measureId": "IA_PM_18",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "populationManagement"
+  },
+  {
+    "category": "ia",
+    "title": "Glycemic Screening Services",
+    "description": "For at-risk outpatient Medicare beneficiaries, individual MIPS eligible clinicians and groups must attest to implementation of systematic preventive approaches in clinical practice for at least 60 percent for the 2018 performance period and 75 percent in future years, of electronic medical records with documentation of screening patients for abnormal blood glucose according to current US Preventive Services Task Force (USPSTF) and/or American Diabetes Association (ADA) guidelines.",
+    "measureId": "IA_PM_19",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "populationManagement"
+  },
+  {
+    "category": "ia",
+    "title": "Glycemic Referring Services",
+    "description": "For at-risk outpatient Medicare beneficiaries, individual MIPS eligible clinicians and groups must attest to implementation of systematic preventive approaches in clinical practice for at least 60 percent for the CY 2018 performance period and 75 percent in future years, of medical records with documentation of referring eligible patients with prediabetes to a CDC-recognized diabetes prevention program operating under the framework of the National Diabetes Prevention Program.",
+    "measureId": "IA_PM_20",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "populationManagement"
+  },
+  {
+    "category": "ia",
+    "title": "Advance Care Planning",
+    "description": "Implementation of practices/processes to develop advance care planning that includes: documenting the advance care plan or living will within the medical record, educating clinicians about advance care planning motivating them to address advance care planning needs of their patients, and how these needs can translate into quality improvement, educating clinicians on approaches and barriers to talking to patients about end-of-life and palliative care needs and ways to manage its documentation, as well as informing clinicians of the healthcare policy side of advance care planning.",
+    "measureId": "IA_PM_21",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "populationManagement"
+  },
+  {
+    "category": "ia",
+    "title": "Implementation of Use of Specialist Reports Back to Referring Clinician or Group to Close Referral Loop",
+    "description": "Performance of regular practices that include providing specialist reports back to the referring individual MIPS eligible clinician or group to close the referral loop or where the referring individual MIPS eligible clinician or group initiates regular inquiries to specialist for specialist reports which could be documented or noted in the EHR technology.",
+    "measureId": "IA_CC_1",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "careCoordination"
+  },
+  {
+    "category": "ia",
+    "title": "Implementation of improvements that contribute to more timely communication of test results",
+    "description": "Timely communication of test results defined as timely identification of abnormal test results with timely follow-up.",
+    "measureId": "IA_CC_2",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "careCoordination"
+  },
+  {
+    "category": "ia",
+    "title": "Regular training in care coordination",
+    "description": "Implementation of regular care coordination training.",
+    "measureId": "IA_CC_7",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "careCoordination"
+  },
+  {
+    "category": "ia",
+    "title": "Implementation of documentation improvements for practice/process improvements",
+    "description": "Implementation of practices/processes that document care coordination activities (e.g., a documented care coordination encounter that tracks all clinical staff involved and communications from date patient is scheduled for outpatient procedure through day of procedure).",
+    "measureId": "IA_CC_8",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "careCoordination"
+  },
+  {
+    "category": "ia",
+    "title": "Implementation of practices/processes for developing regular individual care plans",
+    "description": "Implementation of practices/processes, including a discussion on care, to develop regularly updated individual care plans for at-risk patients that are shared with the beneficiary or caregiver(s). Individual care plans should include consideration of a patient’s goals and priorities, as well as desired outcomes of care.",
+    "measureId": "IA_CC_9",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "careCoordination"
+  },
+  {
+    "category": "ia",
+    "title": "Care transition documentation practice improvements",
+    "description": "In order to receive credit for this activity, a MIPS eligible clinician must document practices/processes for care transition with documentation of how a MIPS eligible clinician or group carried out an action plan for the patient with the patient’s preferences in mind (that is, a “patient-centered” plan) during the first 30 days following a discharge. Examples of these practices/processes for care transition include: staff involved in the care transition; phone calls conducted in support of transition; accompaniments of patients to appointments or other navigation actions; home visits; patient information access to their medical records; real time communication between PCP and consulting clinicians; PCP included on specialist follow-up or transition communications.",
+    "measureId": "IA_CC_10",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "careCoordination"
+  },
+  {
+    "category": "ia",
+    "title": "Care transition standard operational improvements",
+    "description": "Establish standard operations to manage transitions of care that could include one or more of the following: • Establish formalized lines of communication with local settings in which empaneled patients receive care to ensure documented flow of information and seamless transitions in care; and/or• Partner with community or hospital-based transitional care services.",
+    "measureId": "IA_CC_11",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "careCoordination"
+  },
+  {
+    "category": "ia",
+    "title": "Care coordination agreements that promote improvements in patient tracking across settings",
+    "description": "Establish effective care coordination and active referral management that could include one or more of the following:• Establish care coordination agreements with frequently used consultants that set expectations for documented flow of information and MIPS eligible clinician or MIPS eligible clinician group expectations between settings. Provide patients with information that sets their expectations consistently with the care coordination agreements; • Track patients referred to specialist through the entire process; and/or• Systematically integrate information from referrals into the plan of care.",
+    "measureId": "IA_CC_12",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "careCoordination"
+  },
+  {
+    "category": "ia",
+    "title": "Practice Improvements for Bilateral Exchange of Patient Information",
+    "description": "Ensure that there is bilateral exchange of necessary patient information to guide patient care, such as Open Notes, that could include one or more of the following: • Participate in a Health Information Exchange if available; and/or • Use structured referral notes.",
+    "measureId": "IA_CC_13",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "careCoordination"
+  },
+  {
+    "category": "ia",
+    "title": "Practice improvements that engage community resources to support patient health goals",
+    "description": "Select and screen for the health-related social needs (HRSN) that are relevant for your patient population using tools that have been tested with underserved populations. If possible, use a screening tool that is health IT-enabled and includes standards-based, coded question/field for the capture of data. After screening, address HRSNs identified through at least one of the following:• Maintain formal relationships with community- based organizations to strengthen the community service referral process, implementing closed-loop referrals where feasible; or • Update a guide to available community resources, or work with community partners to provide a community resource guide and provide it to patients who are found to be at risk in one or more HRSN area; or• Record findings of screening and trigger follow-up within the electronic health record (EHR); then analyze EHR data on patients with one or more HRSN needed to identify and implement approaches to better serve their holistic needs through linkages with community resources. HRSNs prioritized by your practice might include health-harming legal needs, which require both health and legal support to resolve, areas such as food and housing insecurity, or needs such as exercise, nutrition, or chronic disease self-management.",
+    "measureId": "IA_CC_14",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "careCoordination"
+  },
+  {
+    "category": "ia",
+    "title": "PSH Care Coordination",
+    "description": "Participation in a Perioperative Surgical Home (PSH) that provides a patient-centered, physician-led, interdisciplinary, and team-based system of coordinated patient care, which coordinates care from pre-procedure assessment through the acute care episode, recovery, and post-acute care. This activity allows for reporting of strategies and processes related to care coordination of patients receiving surgical or procedural care within a PSH. The clinician must perform one or more of the following care coordination activities:• Coordinate with care managers/navigators in preoperative clinic to plan and implementation comprehensive post discharge plan of care;• Deploy perioperative clinic and care processes to reduce post-operative visits to emergency rooms;• Implement evidence-informed practices and standardize care across the entire spectrum of surgical patients; or• Implement processes to ensure effective communications and education of patients’ post-discharge instructions.",
+    "measureId": "IA_CC_15",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "careCoordination"
+  },
+  {
+    "category": "ia",
+    "title": "Primary Care Physician and Behavioral Health Bilateral Electronic Exchange of Information for Shared Patients",
+    "description": "The primary care and behavioral health practices use the same electronic health record system for shared patients or have an established bidirectional flow of primary care and behavioral health records.",
+    "measureId": "IA_CC_16",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "careCoordination"
+  },
+  {
+    "category": "ia",
+    "title": "Patient Navigator Program",
+    "description": "Implement a Patient Navigator Program that offers evidence-based resources and tools to reduce avoidable hospital readmissions, utilizing a patient-centered and team-based approach, leveraging evidence-based best practices to improve care for patients by making hospitalizations less stressful, and the recovery period more supportive by implementing quality improvement strategies.",
+    "measureId": "IA_CC_17",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "careCoordination"
+  },
+  {
+    "category": "ia",
+    "title": "Relationship-Centered Communication",
+    "description": "In order to receive credit for this activity, MIPS eligible clinicians must participate in a minimum of eight hours of training on relationship-centered care tenets such as making effective open-ended inquiries; eliciting patient stories and perspectives; listening and responding with empathy; using the ART (ask, respond, tell) communication technique to engage patients, and developing a shared care plan. The training may be conducted in formats such as, but not limited to: interactive simulations practicing the skills above, or didactic instructions on how to implement improvement action plans, monitor progress, and promote stability around improved clinician communication.",
+    "measureId": "IA_CC_18",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "careCoordination"
+  },
+  {
+    "category": "ia",
+    "title": "Tracking of clinician’s relationship to and responsibility for a patient by reporting MACRA patient relationship codes.",
+    "description": "To receive credit for this improvement activity, a MIPS eligible clinician must attest that they reported MACRA patient relationship codes (PRC) using the applicable HCPCS modifiers on 50 percent or more of their Medicare claims for a minimum of a continuous 90-day period within the performance period. Reporting the PRC modifiers enables the identification of a clinician’s relationship with, and responsibility for, a patient at the time of furnishing an item or service. See the CY 2018 PFS final rule (82 FR 53232 through 53234) for more details on these codes.",
+    "measureId": "IA_CC_19",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2020,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "careCoordination"
+  },
+  {
+    "category": "ia",
+    "title": "Use of certified EHR to capture patient reported outcomes",
+    "description": "To improve patient access, perform activities beyond routine care that enable capture of patient reported outcomes (for example, related to functional status, symptoms and symptom burden, health behaviors, or patient experience) or patient activation measures (that is, measures of patient involvement in their care) through use of certified electronic health record technology, and record these outcomes data for clinician review.",
+    "measureId": "IA_BE_1",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "beneficiaryEngagement"
+  },
+  {
+    "category": "ia",
+    "title": "Engagement with QIN-QIO to implement self-management training programs",
+    "description": "Engagement with a Quality Innovation Network-Quality Improvement Organization, which may include participation in self-management training programs such as diabetes.",
+    "measureId": "IA_BE_3",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "beneficiaryEngagement"
+  },
+  {
+    "category": "ia",
+    "title": "Engagement of patients through implementation of improvements in patient portal",
+    "description": "To receive credit for this activity, MIPS eligible clinicians must provide access to an enhanced patient/caregiver portal that allows users (patients or caregivers and their clinicians) to engage in bidirectional information exchange. The primary use of this portal should be clinical and not administrative. Examples of the use of such a portal include, but are not limited to:  brief patient reevaluation by messaging; communication about test results and follow up; communication about medication adherence, side effects, and refills; blood pressure management for a patient with hypertension; blood sugar management for a patient with diabetes; or any relevant acute or chronic disease management.",
+    "measureId": "IA_BE_4",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "beneficiaryEngagement"
+  },
+  {
+    "category": "ia",
+    "title": "Enhancements/regular updates to practice websites/tools that also include considerations for patients with cognitive disabilities",
+    "description": "Enhancements and ongoing regular updates and use of websites/tools that include consideration for compliance with section 508 of the Rehabilitation Act of 1973 or for improved design for patients with cognitive disabilities. Refer to the CMS website on Section 508 of the Rehabilitation Act https://www.cms.gov/Research-Statistics-Data-and-Systems/CMS-Information-Technology/Section508/index.html?redirect=/InfoTechGenInfo/07_Section508.asp that requires that institutions receiving federal funds solicit, procure, maintain and use all electronic and information technology (EIT) so that equal or alternate/comparable access is given to members of the public with and without disabilities. For example, this includes designing a patient portal or website that is compliant with section 508 of the Rehabilitation Act of 1973.",
+    "measureId": "IA_BE_5",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "beneficiaryEngagement"
+  },
+  {
+    "category": "ia",
+    "title": "Regularly Assess Patient Experience of Care and Follow Up on Findings",
+    "description": "Collect and follow up on patient experience and satisfaction data. This activity also requires follow-up on findings of assessments, including the development and implementation of improvement plans. To fulfill the requirements of this activity, MIPS eligible clinicians can use surveys (e.g., Consumer Assessment of Healthcare Providers and Systems Survey), advisory councils, or other mechanisms. MIPS eligible clinicians may consider implementing patient surveys in multiple languages, based on the needs of their patient population.",
+    "measureId": "IA_BE_6",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "beneficiaryEngagement"
+  },
+  {
+    "category": "ia",
+    "title": "Participation in a QCDR, that promotes use of patient engagement tools.",
+    "description": "Participation in a Qualified Clinical Data Registry (QCDR), that promotes patient engagement, including:• Use of processes and tools that engage patients for adherence to treatment plans;• Implementation of patient self-action plans;• Implementation of shared clinical decision making capabilities; or• Use of QCDR patient experience data to inform and advance improvements in beneficiary engagement.",
+    "measureId": "IA_BE_7",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "beneficiaryEngagement"
+  },
+  {
+    "category": "ia",
+    "title": "Participation in a QCDR, that promotes collaborative learning network opportunities that are interactive.",
+    "description": "Participation in a QCDR, that promotes collaborative learning network opportunities that are interactive.",
+    "measureId": "IA_BE_8",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "beneficiaryEngagement"
+  },
+  {
+    "category": "ia",
+    "title": "Use evidence-based decision aids to support shared decision-making.",
+    "description": "Use evidence-based decision aids to support shared decision-making.",
+    "measureId": "IA_BE_12",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "beneficiaryEngagement"
+  },
+  {
+    "category": "ia",
+    "title": "Engage Patients and Families to Guide Improvement in the System of Care",
+    "description": "Engage patients and families to guide improvement in the system of care by leveraging digital tools for ongoing guidance and assessments outside the encounter, including the collection and use of patient data for return-to-work and patient quality of life improvement. Platforms and devices that collect patient-generated health data (PGHD) must do so with an active feedback loop, either providing PGHD in real or near-real time to the care team, or generating clinically endorsed real or near-real time automated feedback to the patient, including patient reported outcomes (PROs). Examples include patient engagement and outcomes tracking platforms, cellular or web-enabled bi-directional systems, and other devices that transmit clinically valid objective and subjective data back to care teams. Because many consumer-grade devices capture PGHD (for example, wellness devices), platforms or devices eligible for this improvement activity must be, at a minimum, endorsed and offered clinically by care teams to patients to automatically send ongoing guidance (one way). Platforms and devices that additionally collect PGHD must do so with an active feedback loop, either providing PGHD in real or near-real time to the care team, or generating clinically endorsed real or near-real time automated feedback to the patient (e.g. automated patient-facing instructions based on glucometer readings). Therefore, unlike passive platforms or devices that may collect but do not transmit PGHD in real or near-real time to clinical care teams, active devices and platforms can inform the patient or the clinical care team in a timely manner of important parameters regarding a patient’s status, adherence, comprehension, and indicators of clinical concern.",
+    "measureId": "IA_BE_14",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "beneficiaryEngagement"
+  },
+  {
+    "category": "ia",
+    "title": "Engagement of Patients, Family, and Caregivers in Developing a Plan of Care",
+    "description": "Engage patients, family, and caregivers in developing a plan of care and prioritizing their goals for action, documented in the electronic health record (EHR) technology.",
+    "measureId": "IA_BE_15",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "beneficiaryEngagement"
+  },
+  {
+    "category": "ia",
+    "title": "Promote Self-management in Usual Care",
+    "description": "To help patients self-manage their care, incorporate culturally and linguistically tailored evidence-based techniques for promoting self-management into usual care, and provide patients with tools and resources for self-management. Examples of evidence-based techniques to use in usual care include: goal setting with structured follow-up, Teach-back methods, action planning, assessment of need for self-management (for example, the Patient Activation Measure), and motivational interviewing. Examples of tools and resources to provide patients directly or through community organizations include: peer-led support for self-management, condition-specific chronic disease or substance use disorder self-management programs, and self-management materials.",
+    "measureId": "IA_BE_16",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "beneficiaryEngagement"
+  },
+  {
+    "category": "ia",
+    "title": "Use group visits for common chronic conditions (e.g., diabetes).",
+    "description": "Use group visits for common chronic conditions (e.g., diabetes).",
+    "measureId": "IA_BE_19",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "beneficiaryEngagement"
+  },
+  {
+    "category": "ia",
+    "title": "Improved Practices that Engage Patients Pre-Visit",
+    "description": "Implementation of workflow changes that engage patients prior to the visit, such as a pre-visit development of a shared visit agenda with the patient, or targeted pre-visit laboratory testing that will be resulted and available to the MIPS eligible clinician to review and discuss during the patient’s appointment.",
+    "measureId": "IA_BE_22",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "beneficiaryEngagement"
+  },
+  {
+    "category": "ia",
+    "title": "Integration of patient coaching practices between visits",
+    "description": "Provide coaching between visits with follow-up on care plan and goals.",
+    "measureId": "IA_BE_23",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "beneficiaryEngagement"
+  },
+  {
+    "category": "ia",
+    "title": "Financial Navigation Program",
+    "description": "In order to receive credit for this activity, MIPS eligible clinicians must attest that their practice provides financial counseling to patients or their caregiver about costs of care and an exploration of different payment options. The MIPS eligible clinician may accomplish this by working with other members of their practice (for example, financial counselor or patient navigator) as part of a team-based care approach in which members of the patient care team collaborate to support patient- centered goals. For example, a financial counselor could provide patients with resources with further information or support options, or facilitate a conversation with a patient or caregiver that could address concerns. This activity may occur during diagnosis stage, before treatment, during treatment, and/or during survivorship planning, as appropriate.",
+    "measureId": "IA_BE_24",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "beneficiaryEngagement"
+  },
+  {
+    "category": "ia",
+    "title": "Drug Cost Transparency",
+    "description": "Provide counseling to patients and/or their caregivers regarding: costs of medications using a real time benefit tool (RTBT) which provides to the prescriber real-time patient-specific formulary and benefit information for drugs, including cost-sharing for a beneficiary.",
+    "measureId": "IA_BE_25",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2020,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "beneficiaryEngagement"
+  },
+  {
+    "category": "ia",
+    "title": "Participation in an AHRQ-listed patient safety organization.",
+    "description": "Participation in an AHRQ-listed patient safety organization.",
+    "measureId": "IA_PSPA_1",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Participation in MOC Part IV",
+    "description": "In order to receive credit for this activity, a MIPS eligible clinician must participate in Maintenance of Certification (MOC) Part IV. Maintenance of Certification (MOC) Part IV requires clinicians to perform monthly activities across practice to regularly assess performance by reviewing outcomes addressing identified areas for improvement and evaluating the results. Some examples of activities that can be completed to receive MOC Part IV credit are: the American Board of Internal Medicine (ABIM) Approved Quality Improvement (AQI) Program, National Cardiovascular Data Registry (NCDR) Clinical Quality Coach, Quality Practice Initiative Certification Program, American Board of Medical Specialties Practice Performance Improvement Module or American Society of Anesthesiologists (ASA) Simulation Education Network, for improving professional practice including participation in a local, regional or national outcomes registry or quality assessment program; specialty- specific activities including Safety Certification in Outpatient Practice Excellence (SCOPE); American Psychiatric Association (APA) Performance in Practice modules.",
+    "measureId": "IA_PSPA_2",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Participate in IHI Training/Forum Event; National Academy of Medicine, AHRQ Team STEPPS® or Other Similar Activity",
+    "description": "For MIPS eligible clinicians not participating in Maintenance of Certification (MOC) Part IV, new engagement for MOC Part IV, such as the Institute for Healthcare Improvement (IHI) Training/Forum Event; National Academy of Medicine, Agency for Healthcare Research and Quality (AHRQ) Team STEPPS®, or the American Board of Family Medicine (ABFM) Performance in Practice Modules.",
+    "measureId": "IA_PSPA_3",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Administration of the AHRQ Survey of Patient Safety Culture",
+    "description": "Administration of the AHRQ Survey of Patient Safety Culture and submission of data to the comparative database (refer to AHRQ Survey of Patient Safety Culture website http://www.ahrq.gov/professionals/quality-patient-safety/patientsafetyculture/index.html). Note: This activity may be selected once every 4 years, to avoid duplicative information given that some of the modules may change on a year by year basis but over 4 years there would be a reasonable expectation for the set of modules to have undergone substantive change, for the improvement activities performance category score.",
+    "measureId": "IA_PSPA_4",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Consultation of the Prescription Drug Monitoring program",
+    "description": "Review the history of controlled substance prescriptions for 90 percent* of patients using state prescription drug monitoring program (PDMP) data prior to the issuance of a Controlled Substance Schedule II (CSII) opioid prescription lasting longer than 3 days. *Apply exceptions for patients receiving palliative and hospice care.",
+    "measureId": "IA_PSPA_6",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Use of QCDR data for ongoing practice assessment and improvements",
+    "description": "Participation in a Qualified Clinical Data Registry (QCDR) and use of QCDR data for ongoing practice assessment and improvements in patient safety, including:• Performance of activities that promote use of standard practices, tools and processes for quality improvement (for example, documented preventative screening and vaccinations that can be shared across MIPS eligible clinician or groups);• Use of standard questionnaires for assessing improvements in health disparities related to functional health status (for example, use of Seattle Angina Questionnaire, MD Anderson Symptom Inventory, and/or SF-12/VR-12 functional health status assessment);• Use of standardized processes for screening for social determinants of health such as food security, employment, and housing;• Use of supporting QCDR modules that can be incorporated into the certified EHR technology; or• Use of QCDR data for quality improvement such as comparative analysis across specific patient populations for adverse outcomes after an outpatient surgical procedure and corrective steps to address adverse outcomes.",
+    "measureId": "IA_PSPA_7",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Use of Patient Safety Tools",
+    "description": "In order to receive credit for this activity, a MIPS eligible clinician must use tools that assist specialty practices in tracking specific measures that are meaningful to their practice.Some examples of tools that could satisfy this activity are: a surgical risk calculator; evidence based protocols, such as Enhanced Recovery After Surgery (ERAS) protocols; the Centers for Disease Control (CDC) Guide for Infection Prevention for Outpatient Settings predictive algorithms; and the opiate risk tool (ORT) or similar tool.",
+    "measureId": "IA_PSPA_8",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Completion of the AMA STEPS Forward program",
+    "description": "Completion of the American Medical Association’s STEPS Forward program.",
+    "measureId": "IA_PSPA_9",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Completion of training and receipt of approved waiver for provision opioid medication-assisted treatments",
+    "description": "Completion of training and obtaining an approved waiver for provision of medication -assisted treatment of opioid use disorders using buprenorphine.",
+    "measureId": "IA_PSPA_10",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Participation in private payer CPIA",
+    "description": "Participation in designated private payer clinical practice improvement activities.",
+    "measureId": "IA_PSPA_12",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Participation in Joint Commission Evaluation Initiative",
+    "description": "Participation in Joint Commission Ongoing Professional Practice Evaluation initiative.",
+    "measureId": "IA_PSPA_13",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Implementation of an ASP",
+    "description": "Leadership of an Antimicrobial Stewardship Program (ASP) that includes implementation of an ASP that measures the appropriate use of antibiotics for several different conditions (such as but not limited to upper respiratory infection treatment in children, diagnosis of pharyngitis, bronchitis treatment in adults) according to clinical guidelines for diagnostics and therapeutics. Specific activities may include: • Develop facility-specific antibiogram and prepare report of findings with specific action plan that aligns with overall facility or practice strategic plan.• Lead the development, implementation, and monitoring of patient care and patient safety protocols for the delivery of ASP including protocols pertaining to the most appropriate setting for such services (i.e., outpatient or inpatient). • Assist in improving ASP service line efficiency and effectiveness by evaluating and recommending improvements in the management structure and workflow of ASP processes.• Manage compliance of the ASP policies and assist with implementation of corrective actions in accordance with facility or clinic compliance policies and hospital medical staff by-laws. • Lead the education and training of professional support staff for the purpose of maintaining an efficient and effective ASP.• Coordinate communications between ASP management and facility or practice personnel regarding activities, services, and operational/clinical protocols to achieve overall compliance and understanding of the ASP.• Assist, at the request of the facility or practice, in preparing for and responding to third-party requests, including but not limited to payer audits, governmental inquiries, and professional inquiries that pertain to the ASP service line. • Implementing and tracking an evidence-based policy or practice aimed at improving antibiotic prescribing practices for high-priority conditions.  • Developing and implementing evidence-based protocols and decision-support for diagnosis and treatment of common infections.• Implementing evidence-based protocols that align with recommendations in the Centers for Disease Control and Prevention’s Core Elements of Outpatient Antibiotic Stewardship guidance.",
+    "measureId": "IA_PSPA_15",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Use of decision support and standardized treatment protocols",
+    "description": "Use decision support and standardized treatment protocols to manage workflow in the team to meet patient needs.",
+    "measureId": "IA_PSPA_16",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Implementation of analytic capabilities to manage total cost of care for practice population",
+    "description": "In order to receive credit for this activity, a MIPS eligible clinician must conduct or build the capacity to conduct analytic activities to manage total cost of care for the practice population. Examples of these activities could include:1.) Train appropriate staff on interpretation of cost and utilization information;2.) Use available data regularly to analyze opportunities to reduce cost through improved care. An example of a platform with the necessary analytic capability to do this is the American Society for Gastrointestinal (GI) Endoscopy’s GI Operations Benchmarking Platform.",
+    "measureId": "IA_PSPA_17",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Measurement and improvement at the practice and panel level",
+    "description": "Measure and improve quality at the practice and panel level, such as the American Board of Orthopaedic Surgery (ABOS) Physician Scorecards that could include one or more of the following:•\tRegularly review measures of quality, utilization, patient satisfaction and other measures; and/or•\tUse relevant data sources to create benchmarks and goals for performance at the practice or panel levels.MIPS eligible clinicians can apply the measurement and quality improvement to address inequities in quality and outcomes for underserved populations, including racial, ethnic, and/or gender minorities.",
+    "measureId": "IA_PSPA_18",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Implementation of formal quality improvement methods, practice changes, or other practice improvement processes",
+    "description": "Adopt a formal model for quality improvement and create a culture in which all staff actively participates in improvement activities that could include one or more of the following, such as:• Participation in multisource feedback; • Train all staff in quality improvement methods;• Integrate practice change/quality improvement into staff duties;• Engage all staff in identifying and testing practices changes;• Designate regular team meetings to review data and plan improvement cycles;• Promote transparency and accelerate improvement by sharing practice level and panel level quality of care, patient experience and utilization data with staff;• Promote transparency and engage patients and families by sharing practice level quality of care, patient experience and utilization data with patients and families, including activities in which clinicians act upon patient experience data;• Participation in Bridges to Excellence;• Participation in American Board of Medical Specialties (ABMS) Multi-Specialty Portfolio Program.",
+    "measureId": "IA_PSPA_19",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Leadership engagement in regular guidance and demonstrated commitment for implementing practice improvement changes",
+    "description": "Ensure full engagement of clinical and administrative leadership in practice improvement that could include one or more of the following:   • Make responsibility for guidance of practice change a component of clinical and administrative leadership roles; • Allocate time for clinical and administrative leadership for practice improvement efforts, including participation in regular team meetings; and/or• Incorporate population health, quality and patient experience metrics in regular reviews of practice performance.",
+    "measureId": "IA_PSPA_20",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Implementation of fall screening and assessment programs",
+    "description": "Implementation of fall screening and assessment programs to identify patients at risk for falls and address modifiable risk factors (e.g., Clinical decision support/prompts in the electronic health record that help manage the use of medications, such as benzodiazepines, that increase fall risk).",
+    "measureId": "IA_PSPA_21",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "CDC Training on CDC’s Guideline for Prescribing Opioids for Chronic Pain",
+    "description": "Completion of all the modules of the Centers for Disease Control and Prevention (CDC) course “Applying CDC’s Guideline for Prescribing Opioids” that reviews the 2016 “Guideline for Prescribing Opioids for Chronic Pain.” Note: This activity may be selected once every 4 years, to avoid duplicative information given that some of the modules may change on a year by year basis but over 4 years there would be a reasonable expectation for the set of modules to have undergone substantive change, for the improvement activities performance category score.",
+    "measureId": "IA_PSPA_22",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Completion of CDC Training on Antibiotic Stewardship",
+    "description": "Completion of all modules of the Centers for Disease Control and Prevention antibiotic stewardship course. Note: This activity may be selected once every 4 years, to avoid duplicative information given that some of the modules may change on a year by year basis but over 4 years there would be a reasonable expectation for the set of modules to have undergone substantive change, for the improvement activities performance category score.",
+    "measureId": "IA_PSPA_23",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Cost Display for Laboratory and Radiographic Orders",
+    "description": "Implementation of a cost display for laboratory and radiographic orders, such as costs that can be obtained through the Medicare clinical laboratory fee schedule.",
+    "measureId": "IA_PSPA_25",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Communication of Unscheduled Visit for Adverse Drug Event and Nature of Event",
+    "description": "A MIPS eligible clinician providing unscheduled care (such as an emergency room, urgent care, or other unplanned encounter) attests that, for greater than 75 percent of case visits that result from a clinically significant adverse drug event, the MIPS eligible clinician provides information, including through the use of health IT to the patient’s primary care clinician regarding both the unscheduled visit and the nature of the adverse drug event within 48 hours. A clinically significant adverse event is defined as a medication-related harm or injury such as side-effects, supratherapeutic effects, allergic reactions, laboratory abnormalities, or medication errors requiring urgent/emergent evaluation, treatment, or hospitalization.",
+    "measureId": "IA_PSPA_26",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Invasive Procedure or Surgery Anticoagulation Medication Management",
+    "description": "For an anticoagulated patient undergoing a planned invasive procedure for which interruption in anticoagulation is anticipated, including patients taking vitamin K antagonists (warfarin), target specific oral anticoagulants (such as apixaban, dabigatran, and rivaroxaban), and heparins/low molecular weight heparins, documentation, including through the use of electronic tools, that the plan for anticoagulation management in the periprocedural period was discussed with the patient and with the clinician responsible for managing the patient’s anticoagulation. Elements of the plan should include the following: discontinuation, resumption, and, if applicable, bridging, laboratory monitoring, and management of concomitant antithrombotic medications (such as antiplatelets and nonsteroidal anti-inflammatory drugs (NSAIDs)). An invasive or surgical procedure is defined as a procedure in which skin or mucous membranes and connective tissue are incised, or an instrument is introduced through a natural body orifice.",
+    "measureId": "IA_PSPA_27",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Completion of an Accredited Safety or Quality Improvement Program",
+    "description": "Completion of an accredited performance improvement continuing medical education (CME) program that addresses performance or quality improvement according to the following criteria:• The activity must address a quality or safety gap that is supported by a needs assessment or problem analysis, or must support the completion of such a needs assessment as part of the activity;• The activity must have specific, measurable aim(s) for improvement;• The activity must include interventions intended to result in improvement;• The activity must include data collection and analysis of performance data to assess the impact of the interventions; and• The accredited program must define meaningful clinician participation in their activity, describe the mechanism for identifying clinicians who meet the requirements, and provide participant completion information.An example of an activity that could satisfy this improvement activity is completion of an accredited continuing medical education program related to opioid analgesic risk and evaluation strategy (REMS) to address pain control (that is, acute and chronic pain).",
+    "measureId": "IA_PSPA_28",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Consulting AUC Using Clinical Decision Support when Ordering Advanced",
+    "description": "Clinicians attest that they are consulting specified applicable AUC through a qualified clinical decision support mechanism for all applicable imaging services furnished in an applicable setting, paid for under an applicable payment system, and ordered on or after January 1, 2018. This activity is for clinicians that are early adopters of the Medicare AUC program (2018 performance year) and for clinicians that begin the Medicare AUC program in future years as specified in our regulation at §414.94. The AUC program is required under section 218 of the Protecting Access to Medicare Act of 2014. Qualified mechanisms will be able to provide a report to the ordering clinician that can be used to assess patterns of image-ordering and improve upon those patterns to ensure that patients are receiving the most appropriate imaging for their individual condition.",
+    "measureId": "IA_PSPA_29",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "PCI Bleeding Campaign",
+    "description": "This activity is suspended; the PCI Bleeding Campaign ended in August 2021, making this activity obsolete for performance after that date.",
+    "measureId": "IA_PSPA_30",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Patient Medication Risk Education",
+    "description": "In order to receive credit for this activity, MIPS eligible clinicians must provide both written and verbal education regarding the risks of concurrent opioid and benzodiazepine use for patients who are prescribed both benzodiazepines and opioids. Education must be completed for at least 75% of qualifying patients and occur: (1) at the time of initial co-prescribing and again following greater than 6 months of co- prescribing of benzodiazepines and opioids, or (2) at least once per MIPS performance period for patients taking concurrent opioid and benzodiazepine therapy.",
+    "measureId": "IA_PSPA_31",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Use of CDC Guideline for Clinical Decision Support to Prescribe Opioids for Chronic Pain via Clinical Decision Support",
+    "description": "In order to receive credit for this activity, MIPS eligible clinicians must utilize the Centers for Disease Control (CDC) Guideline for Prescribing Opioids for Chronic Pain via clinical decision support (CDS). For CDS to be most effective, it needs to be built directly into the clinician workflow and support decision making on a specific patient at the point of care. Specific examples of how the guideline could be incorporated into a CDS workflow include, but are not limited to: electronic health record (EHR)-based prescribing prompts, order sets that require review of guidelines before prescriptions can be entered, and prompts requiring review of guidelines before a subsequent action can be taken in the record.",
+    "measureId": "IA_PSPA_32",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Application of CDC’s Training for Healthcare Providers on Lyme Disease",
+    "description": "Apply the Centers for Disease Control and Prevention’s (CDC) Training for Healthcare Providers on Lyme Disease using clinical decision support (CDS). CDS for Lyme disease should be built directly into the clinician workflow and support decision making for a specific patient at the point of care. Specific examples of how the guideline could be incorporated into a CDS workflow include but are not limited to: electronic health record (EHR) based prescribing prompts, order sets that require review of guidelines before prescriptions can be entered, and prompts requiring review of guidelines before a subsequent action can be taken in the record.",
+    "measureId": "IA_PSPA_33",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2022,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "patientSafetyAndPracticeAssessment"
+  },
+  {
+    "category": "ia",
+    "title": "Enhance Engagement of Medicaid and Other Underserved Populations",
+    "description": "To improve responsiveness of care for Medicaid and other underserved patients: use time-to-treat data (i.e., data measuring the time between clinician identifying a need for an appointment and the patient having a scheduled appointment) to identify patterns by which care or engagement with Medicaid patients or other groups of underserved patients has not achieved standard practice guidelines; and with this information, create, implement, and monitor an approach for improvement. This approach may include screening for patient barriers to treatment, especially transportation barriers, and providing resources to improve engagement (e.g., state Medicaid non-emergency medical transportation benefit).",
+    "measureId": "IA_AHE_1",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "achievingHealthEquity"
+  },
+  {
+    "category": "ia",
+    "title": "Promote Use of Patient-Reported Outcome Tools",
+    "description": "Demonstrate performance of activities for employing patient-reported outcome (PRO) tools and corresponding collection of PRO data such as the use of PHQ-2 or PHQ-9, PROMIS instruments, patient reported Wound-Quality of Life (QoL), patient reported Wound Outcome, and patient reported Nutritional Screening.",
+    "measureId": "IA_AHE_3",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "achievingHealthEquity"
+  },
+  {
+    "category": "ia",
+    "title": "MIPS Eligible Clinician Leadership in Clinical Trials or CBPR",
+    "description": "Lead clinical trials, research alliances, or community-based participatory research (CBPR) that identify tools, research, or processes that focus on minimizing disparities in healthcare access, care quality, affordability, or outcomes. Research could include addressing health-related social needs like food insecurity, housing insecurity, transportation barriers, utility needs, and interpersonal safety.",
+    "measureId": "IA_AHE_5",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "achievingHealthEquity"
+  },
+  {
+    "category": "ia",
+    "title": "Provide Education Opportunities for New Clinicians",
+    "description": "MIPS eligible clinicians acting as a preceptor for clinicians-in-training (such as medical residents/fellows, medical students, physician assistants, nurse practitioners, or clinical nurse specialists) and accepting such clinicians for clinical rotations in community practices in small, underserved, or rural areas.",
+    "measureId": "IA_AHE_6",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "achievingHealthEquity"
+  },
+  {
+    "category": "ia",
+    "title": "Comprehensive Eye Exams",
+    "description": "To receive credit for this activity, MIPS eligible clinicians must promote the importance of a comprehensive eye exam, which may be accomplished by any one or more of the following:  • providing literature, • facilitating a conversation about this topic using resources such as the \"Think About Your Eyes\" campaign,  • referring patients to resources providing no-cost eye exams, such as the American Academy of Ophthalmology’s EyeCare America and the American Optometric Association’s VISION USA, or • promoting access to vision rehabilitation services as appropriate for individuals with chronic vision impairment.This activity is intended for:  • Non-ophthalmologists / optometrists who refer patients to an ophthalmologist/optometrist;• Ophthalmologists/optometrists caring for underserved patients at no cost; or• Any clinician providing literature and/or resources on this topic.This activity must be targeted at underserved and/or high-risk populations that would benefit from engagement regarding their eye health with the aim of improving their access to comprehensive eye exams or vision rehabilitation services.",
+    "measureId": "IA_AHE_7",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "achievingHealthEquity"
+  },
+  {
+    "category": "ia",
+    "title": "Create and Implement an Anti-Racism Plan",
+    "description": "Create and implement an anti-racism plan using the CMS Disparities Impact Statement or other anti-racism planning tools. The plan should include a clinic-wide review of existing tools and policies, such as value statements or clinical practice guidelines, to ensure that they include and are aligned with a commitment to anti-racism and an understanding of race as a political and social construct, not a physiological one. The plan should also identify ways in which issues and gaps identified in the review can be addressed and should include target goals and milestones for addressing prioritized issues and gaps. This may also include an assessment and drafting of an organization’s plan to prevent and address racism and/or improve language access and accessibility to ensure services are accessible and understandable for those seeking care. The MIPS eligible clinician or practice can also consider including in their plan ongoing training on anti-racism and/or other processes to support identifying explicit and implicit biases in patient care and addressing historic health inequities experienced by people of color. More information about elements of the CMS Disparities Impact Statement is detailed in the template and action plan document at https://www.cms.gov/About-CMS/Agency-Information/OMH/Downloads/Disparities-Impact-Statement-508-rev102018.pdf.",
+    "measureId": "IA_AHE_8",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2022,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "achievingHealthEquity"
+  },
+  {
+    "category": "ia",
+    "title": "Implement Food Insecurity and Nutrition Risk Identification and Treatment Protocols",
+    "description": "Create or improve, and then implement, protocols for identifying and providing appropriate support to: a) patients with or at risk for food insecurity, and b) patients with or at risk for poor nutritional status. (Poor nutritional status is sometimes referred to as clinical malnutrition or undernutrition and applies to people who are overweight and underweight.) Actions to implement this improvement activity may include, but are not limited to, the following:•\tUse Malnutrition Quality Improvement Initiative (MQii) or other quality improvement resources and standardized screening tools to assess and improve current food insecurity and nutritional screening and care practices.•\tUpdate and use clinical decision support tools within the MIPS eligible clinician’s electronic medical record to align with the new food insecurity and nutrition risk protocols.•\tUpdate and apply requirements for staff training on food security and nutrition.•\tUpdate and provide resources and referral lists, and/or engage with community partners to facilitate referrals for patients who are identified as at risk for food insecurity or poor nutritional status during screening. Activities must be focused on patients at greatest risk for food insecurity and/or malnutrition—for example patients with low income who live in areas with limited access to affordable fresh food, or who are isolated or have limited mobility.",
+    "measureId": "IA_AHE_9",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2022,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "achievingHealthEquity"
+  },
+  {
+    "category": "ia",
+    "title": "Participation on Disaster Medical Assistance Team, registered for 6 months.",
+    "description": "Participation in Disaster Medical Assistance Teams, or Community Emergency Responder Teams. Activities that simply involve registration are not sufficient.  MIPS eligible clinicians and MIPS eligible clinician groups must be registered for a minimum of 6 months as a volunteer for disaster or emergency response.",
+    "measureId": "IA_ERP_1",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "emergencyResponseAndPreparedness"
+  },
+  {
+    "category": "ia",
+    "title": "Participation in a 60-day or greater effort to support domestic or international humanitarian needs.",
+    "description": "Participation in domestic or international humanitarian volunteer work. Activities that simply involve registration are not sufficient.  MIPS eligible clinicians and groups attest to domestic or international humanitarian volunteer work for a period of a continuous 60 days or greater.",
+    "measureId": "IA_ERP_2",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "emergencyResponseAndPreparedness"
+  },
+  {
+    "category": "ia",
+    "title": "COVID-19 Clinical Data Reporting with or without Clinical Trial",
+    "description": "To receive credit for this improvement activity, a MIPS eligible clinician or group must: (1) participate in a COVID-19 clinical trial utilizing a drug or biological product to treat a patient with a COVID-19 infection and report their findings through a clinical data repository or clinical data registry for the duration of their study; or (2) participate in the care of patients diagnosed with COVID-19 and simultaneously submit relevant clinical data to a clinical data registry for ongoing or future COVID-19 research. Data would be submitted to the extent permitted by applicable privacy and security laws. Examples of COVID-19 clinical trials may be found on the U.S. National Library of Medicine website at https://clinicaltrials.gov/ct2/results?cond=COVID-19. In addition, examples of COVID-19 clinical data registries may be found on the National Institute of Health website at https://search.nih.gov/search?utf8=%E2%9C%93&affiliate=nih&query=COVID19+registries&commit=Search. For purposes of this improvement activity, clinical data registries must meet the following requirements: (1) the receiving entity must declare that they are ready to accept data as a clinical registry; and (2) be using the data to improve population health outcomes. Most public health agencies and clinical data registries declare readiness to accept data from clinicians via a public online posting. Clinical data registries should make publically available specific information on what data the registry gathers, technical requirements or specifications for how the registry can receive the data, and how the registry may use, re-use, or disclose individually identifiable data it receives. For purposes of credit toward this improvement activity, any data should be sent to the clinical data registry in a structured format, which the registry is capable of receiving. A MIPS-eligible clinician may submit the data using any standard or format that is supported by the clinician’s health IT systems, including but not limited to, certified functions within those systems. Such methods may include, but are not limited to, a secure upload function on a web portal, or submission via an intermediary, such as a health information exchange. To ensure interoperability and versatility of the data submitted, any electronic data should be submitted to the clinical data registry using appropriate vocabulary standards for the specific data elements, such as those identified in the United States Core Data for Interoperability (USCDI) standard adopted in 45 CFR 170.213.",
+    "measureId": "IA_ERP_3",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2020,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "emergencyResponseAndPreparedness"
+  },
+  {
+    "category": "ia",
+    "title": "Implementation of a Personal Protective Equipment (PPE) Plan",
+    "description": "Implement a plan to acquire, store, maintain, and replenish supplies of personal protective equipment (PPE) for all clinicians or other staff who are in physical proximity to patients.In accordance with guidance from the Centers for Disease Control and Prevention (CDC) the PPE plan should address:•\tConventional capacity: PPE controls that should be implemented in general infection prevention and control plans in healthcare settings, including training in proper PPE use.•\tContingency capacity: actions that may be used temporarily during periods of expected PPE shortages.•\tCrisis capacity: strategies that may need to be considered during periods of known PPE shortages.The PPE plan should address all of the following types of PPE:•\tStandard precautions (e.g., hand hygiene, prevention of needle-stick or sharps injuries, safe waste management, cleaning and disinfection of the environment)•\tEye protection•\tGowns (including coveralls or aprons)•\tGloves•\tFacemasks•\tRespirators (including N95 respirators)",
+    "measureId": "IA_ERP_4",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2022,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "emergencyResponseAndPreparedness"
+  },
+  {
+    "category": "ia",
+    "title": "Implementation of a Laboratory Preparedness Plan",
+    "description": "Develop, implement, update, and maintain a preparedness plan for a laboratory intended to support continued or expanded patient care during COVID-19 or another public health emergency. The plan should address how the laboratory would maintain or expand patient access to health care services to improve beneficiary health outcomes and reduce healthcare disparities. For laboratories without a preparedness plan, MIPS eligible clinicians would meet with stakeholders, record minutes, and document a preparedness plan, as needed. The laboratory must then implement the steps identified in the plan and maintain them. For laboratories with existing preparedness plans, MIPS eligible clinicians should review, revise, or update the plan as necessary to meet the needs of the current PHE, implement new procedures, and maintain the plan.Maintenance of the plan in this activity could include additional hazard assessments, drills, training, and/or developing checklists to facilitate execution of the plan. Participation in debriefings to evaluate the effectiveness of plans are additional examples of engagement in this activity.",
+    "measureId": "IA_ERP_5",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2022,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "emergencyResponseAndPreparedness"
+  },
+  {
+    "category": "ia",
+    "title": "Diabetes screening",
+    "description": "Diabetes screening for people with schizophrenia or bipolar disease who are using antipsychotic medication.",
+    "measureId": "IA_BMH_1",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "behavioralAndMentalHealth"
+  },
+  {
+    "category": "ia",
+    "title": "Tobacco use",
+    "description": "Tobacco use: Regular engagement of MIPS eligible clinicians or  groups in integrated prevention and treatment interventions, including tobacco use screening and cessation interventions (refer to NQF #0028) for patients with co-occurring conditions of behavioral or mental health and at risk factors for tobacco dependence.",
+    "measureId": "IA_BMH_2",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "behavioralAndMentalHealth"
+  },
+  {
+    "category": "ia",
+    "title": "Depression screening",
+    "description": "Depression screening and follow-up plan:  Regular engagement of MIPS eligible clinicians or groups in integrated prevention and treatment interventions, including depression screening and follow-up plan (refer to NQF #0418) for patients with co-occurring conditions of behavioral or mental health conditions.",
+    "measureId": "IA_BMH_4",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "behavioralAndMentalHealth"
+  },
+  {
+    "category": "ia",
+    "title": "MDD prevention and treatment interventions",
+    "description": "Major depressive disorder: Regular engagement of MIPS eligible clinicians or groups in integrated prevention and treatment interventions, including suicide risk assessment (refer to NQF #0104) for mental health patients with co-occurring conditions of behavioral or mental health conditions.",
+    "measureId": "IA_BMH_5",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "behavioralAndMentalHealth"
+  },
+  {
+    "category": "ia",
+    "title": "Implementation of co-location PCP and MH services",
+    "description": "Integration facilitation and promotion of the colocation of mental health and substance use disorder services in primary and/or non-primary clinical care settings.",
+    "measureId": "IA_BMH_6",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "behavioralAndMentalHealth"
+  },
+  {
+    "category": "ia",
+    "title": "Implementation of Integrated Patient Centered Behavioral Health Model",
+    "description": "Offer integrated behavioral health services to support patients with behavioral health needs who also have conditions such as dementia or other poorly controlled chronic illnesses.  The services could include one or more of the following: •  Use evidence-based treatment protocols and treatment to goal where appropriate;• Use evidence-based screening and case finding strategies to identify individuals at risk and in need of services;•  Ensure regular communication and coordinated workflows between MIPS eligible clinicians in primary care and behavioral health;•  Conduct regular case reviews for at-risk or unstable patients and those who are not responding to treatment;•  Use of a registry or health information technology functionality to support active care management and outreach to patients in treatment;•  Integrate behavioral health and medical care plans and facilitate integration through co-location of services when feasible; and/or•  Participate in the National Partnership to Improve Dementia Care Initiative, which promotes a multidimensional approach that includes public reporting, state-based coalitions, research, training, and revised surveyor guidance.",
+    "measureId": "IA_BMH_7",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "behavioralAndMentalHealth"
+  },
+  {
+    "category": "ia",
+    "title": "Electronic Health Record Enhancements for BH data capture",
+    "description": "Enhancements to an electronic health record to capture additional data on behavioral health (BH) populations and use that data for additional decision-making purposes (e.g., capture of additional BH data results in additional depression screening for at-risk patient not previously identified).",
+    "measureId": "IA_BMH_8",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "behavioralAndMentalHealth"
+  },
+  {
+    "category": "ia",
+    "title": "Unhealthy Alcohol Use for Patients with Co-occurring Conditions of Mental Health and Substance Abuse and Ambulatory Care Patients",
+    "description": "Individual MIPS eligible clinicians or groups must regularly engage in integrated prevention and treatment interventions, including screening and brief counseling (for example:  NQF #2152) for patients with co-occurring conditions of mental health and substance abuse. MIPS eligible clinicians would attest that 60 percent for the CY 2018 Quality Payment Program performance period, and 75 percent beginning in the 2019 performance period, of their ambulatory care patients are screened for unhealthy alcohol use.",
+    "measureId": "IA_BMH_9",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "behavioralAndMentalHealth"
+  },
+  {
+    "category": "ia",
+    "title": "Completion of Collaborative Care Management Training Program",
+    "description": "To receive credit for this activity, MIPS eligible clinicians must complete a collaborative care management training program, such as the American Psychiatric Association (APA) Collaborative Care Model training program available to the public, in order to implement a collaborative care management approach that provides comprehensive training in the integration of behavioral health into the primary care practice.",
+    "measureId": "IA_BMH_10",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "behavioralAndMentalHealth"
+  },
+  {
+    "category": "ia",
+    "title": "Implementation of a Trauma-Informed Care (TIC) Approach to Clinical Practice",
+    "description": "Create and implement a plan for trauma-informed care (TIC) that recognizes the potential impact of trauma experiences on patients and takes steps to mitigate the effects of adverse events in order to avoid re-traumatizing or triggering past trauma. Actions in this plan may include, but are not limited to, the following:•\tIncorporate trauma-informed training into new employee orientation •\tOffer annual refreshers and/or trainings for all staff •\tRecommend and supply TIC materials to third party partners, including care management companies and billing services•\tIdentify patients using a screening methodology•\tFlag charts for patients with one or more adverse events that might have caused trauma•\tUse ICD-10 diagnosis codes for adverse events when appropriateTIC is a strengths-based healthcare delivery approach that emphasizes physical, psychological, and emotional safety for both trauma survivors and their providers. Core components of a TIC approach are: awareness of the prevalence of trauma; understanding of the impact of past trauma on services utilization and engagement; and a commitment and plan to incorporate that understanding into training, policy, procedure, and practice.",
+    "measureId": "IA_BMH_11",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2022,
+    "lastPerformanceYear": null,
+    "weight": "medium",
+    "subcategoryId": "behavioralAndMentalHealth"
+  },
+  {
+    "category": "ia",
+    "title": "Promoting Clinician Well-Being",
+    "description": "Develop and implement programs to support clinician well-being and resilience—for example, through relationship-building opportunities, leadership development plans, or creation of a team within a practice to address clinician well-being—using one of the following approaches:•\tCompletion of clinician survey on clinician well-being with subsequent implementation of an improvement plan based on the results of the survey.•\tCompletion of training regarding clinician well-being with subsequent implementation of a plan for improvement.",
+    "measureId": "IA_BMH_12",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2022,
+    "lastPerformanceYear": null,
+    "weight": "high",
+    "subcategoryId": "behavioralAndMentalHealth"
+  },
+  {
+    "category": "ia",
+    "title": "Electronic submission of Patient Centered Medical Home accreditation",
+    "description": "I attest that I am a Patient Centered Medical Home (PCMH) or Comparable Specialty Practice that has achieved certification from a national program, regional or state program, private payer, or other body that administers patient-centered medical home accreditation and should receive full credit for the Improvement Activities performance category.",
+    "measureId": "IA_PCMH",
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "weight": null,
+    "subcategoryId": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_PPHI_1",
+    "title": "Security Risk Analysis",
+    "description": "Conduct or review a security risk analysis in accordance with the requirements in 45 CFR 164.308(a)(1), including addressing the security (to include encryption) of ePHI data created or maintained by certified electronic health record technology (CEHRT) in accordance with requirements in 45 CFR 164.312(a)(2)(iv) and 45 CFR 164.306(d)(3), implement security updates as necessary, and correct identified security deficiencies as part of the MIPS eligible clinician's risk management process.",
+    "isRequired": true,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "objective": "protectPatientHealthInformation",
+    "isBonus": false,
+    "reportingCategory": "required",
+    "substitutes": [],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/pi_specifications/Measure%20Specifications/2022%20MIPS%20PI%20Measures%20Security%20Risk%20Analysis.pdf"
+    },
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_PPHI_2",
+    "title": "High Priority Practices Guide of the Safety Assurance Factors for EHR  Resilience (SAFER) Guides",
+    "description": "Conduct an annual assessment of the High Priority Practices Guide SAFER Guides beginning with the 2022 performance period.",
+    "isRequired": true,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2022,
+    "lastPerformanceYear": null,
+    "objective": "protectPatientHealthInformation",
+    "isBonus": false,
+    "reportingCategory": "required",
+    "substitutes": [],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/pi_specifications/Measure%20Specifications/2022%20MIPS%20PI%20Measures%20Safety%20Assurance%20Factors%20for%20EHR%20Resilience.pdf"
+    },
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_ONCDIR_1",
+    "title": "ONC Direct Review Attestation",
+    "description": "I attest that I - (1) Acknowledge the requirement to cooperate in good faith with ONC direct review of his or her health information technology certified under the ONC Health IT Certification Program if a request to assist in ONC direct review is received; and (2) If requested, cooperated in good faith with ONC direct review of his or her health information technology certified under the ONC Health IT Certification Program as authorized by 45 CFR part 170, subpart E, to the extent that such technology meets (or can be used to meet) the definition of CEHRT, including by permitting timely access to such technology and demonstrating its capabilities as implemented and used by the MIPS eligible clinician in the field.",
+    "isRequired": true,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "objective": "attestation",
+    "isBonus": false,
+    "reportingCategory": "required",
+    "substitutes": [],
+    "measureSpecification": null,
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_INFBLO_1",
+    "title": "Actions to Limit or Restrict the Compatibility of CEHRT",
+    "description": "I attest to CMS that I did not knowingly and willfully take action (such as to disable functionality) to limit or restrict the compatibility or interoperability of certified EHR technology.",
+    "isRequired": true,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "objective": "attestation",
+    "isBonus": false,
+    "reportingCategory": "required",
+    "substitutes": [],
+    "measureSpecification": null,
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_ONCACB_1",
+    "title": "ONC-ACB Surveillance Attestation",
+    "description": "I have (1) Acknowledged the option to cooperate in good faith with ONC-ACB surveillance of his or her health information technology certified under the ONC Health IT Certification Program if a request to assist in ONC-ACB surveillance is received; and (2) If requested, cooperated in good faith with ONC-ACB surveillance of his or her health information technology certified under the ONC Health IT Certification Program as authorized by 45 CFR part 170, subpart E, to the extent that such technology meets (or can be used to meet) the definition of CEHRT, including by permitting timely access to such technology and demonstrating its capabilities as implemented and used by the MIPS eligible clinician in the field.",
+    "isRequired": false,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "objective": "attestation",
+    "isBonus": false,
+    "reportingCategory": null,
+    "substitutes": [],
+    "measureSpecification": null,
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_EP_1",
+    "title": "e-Prescribing",
+    "description": "At least one permissible prescription written by the MIPS eligible clinician is  transmitted electronically using CEHRT.",
+    "isRequired": true,
+    "metricType": "proportion",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "objective": "electronicPrescribing",
+    "isBonus": false,
+    "reportingCategory": "required",
+    "substitutes": [],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/pi_specifications/Measure%20Specifications/2022%20MIPS%20PI%20Measures%20e-Prescribing.pdf"
+    },
+    "measureSets": [],
+    "exclusion": [
+      "PI_LVPP_1"
+    ]
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_LVPP_1",
+    "title": "e-Prescribing Exclusion",
+    "description": "Any MIPS eligible clinician who writes fewer than 100 permissible prescriptions during the performance period.",
+    "isRequired": false,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "objective": "electronicPrescribing",
+    "isBonus": false,
+    "reportingCategory": "exclusion",
+    "substitutes": [],
+    "measureSpecification": null,
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_EP_2",
+    "title": "Query of the Prescription Drug Monitoring Program (PDMP)",
+    "description": "For at least one Schedule II opioid electronically prescribed using CEHRT during the performance period, the MIPS eligible clinician uses data from CEHRT to conduct a query of a PDMP for prescription drug history, except where prohibited and in accordance with applicable law.",
+    "isRequired": false,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "objective": "electronicPrescribing",
+    "isBonus": true,
+    "reportingCategory": "bonus",
+    "substitutes": [],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/pi_specifications/Measure%20Specifications/2022%20MIPS%20PI%20Measures%20Query%20of%20Prescription%20Drug%20Monitoring%20Program.pdf"
+    },
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_HIE_1",
+    "title": "Support Electronic Referral Loops By Sending Health Information",
+    "description": "For at least one transition of care or referral, the MIPS eligible clinician that transitions or refers their patient to another setting of care or health care provider (1) creates a summary of care record using certified electronic health record technology (CEHRT); and (2) electronically exchanges the summary of care record.",
+    "isRequired": true,
+    "metricType": "proportion",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "objective": "healthInformationExchange",
+    "isBonus": false,
+    "reportingCategory": "required",
+    "substitutes": [
+      "PI_HIE_5"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/pi_specifications/Measure%20Specifications/2022%20MIPS%20PI%20Measures%20Support%20Electronic%20Referral%20Loops%20by%20Sending%20Health%20Info.pdf"
+    },
+    "measureSets": [],
+    "exclusion": [
+      "PI_LVOTC_1"
+    ]
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_LVOTC_1",
+    "title": "Support Electronic Referral Loops By Sending Health Information Exclusion",
+    "description": "Any MIPS eligible clinician who transfers a patient to another setting or refers a patient fewer than 100 times during the performance period.",
+    "isRequired": false,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "objective": "healthInformationExchange",
+    "isBonus": false,
+    "reportingCategory": "exclusion",
+    "substitutes": [],
+    "measureSpecification": null,
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_HIE_4",
+    "title": "Support Electronic Referral Loops By Receiving and Reconciling Health Information",
+    "description": "For at least one electronic summary of care record received for patient encounters during the performance period for which a MIPS eligible clinician was the receiving party of a transition of care or referral, or for patient encounters during the performance period in which the MIPS eligible clinician has never before encountered the patient, the MIPS eligible clinician conducts clinical information reconciliation for medication, medication allergy, and current problem list.",
+    "isRequired": true,
+    "metricType": "proportion",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "objective": "healthInformationExchange",
+    "isBonus": false,
+    "reportingCategory": "required",
+    "substitutes": [
+      "PI_HIE_5"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/pi_specifications/Measure%20Specifications/2022%20MIPS%20PI%20Measures%20Support%20Electronic%20Referral%20Loops%20Receiving%20and%20Reconcilling.pdf"
+    },
+    "measureSets": [],
+    "exclusion": [
+      "PI_LVITC_2"
+    ]
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_LVITC_2",
+    "title": "Support Electronic Referral Loops By Receiving and Reconciling Health Information Exclusion",
+    "description": "Any MIPS eligible clinician who receives transitions of care or referrals or has patient encounters in which the MIPS eligible clinician has never before encountered the patient fewer than 100 times during the performance period.",
+    "isRequired": false,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "objective": "healthInformationExchange",
+    "isBonus": false,
+    "reportingCategory": "exclusion",
+    "substitutes": [],
+    "measureSpecification": null,
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_HIE_5",
+    "title": "Health Information Exchange\n(HIE) Bi-Directional Exchange",
+    "description": "The MIPS eligible clinician or group must establish the technical capacity and workflows to engage in bi-directional exchange via an HIE for all patients seen by the eligible clinician and for any patient record stored or maintained in their EHR.\nThe MIPS eligible clinician or group must attest that they engage in bi-directional exchange with an HIE to support transitions of care.",
+    "isRequired": true,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2021,
+    "lastPerformanceYear": null,
+    "objective": "healthInformationExchange",
+    "isBonus": false,
+    "reportingCategory": "required",
+    "substitutes": [
+      "PI_HIE_1",
+      "PI_HIE_4"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/pi_specifications/Measure%20Specifications/2022%20MIPS%20PI%20Measures%20HIE%20Bi-Directional%20Exchange.pdf"
+    },
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_PEA_1",
+    "title": "Provide Patients Electronic Access to Their Health Information",
+    "description": "For at least one unique patient seen by the MIPS eligible clinician: (1) The patient (or the patient-authorized representative) is provided timely access to view online, download, and transmit his or her health information; and (2) The MIPS eligible clinician ensures the patient's health information is available for the patient (or patient-authorized representative) to access using any application of their choice that is configured to meet the technical specifications of the Application Programming Interface (API) in the MIPS eligible clinician's certified electronic health record technology (CEHRT).",
+    "isRequired": true,
+    "metricType": "proportion",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "objective": "providerToPatientExchange",
+    "isBonus": false,
+    "reportingCategory": "required",
+    "substitutes": [],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/pi_specifications/Measure%20Specifications/2022%20MIPS%20PI%20Measures%20Provide%20Patients%20Electronic%20Access.pdf"
+    },
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_PHCDRR_2",
+    "title": "Syndromic Surveillance Reporting",
+    "description": "The MIPS eligible clinician is in active engagement with a public health agency to submit syndromic surveillance data from an urgent care setting.",
+    "isRequired": false,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "objective": "publicHealthAndClinicalDataExchange",
+    "isBonus": true,
+    "reportingCategory": "bonus",
+    "substitutes": [
+      "PI_PHCDRR_4",
+      "PI_PHCDRR_5"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/pi_specifications/Measure%20Specifications/2022%20MIPS%20PI%20Measures%20Syndromic%20Surveillance%20Reporting.pdf"
+    },
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_PHCDRR_1",
+    "title": "Immunization Registry Reporting",
+    "description": "The MIPS eligible clinician is in active engagement with a public health agency to submit immunization data and receive immunization forecasts and histories from the public health immunization registry/immunization information system (IIS).",
+    "isRequired": true,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "objective": "publicHealthAndClinicalDataExchange",
+    "isBonus": false,
+    "reportingCategory": "required",
+    "substitutes": [],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/pi_specifications/Measure%20Specifications/2022%20MIPS%20PI%20Measures%20Immunization%20Registry%20Reporting.pdf"
+    },
+    "measureSets": [],
+    "exclusion": [
+      "PI_PHCDRR_1_EX_1",
+      "PI_PHCDRR_1_EX_2",
+      "PI_PHCDRR_1_EX_3"
+    ]
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_PHCDRR_1_EX_1",
+    "title": "Immunization Registry Reporting Exclusion",
+    "description": "Any MIPS eligible clinician who does not administer any immunizations to any of the populations for which data is collected by its jurisdiction's immunization registry or immunization information system during the performance period.",
+    "isRequired": false,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "objective": "publicHealthAndClinicalDataExchange",
+    "isBonus": false,
+    "reportingCategory": "exclusion",
+    "substitutes": [
+      "PI_PHCDRR_1_EX_2",
+      "PI_PHCDRR_1_EX_3"
+    ],
+    "measureSpecification": null,
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_PHCDRR_1_EX_2",
+    "title": "Immunization Registry Reporting Exclusion",
+    "description": "Any MIPS eligible clinician who operates in a jurisdiction for which no immunization registry or immunization information system is capable of accepting the specific standards required to meet the CEHRT definition at the start of the performance period.",
+    "isRequired": false,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "objective": "publicHealthAndClinicalDataExchange",
+    "isBonus": false,
+    "reportingCategory": "exclusion",
+    "substitutes": [
+      "PI_PHCDRR_1_EX_1",
+      "PI_PHCDRR_1_EX_3"
+    ],
+    "measureSpecification": null,
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_PHCDRR_1_EX_3",
+    "title": "Immunization Registry Reporting Exclusion",
+    "description": "Any MIPS eligible clinician who operates in a jurisdiction where no immunization registry or immunization information system has declared readiness to receive immunization data as of 6 months prior to the start of the performance period.",
+    "isRequired": false,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "objective": "publicHealthAndClinicalDataExchange",
+    "isBonus": false,
+    "reportingCategory": "exclusion",
+    "substitutes": [
+      "PI_PHCDRR_1_EX_1",
+      "PI_PHCDRR_1_EX_2"
+    ],
+    "measureSpecification": null,
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_PHCDRR_3",
+    "title": "Electronic Case Reporting",
+    "description": "The MIPS eligible clinician is in active engagement with a public health agency to electronically submit case reporting of reportable conditions.",
+    "isRequired": true,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "objective": "publicHealthAndClinicalDataExchange",
+    "isBonus": false,
+    "reportingCategory": "required",
+    "substitutes": [],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/pi_specifications/Measure%20Specifications/2022%20MIPS%20PI%20Measures%20Electronic%20Case%20Reporting.pdf"
+    },
+    "measureSets": [],
+    "exclusion": [
+      "PI_PHCDRR_3_EX_1",
+      "PI_PHCDRR_3_EX_2",
+      "PI_PHCDRR_3_EX_3",
+      "PI_PHCDRR_3_EX_4"
+    ]
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_PHCDRR_3_EX_1",
+    "title": "Electronic Case Reporting Exclusion",
+    "description": "Any MIPS eligible clinician who does not treat or diagnose any reportable diseases for which data is collected by their jurisdiction's reportable disease system during the performance period.",
+    "isRequired": false,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "objective": "publicHealthAndClinicalDataExchange",
+    "isBonus": false,
+    "reportingCategory": "exclusion",
+    "substitutes": [
+      "PI_PHCDRR_3_EX_2",
+      "PI_PHCDRR_3_EX_3",
+      "PI_PHCDRR_3_EX_4"
+    ],
+    "measureSpecification": null,
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_PHCDRR_3_EX_2",
+    "title": "Electronic Case Reporting Exclusion",
+    "description": "Any MIPS eligible clinician who operates in a jurisdiction for which no public health agency is capable of receiving electronic case reporting data in the specific standards required to meet the CEHRT definition at the start of the performance period.",
+    "isRequired": false,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "objective": "publicHealthAndClinicalDataExchange",
+    "isBonus": false,
+    "reportingCategory": "exclusion",
+    "substitutes": [
+      "PI_PHCDRR_3_EX_1",
+      "PI_PHCDRR_3_EX_3",
+      "PI_PHCDRR_3_EX_4"
+    ],
+    "measureSpecification": null,
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_PHCDRR_3_EX_3",
+    "title": "Electronic Case Reporting Exclusion",
+    "description": "Any MIPS eligible clinician who operates in a jurisdiction where no public health agency has declared readiness to receive electronic case reporting data as of 6 months prior to the start of the performance period.",
+    "isRequired": false,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "objective": "publicHealthAndClinicalDataExchange",
+    "isBonus": false,
+    "reportingCategory": "exclusion",
+    "substitutes": [
+      "PI_PHCDRR_3_EX_1",
+      "PI_PHCDRR_3_EX_2",
+      "PI_PHCDRR_3_EX_4"
+    ],
+    "measureSpecification": null,
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_PHCDRR_3_EX_4",
+    "title": "Electronic Case Reporting Exclusion",
+    "description": "For the CY 2022 performance period/CY 2024 MIPS payment year only, the MIPS eligible clinician uses CEHRT that is not certified to the electronic case reporting certification criterion at CFR 170.315(f)(5) prior to the start of the performance period they select in CY 2022.",
+    "isRequired": false,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2022,
+    "lastPerformanceYear": null,
+    "objective": "publicHealthAndClinicalDataExchange",
+    "isBonus": false,
+    "reportingCategory": "exclusion",
+    "substitutes": [
+      "PI_PHCDRR_3_EX_1",
+      "PI_PHCDRR_3_EX_2",
+      "PI_PHCDRR_3_EX_3"
+    ],
+    "measureSpecification": null,
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_PHCDRR_4",
+    "title": "Public Health Registry Reporting",
+    "description": "The MIPS eligible clinician is in active engagement with a public health agency to submit data to public health registries.",
+    "isRequired": false,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "objective": "publicHealthAndClinicalDataExchange",
+    "isBonus": true,
+    "reportingCategory": "bonus",
+    "substitutes": [
+      "PI_PHCDRR_2",
+      "PI_PHCDRR_5"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/pi_specifications/Measure%20Specifications/2022%20MIPS%20PI%20Measures%20Public%20Health%20Registry%20Reporting.pdf"
+    },
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "category": "pi",
+    "measureId": "PI_PHCDRR_5",
+    "title": "Clinical Data Registry Reporting",
+    "description": "The MIPS eligible clinician is in active engagement to submit data to a clinical data registry.",
+    "isRequired": false,
+    "metricType": "boolean",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "objective": "publicHealthAndClinicalDataExchange",
+    "isBonus": true,
+    "reportingCategory": "bonus",
+    "substitutes": [
+      "PI_PHCDRR_2",
+      "PI_PHCDRR_4"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/pi_specifications/Measure%20Specifications/2022%20MIPS%20PI%20Measures%20Clinical%20Data%20Registry%20Reporting.pdf"
+    },
+    "measureSets": [],
+    "exclusion": null
+  },
+  {
+    "title": "Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%)",
+    "eMeasureId": "CMS122v10",
+    "nqfEMeasureId": null,
+    "nqfId": "0059",
+    "measureId": "001",
+    "description": "Percentage of patients 18-75 years of age with diabetes who had hemoglobin A1c > 9.0% during the measurement period.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "intermediateOutcome",
+    "isHighPriority": true,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf",
+      "app1"
+    ],
+    "submissionMethods": [
+      "claims",
+      "electronicHealthRecord",
+      "cmsWebInterface",
+      "registry"
+    ],
+    "measureSets": [
+      "endocrinology",
+      "familyMedicine",
+      "internalMedicine",
+      "nephrology",
+      "preventiveMedicine"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms122v10",
+      "cmsWebInterface": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Web-Interface-Measures/2022_Measure_DM-2_CMSWebInterface_v6.0.pdf",
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_001_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_001_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) or Angiotensin Receptor-Neprilysin Inhibitor (ARNI) Therapy for Left Ventricular Systolic Dysfunction (LVSD)",
+    "eMeasureId": "CMS135v10",
+    "nqfEMeasureId": "0081e",
+    "nqfId": "0081",
+    "measureId": "005",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of heart failure (HF) with a current or prior left ventricular ejection fraction (LVEF) < 40% who were prescribed ACE inhibitor or ARB or ARNI therapy either within a 12-month period when seen in the outpatient setting OR at each hospital discharge.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Heart Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord",
+      "registry"
+    ],
+    "measureSets": [
+      "cardiology",
+      "familyMedicine",
+      "hospitalists",
+      "internalMedicine"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms135v10",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_005_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Coronary Artery Disease (CAD): Antiplatelet Therapy",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0067",
+    "measureId": "006",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease (CAD) seen within a 12-month period who were prescribed aspirin or clopidogrel.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Heart Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "cardiology",
+      "familyMedicine",
+      "internalMedicine",
+      "skilledNursingFacility"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_006_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Coronary Artery Disease (CAD): Beta-Blocker Therapy - Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF < 40%)",
+    "eMeasureId": "CMS145v10",
+    "nqfEMeasureId": "0070e",
+    "nqfId": "0070",
+    "measureId": "007",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease seen within a 12-month period who also have a prior MI or a current or prior LVEF < 40% who were prescribed beta-blocker therapy.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Heart Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord",
+      "registry"
+    ],
+    "measureSets": [
+      "cardiology",
+      "familyMedicine",
+      "internalMedicine",
+      "skilledNursingFacility"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms145v10",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_007_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Heart Failure (HF): Beta-Blocker Therapy for Left Ventricular Systolic Dysfunction (LVSD)",
+    "eMeasureId": "CMS144v10",
+    "nqfEMeasureId": "0083e",
+    "nqfId": "0083",
+    "measureId": "008",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of heart failure (HF) with a current or prior left ventricular ejection fraction (LVEF) < 40% who were prescribed beta-blocker therapy either within a 12-month period when seen in the outpatient setting OR at each hospital discharge.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Heart Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord",
+      "registry"
+    ],
+    "measureSets": [
+      "cardiology",
+      "familyMedicine",
+      "hospitalists",
+      "internalMedicine",
+      "skilledNursingFacility"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms144v10",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_008_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Anti-Depressant Medication Management",
+    "eMeasureId": "CMS128v10",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "009",
+    "description": "Percentage of patients 18 years of age and older who were treated with antidepressant medication, had a diagnosis of major depression, and who remained on an antidepressant medication treatment. Two rates are reported. a. Percentage of patients who remained on an antidepressant medication for at least 84 days (12 weeks). b. Percentage of patients who remained on an antidepressant medication for at least 180 days (6 months).",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "overallAlgorithm": "simpleAverage",
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "multiPerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "familyMedicine",
+      "internalMedicine",
+      "mentalBehavioralHealth"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms128v10"
+    },
+    "strata": [
+      {
+        "name": ">=84Days",
+        "description": "Percentage of patients who remained on an antidepressant medication for at least 84 days (12 weeks)."
+      },
+      {
+        "name": ">=180Days",
+        "description": "Percentage of patients who remained on an antidepressant medication for at least 180 days (6 months)"
+      }
+    ]
+  },
+  {
+    "title": "Primary Open-Angle Glaucoma (POAG): Optic Nerve Evaluation",
+    "eMeasureId": "CMS143v10",
+    "nqfEMeasureId": "0086e",
+    "nqfId": null,
+    "measureId": "012",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of primary open-angle glaucoma (POAG) who have an optic nerve head evaluation during one or more office visits within 12 months.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Academy of Ophthalmology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "ophthalmology"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms143v10"
+    }
+  },
+  {
+    "title": "Age-Related Macular Degeneration (AMD): Dilated Macular Examination",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0087",
+    "measureId": "014",
+    "description": "Percentage of patients aged 50 years and older with a diagnosis of age-related macular degeneration (AMD) who had a dilated macular examination performed which included documentation of the presence or absence of macular thickening or geographic atrophy or hemorrhage AND the level of macular degeneration severity during one or more office visits within the 12 month performance period.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Academy of Ophthalmology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "ophthalmology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_014_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Diabetic Retinopathy: Communication with the Physician Managing Ongoing Diabetes Care",
+    "eMeasureId": "CMS142v10",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "019",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of diabetic retinopathy who had a dilated macular or fundus exam performed with documented communication to the physician who manages the ongoing care of the patient with diabetes mellitus regarding the findings of the macular or fundus exam at least once within 12 months.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Ophthalmology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord",
+      "registry"
+    ],
+    "measureSets": [
+      "ophthalmology"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms142v10",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_019_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Communication with the Physician or Other Clinician Managing On-Going Care Post-Fracture for Men and Women Aged 50 Years and Older",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "024",
+    "description": "Percentage of patients aged 50 years and older treated for a fracture with documentation of communication, between the physician treating the fracture and the physician or other clinician managing the patient's on-going care, that a fracture occurred and that the patient was or should be considered for osteoporosis treatment or testing. This measure is submitted by the physician who treats the fracture and who therefore is held accountable for the communication.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "familyMedicine",
+      "internalMedicine",
+      "orthopedicSurgery",
+      "preventiveMedicine",
+      "rheumatology"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_024_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_024_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Screening for Osteoporosis for Women Aged 65-85 Years of Age",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0046",
+    "measureId": "039",
+    "description": "Percentage of female patients aged 65-85 years of age who ever had a central dual-energy X-ray absorptiometry (DXA) to check for osteoporosis.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "endocrinology",
+      "familyMedicine",
+      "geriatrics",
+      "internalMedicine",
+      "preventiveMedicine",
+      "rheumatology"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_039_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_039_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Advance Care Plan",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0326",
+    "measureId": "047",
+    "description": "Percentage of patients aged 65 years and older who have an advance care plan or surrogate decision maker documented in the medical record or documentation in the medical record that an advance care plan was discussed but the patient did not wish or was not able to name a surrogate decision maker or provide an advance care plan.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "cardiology",
+      "certifiedNurseMidwife",
+      "clinicalSocialWork",
+      "familyMedicine",
+      "gastroenterology",
+      "generalSurgery",
+      "geriatrics",
+      "hospitalists",
+      "internalMedicine",
+      "nephrology",
+      "neurology",
+      "obstetricsGynecology",
+      "oncology",
+      "orthopedicSurgery",
+      "otolaryngology",
+      "physicalMedicine",
+      "preventiveMedicine",
+      "pulmonology",
+      "rheumatology",
+      "skilledNursingFacility",
+      "thoracicSurgery",
+      "urology",
+      "vascularSurgery"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_047_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_047_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Urinary Incontinence: Assessment of Presence or Absence of Urinary Incontinence in Women Aged 65 Years and Older",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "048",
+    "description": "Percentage of female patients aged 65 years and older who were assessed for the presence or absence of urinary incontinence within 12 months.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "familyMedicine",
+      "geriatrics",
+      "internalMedicine",
+      "obstetricsGynecology",
+      "preventiveMedicine",
+      "urology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_048_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Urinary Incontinence: Plan of Care for Urinary Incontinence in Women Aged 65 Years and Older",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "050",
+    "description": "Percentage of female patients aged 65 years and older with a diagnosis of urinary incontinence with a documented plan of care for urinary incontinence at least once within 12 months.",
+    "nationalQualityStrategyDomain": "Person and Caregiver-Centered Experience and Outcomes",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "familyMedicine",
+      "geriatrics",
+      "internalMedicine",
+      "obstetricsGynecology",
+      "physicalTherapyOccupationalTherapy",
+      "urology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_050_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Chronic Obstructive Pulmonary Disease (COPD): Long-Acting Inhaled Bronchodilator Therapy",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0102",
+    "measureId": "052",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of COPD (FEV1/FVC < 70%) and who have an FEV1 less than 60% predicted and have symptoms who were prescribed a long-acting inhaled bronchodilator.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Thoracic Society",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "pulmonology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_052_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Appropriate Treatment for Upper Respiratory Infection (URI)",
+    "eMeasureId": "CMS154v10",
+    "nqfEMeasureId": null,
+    "nqfId": "0069",
+    "measureId": "065",
+    "description": "Percentage of episodes for patients 3 months of age and older with a diagnosis of upper respiratory infection (URI) that did not result in an antibiotic dispensing event.",
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord",
+      "registry"
+    ],
+    "measureSets": [
+      "familyMedicine",
+      "otolaryngology",
+      "pediatrics",
+      "urgentCare"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms154v10",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_065_MIPSCQM.pdf"
+    },
+    "historic_benchmarks": {
+      "registry": "removed"
+    }
+  },
+  {
+    "title": "Appropriate Testing for Pharyngitis",
+    "eMeasureId": "CMS146v10",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "066",
+    "description": "The percentage of episodes for patients 3 years and older with a diagnosis of pharyngitis that resulted in an antibiotic dispensing event and a group A streptococcus (strep) test.",
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord",
+      "registry"
+    ],
+    "measureSets": [
+      "emergencyMedicine",
+      "familyMedicine",
+      "pediatrics",
+      "urgentCare"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms146v10",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_066_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Prevention of Central Venous Catheter (CVC) - Related Bloodstream Infections",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "2726",
+    "measureId": "076",
+    "description": "Percentage of patients, regardless of age, who undergo central venous catheter (CVC) insertion for whom CVC was inserted with all elements of maximal sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound techniques followed.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Society of Anesthesiologists",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "anesthesiology",
+      "hospitalists",
+      "interventionalRadiology"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_076_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_076_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Acute Otitis Externa (AOE): Systemic Antimicrobial Therapy - Avoidance of Inappropriate Use",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0654",
+    "measureId": "093",
+    "description": "Percentage of patients aged 2 years and older with a diagnosis of AOE who were not prescribed systemic antimicrobial therapy.",
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Otolaryngology - Head and Neck Surgery",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "emergencyMedicine",
+      "familyMedicine",
+      "internalMedicine",
+      "otolaryngology",
+      "pediatrics",
+      "urgentCare"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_093_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Prostate Cancer: Avoidance of Overuse of Bone Scan for Staging Low Risk Prostate Cancer Patients",
+    "eMeasureId": "CMS129v11",
+    "nqfEMeasureId": "0389e",
+    "nqfId": "0389",
+    "measureId": "102",
+    "description": "Percentage of patients, regardless of age, with a diagnosis of prostate cancer at low (or very low) risk of recurrence receiving interstitial prostate brachytherapy, OR external beam radiotherapy to the prostate, OR radical prostatectomy who did not have a bone scan performed at any time since diagnosis of prostate cancer.",
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord",
+      "registry"
+    ],
+    "measureSets": [
+      "oncology",
+      "radiationOncology",
+      "urology"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms129v11",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_102_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Prostate Cancer: Combination Androgen Deprivation Therapy for High Risk or Very High Risk Prostate Cancer",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0390",
+    "measureId": "104",
+    "description": "Percentage of patients, regardless of age, with a diagnosis of prostate cancer at high or very high risk of recurrence receiving external beam radiotherapy to the prostate who were prescribed androgen deprivation therapy in combination with external beam radiotherapy to the prostate.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Urological Association Education and Research",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "urology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_104_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Adult Major Depressive Disorder (MDD): Suicide Risk Assessment",
+    "eMeasureId": "CMS161v10",
+    "nqfEMeasureId": "0104e",
+    "nqfId": null,
+    "measureId": "107",
+    "description": "All patient visits during which a new diagnosis of MDD or a new diagnosis of recurrent MDD was identified for patients aged 18 years and older with a suicide risk assessment completed during the visit.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "Mathematica",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "emergencyMedicine",
+      "familyMedicine",
+      "internalMedicine",
+      "mentalBehavioralHealth"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms161v10"
+    }
+  },
+  {
+    "title": "Preventive Care and Screening: Influenza Immunization",
+    "eMeasureId": "CMS147v11",
+    "nqfEMeasureId": "0041e",
+    "nqfId": "0041",
+    "measureId": "110",
+    "description": "Percentage of patients aged 6 months and older seen for a visit between October 1 and March 31 who received an influenza immunization OR who reported previous receipt of an influenza immunization.",
+    "nationalQualityStrategyDomain": "Community/Population Health",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "electronicHealthRecord",
+      "cmsWebInterface",
+      "registry"
+    ],
+    "measureSets": [
+      "allergyImmunology",
+      "cardiology",
+      "certifiedNurseMidwife",
+      "endocrinology",
+      "familyMedicine",
+      "geriatrics",
+      "infectiousDisease",
+      "internalMedicine",
+      "nephrology",
+      "obstetricsGynecology",
+      "oncology",
+      "otolaryngology",
+      "pediatrics",
+      "preventiveMedicine",
+      "pulmonology",
+      "rheumatology",
+      "skilledNursingFacility"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms147v11",
+      "cmsWebInterface": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Web-Interface-Measures/2022_Measure_PREV7_CMSWebInterface_v6.0.pdf",
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_110_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_110_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Pneumococcal Vaccination Status for Older Adults",
+    "eMeasureId": "CMS127v10",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "111",
+    "description": "Percentage of patients 66 years of age and older who have ever received a pneumococcal vaccine.",
+    "nationalQualityStrategyDomain": "Community/Population Health",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "electronicHealthRecord",
+      "registry"
+    ],
+    "measureSets": [
+      "allergyImmunology",
+      "cardiology",
+      "endocrinology",
+      "familyMedicine",
+      "geriatrics",
+      "infectiousDisease",
+      "internalMedicine",
+      "nephrology",
+      "obstetricsGynecology",
+      "oncology",
+      "otolaryngology",
+      "preventiveMedicine",
+      "pulmonology",
+      "rheumatology",
+      "skilledNursingFacility"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms127v10",
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_111_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_111_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Breast Cancer Screening",
+    "eMeasureId": "CMS125v10",
+    "nqfEMeasureId": null,
+    "nqfId": "2372",
+    "measureId": "112",
+    "description": "Percentage of women 50 - 74 years of age who had a mammogram to screen for breast cancer in the 27 months prior to the end of the measurement period.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "electronicHealthRecord",
+      "cmsWebInterface",
+      "registry"
+    ],
+    "measureSets": [
+      "familyMedicine",
+      "obstetricsGynecology",
+      "preventiveMedicine"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms125v10",
+      "cmsWebInterface": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Web-Interface-Measures/2022_Measure_PREV5_CMSWebInterface_v6.0.pdf",
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_112_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_112_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Colorectal Cancer Screening",
+    "eMeasureId": "CMS130v10",
+    "nqfEMeasureId": null,
+    "nqfId": "0034",
+    "measureId": "113",
+    "description": "Percentage of patients 50-75 years of age who had appropriate screening for colorectal cancer.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "electronicHealthRecord",
+      "cmsWebInterface",
+      "registry"
+    ],
+    "measureSets": [
+      "familyMedicine",
+      "preventiveMedicine"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms130v10",
+      "cmsWebInterface": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Web-Interface-Measures/2022_Measure_PREV6_CMSWebInterface_v6.0.pdf",
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_113_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_113_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Avoidance of Antibiotic Treatment for Acute Bronchitis/Bronchiolitis",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0058",
+    "measureId": "116",
+    "description": "The percentage of episodes for patients ages 3 months and older with a diagnosis of acute bronchitis/bronchiolitis that did not result in an antibiotic dispensing event.",
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "emergencyMedicine",
+      "familyMedicine",
+      "internalMedicine",
+      "pediatrics",
+      "preventiveMedicine",
+      "urgentCare"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_116_MIPSCQM.pdf"
+    },
+    "historic_benchmarks": {
+      "registry": "removed"
+    }
+  },
+  {
+    "title": "Diabetes: Eye Exam",
+    "eMeasureId": "CMS131v10",
+    "nqfEMeasureId": null,
+    "nqfId": "0055",
+    "measureId": "117",
+    "description": "Percentage of patients 18-75 years of age with diabetes and an active diagnosis of retinopathy in any part of the measurement period who had a retinal or dilated eye exam by an eye care professional during the measurement period or diabetics with no diagnosis of retinopathy in any part of the measurement period who had a retinal or dilated eye exam by an eye care professional during the measurement period or in the 12 months prior to the measurement period.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "electronicHealthRecord",
+      "registry"
+    ],
+    "measureSets": [
+      "endocrinology",
+      "familyMedicine",
+      "internalMedicine",
+      "ophthalmology"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms131v10",
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_117_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_117_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Coronary Artery Disease (CAD): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) Therapy - Diabetes or Left Ventricular Systolic Dysfunction (LVEF < 40%)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0066",
+    "measureId": "118",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of coronary artery disease seen within a 12 month period who also have diabetes OR a current or prior Left Ventricular Ejection Fraction (LVEF) < 40% who were prescribed ACE inhibitor or ARB therapy.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Heart Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "cardiology",
+      "endocrinology",
+      "skilledNursingFacility"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_118_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Diabetes: Medical Attention for Nephropathy",
+    "eMeasureId": "CMS134v10",
+    "nqfEMeasureId": null,
+    "nqfId": "0062",
+    "measureId": "119",
+    "description": "The percentage of patients 18-75 years of age with diabetes who had a nephropathy screening test or evidence of nephropathy during the measurement period.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord",
+      "registry"
+    ],
+    "measureSets": [
+      "endocrinology",
+      "familyMedicine",
+      "internalMedicine",
+      "nephrology",
+      "preventiveMedicine",
+      "urology"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms134v10",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_119_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Diabetes Mellitus: Diabetic Foot and Ankle Care, Peripheral Neuropathy - Neurological Evaluation",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0417",
+    "measureId": "126",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of diabetes mellitus who had a neurological examination of their lower extremities within 12 months.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Podiatric Medical Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "endocrinology",
+      "familyMedicine",
+      "internalMedicine",
+      "nutritionDietician",
+      "physicalTherapyOccupationalTherapy",
+      "podiatry",
+      "preventiveMedicine"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_126_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Diabetes Mellitus: Diabetic Foot and Ankle Care, Ulcer Prevention - Evaluation of Footwear",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0416",
+    "measureId": "127",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of diabetes mellitus who were evaluated for proper footwear and sizing.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Podiatric Medical Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "nutritionDietician",
+      "physicalTherapyOccupationalTherapy",
+      "podiatry"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_127_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Preventive Care and Screening: Body Mass Index (BMI) Screening and Follow-Up Plan",
+    "eMeasureId": "CMS69v10",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "128",
+    "description": "Percentage of patients aged 18 years and older with a BMI documented during the current encounter or within the previous twelve months AND who had a follow-up plan documented if most recent BMI was outside of normal parameters.",
+    "nationalQualityStrategyDomain": "Community/Population Health",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "electronicHealthRecord",
+      "registry"
+    ],
+    "measureSets": [
+      "cardiology",
+      "endocrinology",
+      "familyMedicine",
+      "gastroenterology",
+      "generalSurgery",
+      "internalMedicine",
+      "mentalBehavioralHealth",
+      "nutritionDietician",
+      "obstetricsGynecology",
+      "orthopedicSurgery",
+      "otolaryngology",
+      "physicalMedicine",
+      "physicalTherapyOccupationalTherapy",
+      "plasticSurgery",
+      "podiatry",
+      "preventiveMedicine",
+      "pulmonology",
+      "rheumatology",
+      "urology",
+      "vascularSurgery"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms069v10",
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_128_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_128_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Documentation of Current Medications in the Medical Record",
+    "eMeasureId": "CMS68v11",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "130",
+    "description": "Percentage of visits for patients aged 18 years and older for which the eligible professional or eligible clinician attests to documenting a list of current medications using all immediate resources available on the date of the encounter.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "electronicHealthRecord",
+      "registry"
+    ],
+    "measureSets": [
+      "allergyImmunology",
+      "audiology",
+      "cardiology",
+      "certifiedNurseMidwife",
+      "clinicalSocialWork",
+      "dermatology",
+      "endocrinology",
+      "familyMedicine",
+      "gastroenterology",
+      "generalSurgery",
+      "geriatrics",
+      "hospitalists",
+      "infectiousDisease",
+      "internalMedicine",
+      "mentalBehavioralHealth",
+      "nephrology",
+      "neurology",
+      "neurosurgical",
+      "nutritionDietician",
+      "obstetricsGynecology",
+      "oncology",
+      "ophthalmology",
+      "orthopedicSurgery",
+      "otolaryngology",
+      "physicalMedicine",
+      "physicalTherapyOccupationalTherapy",
+      "plasticSurgery",
+      "preventiveMedicine",
+      "pulmonology",
+      "rheumatology",
+      "speechLanguagePathology",
+      "thoracicSurgery",
+      "urgentCare",
+      "urology",
+      "vascularSurgery"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms068v11",
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_130_MedicarePartBclaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_130_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Preventive Care and Screening: Screening for Depression and Follow-Up Plan",
+    "eMeasureId": "CMS2v11",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "134",
+    "description": "Percentage of patients aged 12 years and older screened for depression on the date of the encounter or up to 14 days prior to the date of the encounter using an age-appropriate standardized depression screening tool AND if positive, a follow-up plan is documented on the date of the eligible encounter.",
+    "nationalQualityStrategyDomain": "Community/Population Health",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf",
+      "app1"
+    ],
+    "submissionMethods": [
+      "claims",
+      "electronicHealthRecord",
+      "cmsWebInterface",
+      "registry"
+    ],
+    "measureSets": [
+      "audiology",
+      "clinicalSocialWork",
+      "endocrinology",
+      "familyMedicine",
+      "internalMedicine",
+      "mentalBehavioralHealth",
+      "neurology",
+      "orthopedicSurgery",
+      "pediatrics",
+      "physicalTherapyOccupationalTherapy",
+      "preventiveMedicine",
+      "speechLanguagePathology"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms002v11",
+      "cmsWebInterface": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Web-Interface-Measures/2022_Measure_PREV12_CMSWebInterface_v6.0.pdf",
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_134_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_134_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Melanoma: Continuity of Care - Recall System",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "137",
+    "description": "Percentage of patients, regardless of age, with a current diagnosis of melanoma or a history of melanoma whose information was entered, at least once within a 12 month period, into a recall system that includes: A target date for the next complete physical skin exam, AND A process to follow up with patients who either did not make an appointment within the specified timeframe or who missed a scheduled appointment.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "structure",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Dermatology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "dermatology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_137_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Melanoma: Coordination of Care",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "138",
+    "description": "Percentage of patient visits, regardless of age, with a new occurrence of melanoma that have a treatment plan documented in the chart that was communicated to the physician(s) providing continuing care within one month of diagnosis.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Dermatology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "dermatology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_138_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0563",
+    "measureId": "141",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of primary open-angle glaucoma (POAG) whose glaucoma treatment has not failed (the most recent IOP was reduced by at least 15% from the pre-intervention level) OR if the most recent IOP was not reduced by at least 15% from the pre-intervention level, a plan of care was documented within the 12 month performance period.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Ophthalmology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "ophthalmology"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_141_MedicarepartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_141_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Oncology: Medical and Radiation - Pain Intensity Quantified",
+    "eMeasureId": "CMS157v10",
+    "nqfEMeasureId": "0384e",
+    "nqfId": "0384",
+    "measureId": "143",
+    "description": "Percentage of patient visits, regardless of patient age, with a diagnosis of cancer currently receiving chemotherapy or radiation therapy in which pain intensity is quantified.",
+    "nationalQualityStrategyDomain": "Person and Caregiver-Centered Experience and Outcomes",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Society of Clinical Oncology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord",
+      "registry"
+    ],
+    "measureSets": [
+      "oncology",
+      "radiationOncology"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms157v10",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_143_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Oncology: Medical and Radiation - Plan of Care for Pain",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0383",
+    "measureId": "144",
+    "description": "Percentage of visits for patients, regardless of age, with a diagnosis of cancer currently receiving chemotherapy or radiation therapy who report having pain with a documented plan of care to address pain.",
+    "nationalQualityStrategyDomain": "Person and Caregiver-Centered Experience and Outcomes",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Society of Clinical Oncology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "oncology",
+      "radiationOncology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_144_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Radiology: Exposure Dose Indices or Exposure Time and Number of Images Reported for Procedures Using Fluoroscopy",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "145",
+    "description": "Final reports for procedures using fluoroscopy that document radiation exposure indices, or exposure time and number of fluorographic images (if radiation exposure indices are not available).",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American College of Radiology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "diagnosticRadiology",
+      "interventionalRadiology"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_145_MedicarePartBclaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_145_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Nuclear Medicine: Correlation with Existing Imaging Studies for All Patients Undergoing Bone Scintigraphy",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "147",
+    "description": "Percentage of final reports for all patients, regardless of age, undergoing bone scintigraphy that include physician documentation of correlation with existing relevant imaging studies (e.g., x-ray, Magnetic Resonance Imaging (MRI), Computed Tomography (CT), etc.) that were performed.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "Society of Nuclear Medicine and Molecular Imaging",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "diagnosticRadiology"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_147_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_147_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Falls: Plan of Care",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0101",
+    "measureId": "155",
+    "description": "Percentage of patients aged 65 years and older with a history of falls that had a plan of care for falls documented within 12 months.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "audiology",
+      "familyMedicine",
+      "geriatrics",
+      "internalMedicine",
+      "neurology",
+      "orthopedicSurgery",
+      "otolaryngology",
+      "physicalMedicine",
+      "physicalTherapyOccupationalTherapy",
+      "podiatry",
+      "preventiveMedicine",
+      "skilledNursingFacility"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_155_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_155_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Coronary Artery Bypass Graft (CABG): Prolonged Intubation",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0129",
+    "measureId": "164",
+    "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery who require postoperative intubation > 24 hours.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "Society of Thoracic Surgeons",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "thoracicSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_164_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Coronary Artery Bypass Graft (CABG): Postoperative Renal Failure",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0114",
+    "measureId": "167",
+    "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery (without pre-existing renal failure) who develop postoperative renal failure or require dialysis.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "Society of Thoracic Surgeons",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "thoracicSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_167_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Coronary Artery Bypass Graft (CABG): Surgical Re-Exploration",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0115",
+    "measureId": "168",
+    "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery who require a return to the operating room (OR) during the current hospitalization for mediastinal bleeding with or without tamponade, graft occlusion, valve dysfunction, or other cardiac reason.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "Society of Thoracic Surgeons",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "thoracicSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_168_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Tuberculosis Screening Prior to First Course Biologic Therapy",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "176",
+    "description": "If a patient has been newly prescribed a biologic disease-modifying anti-rheumatic drug (DMARD) therapy, then the medical record should indicate TB testing in the preceding 12-month period.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American College of Rheumatology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "dermatology",
+      "rheumatology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_176_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Rheumatoid Arthritis (RA): Periodic Assessment of Disease Activity",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "2523",
+    "measureId": "177",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have an assessment of disease activity using an ACR-preferred RA disease activity assessment tool at 50% of encounters for RA for each patient during the measurement year.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American College of Rheumatology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "rheumatology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_177_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Rheumatoid Arthritis (RA): Functional Status Assessment",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "178",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) for whom a functional status assessment was performed at least once within 12 months.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American College of Rheumatology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "orthopedicSurgery",
+      "rheumatology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_178_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Rheumatoid Arthritis (RA): Glucocorticoid Management",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "180",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of rheumatoid arthritis (RA) who have been assessed for glucocorticoid use and, for those on prolonged doses of prednisone > 5 mg daily (or equivalent) with improvement or no change in disease activity, documentation of glucocorticoid management plan within 12 months.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American College of Rheumatology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "orthopedicSurgery",
+      "rheumatology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_180_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Elder Maltreatment Screen and Follow-Up Plan",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "181",
+    "description": "Percentage of patients aged 65 years and older with a documented elder maltreatment screen using an Elder Maltreatment Screening tool on the date of encounter AND a documented follow-up plan on the date of the positive screen.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "audiology",
+      "clinicalSocialWork",
+      "familyMedicine",
+      "geriatrics",
+      "internalMedicine",
+      "mentalBehavioralHealth",
+      "neurology",
+      "nutritionDietician",
+      "physicalTherapyOccupationalTherapy",
+      "skilledNursingFacility",
+      "speechLanguagePathology"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_181_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_181_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Functional Outcome Assessment",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "182",
+    "description": "Percentage of visits for patients aged 18 years and older with documentation of a current functional outcome assessment using a standardized functional outcome assessment tool on the date of the encounter AND documentation of a care plan based on identified functional outcome deficiencies on the date of the identified deficiencies.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "audiology",
+      "chiropracticMedicine",
+      "familyMedicine",
+      "nephrology",
+      "orthopedicSurgery",
+      "physicalMedicine",
+      "physicalTherapyOccupationalTherapy",
+      "preventiveMedicine",
+      "speechLanguagePathology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_182_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Colonoscopy Interval for Patients with a History of Adenomatous Polyps - Avoidance of Inappropriate Use",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "185",
+    "description": "Percentage of patients aged 18 years and older receiving a surveillance colonoscopy, with a history of prior adenomatous polyp(s) in previous colonoscopy findings, which had an interval of 3 or more years since their last colonoscopy.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Gastroenterological Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "gastroenterology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_185_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Stroke and Stroke Rehabilitation: Thrombolytic Therapy",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "187",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of acute ischemic stroke who arrive at the hospital within two hours of time last known well and for whom IV alteplase was initiated within three hours of time last known well.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Heart Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "emergencyMedicine",
+      "neurosurgical"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_187_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Cataracts: 20/40 or Better Visual Acuity within 90 Days Following Cataract Surgery",
+    "eMeasureId": "CMS133v10",
+    "nqfEMeasureId": "0565e",
+    "nqfId": "0565",
+    "measureId": "191",
+    "description": "Percentage of cataract surgeries for patients aged 18 years and older with a diagnosis of uncomplicated cataract and no significant ocular conditions impacting the visual outcome of surgery and had best-corrected visual acuity of 20/40 or better (distance or near) achieved in the operative eye within 90 days following the cataract surgery.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Ophthalmology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord",
+      "registry"
+    ],
+    "measureSets": [
+      "ophthalmology"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms133v10",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_191_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "HIV/AIDS: Sexually Transmitted Disease Screening for Chlamydia, Gonorrhea, and Syphilis",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0409",
+    "measureId": "205",
+    "description": "Percentage of patients aged 13 years and older with a diagnosis of HIV/AIDS for whom chlamydia, gonorrhea, and syphilis screenings were performed at least once since the diagnosis of HIV infection.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "Health Resources and Services Administration",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "infectiousDisease",
+      "pediatrics"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_205_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Functional Status Change for Patients with Knee Impairments",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "217",
+    "description": "A patient-reported outcome measure of risk-adjusted change in functional status for patients 14 years+ with knee impairments. The change in functional status (FS) is assessed using the FOTO Lower Extremity Physical Function (LEPF) patient-reported outcome measure (PROM). The measure is adjusted to patient characteristics known to be associated with FS outcomes (risk-adjusted) and used as a performance measure at the patient level, at the individual clinician level, and at the clinic level to assess quality. The measure is available as a computer adaptive test, for reduced patient burden, or a short form (static measure).",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "primarySteward": "Focus on Therapeutic Outcomes, Inc.",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "chiropracticMedicine",
+      "orthopedicSurgery",
+      "physicalTherapyOccupationalTherapy"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_217_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Functional Status Change for Patients with Hip Impairments",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "218",
+    "description": "A patient-reported outcome measure of risk-adjusted change in functional status for patients 14 years+ with hip impairments. The change in functional status (FS) is assessed using the FOTO Lower Extremity Physical Function (LEPF) patient-reported outcome measure (PROM). The measure is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician level, and at the clinic level to assess quality. The measure is available as a computer adaptive test, for reduced patient burden, or a short form (static measure).",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "primarySteward": "Focus on Therapeutic Outcomes, Inc.",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "chiropracticMedicine",
+      "orthopedicSurgery",
+      "physicalTherapyOccupationalTherapy"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_218_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Functional Status Change for Patients with Lower Leg, Foot or Ankle Impairments",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "219",
+    "description": "A patient-reported outcome measure of risk-adjusted change in functional status for patients 14 years+ with foot, ankle or lower leg impairments. The change in functional status (FS) is assessed using the FOTO Lower Extremity Physical Function (LEPF) patient- reported outcome measure (PROM). The measure is adjusted to patient characteristics known to be associated with FS outcomes (risk-adjusted) and used as a performance measure at the patient level, at the individual clinician level, and at the clinic level to assess quality. The measure is available as a computer adaptive test, for reduced patient burden, or a short form (static measure).",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "primarySteward": "Focus on Therapeutic Outcomes, Inc.",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "chiropracticMedicine",
+      "orthopedicSurgery",
+      "physicalTherapyOccupationalTherapy"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_219_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Functional Status Change for Patients with Low Back Impairments",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "220",
+    "description": "A patient-reported outcome measure of risk-adjusted change in functional status for patients 14 years+ with low back impairments. The change in functional status (FS) is assessed using the FOTO Low Back FS patient-reported outcome measure (PROM). The measure is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician level, and at the clinic level to assess quality. The measure is available as a computer adaptive test, for reduced patient burden, or a short form (static measure).",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "primarySteward": "Focus on Therapeutic Outcomes, Inc.",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "chiropracticMedicine",
+      "orthopedicSurgery",
+      "physicalTherapyOccupationalTherapy"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_220_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Functional Status Change for Patients with Shoulder Impairments",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "221",
+    "description": "A patient-reported outcome measure of risk-adjusted change in functional status for patients 14 years+ with shoulder impairments. The change in functional status (FS) is assessed using the FOTO Shoulder FS patient-reported outcome measure (PROM). The measure is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician level, and at the clinic level to assess quality. The measure is available as a computer adaptive test, for reduced patient burden, or a short form (static measure).",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "primarySteward": "Focus on Therapeutic Outcomes, Inc.",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "chiropracticMedicine",
+      "orthopedicSurgery",
+      "physicalTherapyOccupationalTherapy"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_221_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Functional Status Change for Patients with Elbow, Wrist or Hand Impairments",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "222",
+    "description": "A patient-reported outcome measure of risk-adjusted change in functional status for patients 14 years+ with elbow, wrist, or hand impairments. The change in functional status (FS) is assessed using the FOTO Elbow/Wrist/Hand FS patient-reported outcome measure (PROM). The measure is adjusted to patient characteristics known to be associated with FS outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician level, and at the clinic level to assess quality. The measure is available as a computer adaptive test, for reduced patient burden, or a short form (static measure).",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "primarySteward": "Focus on Therapeutic Outcomes, Inc.",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "chiropracticMedicine",
+      "orthopedicSurgery",
+      "physicalTherapyOccupationalTherapy"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_222_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention",
+    "eMeasureId": "CMS138v10",
+    "nqfEMeasureId": "0028e",
+    "nqfId": "0028",
+    "measureId": "226",
+    "description": "Percentage of patients aged 18 years and older who were screened for tobacco use one or more times within the measurement period AND who received tobacco cessation intervention on the date of the encounter or within the previous 12 months if identified as a tobacco user.Three rates are reported:a. Percentage of patients aged 18 years and older who were screened for tobacco use one or more times within the measurement period.b. Percentage of patients aged 18 years and older who were identified as a tobacco user who received tobacco cessation intervention on the date of the encounter or within the previous 12 months.c. Percentage of patients aged 18 years and older who were screened for tobacco use one or more times during the measurement period AND who received tobacco cessation intervention if identified as a tobacco user on the date of the encounter or within the previous 12 months.",
+    "nationalQualityStrategyDomain": "Community/Population Health",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "overallAlgorithm": "overallStratumOnly",
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "multiPerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "electronicHealthRecord",
+      "cmsWebInterface",
+      "registry"
+    ],
+    "measureSets": [
+      "allergyImmunology",
+      "audiology",
+      "cardiology",
+      "certifiedNurseMidwife",
+      "clinicalSocialWork",
+      "dermatology",
+      "endocrinology",
+      "familyMedicine",
+      "gastroenterology",
+      "generalSurgery",
+      "internalMedicine",
+      "mentalBehavioralHealth",
+      "neurology",
+      "neurosurgical",
+      "obstetricsGynecology",
+      "oncology",
+      "ophthalmology",
+      "orthopedicSurgery",
+      "otolaryngology",
+      "physicalMedicine",
+      "physicalTherapyOccupationalTherapy",
+      "plasticSurgery",
+      "podiatry",
+      "preventiveMedicine",
+      "pulmonology",
+      "rheumatology",
+      "speechLanguagePathology",
+      "thoracicSurgery",
+      "urgentCare",
+      "urology",
+      "vascularSurgery"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms138v10",
+      "cmsWebInterface": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Web-Interface-Measures/2022_Measure_PREV10_CMSWebInterface_v6.0.pdf",
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_226_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_226_MIPSCQM.pdf"
+    },
+    "strata": [
+      {
+        "name": "screenedForUse",
+        "description": "Percentage of patients aged 18 years and older who were screened for tobacco use one or more times within the measurement period"
+      },
+      {
+        "name": "overall",
+        "description": "Percentage of patients aged 18 years and older who were identified as a tobacco user who received tobacco cessation intervention on the date of the encounter or within the previous 12 months"
+      },
+      {
+        "name": "tobacco",
+        "description": "Percentage of patients aged 18 years and older who were screened for tobacco use one or more times within the measurement period AND who received tobacco cessation intervention if identified as a tobacco user on the date of the encounter or within the previous 12 months"
+      }
+    ],
+    "historic_benchmarks": {
+      "cmsWebInterface": "removed"
+    }
+  },
+  {
+    "title": "Controlling High Blood Pressure",
+    "eMeasureId": "CMS165v10",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "236",
+    "description": "Percentage of patients 18-85 years of age who had a diagnosis of essential hypertension starting before and continuing into, or starting during the first six months of the measurement period, and whose most recent blood pressure was adequately controlled (<140/90mmHg) during the measurement period.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "intermediateOutcome",
+    "isHighPriority": true,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf",
+      "app1"
+    ],
+    "submissionMethods": [
+      "claims",
+      "electronicHealthRecord",
+      "cmsWebInterface",
+      "registry"
+    ],
+    "measureSets": [
+      "cardiology",
+      "endocrinology",
+      "familyMedicine",
+      "internalMedicine",
+      "obstetricsGynecology",
+      "pulmonology",
+      "rheumatology",
+      "vascularSurgery"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms165v10",
+      "cmsWebInterface": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Web-Interface-Measures/2022_Measure_HTN2_CMSWebInterface_v6.0.pdf",
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_236_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_236_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Use of High-Risk Medications in Older Adults",
+    "eMeasureId": "CMS156v10",
+    "nqfEMeasureId": null,
+    "nqfId": "0022",
+    "measureId": "238",
+    "description": "Percentage of patients 65 years of age and older who were ordered at least two high-risk medications from the same drug class.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": "overallStratumOnly",
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "multiPerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord",
+      "registry"
+    ],
+    "measureSets": [
+      "allergyImmunology",
+      "cardiology",
+      "familyMedicine",
+      "geriatrics",
+      "internalMedicine",
+      "ophthalmology",
+      "pulmonology",
+      "rheumatology",
+      "skilledNursingFacility"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms156v10",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_238_MIPSCQM.pdf"
+    },
+    "strata": [
+      {
+        "name": "overall",
+        "description": "Percentage of patients 65 years of age and older who were ordered at least two high-risk medications from the same drug class."
+      },
+      {
+        "name": "diagnosisException",
+        "description": "Percentage of patients 65 years of age and older who were ordered at least two high-risk medications from the same drug class, except for appropriate diagnoses."
+      },
+      {
+        "name": "eCQMTotalRate",
+        "description": "Total rate (the sum of the two numerators divided by the denominator, deduplicating for patients in both numerators)."
+      }
+    ]
+  },
+  {
+    "title": "Weight Assessment and Counseling for Nutrition and Physical Activity for Children/Adolescents",
+    "eMeasureId": "CMS155v10",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "239",
+    "description": "Percentage of patients 3-17 years of age who had an outpatient visit with a Primary Care Physician (PCP) or Obstetrician/Gynecologist (OB/GYN) and who had evidence of the following during the measurement period. Three rates are reported. Percentage of patients with height, weight, and body mass index (BMI) percentile documentation. Percentage of patients with counseling for nutrition. Percentage of patients with counseling for physical activity.",
+    "nationalQualityStrategyDomain": "Community/Population Health",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "overallAlgorithm": "simpleAverage",
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "multiPerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "nutritionDietician",
+      "pediatrics"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms155v10"
+    },
+    "strata": [
+      {
+        "name": "BMI",
+        "description": "Patients who had a height, weight and body mass index (BMI) percentile recorded during the measurement period"
+      },
+      {
+        "name": "nutrition",
+        "description": "Patients who had counseling for nutrition during a visit that occurs during the measurement period"
+      },
+      {
+        "name": "physicalActivity",
+        "description": "Patients who had counseling for physical activity during a visit that occurs during the measurement period"
+      }
+    ]
+  },
+  {
+    "title": "Childhood Immunization Status",
+    "eMeasureId": "CMS117v10",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "240",
+    "description": "Percentage of children 2 years of age who had four diphtheria, tetanus and acellular pertussis (DTaP); three polio (IPV), one measles, mumps and rubella (MMR); three or four H influenza type B (HiB); three hepatitis B (Hep B); one chicken pox (VZV); four pneumococcal conjugate (PCV); one hepatitis A (Hep A); two or three rotavirus (RV); and two influenza (flu) vaccines by their second birthday.",
+    "nationalQualityStrategyDomain": "Community/Population Health",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "pediatrics"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms117v10"
+    }
+  },
+  {
+    "title": "Cardiac Rehabilitation Patient Referral from an Outpatient Setting",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0643",
+    "measureId": "243",
+    "description": "Percentage of patients evaluated in an outpatient setting who within the previous 12 months have experienced an acute myocardial infarction (MI), coronary artery bypass graft (CABG) surgery, a percutaneous coronary intervention (PCI), cardiac valve surgery, or cardiac transplantation, or who have chronic stable angina (CSA) and have not already participated in an early outpatient cardiac rehabilitation/secondary prevention (CR) program for the qualifying event/diagnosis who were referred to a CR program.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Heart Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "cardiology",
+      "familyMedicine",
+      "internalMedicine"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_243_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Barrett's Esophagus",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "249",
+    "description": "Percentage of esophageal biopsy reports that document the presence of Barrett's mucosa that also include a statement about dysplasia.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "College of American Pathologists",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "pathology"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_249_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_249_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Radical Prostatectomy Pathology Reporting",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "250",
+    "description": "Percentage of radical prostatectomy pathology reports that include the pT category, the pN category, the Gleason score and a statement about margin status.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "College of American Pathologists",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "oncology",
+      "pathology"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_250_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_250_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Ultrasound Determination of Pregnancy Location for Pregnant Patients with Abdominal Pain",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "254",
+    "description": "Percentage of pregnant female patients aged 14 to 50 who present to the emergency department (ED) with a chief complaint of abdominal pain or vaginal bleeding who receive a trans-abdominal or trans-vaginal ultrasound to determine pregnancy location.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American College of Emergency Physicians",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "emergencyMedicine"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_254_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Rate of Open Repair of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post-Operative Day #7)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "258",
+    "description": "Percent of patients undergoing open repair of small or moderate sized non-ruptured infrarenal abdominal aortic aneurysms (AAA) who do not experience a major complication (discharge to home no later than post-operative day #7).",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "Society for Vascular Surgeons",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "vascularSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_258_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Rate of Endovascular Aneurysm Repair (EVAR) of Small or Moderate Non-Ruptured Infrarenal Abdominal Aortic Aneurysms (AAA) without Major Complications (Discharged to Home by Post-Operative Day #2)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "259",
+    "description": "Percent of patients undergoing endovascular repair of small or moderate non-ruptured infrarenal abdominal aortic aneurysms (AAA) that do not experience a major complication (discharged to home no later than post-operative day #2).",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "Society for Vascular Surgeons",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "vascularSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_259_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Rate of Carotid Endarterectomy (CEA) for Asymptomatic Patients, without Major Complications (Discharged to Home by Post-Operative Day #2)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "260",
+    "description": "Percent of asymptomatic patients undergoing Carotid Endarterectomy (CEA) who are discharged to home no later than post-operative day #2.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "Society for Vascular Surgeons",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "neurosurgical",
+      "vascularSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_260_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Referral for Otologic Evaluation for Patients with Acute or Chronic Dizziness",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "261",
+    "description": "Percentage of patients aged birth and older referred to a physician (preferably a physician specially trained in disorders of the ear) for an otologic evaluation subsequent to an audiologic evaluation after presenting with acute or chronic dizziness.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "Audiology Quality Consortium",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "audiology"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_261_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_261_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Sentinel Lymph Node Biopsy for Invasive Breast Cancer",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "264",
+    "description": "The percentage of clinically node negative (clinical stage T1N0M0 or T2N0M0) breast cancer patients before or after neoadjuvant systemic therapy, who undergo a sentinel lymph node (SLN) procedure.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Society of Breast Surgeons",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "generalSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_264_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Biopsy Follow-Up",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "265",
+    "description": "Percentage of new patients whose biopsy results have been reviewed and communicated to the primary care/referring physician and patient.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Dermatology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "dermatology",
+      "obstetricsGynecology",
+      "otolaryngology",
+      "urology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_265_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Epilepsy: Counseling for Women of Childbearing Potential with Epilepsy",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "268",
+    "description": "Percentage of all patients of childbearing potential (12 years and older) diagnosed with epilepsy who were counseled at least once a year about how epilepsy and its treatment may affect contraception and pregnancy.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Academy of Neurology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "neurology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_268_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Inflammatory Bowel Disease (IBD): Assessment of Hepatitis B Virus (HBV) Status Before Initiating Anti-TNF (Tumor Necrosis Factor) Therapy",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "275",
+    "description": "Percentage of patients with a diagnosis of inflammatory bowel disease (IBD) who had Hepatitis B Virus (HBV) status assessed and results interpreted prior to initiating anti-TNF (tumor necrosis factor) therapy.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Gastroenterological Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "gastroenterology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_275_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Sleep Apnea: Severity Assessment at Initial Diagnosis",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "277",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of obstructive sleep apnea who had an apnea hypopnea index (AHI) or a respiratory disturbance index (RDI) measured at the time of initial diagnosis.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Academy of Sleep Medicine",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "internalMedicine",
+      "neurology",
+      "otolaryngology",
+      "pulmonology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_277_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Sleep Apnea: Assessment of Adherence to Positive Airway Pressure Therapy",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "279",
+    "description": "Percentage of visits for patients aged 18 years and older with a diagnosis of obstructive sleep apnea who were prescribed positive airway pressure therapy who had documentation that adherence to positive airway pressure therapy was objectively measured.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Academy of Sleep Medicine",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "internalMedicine",
+      "neurology",
+      "otolaryngology",
+      "pulmonology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_279_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Dementia: Cognitive Assessment",
+    "eMeasureId": "CMS149v10",
+    "nqfEMeasureId": "2872e",
+    "nqfId": null,
+    "measureId": "281",
+    "description": "Percentage of patients, regardless of age, with a diagnosis of dementia for whom an assessment of cognition is performed and the results reviewed at least once within a 12-month period.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Academy of Neurology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "clinicalSocialWork",
+      "geriatrics",
+      "mentalBehavioralHealth",
+      "neurology",
+      "physicalTherapyOccupationalTherapy"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms149v10"
+    }
+  },
+  {
+    "title": "Dementia: Functional Status Assessment",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "282",
+    "description": "Percentage of patients with dementia for whom an assessment of functional status was performed at least once in the last 12 months.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Academy of Neurology/American Psychiatric Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "clinicalSocialWork",
+      "geriatrics",
+      "mentalBehavioralHealth",
+      "neurology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_282_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Dementia Associated Behavioral and Psychiatric Symptoms Screening and Management",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "283",
+    "description": "Percentage of patients with dementia for whom there was a documented screening for behavioral and psychiatric symptoms, including depression, and for whom, if symptoms screening was positive, there was also documentation of recommendations for management in the last 12 months.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Academy of Neurology/American Psychiatric Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "clinicalSocialWork",
+      "geriatrics",
+      "mentalBehavioralHealth",
+      "neurology",
+      "physicalTherapyOccupationalTherapy"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_283_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Dementia: Safety Concern Screening and Follow-Up for Patients with Dementia",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "286",
+    "description": "Percentage of patients with dementia or their caregiver(s) for whom there was a documented safety concerns screening in two domains of risk: 1) dangerousness to self or others and 2) environmental risks; and if safety concerns screening was positive in the last 12 months, there was documentation of mitigation recommendations, including but not limited to referral to other resources.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Neurology/American Psychiatric Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "clinicalSocialWork",
+      "geriatrics",
+      "mentalBehavioralHealth",
+      "neurology",
+      "physicalTherapyOccupationalTherapy"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_286_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Dementia: Education and Support of Caregivers for Patients with Dementia",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "288",
+    "description": "Percentage of patients with dementia whose caregiver(s) were provided with education on dementia disease management and health behavior changes AND were referred to additional resources for support in the last 12 months.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Neurology/American Psychiatric Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "clinicalSocialWork",
+      "geriatrics",
+      "mentalBehavioralHealth",
+      "neurology",
+      "physicalTherapyOccupationalTherapy"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_288_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Assessment of Mood Disorders and Psychosis for Patients with Parkinson's Disease",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "290",
+    "description": "Percentage of all patients with a diagnosis of Parkinson's Disease [PD] who were assessed for depression, anxiety, apathy, AND psychosis once during the measurement period.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Academy of Neurology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "neurology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_290_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Assessment of Cognitive Impairment or Dysfunction for Patients with Parkinson's Disease",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "291",
+    "description": "Percentage of all patients with a diagnosis of Parkinson's Disease [PD] who were assessed for cognitive impairment or dysfunction once during the measurement period.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Academy of Neurology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "neurology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_291_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Rehabilitative Therapy Referral for Patients with Parkinson's Disease",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "293",
+    "description": "Percentage of all patients with a diagnosis of Parkinson's Disease  who were referred to physical, occupational, speech, or recreational therapy once during the measurement period.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Neurology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "neurology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_293_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Cataracts: Improvement in Patient's Visual Function within 90 Days Following Cataract Surgery",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "303",
+    "description": "Percentage of patients aged 18 years and older who had cataract surgery and had improvement in visual function achieved within 90 days following the cataract surgery, based on completing a pre-operative and post-operative visual function survey.",
+    "nationalQualityStrategyDomain": "Person and Caregiver-Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Ophthalmology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "ophthalmology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_303_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Cataracts: Patient Satisfaction within 90 Days Following Cataract Surgery",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "304",
+    "description": "Percentage of patients aged 18 years and older who had cataract surgery and were satisfied with their care within 90 days following the cataract surgery, based on completion of the Consumer Assessment of Healthcare Providers and Systems Surgical Care Survey.",
+    "nationalQualityStrategyDomain": "Person and Caregiver-Centered Experience and Outcomes",
+    "measureType": "patientEngagementExperience",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Ophthalmology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "ophthalmology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_304_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Initiation and Engagement of Alcohol and Other Drug Dependence Treatment",
+    "eMeasureId": "CMS137v10",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "305",
+    "description": "Percentage of patients 13 years of age and older with a new episode of alcohol or other drug abuse or (AOD) dependence who received the following. Two rates are reported.a. Percentage of patients who initiated treatment including either an intervention or medication for the treatment of AOD abuse or dependence within 14 days of the diagnosis.b. Percentage of patients who engaged in ongoing treatment including two additional interventions or a medication for the treatment of AOD abuse or dependence within 34 days of the initiation visit. For patients who initiated treatment with a medication, at least one of the two engagement events must be a treatment intervention.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "overallAlgorithm": "simpleAverage",
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "multiPerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "familyMedicine",
+      "internalMedicine",
+      "pediatrics"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms137v10"
+    },
+    "strata": [
+      {
+        "name": "14DaysOfDiagnosis",
+        "description": "Patients who initiated treatment within 14 days of the diagnosis"
+      },
+      {
+        "name": "30DaysOfVisit",
+        "description": "Patients who initiated treatment and who had two or more additional services with an AOD diagnosis within 30 days of the initiation visit"
+      }
+    ]
+  },
+  {
+    "title": "Cervical Cancer Screening",
+    "eMeasureId": "CMS124v10",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "309",
+    "description": "Percentage of women 21-64 years of age who were screened for cervical cancer using either of the following criteria:*  Women age 21-64 who had cervical cytology performed within the last 3 years*  Women age 30-64 who had cervical human papillomavirus (HPV) testing performed within the last 5 years",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "familyMedicine",
+      "internalMedicine",
+      "obstetricsGynecology"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms124v10"
+    }
+  },
+  {
+    "title": "Chlamydia Screening for Women",
+    "eMeasureId": "CMS153v10",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "310",
+    "description": "Percentage of women 16-24 years of age who were identified as sexually active and who had at least one test for chlamydia during the measurement period.",
+    "nationalQualityStrategyDomain": "Community/Population Health",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "obstetricsGynecology",
+      "pediatrics"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms153v10"
+    }
+  },
+  {
+    "title": "Preventive Care and Screening: Screening for High Blood Pressure and Follow-Up Documented",
+    "eMeasureId": "CMS22v10",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "317",
+    "description": "Percentage of patient visits for patients aged 18 years and older seen during the measurement period who were screened for high blood pressure AND a recommended follow-up plan is documented, as indicated, if blood pressure is elevated or hypertensive.",
+    "nationalQualityStrategyDomain": "Community/Population Health",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "electronicHealthRecord",
+      "registry"
+    ],
+    "measureSets": [
+      "allergyImmunology",
+      "cardiology",
+      "dermatology",
+      "emergencyMedicine",
+      "familyMedicine",
+      "gastroenterology",
+      "generalSurgery",
+      "internalMedicine",
+      "mentalBehavioralHealth",
+      "nephrology",
+      "neurology",
+      "obstetricsGynecology",
+      "oncology",
+      "orthopedicSurgery",
+      "otolaryngology",
+      "physicalMedicine",
+      "plasticSurgery",
+      "preventiveMedicine",
+      "rheumatology",
+      "skilledNursingFacility",
+      "urgentCare",
+      "urology",
+      "vascularSurgery"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms022v10",
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_317_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_317_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Falls: Screening for Future Fall Risk",
+    "eMeasureId": "CMS139v10",
+    "nqfEMeasureId": null,
+    "nqfId": "0101",
+    "measureId": "318",
+    "description": "Percentage of patients 65 years of age and older who were screened for future fall risk during the measurement period.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord",
+      "cmsWebInterface"
+    ],
+    "measureSets": [
+      "audiology",
+      "familyMedicine",
+      "internalMedicine",
+      "nephrology",
+      "orthopedicSurgery",
+      "otolaryngology",
+      "physicalTherapyOccupationalTherapy",
+      "podiatry"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms139v10",
+      "cmsWebInterface": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Web-Interface-Measures/2022_Measure_CARE-2_CMSWebInterface_v6.0.pdf"
+    }
+  },
+  {
+    "title": "Appropriate Follow-Up Interval for Normal Colonoscopy in Average Risk Patients",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0658",
+    "measureId": "320",
+    "description": "Percentage of patients aged 50 to 75 years of age receiving a screening colonoscopy without biopsy or polypectomy who had a recommended follow-up interval of at least 10 years for repeat colonoscopy documented in their colonoscopy report.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Gastroenterological Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "gastroenterology"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_320_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_320_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "CAHPS for MIPs Clinician/Group Survey",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0005",
+    "measureId": "321",
+    "description": "The Consumer Assessment of Healthcare Providers and Systems (CAHPS) for MIPS Clinician/Group Survey is comprised of 10 Summary Survey Measures (SSMs) and measures patient experience of care within a group practice. The NQF endorsement status and endorsement id (if applicable) for each SSM utilized in this measure are as follows:                                                                                                                                                                                                                                                                                          Getting Timely Care, Appointments, and Information; (Not endorsed by NQF) How well Providers Communicate; (Not endorsed by NQF) Patient's Rating of Provider; (NQF endorsed # 0005) Access to Specialists; (Not endorsed by NQF) Health Promotion and Education; (Not endorsed by NQF) Shared Decision-Making; (Not endorsed by NQF)  Health Status and Functional Status; (Not endorsed by NQF) Courteous and Helpful Office Staff; (NQF endorsed # 0005) Care Coordination; (Not endorsed by NQF) Stewardship of Patient Resources. (Not endorsed by NQF)",
+    "nationalQualityStrategyDomain": "Person and Caregiver-Centered Experience and Outcomes",
+    "measureType": "patientEngagementExperience",
+    "isHighPriority": true,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "cahps",
+    "allowedPrograms": [
+      "mips",
+      "pcf",
+      "app1"
+    ],
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "familyMedicine",
+      "internalMedicine"
+    ],
+    "measureSpecification": {}
+  },
+  {
+    "title": "Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Preoperative Evaluation in Low-Risk Surgery Patients",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "322",
+    "description": "Percentage of stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), or cardiac magnetic resonance (CMR) performed in low-risk surgery patients 18 years or older for preoperative evaluation during the 12-month submission period.",
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "efficiency",
+    "isHighPriority": true,
+    "primarySteward": "American College of Cardiology Foundation",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "cardiology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_322_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Routine Testing After Percutaneous Coronary Intervention (PCI)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "323",
+    "description": "Percentage of all stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), and cardiovascular magnetic resonance (CMR) performed in patients aged 18 years and older routinely after percutaneous coronary intervention (PCI), with reference to timing of test after PCI and symptom status.",
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "efficiency",
+    "isHighPriority": true,
+    "primarySteward": "American College of Cardiology Foundation",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "cardiology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_323_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Cardiac Stress Imaging Not Meeting Appropriate Use Criteria: Testing in Asymptomatic, Low-Risk Patients",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "324",
+    "description": "Percentage of all stress single-photon emission computed tomography (SPECT) myocardial perfusion imaging (MPI), stress echocardiogram (ECHO), cardiac computed tomography angiography (CCTA), and cardiovascular magnetic resonance (CMR) performed in asymptomatic, low coronary heart disease (CHD) risk patients 18 years and older for initial detection and risk assessment.",
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "efficiency",
+    "isHighPriority": true,
+    "primarySteward": "American College of Cardiology Foundation",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "cardiology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_324_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Atrial Fibrillation and Atrial Flutter: Chronic Anticoagulation Therapy",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "1525",
+    "measureId": "326",
+    "description": "Percentage of patients aged 18 years and older with atrial fibrillation (AF) or atrial flutter who were prescribed an FDA-approved oral anticoagulant drug for the prevention of thromboembolism during the measurement period.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Heart Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": true,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [
+      "registry"
+    ],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "cardiology",
+      "familyMedicine",
+      "internalMedicine",
+      "skilledNursingFacility"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_326_MIPSCQM.pdf"
+    },
+    "historic_benchmarks": {}
+  },
+  {
+    "title": "Adult Sinusitis: Antibiotic Prescribed for Acute Viral Sinusitis (Overuse)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "331",
+    "description": "Percentage of patients, aged 18 years and older, with a diagnosis of acute viral sinusitis who were prescribed an antibiotic within 10 days after onset of symptoms.",
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Otolaryngology - Head and Neck Surgery Foundation",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "allergyImmunology",
+      "emergencyMedicine",
+      "familyMedicine",
+      "internalMedicine",
+      "otolaryngology",
+      "urgentCare"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_331_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Adult Sinusitis: Appropriate Choice of Antibiotic: Amoxicillin With or Without Clavulanate Prescribed for Patients with Acute Bacterial Sinusitis (Appropriate Use)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "332",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of acute bacterial sinusitis that were prescribed amoxicillin, with or without clavulanate, as a first line antibiotic at the time of diagnosis.",
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Otolaryngology - Head and Neck Surgery Foundation",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "allergyImmunology",
+      "emergencyMedicine",
+      "familyMedicine",
+      "internalMedicine",
+      "otolaryngology",
+      "urgentCare"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_332_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Maternity Care: Elective Delivery (Without Medical Indication) at < 39 Weeks (Overuse)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "335",
+    "description": "Percentage of patients, regardless of age, who gave birth during a 12-month period, delivered a live singleton at < 39 weeks of gestation, and had elective deliveries (without medical indication) by cesarean birth or induction of labor.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "certifiedNurseMidwife",
+      "obstetricsGynecology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_335_MIPSCQM.pdf"
+    },
+    "historic_benchmarks": {
+      "registry": "removed"
+    }
+  },
+  {
+    "title": "Maternity Care: Postpartum Follow-up and Care Coordination",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "336",
+    "description": "Percentage of patients, regardless of age, who gave birth during a 12-month period who were seen for postpartum care before or at 12 weeks of giving birth and received the following at a postpartum visit: breast-feeding evaluation and education, postpartum depression screening, postpartum glucose screening for gestational diabetes patients, family and contraceptive planning counseling, tobacco use screening and cessation education, healthy lifestyle behavioral advice, and an immunization review and update.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "certifiedNurseMidwife",
+      "obstetricsGynecology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_336_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "HIV Viral Load Suppression",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "2082",
+    "measureId": "338",
+    "description": "The percentage of patients, regardless of age, with a diagnosis of HIV with a HIV viral load less than 200 copies/mL at last HIV viral load test during the measurement year.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "Health Resources and Services Administration",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "allergyImmunology",
+      "familyMedicine",
+      "infectiousDisease",
+      "internalMedicine"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_338_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "HIV Medical Visit Frequency",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "2079",
+    "measureId": "340",
+    "description": "Percentage of patients, regardless of age with a diagnosis of HIV who had at least one medical visit in each 6 month period of the 24 month measurement period, with a minimum of 60 days between medical visits.",
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "Health Resources and Services Administration",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "allergyImmunology",
+      "infectiousDisease"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_340_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Rate of Carotid Artery Stenting (CAS) for Asymptomatic Patients, Without Major Complications (Discharged to Home by Post-Operative Day #2)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "344",
+    "description": "Percent of asymptomatic patients undergoing CAS who are discharged to home no later than post-operative day #2.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "Society for Vascular Surgeons",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "cardiology",
+      "neurosurgical",
+      "vascularSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_344_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Total Knee or Hip Replacement: Shared Decision-Making: Trial of Conservative (Non-surgical) Therapy",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "350",
+    "description": "Percentage of patients regardless of age undergoing a total knee or total hip replacement with documented shared decision- making with discussion of conservative (non-surgical) therapy (e.g., non-steroidal anti-inflammatory drug (NSAIDs), analgesics, weight loss, exercise, injections) prior to the procedure.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Association of Hip and Knee Surgeons",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "orthopedicSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_350_MIPSCQM.pdf"
+    },
+    "historic_benchmarks": {
+      "registry": "removed"
+    }
+  },
+  {
+    "title": "Total Knee or Hip Replacement: Venous Thromboembolic and Cardiovascular Risk Evaluation",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "351",
+    "description": "Percentage of patients regardless of age undergoing a total knee or total hip replacement who are evaluated for the presence or absence of venous thromboembolic and cardiovascular risk factors within 30 days prior to the procedure (e.g., History of Deep Vein Thrombosis (DVT), Pulmonary Embolism (PE), Myocardial Infarction (MI), Arrhythmia and Stroke).",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Association of Hip and Knee Surgeons",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "orthopedicSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_351_MIPSCQM.pdf"
+    },
+    "historic_benchmarks": {
+      "registry": "removed"
+    }
+  },
+  {
+    "title": "Anastomotic Leak Intervention",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "354",
+    "description": "Percentage of patients aged 18 years and older who required an anastomotic leak intervention following gastric bypass or colectomy surgery.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "American College of Surgeons",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "generalSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_354_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Unplanned Reoperation within the 30 Day Postoperative Period",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "355",
+    "description": "Percentage of patients aged 18 years and older who had any unplanned reoperation within the 30 day postoperative period.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "American College of Surgeons",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "generalSurgery",
+      "plasticSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_355_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Unplanned Hospital Readmission within 30 Days of Principal Procedure",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "356",
+    "description": "Percentage of patients aged 18 years and older who had an unplanned hospital readmission within 30 days of principal procedure.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "American College of Surgeons",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "generalSurgery",
+      "plasticSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_356_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Surgical Site Infection (SSI)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "357",
+    "description": "Percentage of patients aged 18 years and older who had a surgical site infection (SSI).",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "American College of Surgeons",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "generalSurgery",
+      "otolaryngology",
+      "plasticSurgery",
+      "vascularSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_357_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Patient-Centered Surgical Risk Assessment and Communication",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "358",
+    "description": "Percentage of patients who underwent a non-emergency surgery who had their personalized risks of postoperative complications assessed by their surgical team prior to surgery using a clinical data-based, patient-specific risk calculator and who received personal discussion of those risks with the surgeon.",
+    "nationalQualityStrategyDomain": "Person and Caregiver-Centered Experience and Outcomes",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American College of Surgeons",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "generalSurgery",
+      "orthopedicSurgery",
+      "otolaryngology",
+      "plasticSurgery",
+      "thoracicSurgery",
+      "urology",
+      "vascularSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_358_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Optimizing Patient Exposure to Ionizing Radiation: Count of Potential High Dose Radiation Imaging Studies: Computed Tomography (CT) and Cardiac Nuclear Medicine Studies",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "360",
+    "description": "Percentage of computed tomography (CT) and cardiac nuclear medicine (myocardial perfusion studies) imaging reports for all patients, regardless of age, that document a count of known previous CT (any type of CT) and cardiac nuclear medicine (myocardial perfusion) studies that the patient has received in the 12-month period prior to the current study.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American College of Radiology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "diagnosticRadiology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_360_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Optimizing Patient Exposure to Ionizing Radiation: Appropriateness: Follow-up CT Imaging for Incidentally Detected Pulmonary Nodules According to Recommended Guidelines",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "364",
+    "description": "Percentage of final reports for CT imaging studies with a finding of an incidental pulmonary nodule for patients aged 35 years and older that contain an impression or conclusion that includes a recommended interval and modality for follow-up (e.g., type of imaging or biopsy) or for no follow-up, and source of recommendations (e.g., guidelines such as Fleischner Society, American Lung Association, American College of Chest Physicians).",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American College of Radiology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "diagnosticRadiology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_364_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Follow-Up Care for Children Prescribed ADHD Medication (ADD)",
+    "eMeasureId": "CMS136v11",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "366",
+    "description": "Percentage of children 6-12 years of age and newly dispensed a medication for attention-deficit/hyperactivity disorder (ADHD) who had appropriate follow-up care. Two rates are reported.  a) Percentage of children who had one follow-up visit with a practitioner with prescribing authority during the 30-Day Initiation Phase.b) Percentage of children who remained on ADHD medication for at least 210 days and who, in addition to the visit in the Initiation Phase, had at least two additional follow-up visits with a practitioner within 270 days (9 months) after the Initiation Phase ended.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "overallAlgorithm": "overallStratumOnly",
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "multiPerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "mentalBehavioralHealth",
+      "pediatrics"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms136v11"
+    },
+    "strata": [
+      {
+        "name": "visitWithin30Days",
+        "description": "Percentage of children who had one follow-up visit with a practitioner with prescribing authority during the 30-Day Initiation Phase."
+      },
+      {
+        "name": "overall",
+        "description": "Percentage of children who remained on ADHD medication for at least 210 days and who, in addition to the visit in the Initiation Phase, had at least two additional follow-up visits with a practitioner within 270 days (9 months) after the Initiation Phase ended."
+      }
+    ],
+    "historic_benchmarks": {
+      "electronicHealthRecord": "removed"
+    }
+  },
+  {
+    "title": "Depression Remission at Twelve Months",
+    "eMeasureId": "CMS159v10",
+    "nqfEMeasureId": "0710e",
+    "nqfId": "0710",
+    "measureId": "370",
+    "description": "The percentage of adolescent patients 12 to 17 years of age and adult patients 18 years of age or older with major depression or dysthymia who reached remission 12 months (+/- 60 days) after an index event date.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "Minnesota Community Measurement",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "overallAlgorithm": "weightedAverage",
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "multiPerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord",
+      "cmsWebInterface",
+      "registry"
+    ],
+    "measureSets": [
+      "clinicalSocialWork",
+      "familyMedicine",
+      "geriatrics",
+      "internalMedicine",
+      "mentalBehavioralHealth",
+      "pediatrics"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms159v10",
+      "cmsWebInterface": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Web-Interface-Measures/2022_Measure_MH1_CMSWebInterface_v6.0.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_370_MIPSCQM.pdf"
+    },
+    "strata": [
+      {
+        "name": "12-17yrs",
+        "description": "Percentage of adolescent patients (aged 12-17 years) with a diagnosis of major depression or dysthymia and an\ninitial PHQ-9 or PHQ-9M score greater than nine during the index event who reached remission at twelve\nmonths as demonstrated by a twelve month (+/-60 days) PHQ-9 or PHQ-9M score of less than 5."
+      },
+      {
+        "name": "18+",
+        "description": "Percentage of adult patients (aged 18 years or older) with a diagnosis of major depression or dysthymia and an\ninitial PHQ-9 or PHQ-9M score greater than nine during the index event who reached remission at twelve\nmonths as demonstrated by a twelve month (+/-60 days) PHQ-9 or PHQ-9M score of less than 5."
+      }
+    ]
+  },
+  {
+    "title": "Closing the Referral Loop: Receipt of Specialist Report",
+    "eMeasureId": "CMS50v10",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "374",
+    "description": "Percentage of patients with referrals, regardless of age, for which the referring provider receives a report from the provider to whom the patient was referred.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord",
+      "registry"
+    ],
+    "measureSets": [
+      "allergyImmunology",
+      "cardiology",
+      "dermatology",
+      "endocrinology",
+      "familyMedicine",
+      "gastroenterology",
+      "generalSurgery",
+      "internalMedicine",
+      "interventionalRadiology",
+      "neurology",
+      "obstetricsGynecology",
+      "oncology",
+      "ophthalmology",
+      "orthopedicSurgery",
+      "otolaryngology",
+      "physicalMedicine",
+      "preventiveMedicine",
+      "pulmonology",
+      "rheumatology",
+      "thoracicSurgery",
+      "urology",
+      "vascularSurgery"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms050v10",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_374_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Functional Status Assessment for Total Knee Replacement",
+    "eMeasureId": "CMS66v10",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "375",
+    "description": "Percentage of patients 18 years of age and older who received an elective primary total knee arthroplasty (TKA) and completed a functional status assessment within 90 days prior to the surgery and in the 270-365 days after the surgery.",
+    "nationalQualityStrategyDomain": "Person and Caregiver-Centered Experience and Outcomes",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "orthopedicSurgery"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms066v10"
+    }
+  },
+  {
+    "title": "Functional Status Assessment for Total Hip Replacement",
+    "eMeasureId": "CMS56v10",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "376",
+    "description": "Percentage of patients 18 years of age and older who received an elective primary total hip arthroplasty (THA) and completed a functional status assessment within 90 days prior to the surgery and in the 270-365 days after the surgery.",
+    "nationalQualityStrategyDomain": "Person and Caregiver-Centered Experience and Outcomes",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "orthopedicSurgery"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms056v10"
+    }
+  },
+  {
+    "title": "Functional Status Assessments for Heart Failure",
+    "eMeasureId": "CMS90v11",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "377",
+    "description": "Percentage of patients 18 years of age and older with heart failure who completed initial and follow-up patient-reported functional status assessments.",
+    "nationalQualityStrategyDomain": "Person and Caregiver-Centered Experience and Outcomes",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "familyMedicine",
+      "internalMedicine"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms090v11"
+    }
+  },
+  {
+    "title": "Children Who Have Dental Decay or Cavities",
+    "eMeasureId": "CMS75v10",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "378",
+    "description": "Percentage of children, 6 months - 20 years of age at the start of the measurement period, who have had tooth decay or cavities during the measurement period.",
+    "nationalQualityStrategyDomain": "Community/Population Health",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "dentistry"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms075v10"
+    }
+  },
+  {
+    "title": "Primary Caries Prevention Intervention as Offered by Primary Care Providers, including Dentists",
+    "eMeasureId": "CMS74v11",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "379",
+    "description": "Percentage of children, 6 months - 20 years of age, who received a fluoride varnish application during the measurement period.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "dentistry",
+      "pediatrics"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms074v11"
+    }
+  },
+  {
+    "title": "Child and Adolescent Major Depressive Disorder (MDD): Suicide Risk Assessment",
+    "eMeasureId": "CMS177v10",
+    "nqfEMeasureId": "1365e",
+    "nqfId": null,
+    "measureId": "382",
+    "description": "Percentage of patient visits for those patients aged 6 through 17 years with a diagnosis of major depressive disorder with an assessment for suicide risk.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "Mathematica",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "clinicalSocialWork",
+      "mentalBehavioralHealth",
+      "pediatrics"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms177v10"
+    }
+  },
+  {
+    "title": "Adherence to Antipsychotic Medications For Individuals with Schizophrenia",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "1879",
+    "measureId": "383",
+    "description": "Percentage of individuals at least 18 years of age as of the beginning of the performance period with schizophrenia or schizoaffective disorder who had at least two prescriptions filled for any antipsychotic medication and who had a Proportion of Days Covered (PDC) of at least 0.8 for antipsychotic medications during the performance period.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "intermediateOutcome",
+    "isHighPriority": true,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "clinicalSocialWork",
+      "familyMedicine",
+      "internalMedicine",
+      "mentalBehavioralHealth"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_383_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Adult Primary Rhegmatogenous Retinal Detachment Surgery: No Return to the Operating Room Within 90 Days of Surgery",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "384",
+    "description": "Patients aged 18 years and older who had surgery for primary rhegmatogenous retinal detachment who did not require a return to the operating room within 90 days of surgery.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Ophthalmology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "ophthalmology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_384_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Adult Primary Rhegmatogenous Retinal Detachment Surgery: Visual Acuity Improvement Within 90 Days of Surgery",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "385",
+    "description": "Patients aged 18 years and older who had surgery for primary rhegmatogenous retinal detachment and achieved an improvement in their visual acuity, from their preoperative level, within 90 days of surgery in the operative eye.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Ophthalmology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "ophthalmology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_385_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Amyotrophic Lateral Sclerosis (ALS) Patient Care Preferences",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "386",
+    "description": "Percentage of patients diagnosed with Amyotrophic Lateral Sclerosis (ALS) who were offered assistance in planning for end of life issues (e.g., advance directives, invasive ventilation, hospice) at least once annually.",
+    "nationalQualityStrategyDomain": "Person and Caregiver-Centered Experience and Outcomes",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Neurology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "neurology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_386_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Annual Hepatitis C Virus (HCV) Screening for Patients who are Active Injection Drug Users",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "387",
+    "description": "Percentage of patients, regardless of age, who are active injection drug users who received screening for HCV infection within the 12-month reporting period.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Gastroenterological Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "familyMedicine",
+      "internalMedicine"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_387_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Cataract Surgery: Difference Between Planned and Final Refraction",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "389",
+    "description": "Percentage of patients aged 18 years and older who had cataract surgery performed and who achieved a final refraction within +/- 1.0 diopters of their planned (target) refraction.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Ophthalmology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "ophthalmology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_389_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Follow-Up After Hospitalization for Mental Illness (FUH)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0576",
+    "measureId": "391",
+    "description": "The percentage of discharges for patients 6 years of age and older who were hospitalized for treatment of selected mental illness or intentional self-harm diagnoses and who had a follow-up visit with a mental health provider. Two rates are submitted: The percentage of discharges for which the patient received follow-up within 30 days after discharge The percentage of discharges for which the patient received follow-up within 7 days after discharge",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "overallAlgorithm": "overallStratumOnly",
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "multiPerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "internalMedicine",
+      "mentalBehavioralHealth",
+      "pediatrics"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_391_MIPSCQM.pdf"
+    },
+    "strata": [
+      {
+        "name": "30days",
+        "description": "The percentage of discharges for which the patient received follow-up within 30 days after discharge"
+      },
+      {
+        "name": "overall",
+        "description": "The percentage of discharges for which the patient received follow-up within 7 days after discharge"
+      }
+    ]
+  },
+  {
+    "title": "Cardiac Tamponade and/or Pericardiocentesis Following Atrial Fibrillation Ablation",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "2474",
+    "measureId": "392",
+    "description": "Rate of cardiac tamponade and/or pericardiocentesis following atrial fibrillation ablation. This measure is submitted as four rates stratified by age and gender: Submission Age Criteria 1: Females 18-64 years of age Submission Age Criteria 2: Males 18-64 years of age Submission Age Criteria 3: Females 65 years of age and older Submission Age Criteria 4: Males 65 years of age and older",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "American College of Cardiology Foundation",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": "overallStratumOnly",
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "multiPerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "electrophysiologyCardiacSpecialist"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_392.zip"
+    },
+    "strata": [
+      {
+        "name": "18-64F",
+        "description": "Females 18-64 years of age"
+      },
+      {
+        "name": "18-64M",
+        "description": "Males 18-64 years of age"
+      },
+      {
+        "name": "65+F",
+        "description": "Females 65 years of age and older"
+      },
+      {
+        "name": "65+M",
+        "description": "Males 65 years of age and older"
+      },
+      {
+        "name": "overall",
+        "description": "Overall percentage of patients with cardiac tamponade and/or pericardiocentesis occurring within 30 days"
+      }
+    ]
+  },
+  {
+    "title": "Infection within 180 Days of Cardiac Implantable Electronic Device (CIED) Implantation, Replacement, or Revision",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "393",
+    "description": "Infection rate following CIED device implantation, replacement, or revision.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "American College of Cardiology Foundation",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "electrophysiologyCardiacSpecialist"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_393.zip"
+    }
+  },
+  {
+    "title": "Immunizations for Adolescents",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "394",
+    "description": "The percentage of adolescents 13 years of age who had one dose of meningococcal vaccine (serogroups A, C, W, Y), one tetanus, diphtheria toxoids and acellular pertussis (Tdap) vaccine, and have completed the human papillomavirus (HPV) vaccine series by their 13th birthday.",
+    "nationalQualityStrategyDomain": "Community/Population Health",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "overallAlgorithm": "overallStratumOnly",
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "multiPerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "familyMedicine",
+      "pediatrics"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_394_MIPSCQM.pdf"
+    },
+    "strata": [
+      {
+        "name": "meningococcal",
+        "description": "Patients who had one dose of meningococcal vaccine on or between the patient's 11th and 13th birthdays"
+      },
+      {
+        "name": "Tdap",
+        "description": "Patients who had one tetanus, diphtheria toxoids and acellular pertussis vaccine (Tdap) on or between the patient's 10th and 13th birthdays"
+      },
+      {
+        "name": "HPV",
+        "description": "Patients who have completed the HPV vaccine with defferent dates of service on or between the patient's 9th and 13th birthdays"
+      },
+      {
+        "name": "overall",
+        "description": "All patients who are compliant for Meningococcal, Tdap and HPV during the specified timeframes"
+      }
+    ]
+  },
+  {
+    "title": "Lung Cancer Reporting (Biopsy/Cytology Specimens)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "395",
+    "description": "Pathology reports based on lung biopsy and/or cytology specimens with a diagnosis of primary non-small cell lung cancer classified into specific histologic type following the International Association for the Study of Lung Cancer (IASLC) guidance or classified as non-small cell lung cancer not otherwise specified (NSCLC-NOS) with an explanation included in the pathology report.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "College of American Pathologists",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "pathology"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_395_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_395_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Lung Cancer Reporting (Resection Specimens)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "396",
+    "description": "Pathology reports based on lung resection specimens with a diagnosis of primary lung carcinoma that include the pT category, pN category and for non-small cell lung cancer (NSCLC), histologic type.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "College of American Pathologists",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "pathology"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_396_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_396_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Melanoma Reporting",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "397",
+    "description": "Pathology reports for primary malignant cutaneous melanoma that include the pT category, thickness, ulceration and mitotic rate, peripheral and deep margin status and presence or absence of microsatellitosis for invasive tumors.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "College of American Pathologists",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "pathology"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_397_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_397_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Optimal Asthma Control",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "398",
+    "description": "Composite measure of the percentage of pediatric and adult patients whose asthma is well-controlled as demonstrated by one of three age appropriate patient reported outcome tools and not at risk for exacerbation.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "Minnesota Community Measurement",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "overallAlgorithm": "overallStratumOnly",
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "multiPerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "allergyImmunology",
+      "familyMedicine",
+      "internalMedicine",
+      "otolaryngology",
+      "pediatrics",
+      "pulmonology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_398_MIPSCQM.pdf"
+    },
+    "strata": [
+      {
+        "name": "overall",
+        "description": "Overall Percentage for patients (aged 5-50 years) with well-controlled asthma, without elevated risk of exacerbation"
+      },
+      {
+        "name": "5-17yrs",
+        "description": "Percentage of pediatric patients (aged 5-17 years) with well-controlled asthma, without elevated risk of exacerbation."
+      },
+      {
+        "name": "18-50",
+        "description": "Percentage of adult patients (aged 18-50 years) with well-controlled asthma, without elevated risk of exacerbation"
+      },
+      {
+        "name": "ACT5-17",
+        "description": "Asthma well-controlled (submit the most recent specified asthma control tool result) for patients 5 to 17 with Asthma"
+      },
+      {
+        "name": "ACT18-50",
+        "description": "Asthma well-controlled (submit the most recent specified asthma control tool result) for patients 18 to 50 with Asthma"
+      },
+      {
+        "name": "lowRisk5-17",
+        "description": "Patient not at elevated risk of exacerbation for patients 5 to 17 with Asthma"
+      },
+      {
+        "name": "lowRisk18-50",
+        "description": "Patient not at elevated risk of exacerbation for patients 18 to 50 with Asthma"
+      }
+    ]
+  },
+  {
+    "title": "One-Time Screening for Hepatitis C Virus (HCV) for all Patients",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "400",
+    "description": "Percentage of patients age >= 18 years who received one-time screening for hepatitis C virus (HCV) infection.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Gastroenterological Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "familyMedicine",
+      "internalMedicine",
+      "nephrology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_400_MIPSCQM.pdf"
+    },
+    "historic_benchmarks": {
+      "registry": "removed"
+    }
+  },
+  {
+    "title": "Hepatitis C: Screening for Hepatocellular Carcinoma (HCC) in Patients with Cirrhosis",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "401",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of chronic hepatitis C cirrhosis who underwent imaging with either ultrasound, contrast enhanced CT or MRI for hepatocellular carcinoma (HCC) at least once within the 12-month submission period.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Gastroenterological Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "familyMedicine",
+      "gastroenterology",
+      "internalMedicine"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_401_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Tobacco Use and Help with Quitting Among Adolescents",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "402",
+    "description": "The percentage of adolescents 12 to 20 years of age with a primary care visit during the measurement year for whom tobacco use status was documented and received help with quitting if identified as a tobacco user.",
+    "nationalQualityStrategyDomain": "Community/Population Health",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "allergyImmunology",
+      "cardiology",
+      "clinicalSocialWork",
+      "dermatology",
+      "familyMedicine",
+      "gastroenterology",
+      "generalSurgery",
+      "internalMedicine",
+      "mentalBehavioralHealth",
+      "neurology",
+      "obstetricsGynecology",
+      "oncology",
+      "orthopedicSurgery",
+      "otolaryngology",
+      "pediatrics",
+      "physicalMedicine",
+      "preventiveMedicine",
+      "rheumatology",
+      "thoracicSurgery",
+      "urgentCare",
+      "vascularSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_402_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Anesthesiology Smoking Abstinence",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "404",
+    "description": "The percentage of current smokers who abstain from cigarettes prior to anesthesia on the day of elective surgery or procedure.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "intermediateOutcome",
+    "isHighPriority": true,
+    "primarySteward": "American Society of Anesthesiologists",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "anesthesiology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_404_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Appropriate Follow-up Imaging for Incidental Abdominal Lesions",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "405",
+    "description": "Percentage of final reports for imaging studies for patients aged 18 years and older with one or more of the following noted incidentally with a specific recommendation for no follow-up imaging recommended based on radiological findings: Cystic renal lesion that is simple appearing* (Bosniak I or II) Adrenal lesion less than or equal to 1.0 cm Adrenal lesion greater than 1.0 cm but less than or equal to 4.0 cm classified as likely benign or diagnostic benign by unenhanced CT or washout protocol CT, or MRI with in- and opposed-phase sequences or other equivalent institutional imaging protocols",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American College of Radiology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "diagnosticRadiology"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_405_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_405_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Appropriate Follow-up Imaging for Incidental Thyroid Nodules in Patients",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "406",
+    "description": "Percentage of final reports for computed tomography (CT), CT angiography (CTA) or magnetic resonance imaging (MRI) or magnetic resonance angiogram (MRA) studies of the chest or neck for patients aged 18 years and older with no known thyroid disease with a thyroid nodule < 1.0 cm noted incidentally with follow-up imaging recommended.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American College of Radiology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "diagnosticRadiology"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_406_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_406_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Clinical Outcome Post Endovascular Stroke Treatment",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "409",
+    "description": "Percentage of patients with a Modified Rankin Score (mRS) score of 0 to 2 at 90 days following endovascular stroke intervention.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "Society of Interventional Radiology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "interventionalRadiology",
+      "neurosurgical"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_409_MIPSCQM.pdf"
+    },
+    "historic_benchmarks": {
+      "registry": "removed"
+    }
+  },
+  {
+    "title": "Psoriasis: Clinical Response to Systemic Medications",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "410",
+    "description": "Percentage of psoriasis vulgaris patients receiving systemic medication who meet minimal physician-or patient- reported disease activity levels. It is implied that establishment and maintenance of an established minimum level of disease control as measured by physician-and/or patient-reported outcomes will increase patient satisfaction with and adherence to treatment.",
+    "nationalQualityStrategyDomain": "Person and Caregiver-Centered Experience and Outcomes",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Dermatology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "dermatology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_410_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Door to Puncture Time for Endovascular Stroke Treatment",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "413",
+    "description": "Percentage of patients undergoing endovascular stroke treatment who have a door to puncture time of 90 minutes or less.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "intermediateOutcome",
+    "isHighPriority": true,
+    "primarySteward": "Society of Interventional Radiology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "interventionalRadiology",
+      "neurosurgical"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_413_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "415",
+    "description": "Percentage of emergency department visits for patients aged 18 years and older who presented with a minor blunt head trauma who had a head CT for trauma ordered by an emergency care provider who have an indication for a head CT.",
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "efficiency",
+    "isHighPriority": true,
+    "primarySteward": "American College of Emergency Physicians",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "emergencyMedicine"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_415_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Emergency Medicine: Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "416",
+    "description": "Percentage of emergency department visits for patients aged 2 through 17 years who presented with a minor blunt head trauma who had a head CT for trauma ordered by an emergency care provider who are classified as low risk according to the Pediatric Emergency Care Applied Research Network (PECARN) prediction rules for traumatic brain injury.",
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "efficiency",
+    "isHighPriority": true,
+    "primarySteward": "American College of Emergency Physicians",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "emergencyMedicine"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_416_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_416_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Osteoporosis Management in Women Who Had a Fracture",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0053",
+    "measureId": "418",
+    "description": "The percentage of women 50-85 years of age who suffered a fracture and who had either a bone mineral density (BMD) test or prescription for a drug to treat osteoporosis in the six months after the fracture.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "endocrinology",
+      "familyMedicine",
+      "internalMedicine",
+      "obstetricsGynecology",
+      "orthopedicSurgery"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_418_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_418_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Overuse of Imaging for the Evaluation of Primary Headache",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "419",
+    "description": "Percentage of patients for whom imaging of the head (CT or MRI) is obtained for the evaluation of primary headache when clinical indications are not present.",
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Neurology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "neurology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_419_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Varicose Vein Treatment with Saphenous Ablation: Outcome Survey",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "420",
+    "description": "Percentage of patients treated for varicose veins (CEAP C2-S) who are treated with saphenous ablation (with or without adjunctive tributary treatment) that report an improvement on a disease specific patient reported outcome survey instrument after treatment.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "primarySteward": "Society of Interventional Radiology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "interventionalRadiology",
+      "vascularSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_420_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Appropriate Assessment of Retrievable Inferior Vena Cava (IVC) Filters for Removal",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "421",
+    "description": "Percentage of patients in whom a retrievable IVC filter is placed who, within 3 months post-placement, have a documented assessment for the appropriateness of continued filtration, device removal or the inability to contact the patient with at least two attempts.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "Society of Interventional Radiology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "interventionalRadiology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_421_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Performing Cystoscopy at the Time of Hysterectomy for Pelvic Organ Prolapse to Detect Lower Urinary Tract Injury",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "2063",
+    "measureId": "422",
+    "description": "Percentage of patients who undergo cystoscopy to evaluate for lower urinary tract injury at the time of hysterectomy for pelvic organ prolapse.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Urogynecologic Society",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "obstetricsGynecology"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_422_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_422_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Perioperative Temperature Management",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "424",
+    "description": "Percentage of patients, regardless of age, who undergo surgical or therapeutic procedures under general or neuraxial anesthesia of 60 minutes duration or longer for whom at least one body temperature greater than or equal to 35.5 degrees Celsius (or 95.9 degrees Fahrenheit) was achieved within the 30 minutes immediately before or the 15 minutes immediately after anesthesia end time.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "American Society of Anesthesiologists",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "anesthesiology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_424_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Photodocumentation of Cecal Intubation",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "425",
+    "description": "The rate of screening and surveillance colonoscopies for which photodocumentation of at least two landmarks of cecal intubation is performed to establish a complete examination.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Society for Gastrointestinal Endoscopy",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "gastroenterology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_425_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Prevention of Post-Operative Nausea and Vomiting (PONV) - Combination Therapy",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "430",
+    "description": "Percentage of patients, aged 18 years and older, who undergo a procedure under an inhalational general anesthetic, AND who have three or more risk factors for post-operative nausea and vomiting (PONV), who receive combination therapy consisting of at least two prophylactic pharmacologic antiemetic agents of different classes preoperatively and/or intraoperatively.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Society of Anesthesiologists",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "anesthesiology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_430_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Preventive Care and Screening: Unhealthy Alcohol Use: Screening & Brief Counseling",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "2152",
+    "measureId": "431",
+    "description": "Percentage of patients aged 18 years and older who were screened for unhealthy alcohol use using a systematic screening method at least once within the last 12 months AND who received brief counseling if identified as an unhealthy alcohol user.",
+    "nationalQualityStrategyDomain": "Community/Population Health",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "overallAlgorithm": "overallStratumOnly",
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "multiPerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "cardiology",
+      "certifiedNurseMidwife",
+      "clinicalSocialWork",
+      "familyMedicine",
+      "gastroenterology",
+      "internalMedicine",
+      "mentalBehavioralHealth",
+      "neurology",
+      "nutritionDietician",
+      "obstetricsGynecology",
+      "oncology",
+      "otolaryngology",
+      "physicalMedicine",
+      "preventiveMedicine",
+      "pulmonology",
+      "urgentCare",
+      "urology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_431_MIPSCQM.pdf"
+    },
+    "strata": [
+      {
+        "name": "screenedForUse",
+        "description": "Percentage of patients aged 18 years and older who were screened for unhealthy alcohol use using a systematic screening method at least once within the last 12 months"
+      },
+      {
+        "name": "overall",
+        "description": "Percentage of patients aged 18 years and older who were identified as unhealthy alcohol users who received brief counseling"
+      },
+      {
+        "name": "counseling",
+        "description": "Percentage of patients aged 18 years and older who were screened for unhealthy alcohol use using a systematic screening method at least once within the last 12 months AND who received brief counseling if identified as unhealthy alcohol users"
+      }
+    ]
+  },
+  {
+    "title": "Proportion of Patients Sustaining a Bladder Injury at the Time of any Pelvic Organ Prolapse Repair",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "432",
+    "description": "Percentage of patients undergoing pelvic organ prolapse repairs who sustain an injury to the bladder recognized either during or within 30 days after surgery.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "American Urogynecologic Society",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "obstetricsGynecology",
+      "urology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_432_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Proportion of Patients Sustaining a Bowel Injury at the time of any Pelvic Organ Prolapse Repair",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "433",
+    "description": "Percentage of patients undergoing surgical repair of pelvic organ prolapse that is complicated by a bowel injury at the time of index surgery that is recognized intraoperatively or within 30 days after surgery.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "American Urogynecologic Society",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "obstetricsGynecology",
+      "urology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_433_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Radiation Consideration for Adult CT: Utilization of Dose Lowering Techniques",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "436",
+    "description": "Percentage of final reports for patients aged 18 years and older undergoing computed tomography (CT) with documentation that one or more of the following dose reduction techniques were used: Automated exposure control. Adjustment of the mA and/or kV according to patient size. Use of iterative reconstruction technique.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American College of Radiology/ American Medical Association/ National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "claims",
+      "registry"
+    ],
+    "measureSets": [
+      "diagnosticRadiology"
+    ],
+    "measureSpecification": {
+      "claims": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Claims-Registry-Measures/2022_Measure_436_MedicarePartBClaims.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_436_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Statin Therapy for the Prevention and Treatment of Cardiovascular Disease",
+    "eMeasureId": "CMS347v5",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "438",
+    "description": "Percentage of the following patients - all considered at high risk of cardiovascular events - who were prescribed or were on statin therapy during the measurement period: *All patients who were previously diagnosed with or currently have an active diagnosis of clinical atherosclerotic cardiovascular disease (ASCVD), including an ASCVD procedure; OR *Patients aged >= 20 years who have ever had a low-density lipoprotein cholesterol (LDL-C) level >= 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial hypercholesterolemia; OR *Patients aged 40-75 years with a diagnosis of diabetes",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord",
+      "cmsWebInterface",
+      "registry"
+    ],
+    "measureSets": [
+      "cardiology",
+      "endocrinology",
+      "familyMedicine",
+      "internalMedicine",
+      "preventiveMedicine"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms347v5",
+      "cmsWebInterface": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/Web-Interface-Measures/2022_Measure_PREV13_CMSWebInterface_v6.0.pdf",
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_438_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Age Appropriate Screening Colonoscopy",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "439",
+    "description": "The percentage of screening colonoscopies performed in patients greater than or equal to 86 years of age from January 1 to December 31.",
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "efficiency",
+    "isHighPriority": true,
+    "primarySteward": "American Gastroenterological Association",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "gastroenterology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_439_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Skin Cancer: Biopsy Reporting Time - Pathologist to Clinician",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "440",
+    "description": "Percentage of biopsies with a diagnosis of cutaneous Basal Cell Carcinoma (BCC) and Squamous Cell Carcinoma (SCC), or melanoma (including in situ disease) in which the pathologist communicates results to the clinician within 7 days from the time when the tissue specimen was received by the pathologist.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Dermatology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "dermatology",
+      "pathology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_440_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Ischemic Vascular Disease (IVD) All or None Outcome Measure (Optimal Control)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "441",
+    "description": "The IVD All-or-None Measure is one outcome measure (optimal control). The measure contains four goals. All four goals within a measure must be reached in order to meet that measure. The numerator for the all-or-none measure should be collected from the organization's total IVD denominator. All-or-None Outcome Measure (Optimal Control) - Using the IVD denominator optimal results include:  Most recent blood pressure (BP) measurement is less than or equal to 140/90 mm Hg -- AND Most recent tobacco status is Tobacco Free -- AND Daily Aspirin or Other Antiplatelet Unless Contraindicated -- AND Statin Use Unless Contraindicated",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "intermediateOutcome",
+    "isHighPriority": true,
+    "primarySteward": "Wisconsin Collaborative for Healthcare Quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "cardiology",
+      "familyMedicine",
+      "internalMedicine",
+      "vascularSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_441_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Non-Recommended Cervical Cancer Screening in Adolescent Females",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "443",
+    "description": "The percentage of adolescent females 16-20 years of age who were screened unnecessarily for cervical cancer.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "National Committee for Quality Assurance",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "familyMedicine",
+      "internalMedicine",
+      "obstetricsGynecology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_443_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Risk-Adjusted Operative Mortality for Coronary Artery Bypass Graft (CABG)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0119",
+    "measureId": "445",
+    "description": "Percent of patients aged 18 years and older undergoing isolated CABG who die, including both all deaths occurring during the hospitalization in which the CABG was performed, even if after 30 days, and those deaths occurring after discharge from the hospital, but within 30 days of the procedure.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "Society of Thoracic Surgeons",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "thoracicSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_445_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Appropriate Workup Prior to Endometrial Ablation",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "448",
+    "description": "Percentage of patients, aged 18 years and older, who undergo endometrial sampling or hysteroscopy with biopsy and results are documented before undergoing an endometrial ablation.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "obstetricsGynecology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_measure_448_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Appropriate Treatment for Patients with Stage I (T1c) - III HER2 Positive Breast Cancer",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "1858",
+    "measureId": "450",
+    "description": "Percentage of female patients aged 18 to 70 with stage I (T1c) - III HER2 positive breast cancer for whom appropriate treatment is initiated.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Society of Clinical Oncology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "oncology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_450_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "RAS (KRAS and NRAS) Gene Mutation Testing Performed for Patients with Metastatic Colorectal Cancer who receive Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibody Therapy",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "1859",
+    "measureId": "451",
+    "description": "Percentage of adult patients (aged 18 or over) with metastatic colorectal cancer who receive anti-epidermal growth factor receptor monoclonal antibody therapy for whom RAS (KRAS and NRAS) gene mutation testing was performed.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "American Society of Clinical Oncology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "oncology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_451_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Patients with Metastatic Colorectal Cancer and RAS (KRAS or NRAS) Gene Mutation Spared Treatment with Anti-epidermal Growth Factor Receptor (EGFR) Monoclonal Antibodies",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "1860",
+    "measureId": "452",
+    "description": "Percentage of adult patients (aged 18 or over) with metastatic colorectal cancer and RAS (KRAS or NRAS) gene mutation spared treatment with anti-EGFR monoclonal antibodies.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Society of Clinical Oncology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "oncology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_452_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Percentage of Patients Who Died from Cancer Receiving Chemotherapy in the Last 14 Days of Life (lower score - better)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0210",
+    "measureId": "453",
+    "description": "Percentage of patients who died from cancer receiving chemotherapy in the last 14 days of life.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Society of Clinical Oncology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "oncology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_453_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Percentage of Patients Who Died from Cancer Admitted to the Intensive Care Unit (ICU) in the Last 30 Days of Life (lower score - better)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0213",
+    "measureId": "455",
+    "description": "Percentage of patients who died from cancer admitted to the ICU in the last 30 days of life.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "American Society of Clinical Oncology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "geriatrics",
+      "oncology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_455_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Percentage of Patients Who Died from Cancer Admitted to Hospice for Less than 3 days (lower score - better)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0216",
+    "measureId": "457",
+    "description": "Percentage of patients who died from cancer, and admitted to hospice and spent less than 3 days there.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "American Society of Clinical Oncology",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "oncology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_457_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Back Pain After Lumbar Discectomy/Laminectomy",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "459",
+    "description": "For patients 18 years of age or older who had a lumbar discectomy/laminectomy procedure, back pain is rated by the patients as less than or equal to 3.0 OR an improvement of 5.0 points or greater on the Visual Analog Scale (VAS) Pain scale at three months (6 to 20 weeks) postoperatively.",
+    "nationalQualityStrategyDomain": "Person and Caregiver-Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "primarySteward": "Minnesota Community Measurement",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "neurosurgical",
+      "orthopedicSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_459_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Back Pain After Lumbar Fusion",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "460",
+    "description": "For patients 18 years of age or older who had a lumbar fusion procedure, back pain is rated by the patient as less than or equal to 3.0 OR an improvement of 5.0 points or greater on the Visual Analog Scale (VAS) Pain scale at one year (9 to 15 months) postoperatively.",
+    "nationalQualityStrategyDomain": "Person and Caregiver-Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "primarySteward": "Minnesota Community Measurement",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "neurosurgical",
+      "orthopedicSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_460_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Leg Pain After Lumbar Discectomy/Laminectomy",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "461",
+    "description": "For patients 18 years of age or older who had a lumbar discectomy/laminectomy procedure, leg pain is rated by the patient as less than or equal to 3.0 OR an improvement of 5.0 points or greater on the VAS Pain scale at three months (6 to 20 weeks) postoperatively.",
+    "nationalQualityStrategyDomain": "Person and Caregiver-Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "primarySteward": "Minnesota Community Measurement",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "neurosurgical",
+      "orthopedicSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_461_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Bone Density Evaluation for Patients with Prostate Cancer and Receiving Androgen Deprivation Therapy",
+    "eMeasureId": "CMS645v5",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "462",
+    "description": "Patients determined as having prostate cancer who are currently starting or undergoing androgen deprivation therapy (ADT), for an anticipated period of 12 months or greater and who receive an initial bone density evaluation. The bone density evaluation must be prior to the start of ADT or within 3 months of the start of ADT.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "Oregon Urology Institute",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "endocrinology",
+      "oncology",
+      "urology"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms645v5"
+    }
+  },
+  {
+    "title": "Prevention of Post-Operative Vomiting (POV) - Combination Therapy (Pediatrics)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "463",
+    "description": "Percentage of patients aged 3 through 17 years, who undergo a procedure under general anesthesia in which an inhalational anesthetic is used for maintenance AND who have two or more risk factors for post-operative vomiting (POV), who receive combination therapy consisting of at least two prophylactic pharmacologic anti-emetic agents of different classes preoperatively and/or intraoperatively.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Society of Anesthesiologists",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "anesthesiology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_463_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Otitis Media with Effusion: Systemic Antimicrobials - Avoidance of Inappropriate Use",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0657",
+    "measureId": "464",
+    "description": "Percentage of patients aged 2 months through 12 years with a diagnosis of OME who were not prescribed systemic antimicrobials.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Academy of Otolaryngology - Head and Neck Surgery Foundation",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "familyMedicine",
+      "otolaryngology",
+      "pediatrics",
+      "urgentCare"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_464_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Uterine Artery Embolization Technique: Documentation of Angiographic Endpoints and Interrogation of Ovarian Arteries",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "465",
+    "description": "The percentage of patients with documentation of angiographic endpoints of embolization AND the documentation of embolization strategies in the presence of unilateral or bilateral absent uterine arteries.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "Society of Interventional Radiology",
+    "firstPerformanceYear": 2018,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "interventionalRadiology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_465_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Continuity of Pharmacotherapy for Opioid Use Disorder (OUD)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "468",
+    "description": "Percentage of adults aged 18 years and older with pharmacotherapy for opioid use disorder (OUD) who have at least 180 days of continuous treatment.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "University of Southern California",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "familyMedicine",
+      "internalMedicine",
+      "mentalBehavioralHealth",
+      "physicalMedicine"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_468_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Functional Status After Lumbar Fusion",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "469",
+    "description": "For patients 18 years of age and older who had a lumbar fusion procedure, functional status is rated by the patient as less than or equal to 22 OR an improvement of 30 points or greater on the Oswestry Disability Index (ODI version 2.1a) at one year (9 to 15 months) postoperatively.",
+    "nationalQualityStrategyDomain": "Person and Caregiver-Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "primarySteward": "Minnesota Community Measurement",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "neurosurgical",
+      "orthopedicSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_469_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Functional Status After Primary Total Knee Replacement",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "470",
+    "description": "For patients age 18 and older who had a primary total knee replacement procedure, functional status is rated by the patient as greater than or equal to 37 on the Oxford Knee Score (OKS) or a 71 or greater on the KOOS, JR tool at one year (9 to 15 months) postoperatively.",
+    "nationalQualityStrategyDomain": "Person and Caregiver-Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "primarySteward": "Minnesota Community Measurement",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "orthopedicSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_470_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Functional Status After Lumbar Discectomy/Laminectomy",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "471",
+    "description": "For patients age 18 and older who had lumbar discectomy/laminectomy procedure, functional status is rated by the patient as less than or equal to 22 OR an improvement of 30 points or greater on the Oswestry Disability Index (ODI version 2.1a) at three months (6 to 20 weeks) postoperatively.",
+    "nationalQualityStrategyDomain": "Person and Caregiver-Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "primarySteward": "Minnesota Community Measurement",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "neurosurgical",
+      "orthopedicSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_471_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Appropriate Use of DXA Scans in Women Under 65 Years Who Do Not Meet the Risk Factor Profile for Osteoporotic Fracture",
+    "eMeasureId": "CMS249v4",
+    "nqfEMeasureId": "3475e",
+    "nqfId": null,
+    "measureId": "472",
+    "description": "Percentage of female patients 50 to 64 years of age without select risk factors for osteoporotic fracture who received an order for a dual-energy x-ray absorptiometry (DXA) scan during the measurement period.",
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "familyMedicine",
+      "internalMedicine",
+      "obstetricsGynecology"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms249v4"
+    }
+  },
+  {
+    "title": "Leg Pain After Lumbar Fusion",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "473",
+    "description": "For patients 18 years of age or older who had a lumbar fusion procedure, leg pain is rated by the patient as less than or equal to 3.0 OR an improvement of 5.0 points or greater on the Visual Analog Scale (VAS) Pain scale at one year (9 to 15 months) postoperatively.",
+    "nationalQualityStrategyDomain": "Person and Caregiver-Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "primarySteward": "Minnesota Community Measurement",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "neurosurgical",
+      "orthopedicSurgery"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_473_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "HIV Screening",
+    "eMeasureId": "CMS349v4",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "475",
+    "description": "Percentage of patients aged 15-65 at the start of the measurement period who were between 15-65 years old when tested for HIV.",
+    "nationalQualityStrategyDomain": "Community/Population Health",
+    "measureType": "process",
+    "isHighPriority": false,
+    "primarySteward": "Centers for Disease Control and Prevention",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "certifiedNurseMidwife",
+      "familyMedicine",
+      "infectiousDisease",
+      "internalMedicine",
+      "obstetricsGynecology",
+      "preventiveMedicine"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms349v4"
+    }
+  },
+  {
+    "title": "Urinary Symptom Score Change 6-12 Months After Diagnosis of Benign Prostatic Hyperplasia",
+    "eMeasureId": "CMS771v3",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "476",
+    "description": "Percentage of patients with an office visit within the measurement period and with a new diagnosis of clinically significant Benign Prostatic Hyperplasia who have International Prostate Symptoms Score (IPSS) or American Urological Association (AUA) Symptom Index (SI) documented at time of diagnosis and again 6-12 months later with an improvement of 3 points.",
+    "nationalQualityStrategyDomain": "Person and Caregiver-centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "primarySteward": "Large Urology Group Practice Association and Oregon Urology Institute",
+    "firstPerformanceYear": 2020,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "geriatrics",
+      "urology"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms771v3"
+    }
+  },
+  {
+    "title": "Multimodal Pain Management",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "477",
+    "description": "Percentage of patients, aged 18 years and older, undergoing selected surgical procedures that were managed with multimodal pain medicine.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "American Society of Anesthesiologists",
+    "firstPerformanceYear": 2020,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "anesthesiology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_477_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Functional Status Change for Patients with Neck Impairments",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "478",
+    "description": "A patient-reported outcome measure of risk-adjusted change in functional status for patients 14 years+ with neck impairments. The change in functional status (FS) is assessed using the FOTO Neck FS patient-reported outcome measure (PROM). The measure is adjusted to patient characteristics known to be associated with FS outcomes (risk-adjusted) and  used as a performance measure at the patient level, at the individual clinician level, and at the clinic level to assess quality. The measure is available as a computer adaptive test, for reduced patient burden, or a short form (static/paper-pencil).",
+    "nationalQualityStrategyDomain": "Person and Caregiver-centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "primarySteward": "Focus on Therapeutic Outcomes, Inc.",
+    "firstPerformanceYear": 2020,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "chiropracticMedicine",
+      "orthopedicSurgery",
+      "physicalTherapyOccupationalTherapy"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_478_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Hospital-Wide, 30-Day, All-Cause Unplanned Readmission (HWR) Rate for the Merit-Based Incentive Payment System (MIPS) Groups",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "479",
+    "description": "This measure is a re-specified version of the measure, \"Risk-adjusted readmission rate (RARR) of unplanned readmission within 30 days of hospital discharge for any condition\" (NQF 1789), which was developed for patients 65 years and older using Medicare claims. This re-specified measure attributes outcomes to MIPS participating clinician groups and assesses each group's readmission rate. The measure comprises a single summary score, derived from the results of five models, one for each of the following specialty cohorts (groups of discharge condition categories or procedure categories): medicine, surgery/gynecology, cardio-respiratory, cardiovascular, and neurology.",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2021,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "costScore",
+    "allowedPrograms": [
+      "mips",
+      "pcf",
+      "app1"
+    ],
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSets": [],
+    "measureSpecification": {}
+  },
+  {
+    "title": "Risk-standardized complication rate (RSCR) following elective primary total hip arthroplasty (THA) and/or total knee arthroplasty (TKA) for Merit-based Incentive Payment System (MIPS)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "3493",
+    "measureId": "480",
+    "description": "This measure is a re-specified version of the measure, \"Hospital-level Risk-standardized Complication rate (RSCR) following Elective Primary Total Hip Arthroplasty (THA) and/or Total Knee Arthroplasty (TKA)\" (National Quality Forum 1550), which was developed for patients 65 years and older using Medicare claims. This re-specified measure attributes outcomes to Merit-based Incentive Payment System participating clinicians and/or clinician groups (\"provider\") and assesses each provider's complication rate, defined as any one of the specified complications occurring from the date of index admission to up to 90 days post date of the index procedure.",
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2021,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "costScore",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSets": [],
+    "measureSpecification": {}
+  },
+  {
+    "title": "Intravesical Bacillus-Calmette Guerin for Non-muscle Invasive Bladder Cancer",
+    "eMeasureId": "CMS646v2",
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "481",
+    "description": "Percentage of patients initially diagnosed with non-muscle invasive bladder cancer and who received intravesical Bacillus-Calmette-Guerin (BCG) within 6 months of bladder cancer staging.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "primarySteward": "Oregon Urology",
+    "firstPerformanceYear": 2022,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "electronicHealthRecord"
+    ],
+    "measureSets": [
+      "urology"
+    ],
+    "measureSpecification": {
+      "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ep/2022/cms646v2"
+    }
+  },
+  {
+    "title": "Hemodialysis Vascular Access: Practitioner Level Long-term Catheter Rate",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "482",
+    "description": "Percentage of adult hemodialysis patient-months using a catheter continuously for three months or longer for vascular access attributable to an individual practitioner or group practice.",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "intermediateOutcome",
+    "isHighPriority": true,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2022,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "nephrology"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_482_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Person-Centered Primary Care Measure Patient Reported Outcome Performance Measure (PCPCM PRO-PM)",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "483",
+    "description": "The Person-Centered Primary Care Measure Patient Reported Outcome Performance Measure (PCPCM PRO-PM) uses the PCPCM PROM (a comprehensive and parsimonious set of 11 patient-reported items) to assess the broad scope of primary care. Unlike other primary care measures, the PCPCM PRO-PM measures the high value aspects of primary care based on a patient's relationship with the clinician or practice. Patients identify the PCPCM PROM as meaningful and able to communicate the quality of their care to their clinicians and/or care team. The items within the PCPCM PROM are based on extensive stakeholder engagement and comprehensive reviews of the literature.",
+    "nationalQualityStrategyDomain": "Person and Caregiver-centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "primarySteward": "The American Board of Family Medicine",
+    "firstPerformanceYear": 2022,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "singlePerformanceRate",
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "measureSets": [
+      "familyMedicine",
+      "internalMedicine"
+    ],
+    "measureSpecification": {
+      "registry": "https://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2022_Measure_483_MIPSCQM.pdf"
+    }
+  },
+  {
+    "title": "Clinician and Clinician Group Risk-standardized Hospital Admission Rates for Patients with Multiple Chronic Conditions",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "measureId": "484",
+    "description": "Annual risk-standardized rate of acute, unplanned hospital admissions among Medicare Fee-for-Service (FFS) patients aged 65 years and older with multiple chronic conditions (MCCs).",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "primarySteward": "Centers for Medicare & Medicaid Services",
+    "firstPerformanceYear": 2022,
+    "lastPerformanceYear": null,
+    "isInverse": false,
+    "category": "quality",
+    "isRegistryMeasure": false,
+    "isRiskAdjusted": false,
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "isIcdImpacted": false,
+    "clinicalGuidelineChanged": [],
+    "metricType": "costScore",
+    "allowedPrograms": [
+      "mips",
+      "pcf",
+      "app1"
+    ],
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSets": [],
+    "measureSpecification": {}
+  },
+  {
+    "category": "cost",
+    "title": "Medicare Spending Per Beneficiary (MSPB) Clinician",
+    "description": "The MSPB Clinician measure assesses the risk-adjusted cost to Medicare for services performed as a result of a clinician's care for a patient's inpatient hospital stay during the period 3 days prior to a hospital stay (also known as the \"index admission\" for the episode) through 30 days after discharge. The measure excludes costs from a defined list of services that are unlikely to be influenced by the clinician's care decisions and are thus considered unrelated to the index admission. In all supplemental documentation, the term \"cost\" generally means the standardized Medicare allowed amount.",
+    "measureId": "MSPB_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": "simpleAverage",
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-mspb-clinician.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Total Per Capita Cost (TPCC)",
+    "description": "The TPCC measure assesses the overall cost of care delivered to a patient with a focus on the primary care they receive from their provider(s). The measure is payment-standardized, risk-adjusted, and specialty-adjusted. In all supplemental documentation, the term \"cost\" generally means the standardized Medicare allowed amount.",
+    "measureId": "TPCC_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": "simpleAverage",
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-tpcc.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Routine Cataract Removal with Intraocular Lens (IOL) Implantation",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A and B are used to construct the episode-based cost measures. The Routine Cataract Removal with IOL Implantation episode-based cost measure evaluates a clinician's risk-adjusted cost to Medicare for patients who undergo a procedure for routine cataract removal with IOL implantation during the performance period. The measure score is the clinician's risk-adjusted cost for the episode group averaged across all episodes attributed to the clinician. This procedural measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from 60 days prior to the clinical event that opens, or \"triggers,\" the episode through 90 days after the trigger.",
+    "measureId": "COST_IOL_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": "simpleAverage",
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-cataract.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Intracranial Hemorrhage or Cerebral Infarction",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A and B are used to construct the episode-based cost measures. The Intracranial Hemorrhage or Cerebral Infarction episode-based cost measure evaluates a clinician's risk-adjusted cost to Medicare for patients who receive inpatient treatment for cerebral infarction or intracranial hemorrhage during the performance period. The measure score is the clinician's risk-adjusted cost for the episode group averaged across all episodes attributed to the clinician. This acute inpatient medical condition measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from the clinical event that opens, or \"triggers,\" the episode through 90 days after the trigger.",
+    "measureId": "COST_IHCI_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": "simpleAverage",
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-ich-cva.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Knee Arthroplasty",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A and B are used to construct the episode-based cost measures. The Knee Arthroplasty episode-based cost measure evaluates a clinician's risk-adjusted cost to Medicare for patients who receive an elective knee arthroplasty during the performance period. The measure score is the clinician's risk-adjusted cost for the episode group averaged across all episodes attributed to the clinician. This procedural measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from 30 days prior to the clinical event that opens, or \"triggers,\" the episode through 90 days after the trigger.",
+    "measureId": "COST_KA_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": "simpleAverage",
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-knee-arthro.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Elective Outpatient Percutaneous Coronary Intervention (PCI)",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A and B are used to construct the episode-based cost measures. The Elective Outpatient PCI episode-based cost measure evaluates a clinician's risk-adjusted cost to Medicare for patients who undergo elective outpatient PCI surgery to place a coronary stent for heart disease during the performance period. The measure score is the clinician's risk-adjusted cost for the episode group averaged across all episodes attributed to the clinician. This procedural measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from the clinical event that opens, or \"triggers,\" the episode through 30 days after the trigger.",
+    "measureId": "COST_EOPCI_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": "simpleAverage",
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-op-pci.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Simple Pneumonia with Hospitalization",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A and B are used to construct the episode-based cost measures. The Simple Pneumonia with Hospitalization episode-based cost measure evaluates a clinician's risk-adjusted cost to Medicare for patients who receive inpatient treatment for simple pneumonia during the performance period. The measure score is the clinician's risk-adjusted cost for the episode group averaged across all episodes attributed to the clinician. This acute inpatient medical condition measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from the clinical event that opens, or \"triggers,\" the episode through 30 days after the trigger.",
+    "measureId": "COST_SPH_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": "simpleAverage",
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-pna-hosp.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Revascularization for Lower Extremity Chronic Critical Limb Ischemia",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A and B are used to construct the episode-based cost measures. The Revascularization for Lower Extremity Chronic Critical Limb Ischemia episode-based cost measure evaluates a clinician's risk-adjusted cost to Medicare for patients who undergo elective revascularization surgery for lower extremity chronic critical limb ischemia during the performance period. The measure score is the clinician's risk-adjusted cost for the episode group averaged across all episodes attributed to the clinician. This procedural measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from 30 days prior to the clinical event that opens, or \"triggers,\" the episode through 90 days after the trigger.",
+    "measureId": "COST_CCLI_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": "simpleAverage",
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-rleccli.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Screening/Surveillance Colonoscopy",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A and B are used to construct the episode-based cost measures. The Screening/Surveillance Colonoscopy episode-based cost measure evaluates a clinician's risk-adjusted cost to Medicare for patients who undergo a screening or surveillance colonoscopy procedure during the performance period. The measure score is the clinician's risk-adjusted cost for the episode group averaged across all episodes attributed to the clinician. This procedural measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from the clinical event that opens, or \"triggers,\" the episode through 14 days after the trigger.",
+    "measureId": "COST_SSC_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": "simpleAverage",
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-ss-clnscpy.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "ST-Elevation Myocardial Infarction (STEMI) with Percutaneous Coronary Intervention (PCI)",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A and B are used to construct the episode-based cost measures. The STEMI with PCI episode-based cost measure evaluates a clinician's risk-adjusted cost to Medicare for patients who present with STEMI indicating complete blockage of a coronary artery who emergently receive PCI as treatment during the performance period. The measure score is the clinician's risk-adjusted cost for the episode group averaged across all episodes attributed to the clinician. This acute inpatient medical condition measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from the clinical event that opens, or \"triggers,\" the episode through 30 days after the trigger.",
+    "measureId": "COST_STEMI_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2019,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": "simpleAverage",
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-stemi-pci.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Acute Kidney Injury Requiring New Inpatient Dialysis",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A and B are used to construct the episode-based cost measures. The Acute Kidney Injury Requiring New Inpatient Dialysis episode-based cost measure evaluates a clinician's risk-adjusted cost to Medicare for patients who receive their first inpatient dialysis service for acute kidney injury during the performance period. The measure score is the clinician's risk-adjusted cost for the episode group averaged across all episodes attributed to the clinician. This procedural measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from the clinical event that opens, or \"triggers,\" the episode through 30 days after the trigger.",
+    "measureId": "COST_AKID_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2020,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": null,
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-aki-new-hd.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Elective Primary Hip Arthroplasty",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A and B are used to construct the episode-based cost measures. The Elective Primary Hip Arthroplasty episode-based cost measure evaluates a clinician's risk\u0002adjusted cost to Medicare for patients who receive an elective primary hip arthroplasty during the performance period. The measure score is the clinician's risk-adjusted cost for the episode group averaged across all episodes attributed to the clinician. This procedural measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from 30 days prior to the clinical event that opens, or \"triggers,\" the episode through 90 days after the trigger.",
+    "measureId": "COST_PHA_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2020,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": null,
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-el-ha.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Femoral or Inguinal Hernia Repair",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A and B are used to construct the episode-based cost measures. The Femoral or Inguinal Hernia Repair episode-based cost measure evaluates a clinician's risk\u0002adjusted cost to Medicare for patients who undergo surgical procedure to repair a femoral or inguinal hernia during the performance period. The measure score is the clinician's risk-adjusted cost for the episode group averaged across all episodes attributed to the clinician. This procedural measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from 30 days prior to the clinical event that opens, or \"triggers,\" the episode through 90 days after the trigger.",
+    "measureId": "COST_FIHR_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2020,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": null,
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-fihr.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Hemodialysis Access Creation",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A and B are used to construct the episode-based cost measures. The Hemodialysis Access Creation episode-based cost measure evaluates a clinician's risk\u0002adjusted cost to Medicare for patients who undergo a procedure for the creation of graft or fistula access for long-term hemodialysis during the performance period. The measure score is the clinician's risk-adjusted cost for the episode group averaged across all episodes attributed to the clinician. This procedural measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from 60 days prior to the clinical event that opens, or \"triggers,\" the episode through 90 days after the trigger.",
+    "measureId": "COST_HAC_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2020,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": null,
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-hd-access.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Inpatient Chronic Obstructive Pulmonary Disease (COPD) Exacerbation",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A and B are used to construct the episode-based cost measures. The Inpatient COPD Exacerbation episode-based cost measure evaluates a clinician's risk\u0002adjusted cost to Medicare for patients who receive inpatient treatment for an acute exacerbation of COPD during the performance period. The measure score is the clinician's risk-adjusted cost for the episode group averaged across all episodes attributed to the clinician. This acute inpatient medical condition measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from the clinical event that opens, or \"triggers,\" the episode through 60 days after the trigger.",
+    "measureId": "COST_COPDE_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2020,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": null,
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-ip-copd.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Lower Gastrointestinal Hemorrhage (groups only)",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A and B are used to construct the episode-based cost measures. The Lower Gastrointestinal Hemorrhage episode-based cost measure evaluates a clinician's risk-adjusted cost to Medicare for patients who receive inpatient non-surgical treatment for acute bleeding in the lower gastrointestinal tract during the performance period. The measure score is the clinician's risk-adjusted cost for the episode group averaged across all episodes attributed to the clinician. This acute inpatient medical condition measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from the clinical event that opens, or \"triggers,\" the episode through 35 days after the trigger.",
+    "measureId": "COST_LGH_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2020,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": null,
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-lgi-bleed.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Lumbar Spine Fusion for Degenerative Disease, 1-3 Levels",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A and B are used to construct the episode-based cost measures. The Lumbar Spine Fusion for Degenerative Disease, 1-3 Levels episode-based cost measure evaluates a clinician's risk-adjusted cost to Medicare for patients who undergo surgery for lumbar spine fusion during the performance period. The measure score is the clinician's risk\u0002adjusted cost for the episode group averaged across all episodes attributed to the clinician. This procedural measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from 30 days prior to the clinical event that opens, or \"triggers,\" the episode through 90 days after the trigger.",
+    "measureId": "COST_LSFDD_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2020,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": null,
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-l-fusion.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Lumpectomy, Partial Mastectomy, Simple Mastectomy",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A and B are used to construct the episode-based cost measures. The Lumpectomy, Partial Mastectomy, Simple Mastectomy episode-based cost measure evaluates a clinician's risk-adjusted cost to Medicare for patients who undergo partial or total mastectomy for breast cancer during the performance period. The measure score is the clinician's risk-adjusted cost for the episode group averaged across all episodes attributed to the clinician. This procedural measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from 30 days prior to the clinical event that opens, or \"triggers,\" the episode through 90 days after the trigger.",
+    "measureId": "COST_LPMSM_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2020,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": null,
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-lump-mast.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Non-Emergent Coronary Artery Bypass Graft (CABG)",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A and B are used to construct the episode-based cost measures. The Non-Emergent CABG episode-based cost measure evaluates a clinician's risk-adjusted cost to Medicare for patients who undergo a CABG procedure during the performance period. The measure score is the clinician's risk-adjusted cost for the episode group averaged across all episodes attributed to the clinician. This procedural measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from 30 days prior to the clinical event that opens, or \"triggers,\" the episode through 90 days after the trigger.",
+    "measureId": "COST_NECABG_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2020,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": null,
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-ne-cabg.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Renal or Ureteral Stone Surgical Treatment",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A and B are used to construct the episode-based cost measures. The Renal or Ureteral Stone Surgical Treatment episode-based cost measure evaluates a clinician's risk-adjusted cost to Medicare for patients who receive surgical treatment for renal or ureteral stones during the performance period. The measure score is the clinician's risk\u0002adjusted cost for the episode group averaged across all episodes attributed to the clinician. This procedural measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from 90 days prior to the clinical event that opens, or \"triggers,\" the episode through 30 days after the trigger.",
+    "measureId": "COST_RUSST_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2020,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": null,
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-rn-stone.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Colon and Rectal Resection",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A and B are used to construct the episode-based cost measures. The Colon and Rectal Resection episode-based cost measure evaluates a clinician's risk-adjusted cost to Medicare for patients who receive colon or rectal resection for either benign or malignant indications during the performance period. The measure score is the clinician's risk-adjusted cost for the episode group averaged across all episodes attributed to the clinician. This procedural measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from 15 days prior to the clinical event that opens, or \"triggers,\" the episode through 90 days after the trigger.",
+    "measureId": "COST_CRR_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2022,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": null,
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-colrec-rsct.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Melanoma Resection",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A and B are used to construct the episode-based cost measures. The Melanoma Resection episode-based cost measure evaluates a clinician's risk-adjusted cost to Medicare for patients who undergo an excision procedure to remove a cutaneous melanoma during the performance period. The measure score is the clinician's risk-adjusted cost for the episode group averaged across all episodes attributed to the clinician. This procedural measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from 30 days prior to the clinical event that opens, or \"triggers,\" the episode through 90 days after the trigger.",
+    "measureId": "COST_MR_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2022,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": null,
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-mel-rsct.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Sepsis",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A, B, and D are used to construct the episode-based cost measures. The Sepsis episode-based cost measure evaluates a clinician's risk-adjusted cost to Medicare for patients who receive inpatient medical treatment for sepsis during the performance period. The measure score is the clinician's risk-adjusted cost for the episode group averaged across all episodes attributed to the clinician. This acute inpatient medical condition measure includes costs of services that are clinically related to the attributed clinician's role in managing care during each episode from the clinical event that opens, or \"triggers,\" the episode through 45 days after the trigger.",
+    "measureId": "COST_S_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2022,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": null,
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-sepsis.pdf"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Diabetes",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, the term \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A, B, and D are used to construct this episode-based cost measure. The Diabetes episode-based cost measure evaluates a clinician's or clinician group's risk-adjusted cost to Medicare for patients receiving medical care to manage and treat diabetes. This chronic condition measure includes the costs of services that are clinically related to the attributed clinician's role in managing care during a Diabetes episode.",
+    "measureId": "COST_D_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2022,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": null,
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-diabetes.zip"
+    }
+  },
+  {
+    "category": "cost",
+    "title": "Asthma/Chronic Obstructive Pulmonary Disease (COPD)",
+    "description": "Episode-based cost measures represent the cost to Medicare for the items and services provided to a patient during an episode of care (\"episode\"). In all supplemental documentation, the term \"cost\" generally means the standardized Medicare allowed amount, and claims data from Medicare Parts A, B, and D are used to construct this episode-based cost measure. The Asthma/COPD episode-based cost measure evaluates a clinician's or clinician group's risk-adjusted cost to Medicare for patients receiving medical care to manage and treat asthma or COPD. This chronic condition measure includes the costs of services that are clinically related to the attributed clinician's role in managing care during an Asthma/COPD episode.",
+    "measureId": "COST_ACOPD_1",
+    "metricType": "costScore",
+    "firstPerformanceYear": 2022,
+    "lastPerformanceYear": null,
+    "isInverse": true,
+    "overallAlgorithm": null,
+    "submissionMethods": [
+      "administrativeClaims"
+    ],
+    "measureSpecification": {
+      "default": "https://qpp.cms.gov/docs/cost_specifications/2021-12-13-mif-ebcm-chron-copd.zip"
+    }
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Getting Timely Care, Appointments, and Information",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_1",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0005",
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "app1"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: How Well Providers Communicate",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_2",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0005",
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "app1"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Patient’s Rating of Provider",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_3",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "app1"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Access to Specialists",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_4",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "app1"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Health Promotion and Education",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_5",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "app1"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Shared Decision Making",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_6",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "app1"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Health Status and Functional Status",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_7",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "app1"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Care Coordination",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_8",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "app1"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Courteous and Helpful Office Staff",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_9",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": "0005",
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "app1"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "category": "quality",
+    "firstPerformanceYear": 2017,
+    "lastPerformanceYear": null,
+    "metricType": "cahps",
+    "title": "CAHPS for MIPS SSM: Stewardship of Patient Resources",
+    "description": "",
+    "nationalQualityStrategyDomain": null,
+    "measureType": "patientEngagementExperience",
+    "measureId": "CAHPS_11",
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "nqfId": null,
+    "isInverse": false,
+    "strata": [],
+    "isHighPriority": true,
+    "isIcdImpacted": false,
+    "primarySteward": "Agency for Healthcare Research & Quality",
+    "submissionMethods": [
+      "certifiedSurveyVendor"
+    ],
+    "measureSets": [
+      "generalPracticeFamilyMedicine"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "app1"
+    ],
+    "isRegistryMeasure": false
+  },
+  {
+    "measureId": "AAAAI17",
+    "title": "Asthma Control: Minimal Important Difference Improvement",
+    "description": "Percentage of patients aged 12 years and older whose asthma is not well-controlled as indicated by the Asthma Control Test, Asthma Control Questionnaire, or Asthma Therapy Assessment Questionnaire and who demonstrated a minimal important difference improvement upon a subsequent office visit during the 12-month reporting period. National Quality Strategy Domain: Person and Caregiver-Centered Experience and Outcomes Outcome Measure",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "AAAAI QCDR - American Academy of Allergy, Asthma, and Immunology Quality Clinical Data Registry Powered by ArborMetrix",
+    "firstPerformanceYear": 2015,
+    "allowedVendors": [
+      "6273354"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAAAI18",
+    "title": "Penicillin Allergy: Appropriate Removal or Confirmation",
+    "description": "Percentage of patients, regardless of age, with a primary diagnosis of penicillin or ampicillin/amoxicillin allergy, who underwent elective skin testing or antibiotic challenge that resulted in the removal of the penicillin or ampicillin/amoxicillin allergy label from the medical record if negative or confirmation of the penicillin or ampicillin/amoxicillin allergy label if positive.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "AAAAI QCDR - American Academy of Allergy, Asthma, and Immunology Quality Clinical Data Registry Powered by ArborMetrix",
+    "firstPerformanceYear": 2015,
+    "allowedVendors": [
+      "6273354"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAAAI2",
+    "title": "Asthma: Assessment of Asthma Control – Ambulatory Care Setting",
+    "description": "Percentage of patients aged 5 years and older with a diagnosis of asthma who were evaluated at least once during the measurement period for asthma control (comprising asthma impairment and asthma risk). National Quality Strategy Domain: Effective Clinical Care Process Measure",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "AAAAI QCDR - American Academy of Allergy, Asthma, and Immunology Quality Clinical Data Registry Powered by ArborMetrix",
+    "firstPerformanceYear": 2014,
+    "allowedVendors": [
+      "6273354"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAAAI6",
+    "title": "Documentation of Clinical Response to Allergen Immunotherapy within One Year",
+    "description": "Percentage of patients aged 5 years and older who were evaluated for clinical improvement and efficacy within one year after initiating allergen immunotherapy AND assessment documented in the medical record. National Quality Strategy Domain: Communication and Care Coordination Process Measure",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "AAAAI QCDR - American Academy of Allergy, Asthma, and Immunology Quality Clinical Data Registry Powered by ArborMetrix",
+    "firstPerformanceYear": 2014,
+    "allowedVendors": [
+      "6273354"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAAAI8",
+    "title": "Achievement of Projected Effective Dose of Standardized Allergens for Patient Treated With Allergen Immunotherapy for at Least One Year",
+    "description": "Proportion of patients receiving subcutaneous allergen immunotherapy that contains at least one standardized extract (mite, ragweed, grass, and/or cat) who achieved the projected effective dose for all included standardized allergen extract(s) after at least one year of treatment.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "AAAAI QCDR - American Academy of Allergy, Asthma, and Immunology Quality Clinical Data Registry Powered by ArborMetrix",
+    "firstPerformanceYear": 2014,
+    "allowedVendors": [
+      "6273354"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAD10",
+    "title": "Dermatitis – Improvement in Patient-Reported Itch Severity",
+    "description": "The percentage of patients, aged 18 years and older, with a diagnosis of dermatitis where at an initial (index) visit have a patient reported itch severity assessments performed, score greater than or equal to 4, and who achieve a score reduction of 2 or more points at a follow up visit.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "AAD’s DataDerm™",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "4649789"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAD11",
+    "title": "Skin Cancer Surgery: Post-Operative Complications",
+    "description": "Percentage of procedures for basal cell carcinoma, squamous cell carcinoma, or melanoma (including in situ disease) with a post-operative complication including infection, bleeding, or hematoma following an excisional or Mohs surgery within 15 days of the procedure.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "AAD’s DataDerm™",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "4649789"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAD12",
+    "title": "Melanoma: – Appropriate Surgical Margins",
+    "description": "Percentage of primary excisional surgeries for melanoma or melanoma in situ with Breslow depth and appropriate surgical margins per the National Comprehensive Cancer Network Clinical Practice Guidelines in Oncology- Melanoma (NCCN Guideline).",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "intermediateOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "AAD’s DataDerm™",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "4649789"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAD13",
+    "title": "Mildly Atypical Dysplastic Nevi – Appropriate Non-Excision",
+    "description": "Percentage of procedures with histologically proven dysplastic nevus/mild atypia that are NOT excised by the biopsying physician and are NOT referred to others for excision.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "AAD’s DataDerm™",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "4649789"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAD14",
+    "title": "Melanoma: Tracking and Evaluation of Recurrence",
+    "description": "Percentage of patients who had an excisional surgery for melanoma or melanoma in situ with initial AJCC staging of 0, I, or II, in the past 5 years in which the operating provider examines and/or diagnoses the patient for recurrence of melanoma.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "AAD’s DataDerm™",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "4649789"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "examPerformed",
+        "description": "NUMERATOR CRITERIA 1: Documentation by the provider who performed the surgery that an exam for recurrence of melanoma was performed on the patient within the reporting period."
+      },
+      {
+        "name": "overall",
+        "description": "NUMERATOR CRITERIA 2: All patients that were diagnosed with a recurrent melanoma in the current reporting year."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAD6",
+    "title": "Skin Cancer: Biopsy Reporting Time - Clinician to Patient",
+    "description": "Percentage of patients with skin biopsy specimens with a diagnosis of cutaneous basal or squamous cell carcinoma or melanoma (including in situ disease) or primary cutaneous malignancies who are notified of their final biopsy pathology findings within less than or equal to 12 days from the time the biopsy was performed.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "AAD’s DataDerm™",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "4649789"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAD7",
+    "title": "Psoriasis: Screening for Psoriatic Arthritis",
+    "description": "Percentage of patients with diagnosis of psoriasis who are screened for psoriatic arthritis at each visit.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "AAD’s DataDerm™",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "4649789"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAD8",
+    "title": "Chronic Skin Conditions: Patient Reported Quality-of-Life",
+    "description": "The percentage of patients aged 18 years and older with a chronic skin condition whose self-assessed quality-of-life was recorded at least once in the medical record within the measurement period.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "AAD’s DataDerm™",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "4649789"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAD9",
+    "title": "Psoriasis – Improvement in Patient-Reported Itch Severity",
+    "description": "The percentage of patients, aged 18 years and older, with a diagnosis of psoriasis where at an initial (index) visit have a patient reported itch severity assessment performed, score greater than or equal to 4, and who achieve a score reduction of 2 or more points at a follow up visit.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "AAD’s DataDerm™",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "4649789"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAN22",
+    "title": "Quality of Life Outcome for Patients with Neurologic Conditions",
+    "description": "Percentage of patients whose quality of life assessment results are maintained or improved during the measurement period.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Axon Registry",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "8933551"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAN25",
+    "title": "Pediatric Medication reconciliation",
+    "description": "Percentage of pediatric patients who had a medication review at every encounter and a medication list present in the medical record.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Axon Registry",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "8933551"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAN26",
+    "title": "Activity counseling for back pain",
+    "description": "Percentage of patients 18 to 65 years of age who were counseled to remain active and exercise or were referred to physical therapy",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Axon Registry",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "8933551"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAN28",
+    "title": "Diabetes/Pre-Diabetes Screening for Patients with DSP",
+    "description": "Percentage of patients age 18 years and older with a diagnosis of distal symmetric polyneuropathy who had screening tests for diabetes (e.g. fasting blood sugar test, a hemoglobin A1C, or a 2 hour Glucose Tolerance Test) reviewed, requested or ordered when seen for an initial evaluation for distal symmetric polyneuropathy and if screen positive referred to endocrinology or PCP.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Axon Registry",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "8933551"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAN29",
+    "title": "Comprehensive Epilepsy Care Center Referral or Discussion for Patients with Epilepsy",
+    "description": "Percentage of patients who were referred or had a discussion of evaluation at a comprehensive epilepsy care center.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Axon Registry",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "8933551"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAN30",
+    "title": "Migraine Preventive Therapy Management",
+    "description": "Percentage of patients aged 6 years and older with a diagnosis of migraine whose migraine frequency is greater than or equal to 6 days per month/4 attacks per month who were managed with an evidence-based preventive migraine therapy, including therapies prescribed by another clinician.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Axon Registry",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "8933551"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAN31",
+    "title": "Acute Treatment Prescribed for Cluster Headache",
+    "description": "Percentage of patients greater than or equal to 18 years of age with a diagnosis of cluster headache (CH) who were prescribed an acute treatment, including treatments prescribed by a different clinician.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Axon Registry",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "8933551"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAN32",
+    "title": "Preventive Treatment Prescribed for Cluster Headache",
+    "description": "Percentage of patients greater than or equal to 18 years of age with a diagnosis of cluster headache (CH) who were prescribed short-term and/or long-term preventive treatment, including treatments prescribed by a different clinician.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Axon Registry",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "8933551"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAN34",
+    "title": "Patient reported falls and plan of care",
+    "description": "Percentage of patients (or caregivers as appropriate) with an active diagnosis of a movement disorder, multiple sclerosis, a neuromuscular disorder, dementia, or stroke who reported a fall occurred and those that fell had a plan of care for falls documented at every visit",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Axon Registry",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "8933551"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAN5",
+    "title": "Medication Prescribed For Acute Migraine Attack",
+    "description": "Percentage of patients age 6 years and older with a diagnosis of migraine who were prescribed a guideline recommended or FDA approved/cleared treatment for acute migraine attacks within the measurement period.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Axon Registry",
+    "firstPerformanceYear": 2016,
+    "allowedVendors": [
+      "8933551"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAN8",
+    "title": "Exercise and Appropriate Physical Activity Counseling for Patients with MS",
+    "description": "Percentage of patients with MS who are counseled* on the benefits of exercise and appropriate physical activity for patients with MS in the past 12 months.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Axon Registry",
+    "firstPerformanceYear": 2016,
+    "allowedVendors": [
+      "8933551"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAN9",
+    "title": "Querying and Follow-Up About Symptoms of Autonomic Dysfunction for Patients with Parkinson's Disease",
+    "description": "Percentage of all patients with a diagnosis of PD (or caregivers, as appropriate) who were queried about symptoms of autonomic dysfunction* in the past 12 months and if autonomic dysfunction identified had appropriate follow-up.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Axon Registry",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "8933551"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAO12",
+    "title": "Tympanostomy Tubes: Topical Ear Drop Monotherapy for Acute Otorrhea",
+    "description": "Percentage of patients age 6 months to 12 years of age at the time of the visit with a current diagnosis of an uncomplicated acute tympanostomy tube otorrhea (TTO) who were prescribed or recommended to use topical antibiotic eardrops and NOT prescribed systemic (IV or PO) antibiotics for acute TTO.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Otolaryngology – Head and Neck Surgery Foundation (AAO-HNSF) Reg-entSM Registry",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "8365868"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAO13",
+    "title": "Bell's Palsy: Inappropriate Use of Magnetic Resonance Imaging or Computed Tomography Scan",
+    "description": "Percentage of patients age 16 years and older with a new onset diagnosis of Bell’s palsy within the past 3 months who had a magnetic resonance imaging (MRI) or a computed tomography (CT) scan of the internal auditory canal, head, neck, or brain ordered for the primary diagnosis of Bell’s palsy.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Otolaryngology – Head and Neck Surgery Foundation (AAO-HNSF) Reg-entSM Registry",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "8365868"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAO16",
+    "title": "Age-Related Hearing Loss: Audiometric Evaluation",
+    "description": "Percentage of patients age 60 years and older who failed a hearing screening and/or who report suspected hearing loss who received, were ordered, or were referred for comprehensive audiometric evaluation within 4 weeks of the office visit.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Otolaryngology – Head and Neck Surgery Foundation (AAO-HNSF) Reg-entSM Registry",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "8365868"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAO20",
+    "title": "Tympanostomy Tubes: Hearing Test",
+    "description": "Percentage of patients age 6 months through 12 years with a diagnosis of otitis media with effusion (OME) who received tympanostomy tube insertion and received a hearing test within 6 months prior to tympanostomy tube insertion.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Otolaryngology – Head and Neck Surgery Foundation (AAO-HNSF) Reg-entSM Registry",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "8365868"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAO21",
+    "title": "Otitis Media with Effusion (OME): Hearing Test for Chronic OME > 3 months",
+    "description": "Percentage of patients age 6 months to 12 years of age at the time of the visit with a diagnosis of otitis media with effusion (OME) including chronic serous, mucoid, or nonsuppurative OME of > 3 months duration who had audiometry performed, ordered, or who were referred for an audiometric evaluation.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Otolaryngology – Head and Neck Surgery Foundation (AAO-HNSF) Reg-entSM Registry",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "8365868"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAO23",
+    "title": "Allergic Rhinitis: Intranasal Corticosteroids or Oral Antihistamines",
+    "description": "Percentage of patients age 2 years and older with allergic rhinitis who are offered intranasal corticosteroids (INS) or non-sedating oral antihistamines.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Otolaryngology – Head and Neck Surgery Foundation (AAO-HNSF) Reg-entSM Registry",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "8365868"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAO24",
+    "title": "Allergic Rhinitis: Avoidance of Leukotriene Inhibitors",
+    "description": "Percentage of patients age 2 years and older with allergic rhinitis who do not receive leukotriene inhibitors.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Otolaryngology – Head and Neck Surgery Foundation (AAO-HNSF) Reg-entSM Registry",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "8365868"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAO32",
+    "title": "Standard Benign Positional Paroxysmal Vertigo (BPPV) Management",
+    "description": "Percentage of Benign Positional Paroxysmal Vertigo (BPPV) patients who received vestibular testing, imaging, and antihistamine or benzodiazepine medications.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Otolaryngology – Head and Neck Surgery Foundation (AAO-HNSF) Reg-entSM Registry",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "8365868"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAO34",
+    "title": "Dysphonia: Postoperative Laryngeal Examination",
+    "description": "Percentage of patients age 18 years and older who were diagnosed with new onset dysphonia within 2 months after a thyroidectomy who received or were referred for a laryngeal examination to examine vocal fold/cord mobility, and, if abnormal vocal fold mobility is identified, receive a plan of care for voice rehabilitation.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Otolaryngology – Head and Neck Surgery Foundation (AAO-HNSF) Reg-entSM Registry",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "8365868"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAO35",
+    "title": "Benign Positional Paroxysmal Vertigo (BPPV): Dix-Hallpike and Canalith Repositioning",
+    "description": "Percentage of patients with Benign Positional Paroxysmal Vertigo (BPPV) who had a Dix-Hallpike maneuver performed AND who had therapeutic canalith repositioning procedure (CRP) performed or who were referred for physical therapy or to a provider who can perform CRP if identified with posterior canal BPPV",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Otolaryngology – Head and Neck Surgery Foundation (AAO-HNSF) Reg-entSM Registry; Axon Registry",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "8365868",
+      "8933551"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AAO36",
+    "title": "Tympanostomy Tubes: Resolution of Otitis Media with Effusion (OME) in Adults and Children",
+    "description": "Percentage of patients aged 6 months and older with a diagnosis of otitis media with effusion (OME) who are seen 2 to 8 weeks after tympanostomy tube surgery and OME is resolved.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Otolaryngology – Head and Neck Surgery Foundation (AAO-HNSF) Reg-entSM Registry",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "8365868"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AASM1",
+    "title": "Pediatric OSA: Objective Assessment of Positive Airway Pressure Therapy Adherence",
+    "description": "Proportion of patients aged less than 18 years diagnosed with OSA that were prescribed positive airway pressure therapy and had documentation of objectively measured adherence to positive airway pressure therapy within 3 months of starting therapy",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Sleep Medicine Sleep Clinical Data Registry (Sleep CDR)",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "4076932"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AASM2",
+    "title": "Pediatric OSA: Objective Assessment of OSA Signs and Symptoms in Children with Complex Medical Conditions",
+    "description": "Proportion of patients aged less than 18 years with complex medical conditions known to be at high risk for OSA and with signs and symptoms of OSA that underwent a PSG or were referred to a sleep specialist, otolaryngologist, or other specialist experienced in evaluation and management of OSA in children",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Sleep Medicine Sleep Clinical Data Registry (Sleep CDR)",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "4076932"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AASM3",
+    "title": "Adult OSA: Screening for Adult OSA by Primary Care Physicians",
+    "description": "All patients aged 18 years and older at high risk for obstructive sleep apnea (OSA) with documentation of screening for OSA using an appropriate standardized tool at least every 12 months AND in whom a recommended follow-up plan is documented based upon the result of the screening",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Sleep Medicine Sleep Clinical Data Registry (Sleep CDR)",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "4076932"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ABFM12",
+    "title": "Measuring the Value-Functions of Primary Care: Physician Level Continuity of Care Measure",
+    "description": "This is a measure evaluating primary care physicians (PCPs); for each PCP, the denominator is all patients seen during the evaluation period who had at least 2 PCP visits. The numerator is the number of those patients whose Bice-Boxerman Continuity of Care Index is >= 0.7. The Bice-Boxerman index is a validated measure of patient-level care continuity that ranges from 0 to 1; 0 reflects completely disjointed care and 1 reflects complete continuity with the same PCP for all visits. (The Bice-Boxerman index was used in a previously primary care NQF endorsed measure for children with medical complexity.) Compared to lower scores (e.g., 0.6 or lower), continuity index scores of 0.7 or higher have been associated with significantly lower Medicare expenditures and significantly lower odds of hospitalization.\nReferences: \n1. Higher Primary Care Physician Continuity is Associated with Lower Costs and Hospitalizations. Bazemore et al. Annals of Family Medicine. 2018. 16, 492-497.",
+    "nqfId": "3617",
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "efficiency",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ABFM PRIME",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "4849508"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ABG40",
+    "title": "Hypotension Prevention After Spinal Placement for Elective Cesarean Section",
+    "description": "Percentage of patients, who present for elective Caesarean section under spinal anesthesia who have phenylephrine infusions started prophylactically to prevent hypotension.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ABG QCDR",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5551268"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ABG41",
+    "title": "Upper Extremity Nerve Blockade in Shoulder Surgery",
+    "description": "Percentage of patients who undergo shoulder arthroscopy or shoulder arthroplasty who have an upper extremity nerve blockade performed before or immediately after the procedure.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ABG QCDR",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5551268",
+      "6169123"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ABG42",
+    "title": "Known or Suspected Difficult Airway Mitigation Strategies",
+    "description": "Percentage of patients with a known or suspected difficult airway who undergo a planned general endotracheal anesthetic that have both a second provider present at the induction and placement of the endotracheal tube and have difficult airway equipment in the room prior to the induction.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ABG QCDR",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5551268"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ABG43",
+    "title": "Use of Capnography for non-Operating Room anesthesia Measure",
+    "description": "Percentage of patients receiving anesthesia in a non-operating room setting who have end-tidal carbon dioxide (ETCO2) monitored using capnography.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ABG QCDR",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "5551268",
+      "6169123"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACEP19",
+    "title": "Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older",
+    "description": "Percentage of emergency department visits for patients aged 18 years and older who presented with a minor blunt head trauma who had a head CT for trauma ordered by an emergency care provider who have an indication for a head CT",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
+    "firstPerformanceYear": 2016,
+    "allowedVendors": [
+      "5133825",
+      "4757099"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACEP21",
+    "title": "Coagulation Studies in Patients Presenting with Chest Pain with No Coagulopathy or Bleeding",
+    "description": "Percentage of emergency department visits for patients aged 18 years and older with an emergency department discharge diagnosis of chest pain during which coagulation studies were ordered by an emergency care provider",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
+    "firstPerformanceYear": 2016,
+    "allowedVendors": [
+      "5133825",
+      "1725296"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACEP22",
+    "title": "Appropriate Emergency Department Utilization of CT for Pulmonary Embolism",
+    "description": "Percentage of emergency department visits during which patients aged 18 years and older had a CT pulmonary angiogram (CTPA) ordered by an emergency care provider, regardless of discharge disposition, with either moderate or high pre-test clinical probability for pulmonary embolism OR positive result or elevated D-dimer level",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
+    "firstPerformanceYear": 2016,
+    "allowedVendors": [
+      "5133825",
+      "1725296"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACEP25",
+    "title": "Tobacco Use: Screening and Cessation Intervention for Patients with Asthma and COPD",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of asthma or COPD seen in the ED and discharged who were screened for tobacco use during any ED encounter AND who received tobacco cessation intervention if identified as a tobacco user",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Community/Population Health",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
+    "firstPerformanceYear": 2016,
+    "allowedVendors": [
+      "5133825"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACEP30",
+    "title": "Sepsis Management: Septic Shock: Lactate Clearance Rate of >=10",
+    "description": "Percentage of emergency department visits for patients aged 18 years and older with septic shock resulting in hospital admission or transfers who had an elevated serum lactate result (>2mmol/L) and a subsequent serum lactate level measurement performed following the elevated serum lactate result with a lactate clearance rate of >= 10% during the emergency department visit",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
+    "firstPerformanceYear": 2016,
+    "allowedVendors": [
+      "5133825",
+      "1725296"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACEP31",
+    "title": "Appropriate Foley catheter use in the emergency department",
+    "description": "Percentage of emergency department (ED) visits for admitted patients aged 18 years and older where an indwelling Foley catheter is ordered and the patient had at least one indication for an indwelling Foley catheter",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
+    "firstPerformanceYear": 2016,
+    "allowedVendors": [
+      "5133825",
+      "1725296"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACEP48",
+    "title": "Sepsis Management: Septic Shock: Lactate Level Measurement, Antibiotics Ordered, and Fluid Resuscitation",
+    "description": "Percentage of emergency department visits resulting in hospital admission or transfers for patients aged 18 years and older with septic shock who had an order for all the following during the emergency department visit: a serum lactate level, antibiotics, and >1L of crystalloids",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "5133825"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACEP50",
+    "title": "ED Median Time from ED arrival to ED departure for all Adult Patients",
+    "description": "Time (in minutes) from ED arrival to ED departure for all Adult Patients",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": true,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR); E-CPR (Emergency - Clinical Performance Registry)",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "5133825",
+      "1718371",
+      "4757099"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACEP51",
+    "title": "ED Median Time from ED arrival to ED departure for all Pediatric ED Patients",
+    "description": "Time (in minutes) from ED arrival to ED departure for all Pediatric Patients",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": true,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR); E-CPR (Emergency - Clinical Performance Registry)",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "5133825",
+      "1718371"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACEP52",
+    "title": "Appropriate Emergency Department Utilization of Lumbar Spine Imaging for Atraumatic Low Back Pain",
+    "description": "Percentage of emergency department visits during which patients aged 18 years and older had a CT or MRI of the Lumbar Spine ordered by an emergency care provider, regardless of discharge disposition, presenting with acute, non-complex low back pain.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "5133825",
+      "1725296"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACEP53",
+    "title": "Appropriate Use of Imaging for Recurrent Renal Colic",
+    "description": "Percentage of emergency department (ED) visits for patients aged 18-50 years presenting with flank pain with a history of kidney stones during which no imaging is ordered, OR appropriate imaging (i.e., plain film radiography or ultrasound) is ordered.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "5133825",
+      "1725296"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACEP54",
+    "title": "Appropriate Utilization of Focused Assessment with Sonography for Trauma (FAST) Exam in the Emergency Department",
+    "description": "Percentage of emergency department visits for patients aged 18 years and older presenting with hemodynamically unstable blunt abdominal trauma (blunt trauma and a systolic blood pressure less than 90 mmHg or heart rate >120 bpm) or penetrating thoracoabdominal trauma who had a FAST exam ordered and/or performed during the emergency department visit",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5133825"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACEP55",
+    "title": "Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years",
+    "description": "Percentage of emergency department visits for patients aged 2 through 17 years who presented with a minor blunt head trauma who had a head CT for trauma ordered by an emergency care provider who are classified as high risk according to the PECARN prediction rules for traumatic brain injury",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5133825"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACEP56",
+    "title": "Follow-Up Care Coordination Documented in Discharge Summary",
+    "description": "Percentage of patients aged 18 years and older for which follow-up care coordination was documented in Hospital Discharge Summary",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5133825"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACEP59",
+    "title": "Chest Pain – Avoidance of admission for adult patients with low-risk chest pain.",
+    "description": "Percentage of adult patients who came to the Emergency Department with low-risk chest pain and were discharged",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "5133825",
+      "1718371",
+      "4757099"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACEP60",
+    "title": "Syncope – Avoidance of admission for adult patients with low-risk syncope",
+    "description": "Percentage of emergency department (ED) visits for patients aged 18-50 years with a diagnosis of low-risk syncope who were discharged",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "5133825",
+      "1718371"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACEP61",
+    "title": "Avoidance of Chest X-ray in pediatric patients with Asthma, Bronchiolitis or Croup",
+    "description": "Percentage of ED visits for pediatric patients with Asthma, Bronchiolitis or Croup for whom a Chest X-ray was ordered/performed.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "5133825",
+      "1718371",
+      "4757099"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACEP62",
+    "title": "Avoidance of Opioid therapy for dental pain.",
+    "description": "All acute encounters for patients aged 18 years and older with, diagnosis of dental pain, who were not prescribed Opioids or Opiates",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "5133825"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACMS10",
+    "title": "Photographic and/or Anatomic Map Documentation to Prevent Wrong-Site Surgery",
+    "description": "Percentage of cases of Mohs Micrographic Surgery undertaken where a photograph and/or anatomic drawing of the biopsy site location is utilized to identify the operative site and documented in the chart",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MohsAIQ",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "6859936"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACMS3",
+    "title": "Antibiotic Prophylaxis for High Risk Cardiac / Orthopedic Cases prior to Mohs micrographic surgery - Prevention of Overuse",
+    "description": "Percentage of cases of Mohs surgery in which preoperative prophylactic antibiotics were provided for which the patient had cardiac / orthopedic prophylaxis indications for preoperative antibiotics.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MohsAIQ",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "6859936"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACMS4",
+    "title": "Surgical Site Infection Rate - Mohs Micrographic Surgery",
+    "description": "Percentage of cases of Mohs surgery that develop a surgical site infection. This measure is to be reported each time a procedure for a Mohs surgery is performed whether or not a surgical site infection develops during the performance period.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "MohsAIQ",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "6859936"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACMS5",
+    "title": "Documentation of High-Risk Squamous Cell Carcinoma Stage in Mohs Micrographic Surgery Record",
+    "description": "Percentage of Mohs surgery cases for high risk cutaneous squamous cell carcinoma (SCC) of the head and neck for which America Joint Committee on Cancer (AJCC) 8th edition staging1 was documented in the medical record. For these purposes high-risk is defined as a tumor stage greater than T2.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MohsAIQ",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "6859936"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACMS8",
+    "title": "Limit quantity of opioids prescribed for pain management in patients following Mohs micrographic surgery",
+    "description": "Percentage of patients prescribed opioids for pain management following Mohs surgery who received ten or fewer pills.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MohsAIQ",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "6859936"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACMS9",
+    "title": "Post-Operative Management of Field Cancerization after Mohs Micrographic Surgery",
+    "description": "Percentage of patients found to have field cancerization on Mohs sections whose referring physician receives notification and recommendations for considering field therapy post wound healing",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MohsAIQ",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "6859936"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACQR12",
+    "title": "ABCDEF Bundle - Early mobility for ICU patients",
+    "description": "Patients admitted to the intensive care unit (ICU) for > or = 4 days should be included in an early mobility program (E of ABCDEF Bundle) to improve their recovery process.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Acute Care Quality Registry",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "4672586",
+      "4757099"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACQR13",
+    "title": "Sepsis: Hour One bundle",
+    "description": "Surviving Sepsis Campaign's Hour One bundle initiation in patients with Sepsis and acute organ dysfunction",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Acute Care Quality Registry",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "4672586",
+      "4757099"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACQR16",
+    "title": "COPD Exacerbation or CHF Exacerbation requiring Hospital Admission: Palliative Care Evaluation",
+    "description": "Patients admitted with 2 or more COPD exacerbations in 12 months or a single admission for COPD with hypercapnic respiratory failure, or being discharged to a SNF or LTACH should receive an evaluation from a palliative care professional, if available; and patients admitted with AHA Class D heart failure and/or patients admitted with Congestive Heart Failure (any class) being discharged to a SNF or LTACH should receive an evaluation from a palliative care professional, if available",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "efficiency",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Acute Care Quality Registry",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "4672586",
+      "4757099"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACQR3",
+    "title": "COPD: Steroids for no more than 5 days in COPD Exacerbation",
+    "description": "Patients should receive no more than 5 days of steroids in treatment for COPD Exacerbation from all sources and routes. Sources may include outpatient, Emergency Department, and Inpatient/Observation treatment. i.e. Full course of steroids not to exceed 7 days.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "efficiency",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Acute Care Quality Registry",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "4672586"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACR10",
+    "title": "Hepatitis B Safety Screening",
+    "description": "If a patient is newly initiating biologic OR new synthetic DMARD therapy (e.g. methotrexate, leflunomide, etc.), then the medical record should indicate appropriate screening for hepatitis B in the preceding 12 month period.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "RISE (Rheumatology Informatics System for Effectiveness)",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "5598408"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACR12",
+    "title": "Disease Activity Measurement for Patients with PsA",
+    "description": "If a patient has psoriatic arthritis, then disease activity using a standardized measurement tool should be assessed at >=50% of encounters for PsA.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "RISE (Rheumatology Informatics System for Effectiveness)",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "5598408"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACR14",
+    "title": "Gout: Serum Urate Target",
+    "description": "The percentage of patients aged 18 and older with at least one clinician encounter (including telehealth) during the measurement period and a diagnosis of gout treated with urate-lowering therapy (ULT) for at least 12 months, whose most recent serum urate result is less than 6.0 mg/dL.",
+    "nqfId": "2549e",
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "intermediateOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "RISE (Rheumatology Informatics System for Effectiveness)",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "5598408"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACR15",
+    "title": "Safe Hydroxychloroquine Dosing",
+    "description": "If a patient is using hydroxychloroquine, then the average daily dose should be less than or equal to 5 mg/kg",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "RISE (Rheumatology Informatics System for Effectiveness)",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5598408"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACR16",
+    "title": "Rheumatoid Arthritis Patients with Low Disease Activity or Remission",
+    "description": "The proportion of individuals with RA who have low disease activity or are in remission based on the last recorded disease activity score as assessed using an ACR-preferred tool in the measurement year.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "intermediateOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "RISE (Rheumatology Informatics System for Effectiveness)",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5598408"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACRAD15",
+    "title": "Report Turnaround Time: Radiography",
+    "description": "Mean radiography report turnaround time (RTAT). (Does not include mammography.)",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "American College of Radiology National Radiology Data Registry",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "5303416",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACRAD16",
+    "title": "Report Turnaround Time: Ultrasound (Excluding Breast US)",
+    "description": "Mean Ultrasound report turnaround time (RTAT)",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "American College of Radiology National Radiology Data Registry",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "5303416",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACRAD17",
+    "title": "Report Turnaround Time: MRI",
+    "description": "Mean MRI report turnaround time (RTAT)",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "American College of Radiology National Radiology Data Registry",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "5303416",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACRAD18",
+    "title": "Report Turnaround Time: CT",
+    "description": "Mean CT report turnaround time (RTAT)",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "American College of Radiology National Radiology Data Registry",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "5303416",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACRAD19",
+    "title": "Report Turnaround Time: PET",
+    "description": "Mean PET report turnaround time (RTAT)",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "American College of Radiology National Radiology Data Registry",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "5303416",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACRAD25",
+    "title": "Report Turnaround Time: Mammography",
+    "description": "Mean mammography report turnaround time (RTAT).",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "American College of Radiology National Radiology Data Registry",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "5303416",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACRAD34",
+    "title": "Multi-strata weighted average for 3 CT Exam Types: Overall Percent of CT exams for which Dose Length Product is at or below the size-specific diagnostic reference level (for CT Abdomen-pelvis with contrast/single phase scan, CT Chest without contrast/single phase scan and CT Head/Brain without contrast/single phase scan)",
+    "description": "Weighted average of 3 former QCDR measures, ACRad 31, ACRad 32, Acrid 33.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American College of Radiology National Radiology Data Registry",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "5303416",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "weightedAverage",
+    "strata": [
+      {
+        "name": "abdomen",
+        "description": "Percent of CT Abdomen-pelvis exams with contrast (single phase scan) for which Dose Length Product is at or below the size-specific diagnostic reference level"
+      },
+      {
+        "name": "chest",
+        "description": "Percent of CT Chest exams without contrast (single phase scan) for which Dose"
+      },
+      {
+        "name": "head",
+        "description": "Percent of CT Head/brain exams without contrast (single phase scan) for which Dose"
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACRAD36",
+    "title": "Incidental Coronary Artery Calcification Reported on Chest CT",
+    "description": "Percentage of final reports for male patients aged 18 years through 50 and female patients aged 18 through 65 years undergoing noncardiac noncontrast chest CT exams or with and without contrast chest CT exams that note presence or absence of coronary artery calcification or not evaluable",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American College of Radiology National Radiology Data Registry",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "5303416",
+      "6394618",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACRAD37",
+    "title": "Interpretation of CT Pulmonary Angiography (CTPA) for Pulmonary Embolism",
+    "description": "Percentage of final reports for patients aged 18 years and older undergoing CT pulmonary angiography (CTPA) with a finding of PE that specify the branching order level of the most proximal level of embolus (i.e. main, lobar, interlobar, segmental, sub segmental)",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American College of Radiology National Radiology Data Registry",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "5303416",
+      "6394618",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACRAD38",
+    "title": "Use of Low Dose Cranial CT or MRI Examinations for Patients with Ventricular Shunts",
+    "description": "Percentage of patients aged less than 18 years with a ventricular shunt undergoing cranial imaging exams to evaluate for ventricular shunt malfunction undergoing either low dose cranial CT exams or MRI",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American College of Radiology National Radiology Data Registry",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "5303416",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACRAD40",
+    "title": "Use of Structured Reporting in Prostate MRI",
+    "description": "Percentage of final reports for male patients aged 18 years and older undergoing prostate MRI for prostate cancer screening or surveillance that include reference to a validated scoring system such as Prostate Imaging Reporting and Data System (PI-RADS)",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American College of Radiology National Radiology Data Registry",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "5303416",
+      "6394618",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACRAD41",
+    "title": "Use of Quantitative Criteria for Oncologic FDG PET Imaging",
+    "description": "Percentage of final reports for all patients, regardless of age, undergoing non-CNS oncologic FDG PET studies that include at a minimum:\na. Serum glucose (e.g., finger stick at time of injection)\nb. Uptake time (interval from injection to initiation of imaging)\nc. One reference background (e.g., volumetric normal liver or mediastinal blood pool) SUV measurement, along with description of the SUV measurement type (e.g., SUVmax) and normalization method (e.g., BMI)\nd. At least one lesional SUV measurement OR diagnosis of \"no disease-specific abnormal uptake\"",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American College of Radiology National Radiology Data Registry",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "5303416",
+      "6394618",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ACRAD42",
+    "title": "Surveillance Imaging for Liver Nodules less than 10mm in Patients at Risk for Hepatocellular Carcinoma (HCC)",
+    "description": "Percentage of final ultrasound reports with findings of liver nodules less than 10 mm for patients aged 18 years and older with a diagnosis of hepatitis B or cirrhosis undergoing screening and/or surveillance imaging for hepatocellular carcinoma with a specific recommendation for follow-up ultrasound imaging in 3-6 months based on radiological findings",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American College of Radiology National Radiology Data Registry",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "5303416"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AQI18",
+    "title": "Coronary Artery Bypass Graft (CABG): Prolonged Intubation – Inverse Measure",
+    "description": "Percentage of patients aged 18 years and older undergoing isolated CABG surgery who require postoperative intubation greater than 24 hours",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "Anesthesia Quality Institute (AQI) National Anesthesia Clinical Outcomes Registry (NACOR)",
+    "firstPerformanceYear": 2016,
+    "allowedVendors": [
+      "5551268",
+      "6169123",
+      "6775913",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AQI48",
+    "title": "Patient-Reported Experience with Anesthesia",
+    "description": "Percentage of patients, aged 18 and older, who were surveyed on their patient experience and satisfaction with anesthesia care and who reported a positive experience. \n\nThis measure will consist of two performance rates:\n\nAQI48a: Percentage of patients, aged 18 and older, who were surveyed on their patient experience and satisfaction with anesthesia care \n\nAQI48b: Percentage of patients, aged 18 and older, who completed a survey on their patient experience and satisfaction with anesthesia care who report a positive experience with anesthesia care\n\nNOTE: The measure requires that a valid survey, as defined in the numerator of AQI48a, be sent to patients between discharge from the facility and within 30 days of facility discharge. To report AQI48b, a minimum number of 20 surveys with the mandatory question completed must be reported. ** In order to be scored on this measure, clinicians must report BOTH AQI48a AND AQI48b.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Anesthesia Quality Institute (AQI) National Anesthesia Clinical Outcomes Registry (NACOR)",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "5551268",
+      "6169123",
+      "6775913",
+      "6394618",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "surveyed",
+        "description": "The first performance rate, AQI48a, describes the percentage of surgical patients who receive a survey of their experience with anesthesia care."
+      },
+      {
+        "name": "overall",
+        "description": "The second performance rate, AQI48b, describes the percentage of surgical patients who report a positive experience with anesthesia care."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AQI49",
+    "title": "Adherence to Blood Conservation Guidelines for Cardiac Operations using Cardiopulmonary Bypass (CPB) – Composite",
+    "description": "Percentage of patients, aged 18 years and older, who undergo a cardiac operation using cardiopulmonary bypass for whom selected blood conservation strategies were used.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Anesthesia Quality Institute (AQI) National Anesthesia Clinical Outcomes Registry (NACOR)",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "5551268",
+      "6169123"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AQI56",
+    "title": "Use of Neuraxial Techniques and/or Peripheral Nerve Blocks for Total Knee Arthroplasty (TKA)",
+    "description": "Percentage of patients, regardless of age, that undergo primary total knee arthroplasty for whom neuraxial anesthesia and/or a peripheral nerve block is performed",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Anesthesia Quality Institute (AQI) National Anesthesia Clinical Outcomes Registry (NACOR)",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "5551268",
+      "6169123",
+      "6775913",
+      "6394618",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AQI57",
+    "title": "Safe Opioid Prescribing Practices",
+    "description": "Percentage of patients, aged 18 years and older, prescribed opioid medications for longer than six weeks’ duration for whom ALL of the following opioid prescribing best practices are followed:\n\n1. Chemical dependency screening (includes laboratory testing and/or questionnaire) within the immediate 6 months prior to the encounter\n2. Co-prescription of naloxone or documented discussion regarding offer of Naloxone co-prescription, if prescription is ?50 MME/day\n3. Non co-prescription of benzodiazepine medications by prescribing pain physician and documentation of a discussion with patient regarding risks of concomitant use of benzodiazepine and opioid medications.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Anesthesia Quality Institute (AQI) National Anesthesia Clinical Outcomes Registry (NACOR)",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "5551268",
+      "6169123",
+      "6775913",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AQI62",
+    "title": "Obstructive Sleep Apnea: Patient Education",
+    "description": "Percentage of patients aged 18 years or older, who undergo an elective procedure requiring anesthesia services who are screened for obstructive sleep apnea (OSA) AND, if positive, have documentation that they received education regarding their risk for obstructive sleep apnea (OSA) prior to PACU discharge",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Anesthesia Quality Institute (AQI) National Anesthesia Clinical Outcomes Registry (NACOR)",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "5551268",
+      "6169123",
+      "6775913",
+      "6394618"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AQI65",
+    "title": "Avoidance of Cerebral Hyperthermia for Procedures Involving Cardiopulmonary Bypass",
+    "description": "Percentage of patients, aged 18 years and older, undergoing a procedure using cardiopulmonary bypass who did not have a documented intraoperative pulmonary artery, oropharyngeal, or nasopharyngeal temperature ?37.0 degrees Celsius during the period of cardiopulmonary bypass",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Anesthesia Quality Institute (AQI) National Anesthesia Clinical Outcomes Registry (NACOR)",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "5551268",
+      "6169123",
+      "6775913",
+      "6394618",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AQI67",
+    "title": "Consultation for Frail Patients",
+    "description": "Percentage of patients aged 70 years or older, who undergo an inpatient procedure requiring anesthesia services and have a positive frailty screening result who receive a multidisciplinary consult or care during the hospital encounter",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Anesthesia Quality Institute (AQI) National Anesthesia Clinical Outcomes Registry (NACOR)",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "5551268",
+      "6169123",
+      "6775913"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AQI68",
+    "title": "Obstructive Sleep Apnea: Mitigation Strategies",
+    "description": "Percentage of patients aged 18 years or older, who undergo an elective procedure requiring anesthesia services who are screened for obstructive sleep apnea (OSA) AND, if positive, for whom two or more selected mitigation strategies was used prior to PACU discharge",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Anesthesia Quality Institute (AQI) National Anesthesia Clinical Outcomes Registry (NACOR)",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "5551268",
+      "6169123",
+      "6775913",
+      "6394618"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AQI69",
+    "title": "Intraoperative Antibiotic Redosing",
+    "description": "Percentage of patients, aged 18 years and older, who received preoperative antibiotic prophylaxis within 60 minutes prior to incision (if fluoroquinolone or vancomycin, two hours) and undergo a procedure greater than two hours duration who received intraoperative antibiotic redosing at a maximum interval of two half-lives of the selected prophylactic antibiotic.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Anesthesia Quality Institute (AQI) National Anesthesia Clinical Outcomes Registry (NACOR)",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5551268",
+      "6169123",
+      "6775913",
+      "4757099",
+      "6394618",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AQI71",
+    "title": "Ambulatory Glucose Management",
+    "description": "Percentage of diabetic patients, aged 18 years and older, who receive an office-based or ambulatory surgery whose blood glucose level is appropriately managed throughout the perioperative period.\n\nThe measure consists of four performance rates:\n\na.\tPercentage of patients, aged 18 years and older, with a current diagnosis of diabetes mellitus receiving anesthesia services for office-based or ambulatory surgery whose blood glucose level is tested prior to the start of anesthesia\n\nb.\tPercentage of patients, aged 18 years and older, with a current diagnosis of diabetes mellitus receiving anesthesia services for office-based or ambulatory surgery who experienced a blood glucose level greater than or equal to 180 mg/dL (10.0 mmol/L) who received insulin prior to anesthesia end time\n\nc.\tPercentage of patients, aged 18 years and older, with a current diagnosis of diabetes mellitus receiving anesthesia services for office-based or ambulatory surgery who received insulin perioperatively and who received a follow-up blood glucose level check following the administration of insulin and prior to discharge\n\nd.\tPercentage of patients, aged 18 years and older, with a current diagnosis of diabetes mellitus receiving anesthesia services for office-based or ambulatory surgery who experienced a blood glucose level greater than or equal to 180 mg/dL (10.0 mmol/L) who received education on managing their glucose in the postoperative period prior to discharge",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Anesthesia Quality Institute (AQI) National Anesthesia Clinical Outcomes Registry (NACOR)",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5551268",
+      "6169123",
+      "6775913",
+      "6394618"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "overall",
+        "description": "The overall measure score will be calculated as an average of the performance rates of parts A, B, C and D. (Rates 2, 3, 4 & 5)"
+      },
+      {
+        "name": "testedPrior",
+        "description": "Percentage of patients, aged 18 years and older, with a current diagnosis of diabetes mellitus receiving anesthesia services for office-based or ambulatory surgery whose blood glucose level is tested prior to the start of anesthesia"
+      },
+      {
+        "name": "insulinPrior",
+        "description": "Percentage of patients, aged 18 years and older, with a current diagnosis of diabetes mellitus receiving anesthesia services for office-based or ambulatory surgery who experienced a blood glucose level >180 mg/dL (10.0 mmol/L) who received insulin prior to anesthesia end time"
+      },
+      {
+        "name": "insulinPostoperative",
+        "description": "Percentage of patients, aged 18 years and older, with a current diagnosis of diabetes mellitus receiving anesthesia services for office-based or ambulatory surgery who received insulin perioperatively and who received a follow-up blood glucose level check following the administration of insulin and prior to discharge"
+      },
+      {
+        "name": "glucoseEducation",
+        "description": "Percentage of patients, aged 18 years and older, with a current diagnosis of diabetes mellitus receiving anesthesia services for office-based or ambulatory surgery who experienced a blood glucose level >180 mg/dL (10.0 mmol/L) who received education on managing their glucose in the postoperative period prior to discharge"
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AQI72",
+    "title": "Perioperative Anemia Management",
+    "description": "Percentage of patients, aged 18 years and older, undergoing elective total joint arthroplasty who were screened for anemia preoperatively AND, if positive, have documentation that one or more of the following management strategies were used prior to PACU discharge.\n\nManagement strategies include one or more of the following: \n•\tCell salvage techniques employed intraoperatively\n•\tIntraoperative antifibrinolytic therapy or tourniquet, if not contraindicated\n•\tPreoperative iron supplementation, epoetin alpha\n•\tUse of evidence-based preoperative anemia management algorithm supplemented with laboratory testing and/or multidisciplinary consult",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Anesthesia Quality Institute (AQI) National Anesthesia Clinical Outcomes Registry (NACOR)",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5551268",
+      "6169123",
+      "6775913",
+      "4757099",
+      "6394618"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AQI73",
+    "title": "Prevention of Arterial Line-Related Bloodstream Infections",
+    "description": "Percentage of patients, regardless of age, who undergo placement of a peripheral intra-arterial catheter for whom the arterial line was inserted with all indicated elements of sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound techniques followed.\n\nThis measure will consist of three performance rates: \n\na.\t Percentage of patients, regardless of age, who undergo placement of a peripheral intra-arterial line in the brachial, radial, posterior tibial or dorsalis pedis artery for whom the arterial line was inserted with all indicated elements of sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound techniques followed\n\nb.\t Percentage of patients, regardless of age, who undergo placement of a peripheral intra-arterial line in the femoral or axillary artery for whom the arterial line was inserted with all indicated elements of maximal sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound technique is followed\n\nNote: The overall measure score will be calculated as an average of the total cases of part A (rate 2) and part B (rate 3). The overall measure score is rate 1.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Anesthesia Quality Institute (AQI) National Anesthesia Clinical Outcomes Registry (NACOR)",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "5551268",
+      "6169123",
+      "6775913",
+      "4757099",
+      "6394618",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "overall",
+        "description": "The overall measure score will be calculated as an average of the performance rates of part A and part B. (Rates 2 & 3)"
+      },
+      {
+        "name": "brachialRadialTibial",
+        "description": "Percentage of patients, regardless of age, who undergo placement of a peripheral intra-arterial line in the brachial, radial, posterior tibial or dorsalis pedis artery for whom the arterial line was inserted with all indicated elements of sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound techniques followed"
+      },
+      {
+        "name": "femoralAxillary",
+        "description": "Percentage of patients, regardless of age, who undergo placement of a peripheral intra-arterial line in the femoral or axillary artery for whom the arterial line was inserted with all indicated elements of maximal sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound technique is followed"
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AQUA14",
+    "title": "Stones: Repeat Shock Wave Lithotripsy (SWL) Within 6 Months of Initial Treatment",
+    "description": "Percentage of patients who underwent repeat Shock Wave Lithotripsy within 6 months of initial procedure",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Urological Association Quality (AQUA) Registry",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "8758330"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AQUA15",
+    "title": "Stones: Urinalysis Performed Before Surgical Stone Procedures",
+    "description": "Percentage of patients with a documented urinalysis 30 days before surgical stone procedures",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Urological Association Quality (AQUA) Registry",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "8758330"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AQUA16",
+    "title": "Non-Muscle Invasive Bladder Cancer: Repeat Transurethral Resection of Bladder Tumor (TURBT) for T1 disease",
+    "description": "Percentage of patients with T1 disease who had a second transurethral resection of bladder tumor (TURBT) within 6 weeks of the initial TURBT",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Urological Association Quality (AQUA) Registry",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "8758330"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AQUA18",
+    "title": "Non-Muscle Invasive Bladder Cancer: Early Surveillance Cystoscopy for Non-Muscle Invasive Bladder Cancer",
+    "description": "Percentage of patients who had surveillance cystoscopy 12 to 16 weeks after undergoing initial Transurethral Resection for Bladder Tumor (TURBT)",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Urological Association Quality (AQUA) Registry",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "8758330"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AQUA26",
+    "title": "Benign Prostate Hyperplasia (BPH): Inappropriate Lab & Imaging Services for Patients with BPH",
+    "description": "Percentage of patients with initial diagnosis of BPH who had a creatinine lab order placed or had a CT abdomen, MRI abdomen, ultrasound abdomen ordered or performed",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Urological Association Quality (AQUA) Registry",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "8758330"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "AQUA8",
+    "title": "Hospital admissions or infectious complications within 30 days of TRUS Biopsy",
+    "description": "Percentage of patients with infection, inpatient consultation, or hospital admission for infection or sepsis within 30 days of undergoing a TRUS biopsy",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Urological Association Quality (AQUA) Registry",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "8758330"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ASPS22",
+    "title": "Coordination of Care for Anticoagulated Patients Undergoing Reconstruction After Skin Cancer Resection",
+    "description": "Percentage of patients aged 18 and older on prescribed anticoagulation medication who underwent reconstruction after skin cancer resection (in any setting) and preoperative modification* to their anticoagulant(s) regimen, who had documentation of coordinated care** prior to their procedure.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ASPS TOPS-QCDR",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "6621356",
+      "6859936"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ASPS24",
+    "title": "Visits to the ER or Urgent Care Following Reconstruction After Skin Cancer Resection",
+    "description": "Part 1: Percentage of patients aged 18 and older who underwent reconstruction after skin cancer resection who were asked* within 30 days of their procedure whether they visited the ER or Urgent Care within 7 days of their procedure, for a reason related to the reconstruction after skin cancer resection surgery.\n\nPart 2: Percentage of patients, aged 18 and older who underwent reconstruction after skin cancer resection and were asked within 30 days of the procedure about visiting the ER, who visited the ER or Urgent Care within 7 days of their procedure for a reason related to the reconstruction after skin cancer resection surgery. (only Part 2 is intended to be reported for accountability, but Part 1 must be completed)",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "ASPS TOPS-QCDR",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "6621356",
+      "6859936"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ASPS26",
+    "title": "Patient Satisfaction with Information Prior to Facial Reconstruction After Skin Cancer Resection Procedures",
+    "description": "Percentage of patients aged 18 and older who underwent facial reconstruction after skin cancer resection who responded to the (6 question) Face-Q Satisfaction with Information: Appearance Module within 60 days of the procedure and scored 15 (52%) or higher or if scored lower than 15 (52%) there is documentation of a provider call to the patient or follow-up visit within 30 days of completion of the tool",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ASPS TOPS-QCDR",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "6621356"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ASPS27",
+    "title": "Avoidance of Post-operative Systemic Antibiotics for Office-based Closures and Reconstruction After Skin Cancer Procedures",
+    "description": "Percentage of procedures in patients aged 18 and older with a diagnosis of skin cancer who underwent intermediate layer or complex linear closure or reconstruction after skin cancer resection in the office-based* setting who were prescribed post-operative systemic antibiotics to be taken immediately following reconstruction surgery (inverse measure)\n\nThis measure is stratified by intermediate layer or complex linear closure or reconstructive procedures.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "AAD’s DataDerm™; ASPS TOPS-QCDR; MohsAIQ",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "4649789",
+      "6621356",
+      "6859936"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "resection",
+        "description": "Strata 1: Intermediate layer or complex linear closures after skin cancer resection"
+      },
+      {
+        "name": "reconstruction",
+        "description": "Strata 2: Reconstruction after skin cancer resection"
+      },
+      {
+        "name": "overall",
+        "description": "Strata 3: FOR REPORTING"
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ASPS28",
+    "title": "Continuation of Anticoagulation Therapy in the Office-based Setting for Closure and Reconstruction After Skin Cancer Resection Procedures",
+    "description": "Percentage of procedures in patients, aged 18 and older with a diagnosis of skin cancer, on prescribed anticoagulation therapy, who had intermediate layer and/or complex linear closures OR reconstruction after skin cancer resection performed in the office-based setting where anticoagulant therapy was continued prior to surgery.\n\nThis measure is stratified by intermediate layer or complex linear closures AND reconstructive procedures.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "AAD’s DataDerm™; ASPS TOPS-QCDR; MohsAIQ",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "4649789",
+      "6621356",
+      "6859936"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "resection",
+        "description": "Strata 1: Intermediate layer or complex linear closures after skin cancer resection"
+      },
+      {
+        "name": "reconstruction",
+        "description": "Strata 2: Reconstruction after skin cancer resection"
+      },
+      {
+        "name": "overall",
+        "description": "Strata 3: FOR REPORTING"
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ASPS29",
+    "title": "Avoidance of Opioid Prescriptions for Closure and Reconstruction After Skin Cancer Resection",
+    "description": "Percentage of procedures in patients, aged 18 and older with a diagnosis of skin cancer, who had intermediate layer and/or complex linear closures OR reconstruction after skin cancer resection where opioid/narcotic therapy* was prescribed as first line therapy (as defined by a prescription in anticipation of or at time of surgery) for post-operative pain management by the reconstructing surgeon. (Inverse measure)",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "AAD’s DataDerm™; ASPS TOPS-QCDR; MohsAIQ",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "4649789",
+      "6621356",
+      "6859936"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "resection",
+        "description": "Strata 1: Intermediate layer or complex linear closures after skin cancer resection"
+      },
+      {
+        "name": "reconstruction",
+        "description": "Strata 2: Reconstruction after skin cancer resection"
+      },
+      {
+        "name": "overall",
+        "description": "Strata 3: FOR REPORTING"
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "CAP22",
+    "title": "Turnaround Time (TAT) - Biopsies",
+    "description": "Percentage of final pathology reports for biopsies that meet the maximum 2 business day turnaround time (TAT) requirement (Report Date – Accession Date is less than or equal to 2 business days).\nINSTRUCTIONS: This measure is to be reported each time a biopsy is performed during the performance period. It is anticipated that eligible clinicians providing the pathology services for procedures will submit this measure.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Pathologists Quality Registry",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "5688621"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "CAP28",
+    "title": "Helicobacter pylori Status and Turnaround Time",
+    "description": "Percentage of stomach biopsy cases with gastritis that address the presence or absence of Helicobacter pylori \nAND\nmeet the maximum 2 business day turnaround time (TAT) requirement (Report Date – Accession Date is less than or equal to 2 business days).\nINSTRUCTIONS: This measure has two performance rates that contribute to the overall performance score:\n1. Percent of cases in which presence or absence of Helicobacter pylori is addressed.\n2. Percent of cases that meet the maximum 2 business day turnaround time.\nThe overall performance score submitted is an average of: (Numerator 1 + Numerator 2)/(Denominator 1 + Denominator 2).",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Pathologists Quality Registry",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "5688621"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "CAP30",
+    "title": "Urinary Bladder Biopsy Diagnostic Requirements For Appropriate Patient Management",
+    "description": "Percentage of urinary bladder carcinoma pathology reports that include the procedure, histologic tumor grade, histologic type, muscularis propria presence, presence/absence of lymphovascular invasion and tumor extent. \nAND \nmeet the maximum 2 business day turnaround time (TAT) requirement (Report Date – Accession Date is less than or equal to 2 business days). \n\nINSTRUCTIONS: This measure has two performance rates that contribute to the overall performance score:\n1.\tPercent of cases for which all required data elements of the urinary bladder carcinoma pathology report are included.\n2.\tPercent of cases that meet the maximum 2 business day turnaround time.\nThe overall performance score submitted is a weighted average of: \n(Performance rate 1 x 70%)+(Performance rate 2 x 30%)",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Pathologists Quality Registry",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "5688621"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "CAP33",
+    "title": "Mismatch Repair (MMR) or Microsatellite Instability (MSI) Biomarker Testing Status in Colorectal Carcinoma, Endometrial, Gastroesophageal, or Small Bowel Carcinoma",
+    "description": "Percentage of surgical pathology reports for primary colorectal, endometrial, gastroesophageal or small bowel carcinoma, biopsy or resection, that contain impression or conclusion of or recommendation for testing of mismatch repair (MMR) by immunohistochemistry (biomarkers MLH1, MSH2, MSH6, and PMS2), or microsatellite instability (MSI) by DNA-based testing status, or both",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Pathologists Quality Registry",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5688621"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "CAP34",
+    "title": "Biomarker Status to Inform Clinical Management and Treatment Decisions in Patients with Non-small Cell Lung Cancer",
+    "description": "Percentage of non-small cell lung cancer (NSCLC) surgical pathology reports that include anaplastic lymphoma kinase (ALK), epidermal growth factor receptor (EGFR), AND tyrosine protein kinase ROS1 mutation status.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Pathologists Quality Registry",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5688621"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "CAP35",
+    "title": "Cancer Protocol and Turnaround Time for Gastrointestinal Carcinomas: Gastric, Esophageal, Colorectal and Hepatocellular Carcinomas",
+    "description": "Percentage of all eligible pathology reports for gastric, esophageal, colorectal, and hepatocellular carcinoma specimens for which all required data elements of the gastrointestinal Cancer Protocols are recorded \nAND \nmeet the maximum 4 business day turnaround time (TAT) requirement (Report Date – Accession Date is less than or equal to 4 business days). \n\nINSTRUCTIONS: This measure has two performance rates that contribute to the overall performance score:\n1.\tPercent of cases for which required data elements for all cancer protocols are recorded.\n2.\tPercent of cases that meet the maximum 4 business day turnaround time.\nThe overall performance score submitted is a weighted average of: \n(Performance rate 1 x 70%)+(Performance rate 2 x 30%)",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Pathologists Quality Registry",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5688621"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "CAP36",
+    "title": "p16 Immunohistochemistry Reporting for Human Papillomavirus in Patients with Oropharyngeal Squamous Cell Carcinoma (OPSCC)",
+    "description": "Percentage of surgical pathology reports for invasive oropharyngeal squamous cell carcinoma (OPSCC) with quantitative p16 immunohistochemistry (IHC) using a greater than or equal to 70% nuclear and cytoplasmic staining cutoff performed as a surrogate for HR-HPV status",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Pathologists Quality Registry",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5688621"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "CAP37",
+    "title": "Cancer Protocol and Turnaround Time for Gynecologic and Genitourinary Carcinomas: Carcinoma of the Endometrium, Prostate, and Renal Tubular Origin",
+    "description": "Percentage of all eligible pathology reports for specimens of carcinoma of the endometrium, prostate and renal tubular origin in which the required data elements of the gynecologic and genitourinary Cancer Protocols are recorded \nAND \nmeet the maximum 4 business day turnaround time (TAT) requirement (Report Date – Accession Date is less than or equal to 4 business days). \n \nINSTRUCTIONS: This measure has two performance rates that contribute to the overall performance score:\n1.\tPercent of cases for which specified data elements for all cancer protocols are recorded.\n2.\tPercent of cases that meet the maximum 4 business day turnaround time.\nThe overall performance score submitted is a weighted average of: \n(Performance rate 1 x 70%)+(Performance rate 2 x 30%)",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Pathologists Quality Registry",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5688621"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "CAP38",
+    "title": "Prostate Cancer Reporting Best Practices",
+    "description": "Percentage of surgical pathology reports for biopsies or radical resections (radical prostatectomy) of primary prostate cancer that include total Gleason score, grade group classification, and Gleason patterns including percent of pattern 4 for specimens in grade group 2 or 3.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Pathologists Quality Registry",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "5688621"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "CCOME4",
+    "title": "Patient-Reported Pain and/or Function Improvement after ACLR Surgery",
+    "description": "Percentage of patients 13 years of age and older who obtained at least a 10% improvement in knee pain and/or function as measured by validated patient-reported outcome measures (PROMs) completed up to 90 days prior to and 9 to 15 months after undergoing primary anterior cruciate ligament reconstruction (ALCR) surgery. PROMs include any validated measures of knee-related measures of pain and/or function, such as KOOS-Pain, KOOS-ADL, KOOS-PS, and KOOS-JR.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Hawkins Foundation in Collaboration with Sharecare",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "1157686"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "CCOME6",
+    "title": "Patient-Reported Pain and/or Function Improvement after APM Surgery",
+    "description": "Percentage of patients 13 years of age and older who obtained at least a 10% improvement in knee pain and/or function as measured by validated patient-reported outcome measures (PROMs) completed up to 90 days prior to and 9 to 15 months after undergoing primary arthroscopic partial meniscectomy (APM) surgery. PROMs include any validated measures of knee-related measures of pain and/or function, such as KOOS-Pain, KOOS-ADL, KOOS-PS, and KOOS-JR.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Hawkins Foundation in Collaboration with Sharecare",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "1157686"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "CCOME7",
+    "title": "Patient-Reported Pain and/or Function Improvement after Total Hip Arthroplasty",
+    "description": "Percentage of patients 18 years of age and older who obtained an improvement of at least 1 minimal clinically important difference (MCID) in hip pain and/or function as measured by validated patient-reported outcome measures (PROMs) completed up to 90 days prior to and 9 to 15 months after undergoing primary total hip arthroplasty (THA) surgery. PROMs include any validated measures of hip-related pain and/or function with MCID thresholds supported by literature, including HOOS-Pain (24 points), HOOS-PS (23 points), and HOOS-JR (18 points).",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Hawkins Foundation in Collaboration with Sharecare",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "1157686",
+      "6394618"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "CCOME8",
+    "title": "Patient-Reported Pain and/or Function Improvement after Total Shoulder Arthroplasty",
+    "description": "Percentage of patients 18 years of age and older who obtained an improvement of at least 1 minimal clinically important difference (MCIDO) in shoulder pain and/or function as measured by validated patient-reported outcome measures (PROMs) completed up to 90 days prior to and 9 to 15 months after undergoing primary total shoulder arthroplasty (TSA) surgery. PROMs include any validated measures of shoulder-related pain and/or function with MCID thresholds supported by literature, including PSS (11.4 points) and ASES (13.6 points).",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Hawkins Foundation in Collaboration with Sharecare",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "1157686"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "CDR2",
+    "title": "Diabetic Foot Ulcer (DFU) Healing or Closure",
+    "description": "Percentage of diabetic foot ulcers among patients aged 18 or older that have achieved healing or closure within 6 months, stratified by the Wound Healing Index. Healing or closure is defined as complete epithelialization without drainage or the need for a dressing over the closed ulceration, although off-loading would still be required.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "U.S. Wound Registry",
+    "firstPerformanceYear": 2014,
+    "allowedVendors": [
+      "6853338"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "bucket1",
+        "description": "0.00 – 62.42"
+      },
+      {
+        "name": "bucket2",
+        "description": "62.42 – 73.19"
+      },
+      {
+        "name": "bucket3",
+        "description": "73.19 – 100"
+      },
+      {
+        "name": "overall",
+        "description": "The average of the three risk stratified buckets which will be the performance rate in the XML submitted."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "CDR6",
+    "title": "Venous Leg Ulcer (VLU) Healing or Closure",
+    "description": "Percentage of venous leg ulcers among patients aged 18 or older that have achieved healing or closure within 12 months, stratified by the Wound Healing Index. Healing or closure is defined as complete epithelialization without drainage or the need for a dressing over the closed ulceration, although venous compression would still be required.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "U.S. Wound Registry",
+    "firstPerformanceYear": 2014,
+    "allowedVendors": [
+      "6853338"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "bucket1",
+        "description": "VLUs likely to heal with conservative care,"
+      },
+      {
+        "name": "bucket2",
+        "description": "VLUs which might or might not heal, and"
+      },
+      {
+        "name": "bucket3",
+        "description": "VLUs highly unlikely to heal with conservative care."
+      },
+      {
+        "name": "overall",
+        "description": "The average of the three risk stratified buckets which will be the performance rate in the JSON XML submitted."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "CDR8",
+    "title": "Appropriate Use of hyperbaric oxygen therapy for patients with diabetic foot ulcers",
+    "description": "Percentage of patient with a diagnosis of a diabetic foot ulcer graded stage 3 or higher on the Wagner Grading System for Diabetic Foot Ulcers that received hyperbaric oxygen therapy (HBOT) appropriately, based on Medicare coverage criteria.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "U.S. Wound Registry",
+    "firstPerformanceYear": 2014,
+    "allowedVendors": [
+      "6853338"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "CESQIP1",
+    "title": "Post operative hypocalcemia after thyroidectomy surgery",
+    "description": "The number or percent of patients with low calcium levels or negligible parathyroid hormone values reported at 30 days or more post op",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": true,
+    "primarySteward": "Collaborative Endocrine Surgery Quality Improvement Program (CESQIP) of the Endocrine Quality Foundation, powered by ArborMetrix",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "9978062"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "CESQIP5",
+    "title": "Related readmission for adrenal related problems",
+    "description": "Track all surgery related readmissions within 30 days after index surgery where reason for readmission is any of: \n 1. Hematoma \n 2. Adrenal Insufficiency \n 3. Hypertension \n 4. Pain \n 5. Wound Infection \n 6. Pneumonia \n 7. Dehydration \n 8. Respiratory Distress",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": true,
+    "primarySteward": "Collaborative Endocrine Surgery Quality Improvement Program (CESQIP) of the Endocrine Quality Foundation, powered by ArborMetrix",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "9978062"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "CESQIP9",
+    "title": "qPTH >50% Reduction at End of Procedure",
+    "description": "The percentage of patients where intra-operative PTH decreased by at least 50% from baseline",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Collaborative Endocrine Surgery Quality Improvement Program (CESQIP) of the Endocrine Quality Foundation, powered by ArborMetrix",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "9978062"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ECPR39",
+    "title": "Avoid Head CT for Patients with Uncomplicated Syncope",
+    "description": "Percentage of Adult Syncope Patients Who Did Not Receive a Head CT Scan Ordered by the Provider",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "E-CPR (Emergency - Clinical Performance Registry)",
+    "firstPerformanceYear": 2016,
+    "allowedVendors": [
+      "5133825",
+      "1718371",
+      "4757099",
+      "1725296"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ECPR41",
+    "title": "Rh Status Evaluation and Treatment of Pregnant Women at Risk of Fetal Blood Exposure",
+    "description": "Percentage of Women Aged 14-50 Years at Risk of Fetal Blood Exposure Who Had Their Rh Status Evaluated in the Emergency Department (ED) and Received Rh-Immunoglobulin (Rhogam) if Rh-negative",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "E-CPR (Emergency - Clinical Performance Registry)",
+    "firstPerformanceYear": 2016,
+    "allowedVendors": [
+      "5133825",
+      "1718371",
+      "4757099"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ECPR46",
+    "title": "Avoidance of Opiates for Low Back Pain or Migraines",
+    "description": "Percentage of Patients with Low Back Pain and/or Migraines Who Were Not Prescribed an Opiate",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "E-CPR (Emergency - Clinical Performance Registry)",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "5133825",
+      "1718371",
+      "4757099",
+      "1725296"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ECPR50",
+    "title": "Door to Diagnostic Evaluation by a Provider Within 30 Minutes – Urgent Care Patients",
+    "description": "Percentage of Urgent Care Patients Who Made Provider Contact Within 30 Minutes of Urgent Care Clinic (UCC) Arrival",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "E-CPR (Emergency - Clinical Performance Registry)",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "5133825",
+      "1718371"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ECPR51",
+    "title": "Discharge Prescription of Naloxone after Opioid Poisoning or Overdose",
+    "description": "Percentage of Opioid Poisoning or Overdose Patients Presenting to An Acute Care Facility Who Were Prescribed Naloxone at Discharge",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "E-CPR (Emergency - Clinical Performance Registry)",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "5133825",
+      "1718371",
+      "4757099",
+      "8483899",
+      "1725296"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ECPR52",
+    "title": "Appropriate Treatment of Psychosis and Agitation in the Emergency Department",
+    "description": "Percentage of Adult Patients With Psychosis or Agitation Who Were Ordered an Oral Antipsychotic Medication in the Emergency Department",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "E-CPR (Emergency - Clinical Performance Registry)",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "5133825",
+      "1718371",
+      "4757099",
+      "1725296"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ECPR55",
+    "title": "Avoidance of Long-Acting (LA) or Extended-Release (ER) Opiate Prescriptions and Opiate Prescriptions for Greater Than 3 Days Duration for Acute Pain",
+    "description": "Percentage of Adult Patients Who Were Prescribed an Opiate Who Were Not Prescribed a Long-Acting (LA) or Extended-Release (ER) Formulation and for Whom the Prescription Duration Was Not Greater than 3 days for Acute Pain",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "E-CPR (Emergency - Clinical Performance Registry)",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "5133825",
+      "1718371",
+      "4757099"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ECPR56",
+    "title": "Opioid Withdrawal: Initiation of Medication-Assisted Treatment (MAT) and Referral to Outpatient Opioid Treatment",
+    "description": "Percentage of Patients Presenting with Opioid Withdrawal Who Were Given Medication-Assisted Treatment and Referred to Outpatient Opioid Treatment",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "E-CPR (Emergency - Clinical Performance Registry)",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "1718371",
+      "4757099",
+      "8483899",
+      "1725296"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "ECPR57",
+    "title": "Clinician Reporting of Loss of Consciousness to State Department of Public Health or Department of Motor Vehicles",
+    "description": "Percentage of Patients At Risk for Recurrent Loss of Consciousness For Whom Loss of Consciousness Information Was Submitted to Department of Public Health or Department of Motor Vehicles",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "E-CPR (Emergency - Clinical Performance Registry)",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "5133825",
+      "1718371",
+      "4757099"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "EPREOP30",
+    "title": "Ultrasound Guidance for Peripheral Nerve Block with Patient Experience",
+    "description": "Percentage of patients, aged 18 years and older, who undergo upper or lower extremity peripheral nerve blockade and for whom ultrasound guidance is used and documented in the medical record and the patient is sent a survey within 30 days and the survey indicates experience with nerve block.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Anesthesia Quality Registry (AQR QCDR)",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "6775913",
+      "6394618"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "EPREOP31",
+    "title": "Intraoperative Hypotension among Non-Emergent Noncardiac Surgical Cases",
+    "description": "Percentage of general anesthesia cases in which mean arterial pressure (MAP) fell below 65 mmHg for cumulative total of 15 minutes or more",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "intermediateOutcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": true,
+    "primarySteward": "Anesthesia Quality Registry (AQR QCDR)",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "6169123",
+      "6775913",
+      "6394618"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "nonProportion",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "FOTO4",
+    "title": "Functional Status Changes for Patients with Upper or Lower Quadrant Edema",
+    "description": "This is a patient-reported outcome performance measure (PRO-PM) consisting of a patient-reported outcome measure (PROM) of risk-adjusted change in functional status (FS) for patients aged 14 years+ with lymphedema or other causes of edema. For patients with such conditions affecting the leg, foot, groin, or lower trunk regions, the change in FS is assessed using the FOTO Lower Quadrant Edema (LQE) FS PROM. For patients with such conditions affecting the arm, hand, chest, or breast body regions, the change in FS is assessed using the FOTO Upper Quadrant Edema (UQE) FS PROM. PROM scores were scaled to the 0-100 metric, with higher scores representing higher perceived functional status. In order to fairly measure performance between providers, the measure is risk-adjusted to patient characteristics known to be associated with FS outcomes and used as a performance measure (PM) at the patient and provider levels to assess quality.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "FOTO QCDR",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "8311170"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "FOTO5",
+    "title": "Functional Status Change in Balance Confidence",
+    "description": "This is a patient-reported outcome performance measure (PRO-PM) consisting of a patient-reported outcome measure (PROM) of risk-adjusted functional status (FS) change in balance confidence for patients aged 14+ with balance impairment. The change in FS is assessed using an item-response theory-based metric derived from the 16-item Activities-specific Balance Confidence (ABC) Scale, scored using the T-score metric (mean=50, SD=10), with higher scores representing higher balance confidence. In order to fairly measure performance between providers, the measure is risk-adjusted to patient characteristics known to be associated with FS outcomes and used as a performance measure (PM) at the patient and provider levels to assess quality.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "FOTO QCDR",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "8311170"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "FOTO6",
+    "title": "Functional Status Change in Dizziness Impact",
+    "description": "This is a patient-reported outcome performance measure (PRO-PM) consisting of a patient-reported outcome measure (PROM) of risk-adjusted functional status (FS) change in dizziness impact from intake to discharge, for patients aged 14 years and older with vestibular impairments. The change in FS is assessed using the FOTO Dizziness Impact Positional (DIP) or Functional (DIF) PROM; these are item-response theory-based measures developed using items from the Dizziness Handicap Inventory, scored using the T-score metric (mean=50, SD=10), with higher scores representing higher dizziness impact (worse functional status). Modern measurement methods, using IRT, did not support use of one overall score for all 25 items from the Dizziness Handicap Inventory (DHI) due to not meeting the assumption of unidimensionality, which is an important psychometric limitation. IRT testing supported a positional domain as a separate and distinct construct for positional impacts of dizziness pertaining to changes in head position such as turning over in bed, looking up, or quick movements of the head whereas functional activities loaded on a separate domain. The DIP will be administered for patients with a DIP T-score of 45 or higher whereas the DIF will be administered for patients with a DIP T-score of less than 45 at initial evaluation. In order to fairly measure performance between providers, the measure is risk-adjusted to patient characteristics known to be associated with FS outcomes and used as a performance measure (PM) at the patient level and provider levels to assess quality.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "FOTO QCDR",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "8311170"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "FOTO7",
+    "title": "Functional Status Change for Patients Post Stroke",
+    "description": "This is a patient-reported outcome performance measure (PRO-PM) consisting of a patient-reported outcome measure (PROM) of risk-adjusted change in functional status (FS) for patients aged 14 years and older who have experienced a stroke with sequelae impacting physical functional abilities. For patients with such conditions affecting use of the hand, arm, and upper trunk, the change in FS is assessed using the FOTO Stroke Upper Extremity (SUE) FS PROM. For patients with such conditions affecting the foot, leg, and lower trunk, the change in FS is assessed using the FOTO Stroke Lower Extremity (SLE) FS PROM. PROM cores were scaled to the 0-100 metric, with higher scores representing higher perceived functional status. In order to fairly measure performance between providers, the measure is risk-adjusted to patient characteristics known to be associated with FS outcomes and used as a performance measure (PM) at the patient and provider levels to assess quality.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "FOTO QCDR",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "8311170"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "GIQIC10",
+    "title": "Appropriate management of anticoagulation in the peri-procedural period rate – EGD",
+    "description": "Percentage of patients undergoing an EGD on an anti-platelet agent or an anticoagulant who leave the endoscopy unit with instructions for management of this medication",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "GIQuIC",
+    "firstPerformanceYear": 2014,
+    "allowedVendors": [
+      "5846856"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "GIQIC23",
+    "title": "Appropriate follow-up interval based on pathology findings in screening colonoscopy",
+    "description": "Percentage of procedures among average-risk patients aged 50 to 75 years receiving a screening colonoscopy with biopsy or polypectomy and pathology findings who had a follow-up interval consistent with US Multi-Society Task Force (USMSTF) recommendations for repeat colonoscopy documented in their colonoscopy report",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "GIQuIC",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5846856",
+      "6981170"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "overall",
+        "description": "Overall percentage of procedures among average-risk patients aged 50 to 75 years receiving a screening colonoscopy with biopsy or polypectomy and pathology findings who had a follow-up interval consistent with US Multi-Society Task Force (USMSTF) recommendations for repeat colonoscopy documented in their colonoscopy report"
+      },
+      {
+        "name": "hyperPolyps&FollowUp",
+        "description": "Percentage of complete and adequately prepped screening colonoscopies of average-risk patients aged 50 to 75 years with biopsy or polypectomy and pathology findings of only hyperplastic polyps for which a recommended follow-up interval of 10 years for repeat colonoscopy was given to the patient"
+      },
+      {
+        "name": "1-2adenoma&FollowUp",
+        "description": "Percentage of complete and adequately prepped screening colonoscopies of average-risk patients aged 50 to 75 years with biopsy or polypectomy and pathology findings of 1-2 tubular adenoma(s) for which a recommended follow-up interval of not less than 7 years and not greater than 10 years was given to the patient"
+      },
+      {
+        "name": "3-4adenomas&FollowUp",
+        "description": "Percentage of complete and adequately prepped screening colonoscopies of average-risk patients aged 50 to 75 years with biopsy or polypectomy and pathology findings of 3-4 tubular adenomas for which a recommended follow-up interval of not less than 3 years and not greater than 5 years was given to the patient"
+      },
+      {
+        "name": "5-10adenoma&FollowUp",
+        "description": "Percentage of complete and adequately prepped screening colonoscopies of average-risk patients aged 50 to 75 years with biopsy or polypectomy and pathology findings of 5-10 tubular adenomas for which a recommended follow-up interval of 3 years was given to the patient"
+      },
+      {
+        "name": "neoplasm&FollowUp",
+        "description": "Percentage of complete and adequately prepped screening colonoscopies of average-risk patients aged 50 to 75 years with biopsy or polypectomy and pathology findings of Advanced Neoplasm (>= 10 mm, high grade dysplasia, villous component) for which a recommended follow-up interval of 3 years for repeat colonoscopy was given to the patient"
+      },
+      {
+        "name": "serration&FollowUp",
+        "description": "Percentage of complete and adequately prepped screening colonoscopies of average-risk patients aged 50 to 75 years with biopsy or polypectomy and pathology findings of Sessile serrated polyp >= 10 mm OR sessile serrated polyp with dysplasia OR traditional serrated adenoma who had a recommended follow-up interval of 3 years for repeat colonoscopy consistent was given to the patient"
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "GIQIC24",
+    "title": "Screening Colonoscopy Adenoma Detection Rate - Male",
+    "description": "The percentage of male patients aged 50 to 75 years with at least one conventional adenoma or colorectal cancer detected during screening colonoscopy",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "GIQuIC",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "5846856",
+      "6981170"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "GIQIC25",
+    "title": "Screening Colonoscopy Adenoma Detection Rate - Female",
+    "description": "The percentage of female patients aged 50 to 75 years with at least one conventional adenoma or colorectal cancer detected during screening colonoscopy",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "GIQuIC",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "5846856",
+      "6981170"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "HCPR14",
+    "title": "Venous Thromboembolism (VTE) Prophylaxis",
+    "description": "Percentage of Adult Patients Who Had VTE Prophylaxis Ordered at the Time of Admission OR Have Documentation of Reason for No VTE Prophylaxis",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "H-CPR (Hospitalist –Clinical Performance Registry)",
+    "firstPerformanceYear": 2015,
+    "allowedVendors": [
+      "4757099",
+      "8483899",
+      "1725296"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "HCPR16",
+    "title": "Physician’s Orders for Life-Sustaining Treatment (POLST) Form",
+    "description": "Percentage of Patients Greater Than or Equal to 65 Years of Age with Physician’s Orders for Life-Sustaining Treatment (POLST) Forms Completed",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "H-CPR (Hospitalist –Clinical Performance Registry)",
+    "firstPerformanceYear": 2015,
+    "allowedVendors": [
+      "4757099",
+      "8483899"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "HCPR17",
+    "title": "Pressure Ulcers – Risk Assessment and Plan of Care",
+    "description": "Percentage of Adult Post-acute Facility Patients That Had a Risk Assessment for Pressure Ulcers and a Plan of Care for Pressure Ulcer Prevention/Treatment Completed",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "H-CPR (Hospitalist –Clinical Performance Registry)",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "4757099",
+      "8483899"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "HCPR18",
+    "title": "Unintentional Weight Loss – Risk Assessment and Plan of Care",
+    "description": "Percentage of Adult Post-acute Facility Patients that Had a Risk Assessment for Unintentional Weight Loss and a Plan of Care for Unintentional Weight Loss Documented by Provider",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "H-CPR (Hospitalist –Clinical Performance Registry)",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "4757099",
+      "8483899"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "HCPR20",
+    "title": "Clostridium Difficile – Risk Assessment and Plan of Care",
+    "description": "Percentage of Adult Patients Who Had a Risk Assessment for C. difficile Infection and, If High-Risk, Had a Plan of Care for C. difficile Completed on the Day Of or Day After Hospital Admission",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "H-CPR (Hospitalist –Clinical Performance Registry)",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "8483899"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "HCPR22",
+    "title": "Critical Care Transfer of Care – Use of Verbal Checklist or Protocol",
+    "description": "Percentage of Adult Patients Transferred from the Critical Care Service to a Non-critical Care Service Who Had Documented Use of a Verbal Protocol for the Transfer of Care Between the Transferring Clinician and the Accepting Clinician",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "H-CPR (Hospitalist –Clinical Performance Registry)",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "8483899"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "HCPR23",
+    "title": "Avoidance of Echocardiogram and Carotid Ultrasound for Syncope",
+    "description": "Percentage of Patients Presenting with Syncope Who Did Not Have an Echocardiogram or Carotid Ultrasound Ordered",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "H-CPR (Hospitalist –Clinical Performance Registry)",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "4757099",
+      "8483899",
+      "1725296"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "HCPR24",
+    "title": "Appropriate Utilization of Vancomycin for Cellulitis",
+    "description": "Percentage of Patients with Cellulitis Who Did Not Receive Vancomycin Unless MRSA Infection or Risk for MRSA Infection Was Identified",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "H-CPR (Hospitalist –Clinical Performance Registry)",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "5133825",
+      "1718371",
+      "4757099",
+      "8483899"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "HM10",
+    "title": "Outcomes of Hearing Loss Treatment",
+    "description": "Percentage of patients aged 50 years and older, who are screened with a hearing loss self-assessment tool that indicated an impact on hearing-related QoL AND if diagnosed with a mild or greater hearing loss in at least one ear or identified with a hearing loss, receive an audiologic care plan and hearing loss intervention(s) AND report a meaningful clinically important difference (MCID) improvement in hearing-related quality of life (QoL) within 12 months of hearing loss diagnosis.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MIPSPRO ENTERPRISE",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "7037323"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "qolSelfAssessment",
+        "description": "Performance"
+      },
+      {
+        "name": "qolPlan&Intervention",
+        "description": "Percentage of patients aged 50 years and older evaluated for hearing loss, who are screened to determine if the hearing loss is impacting their QoL with a self-assessment measure."
+      },
+      {
+        "name": "overall",
+        "description": "Performance"
+      },
+      {
+        "description": "Percentage of patients aged 50 years and older diagnosed with a mild or greater hearing loss in at least one ear or identified with a hearing loss that impacts their hearing-related QoL who receive an audiologic care plan AND hearing loss intervention(s)."
+      },
+      {
+        "description": "Performance"
+      },
+      {
+        "description": "Percentage of patients who report a MCID improvement in hearing-related quality of life (QoL) within 12 months of hearing loss diagnosis if they received an audiologic care plan AND hearing loss intervention(s )."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "HM11",
+    "title": "Outcomes of Treatment of Subjective Tinnitus",
+    "description": "Percentage of patients aged 18 years and older who are screened for bothersome subjective tinnitus AND, if patient reports symptoms, assessed with clinical evaluation for tinnitus severity and impact on hearing-related quality of life (HRQoL) using a validated self-assessment tool AND, if identified with tinnitus that impacts the patients HRQoL, receive a tinnitus-related care plan, and tinnitus-related intervention(s), treatment(s), or management AND who report a meaningful clinically important difference (MCID) improvement in the impact of tinnitus on the patient’s HRQoL within 12 months of initial identification.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MIPSPRO ENTERPRISE",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "7037323"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "tinnitusScreen",
+        "description": "Performance"
+      },
+      {
+        "name": "screenReferOrAssess",
+        "description": "Percentage of patients aged 18 years and older who are screened for presence of bothersome subjective tinnitus"
+      },
+      {
+        "name": "qolPlan&Intervention",
+        "description": "Performance"
+      },
+      {
+        "name": "overall",
+        "description": "Percentage of patients aged 18 years and older reporting bothersome tinnitus symptoms AND referred for further investigation OR assessed with clinical evaluation for tinnitus severity and a validated self-assessment tool (THI, TRQ, TFI) to determine the impact of tinnitus on their HRQoL."
+      },
+      {
+        "description": "Performance"
+      },
+      {
+        "description": "Percentage of patients aged 18 years and older reporting bothersome tinnitus that is impacting their HRQoL who receive a tinnitus-related care plan AND tinnitus-related intervention(s), treatment(s), or management"
+      },
+      {
+        "description": "Performance"
+      },
+      {
+        "description": "Percentage of patients aged 18 years and older identified with bothersome tinnitus that is impacting their HRQoL who have received a tinnitus-related care plan, and tinnitus-related intervention(s), treatment(s), or management AND who report a MCID improvement in the impact of tinnitus on the HRQoL within 12 months of initial identification."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "HM12",
+    "title": "Outcomes of Treatment of Benign Paroxysmal Positional Vertigo",
+    "description": "Percentage of patients aged 18 years and older, who report benign paroxysmal positional vertigo (BPPV)-related symptoms and are screened with a dizziness assessment questionnaire and undergo positional nystagmus testing AND, if diagnosed or identified with BPPV, received a BPPV-related care plan and vestibular intervention(s) or treatment(s) AND who have an improvement in nystagmus or report an improvement in BPPV-related symptoms, and report a meaningful clinically important difference (MCID) improvement of BPPV-related quality of life (QoL).",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MIPSPRO ENTERPRISE",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "7037323"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "bppvScreen",
+        "description": "Performance"
+      },
+      {
+        "name": "bppv&Plan",
+        "description": "Percentage of patients aged 18 years and older, who report BPPV-related symptoms and who are screened with a dizziness assessment questionnaire, undergo positional nystagmus testing, and are referred, identified or diagnosed BPPV."
+      },
+      {
+        "name": "overall",
+        "description": "Performance"
+      },
+      {
+        "description": "Percentage of patients who are screened with a dizziness assessment questionnaire, undergo positional nystagmus testing, and are diagnosed or identified with BPPV who received a BPPV-related care plan on the date the BPPV was identified or diagnosed and received vestibular intervention(s) or treatment(s) within 30 days of the documented BPPV-related care plan."
+      },
+      {
+        "description": "Performance"
+      },
+      {
+        "description": "Percentage of patients who received a BPPV-related care plan, and vestibular intervention(s) or treatment(s) , AND who have an improvement in nystagmus OR report an improvement in BPPV-related symptoms, AND report a MCID improvement of BPPV-related QoL."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "HM7",
+    "title": "Functional Status Change for Patients with Vestibular Dysfunction",
+    "description": "Percentage of patients aged 14 years and older diagnosed with vestibular dysfunction who achieve a Minimal Clinically Important Difference (MCID) as measured via the validated Dizziness Handicap Inventory or equivalent instrument to indicate functional, emotional, and physical improvement \n·        Submission Age Criteria 1: Patients aged 14-17 years of age \n·        Submission Age Criteria 2: Patients aged 18-64 years of age\n·        Submission Age Criteria 3: Patients aged 65 years and older\n·        Submission Criteria 4: Overall total rate of patients aged 14 years and older \nThe measure is adjusted to patient characteristics known to be associated with functional status and quality of life outcomes (risk adjusted) and used as a performance measure at the patient level, at the individual clinician, and at the clinic level to assess quality.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "MIPSPRO ENTERPRISE",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "8411367",
+      "7037323"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "14to17",
+        "description": "SUBMISSION CRITERIA 1: Patients aged 14-17 years of age on date of encounter"
+      },
+      {
+        "name": "18to64",
+        "description": "SUBMISSION CRITERIA 2: Patients aged 18-64 years and older on date of encounter"
+      },
+      {
+        "name": "65over",
+        "description": "SUBMISSION CRITERIA 3: Patients aged 65 years of age and older on date of encounter"
+      },
+      {
+        "name": "overall",
+        "description": "SUBMISSION CRITERIA 4: Patients aged 14 years of age and older on date of encounter"
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "HM9",
+    "title": "Functional Benefit of a Cochlear Implant",
+    "description": "Percentage of patients aged 18 years and older, who are evaluated for hearing loss and complete a hearing loss self-assessment tool that indicated an impact of hearing-related quality of life (QoL), and if diagnosed with a bilateral moderate to profound sensorineural hearing loss (SNHL) and less than 60% open set speech recognition are scheduled or referred for cochlear implant candidacy testing AND for patients who undergo cochlear implantation, demonstrate a meaningful clinically important difference (MCID) improvement in self-assessment of Hearing-related QoL or an improvement in speech recognition within 18 months of cochlear implant activation.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MIPSPRO ENTERPRISE",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "7037323"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "snhl&scheduleOrRefer",
+        "description": "Performance"
+      },
+      {
+        "name": "overall",
+        "description": "Percentage of patients aged 18 years and older, who are evaluated for hearing loss and who indicate, via a hearing self-assessment tool, that the hearing loss is impacting their hearing-related QoL, and if diagnosed with a bilateral moderate to profound SNHL and less than 60% open set speech recognition are scheduled or referred for cochlear implant candidacy testing."
+      },
+      {
+        "description": "Performance"
+      },
+      {
+        "description": "Percentage of patients aged 18 years and older, who are evaluated for hearing loss and who indicate, via a hearing self-assessment tool, that the hearing loss is impacting their hearing-related QoL, and if Percentage of patients aged 18 years or older evaluated for hearing loss who complete a hearing self-assessment tool that indicated an impact of hearing QoL, and if diagnosed with a bilateral moderate to profound SNHL and less than 60% open set speech recognition are scheduled or referred for cochlear implant candidacy testing AND demonstrate a MCID improvement in self-assessment of HRQoL or an improvement in speech recognition within 18 months of cochlear implant activation."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IGR1",
+    "title": "Comprehensive TTE studies reporting a measured value of LVEF AND wall motion findings with LVEF less than 50%",
+    "description": "Percentage of comprehensive TTE studies reporting a measured value of LVEF and wall motion findings with LVEF less than 50% on patients 18 years of age or older.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "efficiency",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ImageGuide Registry",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "6034942"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IGR10",
+    "title": "Transthoracic Echo (TTE) performance per ASE guidelines",
+    "description": "Transthoracic Echo (TTE) performance per ASE guidelines on patients 18 years of age or older. This is a multi-strata measure consisting of the following:\n1. Percentage of comprehensive TTE studies reporting 100% obtainment of required views.\n2. Percentage of limited and comprehensive TTE studies where the study quality was poor or technically difficult that utilized contrast.\n3. Percentage of comprehensive TTE studies reporting pulmonary artery pressures.\n4. Percentage of comprehensive TTE studies reporting of diastolic function.\n5. Percentage of limited and comprehensive TTE studies reporting cardiac function using strain analysis in patients receiving chemotherapy.\nThe overall performance will be calculated using a weighted average.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "efficiency",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ImageGuide Registry",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "6034942"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "weightedAverage",
+    "strata": [
+      {
+        "name": "allViews",
+        "description": "Percentage of comprehensive TTE studies reporting 100% obtainment of required views."
+      },
+      {
+        "name": "poorQuality",
+        "description": "Percentage of limited and comprehensive TTE studies where the study quality was poor or technically difficult that utilized contrast."
+      },
+      {
+        "name": "pulmArtPressure",
+        "description": "Percentage of comprehensive TTE studies reporting pulmonary artery pressures."
+      },
+      {
+        "name": "diastolicFunction",
+        "description": "Percentage of comprehensive TTE studies reporting of diastolic function."
+      },
+      {
+        "name": "strainAnalysis",
+        "description": "Percentage of limited and comprehensive TTE studies reporting cardiac function using strain analysis in patients receiving chemotherapy."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IGR12",
+    "title": "Appropriate diagnosis verification and severity grading for valve disease through transthoracic echocardiography (TTE) quantitative parameters.",
+    "description": "This measure addresses changes in cardiac structure and function in patients with aortic stenosis and/or mitral regurgitation. Changes in left ventricular size and function AND quantitative assessment of severity of aortic stenosis and/or mitral regurgitation should be performed in patients with significant left sided valvular lesions. Both sets of data (left ventricle structure and function, and extent of valvular disease) are needed to reach a conclusion about whether valve surgery or repair is needed. While qualitative assessments are commonly employed, they are generally inadequate to determine severity and to track changes over time.\n\nThis is a multi-strata measure consisting of the following strata: \n1. Percentage of transthoracic echocardiogram reports with at least moderate mitral regurgitation including qualitative MR severity, two quantitative MR measurements to support the qualitative severity grading, quantitative LVEF, one quantitative measurement of LV size at end diastole and end systole, AND blood pressure at time of study. \n2. Percentage of transthoracic echocardiogram reports with at least moderate aortic stenosis including peak velocity, mean systolic gradient, aortic valve area, quantitative LVEF, one quantitative measurement of LV size at end diastole and end systole, AND blood pressure at the time of study\n\nThe overall performance will be calculated using a weighted average.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ImageGuide Registry",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "6034942"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "weightedAverage",
+    "strata": [
+      {
+        "name": "mitralRegurg",
+        "description": "Percentage of transthoracic echocardiogram reports with at least moderate mitral regurgitation including qualitative MR severity, two quantitative MR measurements to support the qualitative severity grading, quantitative LVEF, one quantitative measurement of LV size at end diastole and end systole, AND blood pressure at time of study."
+      },
+      {
+        "name": "stenosis",
+        "description": "Percentage of transthoracic echocardiogram reports with at least moderate aortic stenosis including peak velocity, mean systolic gradient, aortic valve area, quantitative LVEF, one quantitative measurement of LV size at end diastole and end systole, AND blood pressure at the time of study"
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IGR14",
+    "title": "Appropriate Evaluation of Left Ventricular Structure and Systolic Function with Transthoracic Echocardiography (TTE) to Guide Heart Failure and Cardiomyopathy Management",
+    "description": "This measure addresses appropriate evaluation of left ventricular structure and systolic function with TTE to guide heart failure and cardiomyopathy management on patients 18 years of age or older. It examines percentage (%) of comprehensive transthoracic echocardiogram (TTE) studies performed on patients with heart failure/cardiomyopathy as the reason for the study, and including the following parameters for the study: \n - LV end-diastolic and end systolic diameters, end diastolic LV interventricular septum thickness and LV posterior wall thickness measurements \n - LV mass index calculation \n - Strain technology utilization\n - Use of intravenous contrast agent to visualize endocardial borders for LV volumes and ejection fraction (EF) measurement in technically difficult studies.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ImageGuide Registry",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "6034942"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IGR15",
+    "title": "Myocardial Perfusion Imaging (MPI) or Stress Echocardiography Imaging Studies - Adequate Exercise Protocol",
+    "description": "This is a multi-strata measure consisting of the following strata: \n1. Percentage of Single Photon Emission Computed Tomography (SPECT) Myocardial Perfusion Imaging (MPI) or Stress Echocardiography studies using a Stress Test Type that includes exercise performed on patients 18 years of age or older.\n2 .Percentage of Single Photon Emission Computed Tomography (SPECT) Myocardial Perfusion Imaging (MPI) or Stress Echocardiography exercise studies where the stress heart rate >= 85% of maximum heart rate and three or more minutes of exercise performed on patients 18 years of age or older.\n\nThe overall performance will be calculated using a weighted average.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ImageGuide Registry",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "6034942"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "weightedAverage",
+    "strata": [
+      {
+        "name": "exerciseAsStressor",
+        "description": "Percentage of Single Photon Emission Computed Tomography (SPECT) Myocardial Perfusion Imaging (MPI) or Stress Echocardiography studies using a Stress Test Type that includes exercise performed on patients 18 years of age or older."
+      },
+      {
+        "name": "hrAndMinExercised",
+        "description": "Percentage of Single Photon Emission Computed Tomography (SPECT) Myocardial Perfusion Imaging (MPI) or Stress Echocardiography exercise studies where the stress heart rate >= 85% of maximum heart rate and three or more minutes of exercise performed on patients 18 years of age or older."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IGR16",
+    "title": "Myocardial Perfusion Imaging (MPI) Studies, Transthoracic Echo (TTE), or Stress Echocardiography Imaging Studies - Adequate Reporting for Appropriate Interventions",
+    "description": "This is a multi-strata measure consisting of the following strata: \n1. Percentage of Single Photon Emission Computed Tomography (SPECT) and Positron Emission Tomography (PET) Myocardial Perfusion Imaging (MPI) studies that were abnormal and contained perfusion defects documentation including location, severity, and size performed on patients 18 years of age or older.\n2 .Percentage of Single Photon Emission Computed Tomography (SPECT), Positron Emission Tomography (PET) Myocardial Perfusion Imaging (MPI), transthoracic echocardiography, or stress echocardiography imaging studies where the Left Ventricle Ejection Fraction (LVEF) was calculated and included in the report performed on patients 18 years of age or older.\n\nThe overall performance will be calculated using a weighted average.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ImageGuide Registry",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "6034942"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "weightedAverage",
+    "strata": [
+      {
+        "name": "perfusionDefects",
+        "description": "Percentage of Single Photon Emission Computed Tomography (SPECT) and Positron Emission Tomography (PET) Myocardial Perfusion Imaging (MPI) studies that were abnormal and contained perfusion defects documentation including location, severity, and size performed on patients 18 years of age or older."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IGR17",
+    "title": "Myocardial Perfusion Imaging (MPI) studies - Radiation Reduction Strategies",
+    "description": "This is a multi-strata measure consisting of the following strata: \n1. Percentage of Single Photon Emission Computed Tomography (SPECT) and Positron Emission Tomography (PET) Myocardial Perfusion Imaging (MPI) studies where the imaging protocol used was stress only performed on patients 18 years of age or older.\n2. Percentage of Single Photon Emission Computed Tomography (SPECT) Myocardial Perfusion Imaging (MPI) studies where 9 or less millisieverts of radiation were administered per ASNC guideline recommendations on patients 18 years of age or older.\n\nThe overall performance will be calculated using a weighted average.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ImageGuide Registry",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "6034942"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "weightedAverage",
+    "strata": [
+      {
+        "name": "stressOnlyProtocol",
+        "description": "Percentage of Single Photon Emission Computed Tomography (SPECT) and Positron Emission Tomography (PET) Myocardial Perfusion Imaging (MPI) studies where the imaging protocol used was stress only performed on patients 18 years of age or older."
+      },
+      {
+        "name": "9OrLessMillisieverts",
+        "description": "Percentage of Single Photon Emission Computed Tomography (SPECT) Myocardial Perfusion Imaging (MPI) studies where 9 or less millisieverts of radiation were administered per ASNC guideline recommendations on patients 18 years of age or older."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IGR18",
+    "title": "Myocardial Perfusion Imaging (MPI) or Stress Echocardiography imaging studies - Improving Image Quality",
+    "description": "This is a multi-strata measure consisting of the following strata: \n1. Percentage of Single Photon Emission Computed Tomography (SPECT) Myocardial Perfusion Imaging (MPI) studies using Attenuation Correction performed on patients 18 years of age or older.\n2.Percentage of SPECT-MPI or Stress Echocardiography imaging studies where the Imaging Protocol was appropriate for morbidly obese patients 18 years of age or older.\n\nThe overall performance will be calculated using a weighted average.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ImageGuide Registry",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "6034942"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "weightedAverage",
+    "strata": [
+      {
+        "name": "attentuationCorrectn",
+        "description": "Percentage of Single Photon Emission Computed Tomography (SPECT) Myocardial Perfusion Imaging (MPI) studies using Attenuation Correction performed on patients 18 years of age or older."
+      },
+      {
+        "name": "obesityProtocol",
+        "description": "Percentage of SPECT-MPI or Stress Echocardiography imaging studies where the Imaging Protocol was appropriate for morbidly obese patients on patients 18 years of age or older."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IGR2",
+    "title": "Parameters in stress echocardiography dobutamine testing for low flow, low gradient aortic stenosis",
+    "description": "Percentage of low flow, low gradient aortic stenosis studies in the setting of LVEF less than 50% with complete measurements during a dobutamine stress echocardiogram on patients 18 years of age or older.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ImageGuide Registry",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "6034942"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IGR9",
+    "title": "Stress echo performance for shortness of breath per ASE guidelines",
+    "description": "Stress echo performance for shortness of breath per ASE guidelines on patients 18 years of age or older. This is a multi-strata measure consisting of the following: \n1. Percentage of stress echo studies presenting with an indication of unexplained dyspnea that include an interpretation of LV diastolic function parameters with exercise.\n2. Percentage of stress echo studies presenting with significant aortic or mitral valve disease that include reporting of value function and regurgitation with exercise. \nThe overall performance will be calculated using a weighted average.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "efficiency",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ImageGuide Registry",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "6034942"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "weightedAverage",
+    "strata": [
+      {
+        "name": "dyspnea",
+        "description": "Percentage of stress echo studies presenting with an indication of unexplained dyspnea that include an interpretation of LV diastolic function parameters with exercise."
+      },
+      {
+        "name": "aorticMitral",
+        "description": "Percentage of stress echo studies presenting with significant aortic or mitral valve disease that include reporting of value function and regurgitation with exercise."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS1",
+    "title": "Endothelial Keratoplasty - Post-operative improvement in best corrected visual acuity to 20/40 or better",
+    "description": "Percentage of endothelial keratoplasty patients with a best corrected visual acuity of 20/40 or better within 90 days after surgery",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2015,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS13",
+    "title": "Diabetic Macular Edema - Loss of Visual Acuity",
+    "description": "Percentage of patients with a diagnosis of diabetic macular edema with a loss of less than 3 Snellen lines (which is equivalent to less than 0.3 logMAR) within the past 12 months.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2015,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS17",
+    "title": "Acute Anterior Uveitis: Post-treatment Grade 0 anterior chamber cells",
+    "description": "Percentage of patients with acute anterior uveitis post-treatment with Grade 0 anterior chamber cells",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2015,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS2",
+    "title": "Glaucoma – Intraocular Pressure Reduction",
+    "description": "Percentage of glaucoma patient visits where their IOP was below a threshold level based on the severity of their diagnosis.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "intermediateOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2015,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS23",
+    "title": "Refractive Surgery: Patients with a postoperative uncorrected visual acuity (UCVA) of 20/20 or better within 30 days",
+    "description": "Percentage of patients with an uncorrected visual acuity (UCVA) of 20/20 or better within 30 days",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS24",
+    "title": "Refractive Surgery: Patients with a postoperative correction within + or - 0.5 Diopter (D) of the intended correction",
+    "description": "Percentage of patients with an actual spherical equivalent within + or - 0.5 D of the intended correction or SE",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS35",
+    "title": "Improvement of Macular Edema in Patients with Uveitis",
+    "description": "Percentage of patients with uveitis and macular edema with a reduction of 20% or greater in the central subfield thickness on OCT within 90 days after treatment.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS38",
+    "title": "Endothelial Keratoplasty – Dislocation Requiring Surgical Intervention",
+    "description": "Percentage of endothelial keratoplasty patients with a rebubbling or revision or repair procedure within 90 days after surgery",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS39",
+    "title": "Intraocular Pressure Reduction Following Trabeculectomy or an Aqueous Shunt Procedure",
+    "description": "Percentage of patients who underwent trabeculectomy or aqueous shunt procedure who had IOP reduced by 20% or more from their pretreatment between 3 and 4 months of treatment or a reduction in overall number of glaucoma medications.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS41",
+    "title": "Improved visual acuity after epiretinal membrane treatment within 120 days",
+    "description": "Percentage of patients with a 20% improvement in visual acuity within 120 days following epiretinal membrane treatment",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS43",
+    "title": "Intraocular Pressure Reduction Following Laser Trabeculoplasty",
+    "description": "Percentage of patients who underwent laser trabeculoplasty who had IOP reduced by 20% or more from their pretreatment IOP or had a reduction in overall number of glaucoma medications.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS44",
+    "title": "Visual Field Progression in Glaucoma",
+    "description": "Percentage of patients with a diagnosis of glaucoma with a mean deviation loss of 3dB or more from their baseline value.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS46",
+    "title": "Evidence of anatomic closure of macular hole within 90 days after surgery as documented by OCT",
+    "description": "Percentage of patients with a macular hole who have evidence of anatomic closure documented by OCT within 90 days after surgical treatment.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS48",
+    "title": "Adult Surgical Esotropia: Postoperative alignment",
+    "description": "Percentage of adult esotropia patients receiving surgical treatment with a post treatment alignment of 12 prism diopters (PD) or less.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS49",
+    "title": "Surgical Pediatric Esotropia: Postoperative alignment",
+    "description": "Percentage of surgical esotropia pediatric patients with a postoperative alignment of 12 prism diopters (PD) or less without a reoperation.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS50",
+    "title": "Amblyopia: Interocular visual acuity",
+    "description": "Percentage of newly diagnosed amblyopic patients with one or more of the following:\nA. a corrected interocular (or if not reported, the uncorrected) visual acuity difference less than 0.23 logMAR 3-12 months after first diagnosis of amblyopia\nOR\nB. an improvement in the corrected visual acuity of the amblyopic eye of 3 or more Snellen lines (> or = 0.30 logMAR) 3-12 months after first diagnosis of amblyopia \nOR\nC. a final visual acuity in the amblyopic eye equal to 20/30 or better (less than or equal to 0.18 log Mar) 3-12 months after first diagnosis of amblyopia",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS51",
+    "title": "Acute Anterior Uveitis: Post-treatment visual acuity",
+    "description": "Percentage of acute anterior uveitis patients with a post-treatment best corrected visual acuity of 20/20 or better or patients whose visual acuity had returned to their baseline value prior to onset of uveitis.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS53",
+    "title": "Chronic Anterior Uveitis - Post-treatment visual acuity",
+    "description": "Percentage of chronic anterior uveitis patients with a post-treatment best corrected visual acuity of 20/30 or better or patients whose visual acuity had returned to their baseline value prior to onset of uveitis.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS54",
+    "title": "Complications After Cataract Surgery",
+    "description": "Percentage of eyes of patients aged 18 years and older with a diagnosis of cataract who had cataract surgery and had the following complications with 90 days after cataract surgery: prolonged inflammation, incision complications, iris complications, retinal detachment, cystoid macular edema, corneal complications, or a return to OR.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS55",
+    "title": "Visual Acuity Improvement Following Cataract Surgery and Minimally Invasive Glaucoma Surgery",
+    "description": "Percentage of eyes of patients aged 18 years and older with a diagnosis of cataract who had cataract surgery and minimally invasive glaucoma surgery and achieved 20/30 best-corrected distance visual acuity or better OR an improvement in best-corrected distance visual acuity within 4 months following the cataract surgery. Weighted average of performance rates reported.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "weightedAverage",
+    "strata": [
+      {
+        "name": "20/30+",
+        "description": "Includes eyes of patients with mild to moderate stage glaucoma and a 20/30 or better post-operative best-corrected distance visual acuity"
+      },
+      {
+        "name": "20/200",
+        "description": "Includes eyes of patients with severe stage glaucoma or a pre-operative best-corrected visual acuity of 20/200 and a 2 lines or better improvement in the post-operative best-corrected distance visual acuity from preoperative visual acuity"
+      },
+      {
+        "name": "20/400",
+        "description": "Includes eyes of patients with a pre-operative best-corrected visual acuity of 20/400 and a 1 line or better improvement in the post-operative best-corrected distance visual acuity from pre-operative visual acuity"
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS56",
+    "title": "Adult Diplopia: Improvement of ocular deviation or absence of diplopia or functional improvement",
+    "description": "Percentage of patients with a diagnosis of double vision (diplopia) who had an improvement of ocular deviation as determined by reduction of strabismus in primary gaze to less than 10 prism diopters horizontal or less than 2 prism diopters vertical deviation OR were absent of diplopia in primary gaze OR had functional improvement in ptosis within 6 months of initiating treatment.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS57",
+    "title": "Idiopathic Intracranial Hypertension: Improvement of mean deviation or stability of mean deviation",
+    "description": "Percentage of patients with improvement in mean deviation or stability of mean deviation (+1db) within 6 months of initiating therapy.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS58",
+    "title": "Improved Visual Acuity after Vitrectomy for Complications of Diabetic Retinopathy within 120 Days",
+    "description": "Percentage of patients with a 20% or greater improvement in visual acuity within 120 days following vitrectomy for complications of diabetic retinopathy",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS59",
+    "title": "Regaining Vision After Cataract Surgery",
+    "description": "Percentage of eyes of patients aged 18 years and older with a diagnosis of cataract who had cataract surgery and 20/20 best-corrected distance visual acuity or better OR an improvement in best-corrected distance visual acuity within 30 days following the cataract surgery. Weighted average of performance rates reported.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "weightedAverage",
+    "strata": [
+      {
+        "name": "nocomorbidities",
+        "description": "Includes eyes of patients with no comorbidities or additional procedures on the same date as the cataract surgery,"
+      },
+      {
+        "name": "comorbidities&20/200",
+        "description": "Includes eyes of patients with comorbidities with a pre-operative visual acuity of 20/200 or better, and"
+      },
+      {
+        "name": "comorbidities&20/400",
+        "description": "Includes eyes of patients with comorbidities with a pre-operative visual acuity of 20/400 or worse"
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS6",
+    "title": "Acquired Involutional Entropion: Normalized lid position after surgical repair",
+    "description": "Percentage of surgical entropion patients with normalized lid position within 90 days postoperatively.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2015,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IRIS60",
+    "title": "Visual Acuity Improvement Following Cataract Surgery Combined with a Trabeculectomy or an Aqueous Shunt Procedure",
+    "description": "Percentage of eyes of patients who underwent cataract surgery combined with a trabeculectomy or an aqueous shunt procedure who had their visual acuity improve 1 or 2 or more Snellen lines from their preoperative visual acuity between 3 and 6 months postoperatively. Weighted average of performance rates reported.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "weightedAverage",
+    "strata": [
+      {
+        "name": "better20/200",
+        "description": "Includes eyes of patients with a pre-operative visual acuity of better than 20/200 who had an improvement from their preoperative visual acuity of 2 or more lines between 3 and 6 months postoperatively"
+      },
+      {
+        "name": "20/200",
+        "description": "Includes eyes of patients with a pre-operative visual acuity of 20/200 who had an improvement from their preoperative visual acuity of 2 or more lines between 3 and 6 months postoperatively"
+      },
+      {
+        "name": "20/400",
+        "description": "Includes eyes of patients with a pre-operative visual acuity of 20/400 who had an improvement from their preoperative visual acuity of 1 or more lines between 3 and 6 months postoperatively"
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "IROMS11",
+    "title": "Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) to indicate functional improvement in knee rehabilitation of patients with knee injury measured via their validated Knee Outcome Survey (KOS) score, or equivalent instrument which has undergone peer reviewed published validation and demonstrates a peer reviewed published MCID.",
+    "description": "The proportion of patients failing to achieve an MCID of ten (10) points or more improvement in the KOS change score for patients with knee injury treated during the observation period will be reported. \n\nAdditionally, a risk-adjusted MCID proportional difference will be determined by calculating the difference between the risk model predicted and observed MCID proportion will reported for each physical therapist or physical therapy group. The risk adjustment will be calculated using a logistic regression model using: baseline KOS score, baseline pain score, age, sex, payer, and symptom duration (time from surgery or injury to baseline physical therapy visit). \n\nThese measures will serve as a PT/OT performance measure at the eligible PT/OT or PT/OT group level.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": true,
+    "primarySteward": "Keet Outcomes",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "3967247",
+      "1157686",
+      "8411367",
+      "7037323",
+      "2581402"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "notachieving",
+        "description": "Overall proportion of patients not achieving an MCID in KOS change score will be reported."
+      },
+      {
+        "name": "overall",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via KOS) proportion will reported."
+      },
+      {
+        "name": "operativeMCID",
+        "description": "The proportion of patients not achieving an MCID in KOS change score will be reported."
+      },
+      {
+        "name": "operativeRisk",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via KOS) proportion will reported."
+      },
+      {
+        "name": "nonOpMCID",
+        "description": "The proportion of patients not achieving an MCID in KOS change score will be reported."
+      },
+      {
+        "name": "nonOpRisk",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via KOS) proportion will reported."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "historic_benchmarks": {
+      "registry": "removed"
+    }
+  },
+  {
+    "measureId": "IROMS12",
+    "title": "Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with knee injury pain.",
+    "description": "The proportion of patients failing to achieve MCID of two (2) points or more improvement in the NPRS change score for patients with knee injuries treated during the observation period will be reported. \n\nAdditionally, a risk-adjusted MCID proportional difference will be determined by calculating the difference between the risk model predicted and observed MCID proportion will reported for each physical therapist or physical therapy group. The risk adjustment will be calculated using a logistic regression model using: baseline KOS score, baseline pain score, age, sex, payer, and symptom duration (time from surgery or injury to baseline physical therapy visit). \n\nThese measures will serve as a physical or occupational therapy performance measure at the eligible physical or occupational therapist or physical or occupational therapy group level.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": true,
+    "primarySteward": "Keet Outcomes",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "3967247",
+      "1157686",
+      "8411367",
+      "7037323",
+      "2581402"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "notachieving",
+        "description": "Overall proportion of patients not achieving an MCID in the NPRS change score will be reported."
+      },
+      {
+        "name": "overall",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported.    For operative (surgical) patients:"
+      },
+      {
+        "name": "operativeMCID",
+        "description": "The proportion of patients not achieving an MCID in the NPRS change score will be reported."
+      },
+      {
+        "name": "operativeRisk",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported.   For non-operative (non-surgical) patients:"
+      },
+      {
+        "name": "nonOpMCID",
+        "description": "The proportion of patients not achieving an MCID in the NPRS change score will be reported."
+      },
+      {
+        "name": "nonOpRisk",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "historic_benchmarks": {
+      "registry": "removed"
+    }
+  },
+  {
+    "measureId": "IROMS13",
+    "title": "Failure to Progress (FTP): Proportion of patients not achieving a Minimal Clinically Important Difference (MCID) to indicate functional improvement in rehabilitation of patients with hip, leg or ankle injuries using the validated Lower Extremity Function Scale (LEFS) score, or equivalent instrument which has undergone peer reviewed published validation and demonstrates a peer reviewed published MCID.",
+    "description": "The proportion of patients failing to achieve an MCID of nine (9) points or more improvement in the LEFS change score for patients with hip, leg, or ankle injuries treated during the observation period will be reported. \n\nAdditionally, a risk-adjusted MCID proportional difference will be determined by calculating the difference between the risk model predicted and observed MCID proportion will reported for each physical therapist or physical therapy group. The risk adjustment will be calculated using a logistic regression model using: baseline LEFS score, baseline pain score, age, sex, payer, and symptom duration (time from surgery or injury to baseline physical therapy visit). \n\nThese measures will serve as a physical or occupational therapy performance measure at the eligible physical or occupational therapist or physical or occupational therapy group level.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": true,
+    "primarySteward": "Keet Outcomes",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "3967247",
+      "1157686",
+      "8411367",
+      "7037323",
+      "2581402"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "notachieving",
+        "description": "Overall proportion of patients not achieving an MCID in LEFS change score will be reported."
+      },
+      {
+        "name": "overall",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via LEFS) proportion will reported."
+      },
+      {
+        "name": "operativeMCID",
+        "description": "The proportion of patients not achieving an MCID in LEFS change score will be reported."
+      },
+      {
+        "name": "operativeRisk",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via LEFS) proportion will reported."
+      },
+      {
+        "name": "nonOpMCID",
+        "description": "The proportion of patients not achieving an MCID in LEFS change score will be reported."
+      },
+      {
+        "name": "nonOpRisk",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via LEFS) proportion will reported."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "historic_benchmarks": {
+      "registry": "removed"
+    }
+  },
+  {
+    "measureId": "IROMS14",
+    "title": "Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with hip, leg or ankle (lower extremity except knee) injury.",
+    "description": "The proportion of patients failing to achieve an MCID of two (2) points or more improvement in the NPRS change score for patients with hip, leg, or ankle injuries treated during the observation period will be reported. \n\nAdditionally, a risk-adjusted MCID proportional difference will be determined by calculating the difference between the risk model predicted and observed MCID proportion will reported for each physical therapist or physical therapy group. The risk adjustment will be calculated using a logistic regression model using: LEFS score, baseline pain score, age, sex, payer, and symptom duration (time from surgery or injury to baseline physical therapy visit). \n\nThese measures will serve as a physical or occupational therapy performance measure at the eligible physical or occupational therapist or physical or occupational therapy group level.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": true,
+    "primarySteward": "Keet Outcomes",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "3967247",
+      "1157686",
+      "8411367",
+      "7037323",
+      "2581402"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "notachieving",
+        "description": "Overall proportion of patients not achieving an MCID in the NPRS change score will be reported."
+      },
+      {
+        "name": "overall",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported."
+      },
+      {
+        "name": "operativeMCID",
+        "description": "The proportion of patients not achieving an MCID in the NPRS change score will be reported."
+      },
+      {
+        "name": "operativeRisk",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported."
+      },
+      {
+        "name": "nonOpMCID",
+        "description": "The proportion of patients not achieving an MCID in the NPRS change score will be reported."
+      },
+      {
+        "name": "nonOpRisk",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "historic_benchmarks": {
+      "registry": "removed"
+    }
+  },
+  {
+    "measureId": "IROMS16",
+    "title": "Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with neck pain/injury.",
+    "description": "The proportion of patients failing to achieve an MCID of two (2) points or more improvement in the NPRS change score for patients with neck pain/injury treated during the observation period will be reported. \n\nAdditionally, a risk-adjusted MCID proportional difference will be determined by calculating the difference between the risk model predicted and observed MCID proportion will reported for each physical therapist or physical therapy group. The risk adjustment will be calculated using a logistic regression model using: baseline NDI score, baseline pain score, age, sex, payer, and symptom duration (time from surgery or injury to baseline physical therapy visit). \n\nThese measures will serve as a physical or occupational therapy performance measure at the eligible physical or occupational therapist or physical or occupational therapy group level.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": true,
+    "primarySteward": "Keet Outcomes",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "3967247",
+      "1157686",
+      "8411367",
+      "7037323",
+      "2581402"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "notachieving",
+        "description": "Overall proportion of patients not achieving an MCID in the NPRS change score will be reported."
+      },
+      {
+        "name": "overall",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported."
+      },
+      {
+        "name": "operativeMCID",
+        "description": "The proportion of patients not achieving an MCID in the NPRS change score will be reported."
+      },
+      {
+        "name": "operativeRisk",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported."
+      },
+      {
+        "name": "nonOpMCID",
+        "description": "The proportion of patients not achieving an MCID in the NPRS change score will be reported."
+      },
+      {
+        "name": "nonOpRisk",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "historic_benchmarks": {
+      "registry": "removed"
+    }
+  },
+  {
+    "measureId": "IROMS17",
+    "title": "Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) to indicate functional improvement in rehabilitation patients with low back pain measured via the validated Modified Low Back Pain Disability Questionnaire (MDQ) score.",
+    "description": "The proportion of patients failing to achieve an MCID of six (6) points or more improvement in the MDQ change score for patients with low back pain treated during the observation period will be reported. \n\nAdditionally, a risk-adjusted MCID proportional difference will be determined by calculating the difference between the risk model predicted and observed MCID proportion will reported for each physical therapist or physical therapy group. The risk adjustment will be calculated using a logistic regression model using: baseline MDQ score, baseline pain score, age, sex, payer, and symptom duration (time from surgery or injury to baseline physical therapy visit). \n\nThese measures will serve as a physical or occupational therapy performance measure at the eligible physical or occupational therapist or physical or occupational therapy group level.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": true,
+    "primarySteward": "Keet Outcomes",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "3967247",
+      "1157686",
+      "8411367",
+      "7037323",
+      "2581402"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "notachieving",
+        "description": "Overall proportion of patients not achieving an MCID in MDQ change score will be reported."
+      },
+      {
+        "name": "overall",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via MDQ) proportion will reported."
+      },
+      {
+        "name": "operativeMCID",
+        "description": "The proportion of patients not achieving an MCID in MDQ change score will be reported."
+      },
+      {
+        "name": "operativeRisk",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via MDQ) proportion will reported."
+      },
+      {
+        "name": "nonOpMCID",
+        "description": "The proportion of patients not achieving an MCID in MDQ change score will be reported."
+      },
+      {
+        "name": "nonOpRisk",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via MDQ) proportion will reported."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "historic_benchmarks": {
+      "registry": "removed"
+    }
+  },
+  {
+    "measureId": "IROMS18",
+    "title": "Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with low back pain.",
+    "description": "The proportion of patients failing to achieve an MCID of two (2) points or more improvement in the NPRS change score for patients with low back pain treated during the observation period will be reported. \n\nAdditionally, a risk-adjusted MCID proportional difference will be determined by calculating the difference between the risk model predicted and observed MCID proportion will reported for each physical therapist or physical therapy group. The risk adjustment will be calculated using a logistic regression model using: baseline MDQ score, baseline pain score, age, sex, payer, and symptom duration (time from surgery or injury to baseline physical therapy visit). \n\nThese measures will serve as a physical or occupational therapy performance measure at the eligible physical or occupational therapist or physical or occupational therapy group level.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": true,
+    "primarySteward": "Keet Outcomes",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "3967247",
+      "1157686",
+      "8411367",
+      "7037323",
+      "2581402"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "notachieving",
+        "description": "Overall proportion of patients not achieving an MCID in the NPRS change score will be reported."
+      },
+      {
+        "name": "overall",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported."
+      },
+      {
+        "name": "operativeMCID",
+        "description": "The proportion of patients not achieving an MCID in the NPRS change score will be reported."
+      },
+      {
+        "name": "operativeRisk",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported."
+      },
+      {
+        "name": "nonOpMCID",
+        "description": "The proportion of patients not achieving an MCID in the NPRS change score will be reported."
+      },
+      {
+        "name": "nonOpRisk",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "historic_benchmarks": {
+      "registry": "removed"
+    }
+  },
+  {
+    "measureId": "IROMS19",
+    "title": "Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) to indicate functional improvement in rehabilitation of patients with arm, shoulder, and hand injury measured via the validated Disability of Arm Shoulder and Hand (DASH) score, Quick Disability of Arm Shoulder and Hand (QDASH) score, or equivalent instrument which has undergone peer reviewed published validation and demonstrates a peer reviewed published MCID.",
+    "description": "The proportion of patients failing to achieve an MCID of ten (10) points or more improvement in the DASH change score or eight (8) points or more improvement in the QDASH change score for patients with arm, shoulder, and hand injury patients treated during the observation period will be reported. \n\nAdditionally, a risk-adjusted DASH change proportional difference will be determined by calculating the difference between the risk model predicted and observed MCID proportion will reported for each physical therapist or physical therapy group. The risk adjustment will be calculated using a logistic regression model using: baseline MDQ score, baseline pain score, age, sex, payer, and symptom duration (time from surgery or injury to baseline physical therapy visit).\n\nThese measures will serve as a physical and occupational therapy performance measure at the eligible physical or occupational therapist or physical or occupational therapy group level.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": true,
+    "primarySteward": "Keet Outcomes",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "3967247",
+      "1157686",
+      "8411367",
+      "7037323",
+      "2581402"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "notachieving",
+        "description": "Overall proportion of patients not achieving an MCID in DASH change score will be reported."
+      },
+      {
+        "name": "overall",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via DASH) proportion will reported."
+      },
+      {
+        "name": "operativeMCID",
+        "description": "The proportion of patients not achieving an MCID in DASH change score will be reported."
+      },
+      {
+        "name": "operativeRisk",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via DASH) proportion will reported."
+      },
+      {
+        "name": "nonOpMCID",
+        "description": "The proportion of patients not achieving an MCID in DASH change score will be reported."
+      },
+      {
+        "name": "nonOpRisk",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via DASH) proportion will reported."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "historic_benchmarks": {
+      "registry": "removed"
+    }
+  },
+  {
+    "measureId": "IROMS20",
+    "title": "Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with arm, shoulder, or hand injury.",
+    "description": "The proportion of patients failing to achieve an MCID of two (2) points or more improvement in the NPRS change score for patients with arm, shoulder, or hand injury treated during the observation period will be reported. \n\nAdditionally, a risk-adjusted MCID proportional difference will be determined by calculating the difference between the risk model predicted and observed MCID proportion will reported for each physical therapist or physical therapy group. The risk adjustment will be calculated using a logistic regression model using: baseline DASH score, baseline pain score, age, sex, payer, and symptom duration (time from surgery or injury to baseline physical therapy visit). \n\nThese measures will serve as a physical or occupational therapy performance measure at the eligible physical or occupational therapist or physical or occupational therapy group level.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": true,
+    "primarySteward": "Keet Outcomes",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "3967247",
+      "1157686",
+      "8411367",
+      "7037323",
+      "2581402"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "notachieving",
+        "description": "Overall proportion of patients not achieving an MCID in the NPRS change score will be reported."
+      },
+      {
+        "name": "overall",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported."
+      },
+      {
+        "name": "operativeMCID",
+        "description": "The proportion of patients not achieving an MCID in the NPRS change score will be reported."
+      },
+      {
+        "name": "operativeRisk",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported."
+      },
+      {
+        "name": "nonOpMCID",
+        "description": "The proportion of patients not achieving an MCID in the NPRS change score will be reported."
+      },
+      {
+        "name": "nonOpRisk",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ],
+    "historic_benchmarks": {
+      "registry": "removed"
+    }
+  },
+  {
+    "measureId": "KEET01",
+    "title": "Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) to indicate functional improvement in rehabilitation of patients with neck pain/injury measured via the validated Neck Disability Index (NDI).",
+    "description": "The proportion of patients failing to achieve an MCID of seven and a half (7.5) points or more improvement in the NDI change score for neck pain/injury patients treated during the observation period will be reported. \n\nAdditionally, a risk-adjusted NDI change proportional difference will be determined by calculating the difference between the risk model predicted and observed MCID proportion will reported for each physical therapist or physical therapy group. The risk adjustment will be calculated using a logistic regression model using: baseline NDI score, baseline pain score, age, sex, payer, and symptom duration (time from surgery or injury to baseline physical therapy visit).\n\nThese measures will serve as a physical or occupational therapy performance measure at the eligible physical or occupational therapist or physical or occupational therapy group level.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": true,
+    "primarySteward": "Keet Outcomes",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "3967247",
+      "1157686",
+      "8411367",
+      "7037323",
+      "2581402"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "notachieving",
+        "description": "Overall proportion of patients not achieving an MCID in NDI change score will be reported."
+      },
+      {
+        "name": "overall",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via NDI) proportion will reported."
+      },
+      {
+        "name": "operativeMCID",
+        "description": "The proportion of patients not achieving an MCID in NDI change score will be reported."
+      },
+      {
+        "name": "operativeRisk",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via NDI) proportion will reported."
+      },
+      {
+        "name": "nonOpMCID",
+        "description": "The proportion of patients not achieving an MCID in NDI change score will be reported."
+      },
+      {
+        "name": "nonOpRisk",
+        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via NDI) proportion will reported."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "LMBR1",
+    "title": "Patients Suffering From a Knee Injury who Improve Physical Function",
+    "description": "Percentage of patients 18 years or older suffering from a knee injury who achieve the Minimal Clinically Important Difference (MCID) in the PROMIS Upper Extremity Computer Adaptive Testing. The MCID for PROMIS Physical Function is unique and validated for patients suffering knee functional deficits. This measure will be reported as the overall number of patients of rate 1 and rate 2 combined. To qualify, the patient must complete a baseline score and then one follow-up or discharge score. \n\nIn order to fairly measure performance between providers' performance, the measure is risk-adjusted based on a proprietary assessment including age, sex, symptom characteristics, PROMIS baseline scores, social determinants of health, and psychosocial metrics. \n\nThis measure will include three rates:\n1) The number of non-surgical patients achieving a score change of 2.1 points  in PROMIS Physical Function \n2) The number of surgical patients achieving a  score change of 2.1 points  in PROMIS Physical Function \n3) The overall performance rate of Rate 1 and Rate 2 combined",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Limber Outcomes",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "1574559"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "LMBR10",
+    "title": "Patients Suffering From a Shoulder Injury who Demonstrate Improved Pain",
+    "description": "Percentage of patients 18 years or older suffering from shoulder injury who achieve the Minimal Clinically Important Difference (MCID) in the PROMIS Pain Interference Computer Adaptive Testing (CAT). The MCID for PROMIS Pain Interference is unique and validated for patients suffering shoulder functional deficits. This measure will be reported as the overall number of patients of rate 1 and rate 2 combined. To qualify, the patient must complete a baseline score and then one follow-up or discharge score. \n\nIn order to fairly measure performance between providers' performance, the measure is risk-adjusted based on a proprietary assessment including age, sex, symptom characteristics, PROMIS baseline scores, social determinants of health, and psychosocial metrics. \n\nThis measure will include three rates:\n1) The number of non-surgical patients achieving a score change of 2.0 points  in PROMIS Pain Interference\n2) The number of surgical patients achieving a  score change of 2.0 points  in PROMIS Pain Interference\n3) The overall performance rate of Rate 1 and Rate 2 combined",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Limber Outcomes",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "1574559"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "LMBR2",
+    "title": "Patients Suffering From a Lumbar Spine (Low Back) Injury who Improve Physical Function",
+    "description": "Percentage of patients 18 years or older suffering from a lumbar spine (low back) injury who achieve the Minimal Clinically Important Difference (MCID) in the PROMIS Upper Extremity Computer Adaptive Testing. The MCID for PROMIS Physical Function is unique and validated for patients suffering low back functional deficits. This measure will be reported as the overall number of patients of rate 1 and rate 2 combined. To qualify, the patient must complete a baseline score and then one follow-up or discharge score. \n\nIn order to fairly measure performance between providers' performance, the measure is risk-adjusted based on a proprietary assessment including age, sex, symptom characteristics, PROMIS baseline scores, social determinants of health, and psychosocial metrics. \n\nThis measure will include three rates:\n1) The number of non-surgical patients achieving a score change of 2.1 points  in PROMIS Physical Function \n2) The number of surgical patients achieving a  score change of 2.1 points  in PROMIS Physical Function \n3) The overall performance rate of Rate 1 and Rate 2 combined",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Limber Outcomes",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "1574559"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "LMBR3",
+    "title": "Patients Suffering From a Cervical Spine (Neck) Injury who Improve Physical Function",
+    "description": "Percentage of patients 18 years or older suffering from a cervical spine (neck) injury who achieve the Minimal Clinically Important Difference (MCID) in the PROMIS Upper Extremity Computer Adaptive Testing. The MCID for PROMIS Physical Function is unique and validated for patients suffering neck functional deficits. This measure will be reported as the overall number of patients of rate 1 and rate 2 combined. To qualify, the patient must complete a baseline score and then one follow-up or discharge score. \n\nIn order to fairly measure performance between providers' performance, the measure is risk-adjusted based on a proprietary assessment including age, sex, symptom characteristics, PROMIS baseline scores, social determinants of health, and psychosocial metrics. \n\nThis measure will include three rates:\n1) The number of non-surgical patients achieving a score change of 2.1 points  in PROMIS Physical Function \n2) The number of surgical patients achieving a  score change of 2.1 points  in PROMIS Physical Function \n3) The overall performance rate of Rate 1 and Rate 2 combined",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Limber Outcomes",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "1574559"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "LMBR4",
+    "title": "Patients Suffering From a Hip Injury who Improve Physical Function",
+    "description": "Percentage of patients 18 years or older suffering from a hip injury who achieve the Minimal Clinically Important Difference (MCID) in the PROMIS Upper Extremity Computer Adaptive Testing. The MCID for PROMIS Physical Function is unique and validated for patients suffering hip functional deficits. This measure will be reported as the overall number of patients of rate 1 and rate 2 combined. To qualify, the patient must complete a baseline score and then one follow-up or discharge score. \n\nIn order to fairly measure performance between providers' performance, the measure is risk-adjusted based on a proprietary assessment including age, sex, symptom characteristics, PROMIS baseline scores, social determinants of health, and psychosocial metrics. \n\nThis measure will include three rates:\n1) The number of non-surgical patients achieving a score change of 2.1 points  in PROMIS Physical Function \n2) The number of surgical patients achieving a  score change of 2.1 points  in PROMIS Physical Function \n3) The overall performance rate of Rate 1 and Rate 2 combined",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Limber Outcomes",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "1574559"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "LMBR5",
+    "title": "Patients Suffering From a Shoulder Injury who Improve Physical Function",
+    "description": "Percentage of patients 18 years or older suffering from a shoulder injury who achieve the Minimal Clinically Important Difference (MCID) in the PROMIS Upper Extremity Computer Adaptive Testing. The MCID for PROMIS Upper Extremity is unique and validated for patients suffering shoulder functional deficits. This measure will be reported as the overall number of patients of rate 1 and rate 2 combined. To qualify, the patient must complete a baseline score and then one follow-up or discharge score. \n\nIn order to fairly measure performance between providers' performance, the measure is risk-adjusted based on a proprietary assessment including age, sex, symptom characteristics, PROMIS baseline scores, social determinants of health, and psychosocial metrics. \n\nThis measure will include three rates:\n1) The number of non-surgical patients achieving a score change of 2.1 points  in PROMIS Upper Extremity\n2) The number of surgical patients achieving a  score change of 2.1 points  in PROMIS Upper Extremity\n3) The overall performance rate of Rate 1 and Rate 2 combined",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Limber Outcomes",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "1574559"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "LMBR6",
+    "title": "Patients Suffering From a Knee Injury who Demonstrate Improved Pain",
+    "description": "Percentage of patients 18 years or older suffering from knee injury who achieve the Minimal Clinically Important Difference (MCID) in the PROMIS Pain Interference Computer Adaptive Testing (CAT). The MCID for PROMIS Pain Interference is unique and validated for patients suffering knee functional deficits. This measure will be reported as the overall number of patients of rate 1 and rate 2 combined. To qualify, the patient must complete a baseline score and then one follow-up or discharge score. \n\nIn order to fairly measure performance between providers' performance, the measure is risk-adjusted based on a proprietary assessment including age, sex, symptom characteristics, PROMIS baseline scores, social determinants of health, and psychosocial metrics. \n\nThis measure will include three rates:\n1) The number of non-surgical patients achieving a score change of 2.0 points  in PROMIS Pain Interference\n2) The number surgical patients achieving a  score change of 2.0 points  in PROMIS Pain Interference\n3) The overall performance rate of Rate 1 and Rate 2 combined",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Limber Outcomes",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "1574559"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "LMBR7",
+    "title": "Patients Suffering From a Lumbar Spine (Low Back) Injury who Demonstrate Improved Pain",
+    "description": "Percentage of patients 18 years or older suffering from lumbar spine (low back) pain who achieve the Minimal Clinically Important Difference (MCID) in the PROMIS Pain Interference Computer Adaptive Testing (CAT). The MCID for PROMIS Pain Interference is unique and validated for patients suffering low back functional deficits. This measure will be reported as the overall number of patients of rate 1 and rate 2 combined. To qualify, the patient must complete a baseline score and then one follow-up or discharge score. \n\nIn order to fairly measure performance between providers' performance, the measure is risk-adjusted based on a proprietary assessment including age, sex, symptom characteristics, PROMIS baseline scores, social determinants of health, and psychosocial metrics. \n\nThis measure will include three rates:\n1) The number of non-surgical patients achieving a score change of 2.0 points  in PROMIS Pain Interference\n2) The number of surgical patients achieving a  score change of 2.0 points  in PROMIS Pain Interference\n3) The overall performance rate of Rate 1 and Rate 2 combined",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Limber Outcomes",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "1574559"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "LMBR8",
+    "title": "Patients Suffering From a Cervical Spine (Neck) Injury who Demonstrate Improved Pain",
+    "description": "Percentage of patients 18 years or older suffering from cervical spine (neck) injury who achieve the Minimal Clinically Important Difference (MCID) in the PROMIS Pain Interference Computer Adaptive Testing (CAT). The MCID for PROMIS Pain Interference is unique and validated for patients suffering neck functional deficits. This measure will be reported as the overall number of patients of rate 1 and rate 2 combined. To qualify, the patient must complete a baseline score and then one follow-up or discharge score. \n\nIn order to fairly measure performance between providers' performance, the measure is risk-adjusted based on a proprietary assessment including age, sex, symptom characteristics, PROMIS baseline scores, social determinants of health, and psychosocial metrics. \n\nThis measure will include three rates:\n1) The number of non-surgical patients achieving a score change of 2.0 points  in PROMIS Pain Interference\n2) The number of surgical patients achieving a  score change of 2.0 points  in PROMIS Pain Interference\n3) The overall performance rate of Rate 1 and Rate 2 combined",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Limber Outcomes",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "1574559"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "LMBR9",
+    "title": "Patients Suffering From a Hip Injury who Demonstrate Improved Pain",
+    "description": "Percentage of patients 18 years or older suffering from hip injury who achieve the Minimal Clinically Important Difference (MCID) in the PROMIS Pain Interference Computer Adaptive Testing (CAT). The MCID for PROMIS Pain Interference is unique and validated for patients suffering hip functional deficits. This measure will be reported as the overall number of patients of rate 1 and rate 2 combined. To qualify, the patient must complete a baseline score and then one follow-up or discharge score. \n\nIn order to fairly measure performance between providers' performance, the measure is risk-adjusted based on a proprietary assessment including age, sex, symptom characteristics, PROMIS baseline scores, social determinants of health, and psychosocial metrics. \n\nThis measure will include three rates:\n1) The number of non-surgical patients achieving a score change of 2.0 points  in PROMIS Pain Interference\n2) The number of surgical patients achieving a  score change of 2.0 points  in PROMIS Pain Interference\n3) The overall performance rate of Rate 1 and Rate 2 combined",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Limber Outcomes",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "1574559"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MBHR1",
+    "title": "Use of Anxiety Severity Measure",
+    "description": "The percentage of adult patients (18 years and older) with an anxiety disorder diagnosis (e.g., generalized anxiety disorder, social anxiety disorder, or panic disorder) who have completed a standardized tool (e.g., GAD-7, BAI) during measurement period.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Community/Population Health",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MBHR Mental and Behavioral Health Registry",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "4067715"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MBHR10",
+    "title": "Symptom Improvement in adults with ADHD",
+    "description": "The percentage of adult patients (18 years of age or older) with a diagnosis of ADHD who show a reduction in symptoms of 25% on the Adult ADHD Self-Report Scale (ASRS-v1.1)- 18 item self-report scale of ADHD symptoms within 2 to 10months after initially reporting significant symptoms. There are two aspects to this measure. The first is the assessment of the use of the ASRS v.1. during the denominator identification period (Criteria 1 also referred to as Time 1) and the second is the assessment of improvement in the ASRS v.1.1 from the first administration to the second administration of the ASRS v.1.1 (Criteria 2 also referred to as Time 2).",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MBHR Mental and Behavioral Health Registry",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "4067715"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "screening",
+        "description": "Documentation of a standardized tool to assess ADHD (i.e., ASRS checklist) and a document care of plan"
+      },
+      {
+        "name": "overall",
+        "description": "Patient demonstrated an ASRS score that is reduced by 25% or greater from the index score, 2-10 months after index date"
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MBHR11",
+    "title": "Cognitive Assessment with Counseling on Safety and Potential Risk",
+    "description": "Percentage of patients, regardless of age, referred for evaluation due to concerns for cognitive impairment for whom 1) a standardized valid assessment of cognition was performed and 2) reporting of results included counseling on safety and potential risks.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MBHR Mental and Behavioral Health Registry",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "4067715"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MBHR12",
+    "title": "Provision of Feedback Following a Cognitive or Mental Status Assessment with Documentation of Understanding of Test Results and Subsequent Healthcare Plan",
+    "description": "Percentage of patients, regardless of age, who received a standardized cognitive or mental status assessment followed by provision of feedback regarding test results and associated recommendations, who acknowledged understanding of test results and associated recommendations and healthcare plan.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MBHR Mental and Behavioral Health Registry",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "4067715"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MBHR13",
+    "title": "Social Role Functioning Assessment utilizing PROMIS Adult Ability to Participate in Social Roles and Activities",
+    "description": "The percentage of adult patients (18 years of age or older) who report concerns related to their psychosocial function and who have completed a standardized assessment utilizing the PROMIS Adult Ability to Participate in Social Roles and Activities during measurement period.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MBHR Mental and Behavioral Health Registry",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "4067715"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MBHR14",
+    "title": "Sleep Quality Response at 3-months",
+    "description": "Percentage of patients 18 years and older who reported sleep quality concerns (e.g., insomnia) with documentation of a standardized tool AND demonstrated a response to treatment at three months (+/- 60 days) after index visit",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MBHR Mental and Behavioral Health Registry",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "4067715"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MBHR15",
+    "title": "Consideration of Cultural-Linguistic and Demographic Factors in Cognitive Assessment",
+    "description": "Percentage of patients, regardless of age, referred for evaluation due to concerns for cognitive changes or difficulties for whom 1) a standardized valid assessment of cognition was performed and 2) interpretation of results included consideration of appropriate and relevant cultural-linguistic and demographic factors.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MBHR Mental and Behavioral Health Registry",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "4067715"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MBHR16",
+    "title": "Comprehensive Cognitive Assessment Assists with Differential Diagnosis",
+    "description": "Percentage of patients, regardless of age, referred for evaluation due to concerns for cognitive impairment for whom 1) a standardized valid assessment of cognition was performed and 2) results of assessment informed determination of diagnosis or further clarified etiological factors of cognitive impairment or complaints.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MBHR Mental and Behavioral Health Registry",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "4067715"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MBHR17",
+    "title": "Improved Efficiency: Time Interval for reporting results of cognitive assessment",
+    "description": "Percentage of patients, regardless of age, for which the referring provider or patient receives reporting of assessment results within 14 days of the completion of assessment.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MBHR Mental and Behavioral Health Registry",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "4067715"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MBHR2",
+    "title": "Anxiety Response at 6-months",
+    "description": "The percentage of adult patients (18 years of age or older) with an anxiety disorder (e.g., generalized anxiety disorder, social anxiety disorder, or panic disorder) who demonstrated a response to treatment (GAD-7 score at least 25% less than score at index event) at 6-months (+/- 60 days) after an index visit.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "MBHR Mental and Behavioral Health Registry",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "4067715"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MBHR3",
+    "title": "Pain Interference Response utilizing PROMIS",
+    "description": "The percentage of adult patients (18 years of age or older) who report chronic pain issues and demonstrated a response to treatment at one month from the index score",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MBHR Mental and Behavioral Health Registry",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "4067715"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MBHR5",
+    "title": "Monitoring for psychosocial problems among children and youth",
+    "description": "Percentage of children from 3 to 17 years of age who are receiving a psychiatric or behavioral health intake visit AND who demonstrated a reliable change in parent-reported problem behaviors 2 to 10 months after initial positive screen for externalizing and internalizing behavior problems.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MBHR Mental and Behavioral Health Registry",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "4067715"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MBHR7",
+    "title": "Posttraumatic Stress Disorder (PTSD) Outcome Assessment for Adults and Children",
+    "description": "The percentage of patients with a history of a traumatic event (i.e., an experience that was unusually or especially frightening, horrible, or traumatic) who report symptoms consistent with PTSD for at least one month following the traumatic event AND with documentation of a standardized symptom monitor (PCL-5 for adults, CATS for child/adolescent) AND demonstrated a response to treatment at six months (+/- 120 days) after the index visit.\n\nThis measure is a multi-strata measure, which addresses symptom monitoring for both child and adult patients being treated for post-traumatic stress symptoms. Assessment instruments monitoring severity of symptoms for PTSD are validated either for adult or child populations. Thus, while the measurement structure will be similar for both populations, the specified instruments for symptom monitoring will be different.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MBHR Mental and Behavioral Health Registry",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "4067715"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MBHR8",
+    "title": "Alcohol Use Disorder Outcome Response",
+    "description": "The percentage of adult patients (18 years of age or older) who report problems with drinking alcohol (e.g., can be noted through a screening measure such as the AUDIT-C as described in MIPS Clinical Quality Measure Quality ID #431 aka NQF 2152 or other drug/alcohol screeners such as the DAST and TAPS) AND demonstrated a response to treatment at three months (+/- 60 days) after the index visit.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MBHR Mental and Behavioral Health Registry",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "4067715"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MBHR9",
+    "title": "Outcome monitoring of ADHD functional impairment in children and youth",
+    "description": "Percentage of children aged 4 through 18 years, with a diagnosis of attention deficit/hyperactivity disorder (ADHD), who demonstrate a change score of 0.25 or greater on the Weiss Functional Impairment Rating Scale - Parent Report (WFIRS-P) within 2 to 10 months after an initial positive finding of functional impairment.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MBHR Mental and Behavioral Health Registry",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "4067715"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MEDNAX54",
+    "title": "Labor Epidural Failure when Converting from Labor Analgesia to Cesarean Section Anesthesia",
+    "description": "The percentage of patients who have pre-existing labor epidural or combined epidural/spinal technique who require either repeat procedural epidural or spinal, general anesthesia, or supplemental sedation as defined below for cesarean section.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "ABG QCDR",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "5551268"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MEDNAX55",
+    "title": "Use of ASPECTS (Alberta Stroke Program Early CT Score) for non-contrast CT Head performed for suspected acute stroke.",
+    "description": "Percentage non-contrast CT Head performed for suspected acute stroke whose final reports include an ASPECTS value.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MSN Healthcare Solutions, LLC",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "5303416",
+      "6394618",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MEDNAX56",
+    "title": "Use of a “PEG Test” to Manage Patients Receiving Opioids",
+    "description": "Percentage of patients in an outpatient setting, aged 18 and older, in whom a stable dose of opioids are prescribed for greater than 6 weeks for pain control, and the results of a “PEG Test” are correctly interpreted and applied to the management of their opioid prescriptions.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ABG QCDR",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "5551268",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MEX5",
+    "title": "Hammer Toe Outcome",
+    "description": "Percentage of patients with a who have a lesser toe deformity (hammer and claw toes) causing pain that receive an intervention and have clinically significant reduction in pain as a result of that intervention.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Registry Clearinghouse",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "4117893"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MSN13",
+    "title": "Screening Coronary Calcium Scoring for Cardiovascular Risk Assessment Including Coronary Artery Calcification Regional Distribution Scoring",
+    "description": "Percentage of patients, regardless of age, undergoing Coronary Calcium Scoring who have measurable coronary artery calcification (CAC) with total CACS and regional distribution scoring documented in the Final report.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MSN Healthcare Solutions, LLC",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "5303416",
+      "6394618",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MSN15",
+    "title": "Use of Thyroid Imaging Reporting & Data System (TI-RADS) in Final Report to Stratify Thyroid Nodule Risk",
+    "description": "Percentage of patients, 19 years of age or older, undergoing ultrasound of the neck with\nfindings of thyroid nodule(s) whose reports include the TI-RADS assessment.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MSN Healthcare Solutions, LLC",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "5303416",
+      "6394618",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MSN16",
+    "title": "Screening Abdominal Aortic Aneurysm Reporting with Recommendations",
+    "description": "Percentage of patients, aged 50-years-old or older, who have had a screening ultrasound for an abdominal aortic aneurysm with a positive finding of abdominal aortic aneurysm (AAA), that have recognized clinical follow up recommendations documented in the final report and direct communication of findings greater than or equal to 5.5 cm in size made to the ordering provider.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MSN Healthcare Solutions, LLC",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5303416",
+      "6394618",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MUSIC10",
+    "title": "Prostate Cancer: Confirmation testing in low risk active surveillance eligible patients",
+    "description": "Percentage of low risk patients that are eligible for active surveillance who receive confirmation testing within 6 months of diagnosis",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Urological Association Quality (AQUA) Registry",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "8758330"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MUSIC11",
+    "title": "Prostate Cancer: Follow-up testing for patients on active surveillance for at least 30 months",
+    "description": "Percentage of patients on active surveillance that have 2 or more tumor burden reassessments and 3 PSA tests in first 30 months since diagnosis",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Urological Association Quality (AQUA) Registry",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "8758330"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "MUSIC4",
+    "title": "Prostate Cancer: Active Surveillance/Watchful Waiting for Low Risk Prostate Cancer Patients",
+    "description": "Proportion of patients with low-risk prostate cancer receiving active surveillance or watchful waiting",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Urological Association Quality (AQUA) Registry",
+    "firstPerformanceYear": 2014,
+    "allowedVendors": [
+      "8758330"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "NHCR4",
+    "title": "Repeat screening or surveillance colonoscopy recommended within one year due to inadequate/poor bowel preparation",
+    "description": "Percentage of patients recommended for repeat screening or surveillance colonoscopy within one year or less due to inadequate/poor bowel preparation quality",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "GIQuIC; New Hampshire Colonoscopy Registry (NHCR)",
+    "firstPerformanceYear": 2015,
+    "allowedVendors": [
+      "5846856",
+      "6981170"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "NHII1",
+    "title": "Screening and Referral for Transportation Insecurity",
+    "description": "Percentage of patients aged 18 years and older who were screened for transportation insecurity within the measurement period AND/OR received a referral or intervention to address transportation insecurity.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "intermediateOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Nebraska Health information initiative",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "1573453"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "OEIS6",
+    "title": "Appropriate non-invasive arterial testing for patients with intermittent claudication who are undergoing a LE peripheral vascular intervention",
+    "description": "Proportion of patients with non-invasive evaluations present/available prior to LE peripheral vascular interventions in patients with intermittent claudication.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Outpatient Endovascular and Interventional Society National Registry",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "7689991"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "OEIS7",
+    "title": "Structured Walking Program Prior to Intervention for Claudication",
+    "description": "Proportion of patients who completed a structured walking program of a duration not less than 12 weeks prior to undergoing peripheral arterial intervention in patients with claudication",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Outpatient Endovascular and Interventional Society National Registry",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "7689991"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "OEIS8",
+    "title": "Use of ultrasound guidance for vascular access",
+    "description": "Proportion of vascular access using ultrasound guidance for vessel puncture during endovascular procedures.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Outpatient Endovascular and Interventional Society National Registry",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "7689991"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "PIMSH1",
+    "title": "Oncology: Advance Care Planning in Metastatic Cancer Patients",
+    "description": "Percentage of patients with metastatic (stage 4) cancer who have a documented Advance Care Planning discussion in the first 6 months after metastatic diagnosis to inform treatment decisions and end-of-life care.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "patientEngagementExperience",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Practice Insights by McKesson in Collaboration with The US Oncology Network - QCDR",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "8794712"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "PIMSH10",
+    "title": "Oncology: Hepatitis B serology testing and prophylactic treatment prior to receiving anti-CD20 targeting drugs",
+    "description": "Percentage of patients tested for Hepatitis B prior to receiving anti-CD20 targeting treatment, including rituximab, ofatumumab, and Obinutuzumab; patients testing positive for Hepatitis B receive prophylactic treatment.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Practice Insights by McKesson in Collaboration with The US Oncology Network - QCDR",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "8794712"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "PIMSH12",
+    "title": "COVID-19 Vaccinations",
+    "description": "Percentage of patients who have ever completed a full COVID-19 vaccination series",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Community/Population Health",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Practice Insights by McKesson in Collaboration with The US Oncology Network - QCDR",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "8794712"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "PIMSH2",
+    "title": "Oncology: Utilization of GCSF in Metastatic Colorectal Cancer",
+    "description": "Percentage of Stage 4 colon/rectal cancer patients receiving any white cell growth factors with chemotherapy",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "efficiency",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "Practice Insights by McKesson in Collaboration with The US Oncology Network - QCDR",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "8794712"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "PIMSH4",
+    "title": "Oncology: Patient-Reported Pain Improvement",
+    "description": "Percentage of cancer patients currently receiving chemotherapy or radiation therapy who report significant pain improvement (high to moderate, moderate to low, or high to low) within 30 days.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Practice Insights by McKesson in Collaboration with The US Oncology Network - QCDR",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "8794712"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "PIMSH8",
+    "title": "Oncology: Mutation testing for lung cancer completed prior to start of targeted therapy",
+    "description": "Proportion of stage 4 NSCLC patients tested for actionable biomarkers, including EGFR, BRAF mutation; ROS1, ALK rearrangement; PD-L1 expression, and received targeted therapy or chemotherapy based on biomarker results.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Practice Insights by McKesson in Collaboration with The US Oncology Network - QCDR",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "8794712"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "PIMSH9",
+    "title": "Oncology: Supportive Care Drug Utilization in Last 14 Days of Life",
+    "description": "Percentage of patients receiving supportive care drugs (including colony stimulating factors, bone health, supplemental iron medications, and neurokinin 1 (NK1) receptor antagonist antiemetics) during the 14 days prior to and including the date of death.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "efficiency",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "Practice Insights by McKesson in Collaboration with The US Oncology Network - QCDR",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "8794712"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "POLAR1",
+    "title": "Antiemetic Therapy for Low- and Minimal-Emetic-Risk Antineoplastic Agents - Avoidance of Overuse (Lower Score - Better).",
+    "description": "Percentage of cancer patients aged 18 years and older treated with low- or minimal-emetic-risk antineoplastic agents who are administered inappropriate pre-treatment antiemetic therapy.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "POLARIS QCDR in collaboration with the American Society of Clinical Oncology",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "5792497"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "PP10",
+    "title": "Measurement-based Care Processes: Index Assessment, Monitoring and Care Plan Review",
+    "description": "Percentage of individuals 18 years of age and older with a mental and/or substance disorder, who had a comprehensive index assessment in the measurement period, with monitoring and care plan review. Three rates are reported. \n1.\tPercentage of individuals who had a comprehensive index assessment using standardized tools to assess at least 3 of the following 6 domains: functioning, recovery, and symptom severity in depression, anxiety, substance use, and suicidal ideation and behavior. \n2.\tPercentage of individuals who were monitored 90 days (+/- 30 days) from the comprehensive index assessment using standardized tools to assess functioning, recovery, or symptom severity in depression, anxiety, substance use, or suicidal ideation and behavior. \n3.\tPercentage of individuals with documentation of a clinical decision to adjust or maintain their care within 180 days from the comprehensive index assessment using standardized tools to assess functioning, recovery, and symptom severity in depression, anxiety, substance use, or suicidal ideation and behavior.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "PsychPRO",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "4078845"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "simpleAverage",
+    "strata": [
+      {
+        "name": "assessment",
+        "description": "Percentage of individuals who had a comprehensive index assessment using standardized tools to assess at least 3 of the following 6 domains: functioning, recovery, and symptom severity in depression, anxiety, substance use, and suicidal ideation and behavior."
+      },
+      {
+        "name": "monitorAt90Days",
+        "description": "Percentage of individuals who were monitored 90 days (+/- 30 days) from the comprehensive index assessment using standardized tools to assess functioning, recovery, or symptom severity in depression, anxiety, substance use, or suicidal ideation and behavior."
+      },
+      {
+        "name": "maintnCareAt180Days",
+        "description": "Percentage of individuals with documentation of a clinical decision to adjust or maintain their care within 180 days from the comprehensive index assessment using standardized tools to assess functioning, recovery, and symptom severity in depression, anxiety, substance use, or suicidal ideation and behavior."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "PP11",
+    "title": "Improvement or Maintenance in Recovery for Individuals with a Mental Health and/or Substance Use Disorder",
+    "description": "The percentage of individuals aged 18 and older with a mental and/or substance use disorder who demonstrated improvement or maintenance in recovery (as defined, prioritized, and/or reported by the individual) based on results from the 24-item Recovery Assessment Scale (RAS-R) 150 to 210 days after an index assessment.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "PsychPRO",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "4078845"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "PP12",
+    "title": "Utilization and Review of Suicide Safety Plan for Individuals with Suicidal Ideation, Behavior or Suicide Risk",
+    "description": "This measure assesses the percentage of individuals aged 18 and older with suicidal ideation or behavior symptoms (based on results of a standardized assessment tool) or suicide risk (based on the clinician’s evaluation) for whom a suicide safety plan is initiated, reviewed and updated in collaboration between the individual and their clinician at least twice during the measurement period. Two rates are reported: \n1.\tThe percentage of individuals for whom a suicide safety plan is initiated, reviewed, or updated in collaboration between the individual and their clinician (concurrent or within 24 hours of the index clinical encounter). \n2.\tThe percentage of individuals for whom a suicide safety plan is initiated, reviewed, or updated (Numerator 1) AND reviewed and updated in collaboration between the individual and their clinician within 120 days after the index clinical encounter.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "PsychPRO",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "4078845"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "safetyPlanWithIn24hr",
+        "description": "The percentage of individuals for whom a suicide safety plan is initiated, reviewed, or updated in collaboration between the individual and their clinician (concurrent or within 24 hours of the index clinical encounter)."
+      },
+      {
+        "name": "overall",
+        "description": "The percentage of individuals for whom a suicide safety plan is initiated, reviewed, or updated (Numerator 1) AND reviewed and updated in collaboration between the individual and their clinician within 120 days after the index clinical encounter."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "PP13",
+    "title": "Reduction in Suicidal Ideation or Behavior Symptoms",
+    "description": "The percentage of individuals aged 18 and older who demonstrated a reduction in suicidal ideation and/or behavior symptoms based on results from the Columbia-Suicide Severity Rating Scale Screen Version plus the Intensity of Ideation Subscale of the Since Last Visit version of the C-SSRS within 90 days (+30 days) after a baseline visit.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "PsychPRO",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "4078845"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "PQRANES1",
+    "title": "Use of Peripheral Nerve Block within the Emergency Department in Patients Admitted with Low Energy Hip Fracture",
+    "description": "Percentage of patients aged 65 years and older that receive a peripheral nerve block for analgesia following diagnosis of isolated hip fracture within the Emergency Department",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "The PQR-ANES",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "PQRANES2",
+    "title": "Use of Subarachnoid Block (SAB) in Older Patients Undergoing Low Energy Hip Fracture Repair",
+    "description": "Percentage of patients ages 65 years and older that receive SAB for operative fixation of low energy, isolated hip fracture.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "The PQR-ANES",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "QMM16",
+    "title": "IVC Filter Management Confirmation",
+    "description": "Percentage of final reports for eligible exams where an IVC filter is present and the radiologist included a statement of recommendation in the Impression of the report for the treating clinician to:\n1) Assess if there is a management plan in place for the patient’s IVC filter, \nAND \n2) If there is no established management plan for the patient’s IVC filter, refer the patient to an interventional clinician on a nonemergent basis for evaluation.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MSN Healthcare Solutions, LLC",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5303416",
+      "6394618"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "QMM17",
+    "title": "Appropriate Follow-up Recommendations for Ovarian-Adnexal Lesions using the Ovarian-Adnexal Reporting and Data System (O-RADS)",
+    "description": "The percentage of final reports for female patients receiving a transvaginal ultrasound (US) examination of the pelvis (including transabdominal/transvaginal exams) where a clinically relevant lesion is detected, in which the radiologist describes the lesion using O-RADS Lexicon Descriptors and subsequently makes the correct clinical management recommendation based on the O-RADS Risk Stratification and Management System.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MSN Healthcare Solutions, LLC",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5303416",
+      "6394618"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "QMM18",
+    "title": "Use of Breast Cancer Risk Score on Mammography",
+    "description": "The percentage of final reports for screening mammograms which include the patient’s estimated numeric risk assessment based on a valid and published model**, and appropriate recommendations for supplemental screening based on the patient’s estimated risk and documentation of the source of recommendation.\n** Must be one of the models listed in the numerator instructions of this measure specification.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MSN Healthcare Solutions, LLC",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5303416",
+      "6394618",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "QMM19",
+    "title": "DEXA/DXA and Fracture Risk Assessment for Patients with Osteopenia",
+    "description": "All patients with osteopenia, aged 40-90 at time of service, who undergo DEXA scans for bone density who have their FRAX score included in the final report.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MSN Healthcare Solutions, LLC",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5303416",
+      "6394618",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "QMM20",
+    "title": "Opening Pressure in Lumbar Puncture",
+    "description": "Percentage of final reports for patients aged 18 years or older, which include Documentation of Opening Pressure Value obtained during Lumbar Puncture",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MSN Healthcare Solutions, LLC",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "5303416",
+      "6394618",
+      "1725296"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "QMM21",
+    "title": "Incorporating results of concurrent studies into Final Reports for Bone Marrow Aspirate of patients with Leukemia, Myelodysplastic syndrome, or Chronic Anemia",
+    "description": "The percentage of Final Bone Marrow Aspirate Reports of patients with Leukemia, Myelodysplastic syndrome, or Chronic Anemia with documentation of concurrent studies performed and their respective results.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MSN Healthcare Solutions, LLC",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "6394618"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "QMM22",
+    "title": "Multi-gene next-generation sequencing panel recommended on Fine Needle Aspirations (FNA) of Thyroid Nodule(s) with indeterminate cytology",
+    "description": "The percentage of patients with a thyroid nodule of indeterminate cytology with a recommendation for a multi-gene next-generation sequencing panel (ThyroSeq V2) in Final Pathology Report, followed with direct communication to Patient/Ordering or Attending Provider regarding recommendation.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MSN Healthcare Solutions, LLC",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "6394618"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "QOPI23",
+    "title": "Concurrent Chemo radiation for Patients with a Diagnosis of Stage IIIB NSCLC",
+    "description": "Percentage of patients, regardless of age, with a diagnosis of Stage IIIB non-small cell lung cancer (NSCLC) receiving concurrent chemoradiation.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "POLARIS QCDR in collaboration with the American Society of Clinical Oncology",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "5792497"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "QOPI27",
+    "title": "Appropriate Antiemetic Therapy for High- and Moderate Emetic Risk Antineoplastic Agents",
+    "description": "Percentage of cancer patients aged 18 years and older treated with high- or moderate-emetic risk antineoplastic agents who are administered appropriate pre-treatment antiemetic therapy",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "POLARIS QCDR in collaboration with the American Society of Clinical Oncology",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "5792497"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "QUANTUM31",
+    "title": "Central Line Ultrasound Guidance",
+    "description": "Percentage of patients, regardless of age, in whom ultrasound guidance is used by the clinician\nwhen placing a central line for those central lines that are placed in the internal jugular location.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Patient Safety",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ABG QCDR",
+    "firstPerformanceYear": 2016,
+    "allowedVendors": [
+      "5551268",
+      "6169123",
+      "6775913",
+      "6394618",
+      "1725296",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "RCOIR10",
+    "title": "Upper Extremity Edema Improvement",
+    "description": "Upper Extremity Edema Improvement is the percentage of patients with ESRD who present with upper\nextremity edema and report an improvement within 48 hours after an endovascular intervention has been performed.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Renal and Vascular Outcomes Improvement Program, powered by Forward Health Group",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "4302083"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "RCOIR12",
+    "title": "Tunneled Hemodialysis Catheter Success",
+    "description": "Tunneled Hemodialysis Catheter Success is the percentage of patients with ESRD that had insertion or replacement of a central venous access device during the past 12 months who received a full dialysis treatment within 72 hours of catheter insertion or replacement.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Renal and Vascular Outcomes Improvement Program, powered by Forward Health Group",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "4302083"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "RCOIR13",
+    "title": "Percutaneous Arteriovenous Fistula for Dialysis - Clinical Success Rate",
+    "description": "Percentage of clinically successful percutaneously created arteriovenous fistulae (pAVF) for patients aged 18 years and older on maintenance hemodialysis dialysis",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Renal and Vascular Outcomes Improvement Program, powered by Forward Health Group",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "4302083"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "RCOIR5",
+    "title": "End Stage Renal Disease (ESRD) Initiation of Home Dialysis or Self-Care",
+    "description": "End Stage Renal Disease (ESRD) Initiation of Home Dialysis or Self-Care is the percentage of all adult ESRD patients on peritoneal dialysis (PD) or home hemodialysis.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Renal and Vascular Outcomes Improvement Program, powered by Forward Health Group",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "4302083"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "RCOIR7",
+    "title": "Improved Access Site Bleeding",
+    "description": "Improved Access Site Bleeding is the percentage of patients with ESRD and a vascular access site who presented for prolonged bleeding and who reported a reduction in bleeding after an intervention",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Renal and Vascular Outcomes Improvement Program, powered by Forward Health Group",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "4302083"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "REGCLR1",
+    "title": "Heel Pain Treatment Outcomes for Adults",
+    "description": "Percentage of patients aged 18 and older with a diagnosis of heel pain who receive an intervention intended to treat the heel pain and experience a clinically significant decrease in heel pain.\nPatients who have had at least two visits during the reporting period\"",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Registry Clearinghouse",
+    "firstPerformanceYear": 2020,
+    "allowedVendors": [
+      "4117893"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "REGCLR2",
+    "title": "Tendinitis/ Enthesopathy- Injection Treatment Outcomes for Adults",
+    "description": "Percentage of patients aged 18 or older with a diagnosis of Tendinitis that have a reduction in pain after injection therapy.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Registry Clearinghouse",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "4117893"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "REGCLR3",
+    "title": "Bunion Outcome - Adult and Adolescent",
+    "description": "Percentage of patients with a who have a hallux valgus (bunion) deformity causing pain that receive an intervention and have clinically significant reduction in pain as a result of that intervention.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Registry Clearinghouse",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "4117893"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "REGCLR4",
+    "title": "Heel Pain Treatment Outcomes for Pediatric Patients",
+    "description": "Percentage of patients aged 6 to 18 years with a diagnosis of heel pain who receive an intervention intended to treat the heel pain and experience a clinically significant decrease in heel pain.\nPatients who have had at least two visits during the reporting period",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Registry Clearinghouse",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "4117893"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "REGCLR5",
+    "title": "Offloading with Remote Monitoring",
+    "description": "Percentage of patients with a plantar foot ulcer who were compliant with offloading and healed their ulcer in 10 (ten) weeks.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Registry Clearinghouse",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "4117893"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "REGCLR6",
+    "title": "Use of Digital Imaging to Monitor and Improve Treatment Outcomes in Chronic Wound Healing",
+    "description": "This measure is specifically for CHRONIC wounds. Those are wounds that have been present for an extended period of time and have not demonstrated healing. \nPercentage of patients presenting with a non-healing (chronic) wound (present for 6 weeks with no or limited response to treatment) who are currently visiting a provider responsible for their wound care, whose provider is using a software-based wound surface area measurement tool, and whose wound healing rate has accelerated since their provider’s adoption of said tool.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Registry Clearinghouse",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "4117893"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "REGCLR7",
+    "title": "Use of Ankle Foot Orthotics to improve patient function",
+    "description": "This measures the improvement in function of patients who are prescribed foot and ankle braces for plantar fasciitis, Posterior Tibial Tendon Dysfunction, and ankle sprains",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Registry Clearinghouse",
+    "firstPerformanceYear": 2021,
+    "allowedVendors": [
+      "4117893"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "RPAQIR13",
+    "title": "Rate of Timely Documentation Transmission to Dialysis Unit/Referring Physician",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of end-stage renal disease (ESRD) and who are undergoing maintenance hemodialysis or peritoneal dialysis in an outpatient dialysis facility and for whom documentation is sent to the dialysis unit or referring physician within two business days of the procedure completion or consultation by an interventional nephrologist, radiologist, or vascular surgeon.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Renal and Vascular Outcomes Improvement Program, powered by Forward Health Group",
+    "firstPerformanceYear": 2016,
+    "allowedVendors": [
+      "4302083"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "RPAQIR14",
+    "title": "Arteriovenous Graft Thrombectomy Success Rate",
+    "description": "Percentage of clinically successful arteriovenous graft (AVG) thrombectomies for patients aged 18 years and older.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Renal and Vascular Outcomes Improvement Program, powered by Forward Health Group",
+    "firstPerformanceYear": 2016,
+    "allowedVendors": [
+      "4302083"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "RPAQIR15",
+    "title": "Arteriovenous Fistulae Thrombectomy Success Rate",
+    "description": "Percentage of clinically successful arteriovenous fistulae (AVF) thrombectomies for patients aged 18 years and older on maintenance hemodialysis dialysis",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Renal and Vascular Outcomes Improvement Program, powered by Forward Health Group",
+    "firstPerformanceYear": 2016,
+    "allowedVendors": [
+      "4302083"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "RPAQIR16",
+    "title": "Peritoneal Dialysis Catheter Success Rate",
+    "description": "Percentage of clinically successful peritoneal dialysis (PD) catheter placements in patients aged 18 and older.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Renal and Vascular Outcomes Improvement Program, powered by Forward Health Group",
+    "firstPerformanceYear": 2016,
+    "allowedVendors": [
+      "4302083"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "RPAQIR18",
+    "title": "Advance Directives Completed",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of Stage 3, 4 & 5 chronic kidney disease (CKD) or end stage renal disease (ESRD) who have advance directives and/or end of life medical orders (e.g., POLST, MOLST, MOST, POST, etc.) completed based on their preferences.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Renal and Vascular Outcomes Improvement Program, powered by Forward Health Group",
+    "firstPerformanceYear": 2016,
+    "allowedVendors": [
+      "4302083"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "RPAQIR5",
+    "title": "Transplant Referral",
+    "description": "Percentage of patients aged 18 -75 years old with a diagnosis of end-stage renal disease (ESRD) on hemodialysis or peritoneal dialysis for 90 days or longer who are referred to a transplant center for kidney transplant evaluation within a 12-month period.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Communication and Care Coordination",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Renal and Vascular Outcomes Improvement Program, powered by Forward Health Group",
+    "firstPerformanceYear": 2014,
+    "allowedVendors": [
+      "4302083"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "UREQA1",
+    "title": "Ankylosing Spondylitis: Controlled Disease",
+    "description": "Percentage of qualifying visits for patients aged 18 years and older with a diagnosis of ankylosing spondylitis for at least 6 months whose most recent BASDAI score is less than 4.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "UREQA (United Rheumatology Effectiveness and Quality Analytics)",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "1649514"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "UREQA2",
+    "title": "Ankylosing Spondylitis: Appropriate Pharmacologic Therapy",
+    "description": "Percentage of patients aged 18 years and older with a first diagnosis of ankylosing spondylitis who are treated with nonsteroidal anti-inflammatory drugs (NSAIDs) before initiation of biologic therapy.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Efficiency and Cost Reduction",
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "UREQA (United Rheumatology Effectiveness and Quality Analytics)",
+    "firstPerformanceYear": 2018,
+    "allowedVendors": [
+      "1649514"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "UREQA7",
+    "title": "Ankylosing Spondylitis: Improved Disease Function",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of Ankylosing Spondylitis and who were in suboptimal disease control (BASDAI score >= 4.0) and who have seen an improvement by at least one point over the previous BASDAI score within the last 12 months.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "UREQA (United Rheumatology Effectiveness and Quality Analytics)",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "1649514"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "UREQA8",
+    "title": "Vitamin D level: Effective Control of Low Bone Mass/Osteopenia and Osteoporosis: Therapeutic Level Of 25 OH Vitamin D Level Achieved",
+    "description": "Percentage of patients aged 65 years and older diagnosed with osteopenia or osteoporosis whose most recent serum 25 Hydroxy-Vitamin D results is greater than or equal to 30.0 ng/dL. \nReporting Frequency:\nThis measure is reported once per reporting period.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "UREQA (United Rheumatology Effectiveness and Quality Analytics)",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "1649514"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "UREQA9",
+    "title": "Screening for Osteoporosis for Men Aged 70 Years and Older",
+    "description": "Percentage of male patients aged 70 years and older who had a central dual-energy X-ray absorptiometry (DXA) to screen for osteoporosis \n\n\nReporting Frequency:\nThis measure is reported once per reporting period",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "UREQA (United Rheumatology Effectiveness and Quality Analytics)",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "1649514"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "USWR22",
+    "title": "Patient Reported Nutritional Assessment and Intervention Plan in patients with Wounds and Ulcers",
+    "description": "The percentage of patients in the denominator for whom an appropriate intervention plan is recommended by the practitioner based on the assessment results.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "U.S. Wound Registry",
+    "firstPerformanceYear": 2017,
+    "allowedVendors": [
+      "6853338"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "USWR26",
+    "title": "Patient Reported Outcome of late effects of radiation symptoms following treatment with Hyperbaric Oxygen Therapy (HBOT)",
+    "description": "The percentage of patients 18 or older undergoing 10 or more treatments with HBOT for late effects of radiation whose self reported symptoms improve by at least 2 categories on the appropriate questionnaire (e.g. the Hematuria classification scale, the Chandler grade, the Cystitis questionnaire, the Bowel questionnaire, the head and neck questionnaire).",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "U.S. Wound Registry",
+    "firstPerformanceYear": 2019,
+    "allowedVendors": [
+      "6853338"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "USWR29",
+    "title": "Adequate Off-loading of Diabetic Foot Ulcers performed at each visit, appropriate to location of ulcer",
+    "description": "Percentage of visits in which diabetic foot ulcers among patients aged 18 years and received adequate off-loading during a 12-month reporting period, stratified by location of the ulcer. Off-loading is not a simple documentation process but may include performing a procedure such as Total Contact Casting or providing appropriate footwear.\n\nThe location of the diabetic foot ulcer on the foot (e.g., heel/midfoot vs. toes) determines the type of off-loading device that is appropriate, the patient’s risk of falling, the probability of successful off-loading and thus the likelihood of major amputation. The clinician needs to evaluate these factors and then provide the most appropriate off-loading option.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "U.S. Wound Registry",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "6621356",
+      "6853338"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "midfootHeel",
+        "description": "Midfoot/heel"
+      },
+      {
+        "name": "toes",
+        "description": "Toes"
+      },
+      {
+        "name": "overall",
+        "description": "The average of the two risk stratified buckets which will be the performance rate in the JSON or XML file submitted."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "USWR30",
+    "title": "Non-Invasive Arterial Assessment of patients with lower extremity wounds or ulcers for determination of healing potential at the initial visit",
+    "description": "Percentage of patients aged 18 years or older with a non-healing lower extremity wound or ulcer that undergo a non-invasive arterial assessment at the initial visit for the wound or ulcer, once in a 12-month period",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "U.S. Wound Registry",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "6853338"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "USWR31",
+    "title": "Pressure Ulcer* (PU) Healing or Closure (not on the lower extremity )",
+    "description": "Percentage of Stage 2, 3, or 4 pressure ulcers* (not on the lower extremity) among patients aged 18 or older that achieve healing or closure within 6 months, stratified by the Wound Healing Index (WHI). Healing or closure may occur by delayed secondary intention or may be the result of surgical intervention (e.g., rotational flap or skin graft). Lower extremity pressure ulcers are not included in this measure because they commonly overlap with arterial and diabetic foot ulcers and require a separate risk stratification model. [Note: The National Pressure Injury Advisory Panel (NPIA) (formerly the NPUAP) has renamed pressure ulcers “pressure injuries,” but the ICD-10-CM continues to use the term pressure “ulcers”. This measure is limited to open defects (stages 2, 3, 4) which heal by secondary intention or surgical closure, typically referred to as ulcers.]",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Person and Caregiver Centered Experience and Outcomes",
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "U.S. Wound Registry",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "6853338"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "likelyToHeal",
+        "description": "pressure ulcers likely to heal with conservative care,"
+      },
+      {
+        "name": "mayHeal",
+        "description": "pressure ulcers which may or may not heal,"
+      },
+      {
+        "name": "unlikelyToHeal",
+        "description": "pressure ulcers which are unlikely to heal. The average of the three risk stratified buckets which will be the performance rate in the XML submitted."
+      },
+      {
+        "name": "overall",
+        "description": "The average of the three risk stratified buckets which will be the performance rate in the XML submitted."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  },
+  {
+    "measureId": "USWR32",
+    "title": "Adequate Compression at each visit for Patients with Venous Leg Ulcers (VLUs) appropriate to arterial supply",
+    "description": "Percentage of venous leg ulcer visits among patients aged 18 years and older in which adequate compression is performed at each treatment visit in the 12 month reporting period or until VLU outcome . Arterial status must first be assessed at least one time with any non-invasive method (see: USWR 23: Arterial Screening Measure). Compression method should be appropriate to documented arterial supply.",
+    "nqfId": null,
+    "nationalQualityStrategyDomain": "Effective Clinical Care",
+    "measureType": "intermediateOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "U.S. Wound Registry",
+    "firstPerformanceYear": 2022,
+    "allowedVendors": [
+      "6853338"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "overallAlgorithm": "overallStratumOnly",
+    "strata": [
+      {
+        "name": "noRestrictions",
+        "description": "Normal arterial supply based on testing- No restrictions on type of compression"
+      },
+      {
+        "name": "specialConsideration",
+        "description": "Compression bandaging with special considerations (e.g., short stretch bandaging, warnings to the patient to remove bandages if they feel too tight, etc.)"
+      },
+      {
+        "name": "notRecommended",
+        "description": "Compression bandaging not recommended"
+      },
+      {
+        "name": "overall",
+        "description": "The average of the three risk stratified buckets which will be the performance rate in the JSON XML submitted."
+      }
+    ],
+    "submissionMethods": [
+      "registry"
+    ]
+  }
+]

--- a/measures/2023/measures-schema.yaml
+++ b/measures/2023/measures-schema.yaml
@@ -1,0 +1,482 @@
+$id: https://github.com/CMSgov/qpp-measures-data/blob/master/measures/2023/measures-schema.yaml
+$schema: http://json-schema.org/draft-07/schema
+type: array
+items: { $ref: #/definitions/measure }
+uniqueItemProperties: ['measureId'] # used by ajv-keywords
+
+definitions:
+  measure:
+    title: 'Measure'
+    type: object
+    anyOf:
+      - { $ref: #/definitions/iaMeasure }
+      - { $ref: #/definitions/piMeasure }
+      - { $ref: #/definitions/qualityMeasure }
+      - { $ref: #/definitions/aggregateCostMeasure }
+
+  baseMeasure:
+    title: 'Base Measure'
+    type: object
+    properties:
+      measureId:
+        type: string
+        description: For quality measures, the measureId is the same as the quality number. For a Promoting Interoperability (PI, formerly ACI) measure, the measureId is the measure identifier for the PI measure, and for an improvement activity (IA) measure, the measureId is the measure identifier for the IA measure.
+      title: 
+        type: string
+        description: The name of the measure.
+      description: 
+        type: string
+        description: A description of the measure for more detail with key words/phrases.
+      category:
+        description: QPP scoring category to which the measure belongs: Improvement Activities, Quality, Promoting Interoperability (formerly Advancing Care Information), and Cost.
+        enum: [ia, quality, pi, cost]
+      metricType:
+        description: Type of measurement that the measure requires in order to attest.
+        enum: [boolean, proportion, singlePerformanceRate, multiPerformanceRate, registrySinglePerformanceRate, registryMultiPerformanceRate, nonProportion, cahps, costScore]
+      firstPerformanceYear:
+        description: Year in which the measure was introduced.
+        type: integer
+        default: 2017
+      lastPerformanceYear:
+        description: Year in which the measure was deprecated.
+        type: [integer, 'null']
+        default: 'null'
+      measureSpecification:
+        description: URL link for Measure Specification PDF to download by Submission Method.
+        anyOf:
+          - { $ref: #/definitions/measureSpecification }
+          - { type: 'null' }
+      measureSets:
+        description: Quality measures can belong to multiple measure sets that represent different specialties.
+        type: array
+        items: { $ref: #/definitions/measureSets }
+    required: [measureId, title, description, category, metricType, firstPerformanceYear, lastPerformanceYear]
+
+  iaMeasure:
+    $merge:
+      source:
+        { $ref: #/definitions/baseMeasure }
+      with:
+        title: 'IA Measure'
+        type: object
+        additionalProperties: false
+        properties:
+          category: { const ia }
+          weight:
+            description: Determines the points granted for attesting to the measure.
+            enum: [null, medium, high]
+            default: medium
+          subcategoryId:
+            description: IA category which the measure incentivizes.
+            oneOf: [{ $ref: #/definitions/subcategoryIds }]
+        required: [weight, subcategoryId]
+
+  piMeasure:
+    $merge:
+      source:
+        { $ref: #/definitions/baseMeasure }
+      with:
+        title: 'PI Measure'
+        type: object
+        additionalProperties: false
+        properties:
+          category: { const pi }
+          reportingCategory:
+            description: The reporting category of the PI measure.
+            enum: [required, bonus, exclusion, null]
+          objective:
+            description: PI category which the measure incentivizes.
+            oneOf: [{ $ref: #/definitions/objectives }]
+          isRequired:
+            description: If true, attesting to the measure is required in order to receive a non-zero PI score.
+            type: boolean
+            default: false
+          isBonus:
+            description: If true, attesting to the measure will qualify the provider for PI bonus points.
+            type: boolean
+            default: false
+          substitutes:
+            description: Identifiers of other PI measures that can be used instead of the current measure.
+            oneOf: [{ $ref: #/definitions/arrayOfStringIdentifiers}]
+          exclusion:
+            description: Identifiers of other PI measures that can be submitted instead of current measure. Cannot submit both current measure and the exclusion measure.
+        required: [objective, isRequired, isBonus, measureSets]
+
+  aggregateCostMeasure:
+    $merge:
+      source:
+        { $ref: #/definitions/baseMeasure }
+      with:
+        title: 'Cost Measure'
+        type: object
+        additionalProperties: false
+        properties:
+          category: { const cost }
+          isInverse:
+            description: If true, a lower performance rate correlates with better performance.
+            type: boolean
+            default: false
+          overallAlgorithm:
+            description: Formula to determine the overall performance rate, given multiple strata of performance rates. Only applicable to multiPerformanceRate measures.
+            type: ['null', string]
+          submissionMethods:
+            description: Possible methods for submitting performance data for the measure.
+            type: array
+
+  qualityMeasure:
+    $merge:
+      source:
+        { $ref: #/definitions/baseMeasure }
+      with:
+        title: 'Quality Measure'
+        type: object
+        additionalProperties: false
+        properties:
+          category: { const quality }
+          nationalQualityStrategyDomain: 
+            type: ['null', string]
+            description: The area of health care quality (NQS Domain) which this measure improves.
+          measureType:
+            description: Quality category which the measure incentivizes.
+            oneOf: [{ $ref: #/definitions/measureTypes }]
+          eMeasureId:
+            description: Identifier for Electronic Clinical Quality Measures (ECQM).
+            type: ['null', string]
+          eMeasureUuid:
+            description: UUID for Electronic Clinical Quality Measures (ECQM).
+            type: string
+          nqfEMeasureId:
+            description: Identifier for measure specified in the Health Quality Measure Format (HQMF).
+            type: ['null', string]
+          nqfId:
+            description: Identifier for the National Quality Forum (NQF) measure.
+            type: ['null', string]
+          isClinicalGuidelineChanged:
+            description: If true, at least one submission method is listed in clinicalGuidelinesChanged.
+            type: boolean
+          clinicalGuidelineChanged:
+            type: array
+            description: List of submissionMethods that have been suppressed for this year due to potentially no longer aligning with best practices or could lead to patient harm.
+            items: { $ref: #/definitions/methods }
+          isHighPriority:
+            description: If true, can be used in the place of an outcome measure to satisfy quality category requirements.
+            type: boolean
+            default: false
+          isInverse:
+            description: If true, a lower performance rate correlates with better performance.
+            type: boolean
+            default: false
+          overallAlgorithm:
+            description: Formula to determine the overall performance rate, given multiple strata of performance rates. Only applicable to multiPerformanceRate measures.
+            enum: [simpleAverage, weightedAverage, sumNumerators, overallStratumOnly]
+          strata:
+            description: Population segments for which the measure requires reporting data. Only applicable to multiPerformanceRate measures.
+            type: array
+            items: { $ref: #/definitions/performanceStrata }
+          primarySteward:
+            description: Organization who submits and maintains the measure.
+            type: string
+          submissionMethods:
+            description: Possible methods for submitting performance data for the measure.
+            type: array
+            items: { $ref: #/definitions/methods }
+          eligibilityOptions:
+            description: Eligibility options mirror denominator options in QCDR measure specifications. Each option comprises a set of codes used to identify eligible instances of the associated measure.
+            type: array
+            items: { $ref: #/definitions/eligibilityOption }
+          performanceOptions:
+            description: Performance options mirror numerator options in QCDR measure specifications. Each option comprises a set of codes used to identify instances of performance met, performance not met, performance exclusion or performance exception.
+            type: array
+            items: { $ref: #/definitions/performanceOption }
+          allowedPrograms:
+            description: Programs that the measure can be submitted to
+            type: array
+            items: { $ref: #/definitions/programs }
+          requiredForPrograms:
+            description: Programs that the measure is required to be submitted to
+            type: array
+            items: { $ref: #/definitions/programs }
+          allowedVendors:
+            description: List of QCDR Registries that are allowed to submit the QCDR measure
+            type: array
+            items: { type: string }
+          isRegistryMeasure:
+            description: If true, this measure was authored by a QCDR (Qualified Clinical Data Registry).
+            type: boolean
+            default: false
+          isRiskAdjusted:
+            type: boolean
+            description: Risk adjustment refers to the inclusion of risk factors associated with a measure score in a statistical model of measured entity performance captured at the person, facility, community, or other levels. Measure developers often risk adjust outcome measures, however not all outcome measures need risk adjustment.
+            default: false
+          isIcdImpacted:
+            type: boolean
+            description: If true, at least one submission method is listed in icdImpacted.
+            default: false
+          icdImpacted:
+            type: array
+            description: List of submissionMethods where ICD 10 codes for the measure changed during the submission year. Used to indicate that submissions data should be truncated to only the first nine months of the performance year when the ICD 10 codes were unchanged. Typically impacts claims submissionMethod. Does not impact registry submissionMethod.
+            items: { $ref: #/definitions/methods }
+          historic_benchmarks:
+            type: object
+            description: The submissionMethods of the measure which have had their benchmarks removed or flattened for the current year. A benchmark is marked as flat if the measure is determined to have the potential to result in inappropriate treatment of patients if the top decile is higher than 90%, or if inverse less than 10%. 
+            propertyNames: { $ref: #/definitions/methods }
+            patternProperties:
+              "":
+                enum: [removed, flat]
+
+        # measures with metricType multiPerformanceRate must also have the properties overallAlgorithm and strata; other metricTypes do not
+        # Note: Need to add back required: [overallAlgorithm, strata] for multiPerformanceRate, registryMultiPerformanceRate once strata data for 007 has been received
+        oneOf: [
+          {
+            properties: {
+              metricType: { enum: [multiPerformanceRate, registryMultiPerformanceRate] },
+              strata: {
+                type: 'array',
+                minItems: 1,
+                items: { $ref: #/definitions/performanceStrata }
+              }
+            },
+            required: [overallAlgorithm, strata]
+          },
+          {
+            properties: {
+              metricType: { enum: [singlePerformanceRate, nonProportion, cahps, registrySinglePerformanceRate, costScore] }
+            }
+          }
+        ]
+        required: [nationalQualityStrategyDomain, measureType, eMeasureId, nqfEMeasureId, nqfId, isHighPriority, isInverse, primarySteward, submissionMethods, allowedPrograms, isRegistryMeasure, isIcdImpacted]
+
+  performanceStrata:
+    type: object
+    properties:
+      description:
+        type: string
+        description: A detailed description of the strata, outlining exactly which type of patients it applies to.
+      name:
+        type: string
+        description: a one-word tag, unique to the strata.
+        maxLength: 20
+      eMeasureUuids:
+        type: object
+        description: UUID for Electronic Clinical Quality Measures (ECQM).
+        properties:
+          initialPopulationUuid:
+            type: string
+            description: UUID for the initial population.
+          denominatorUuid:
+            type: string
+            description: UUID for the denominator.
+          numeratorUuid:
+            type: string
+            description: UUID for the numerator.
+          denominatorExclusionUuid:
+            type: string
+            description: UUID for the denominator exclusion.
+          denominatorExceptionUuid:
+            type: string
+            description: UUID for the denominator exception.
+
+  subcategoryIds:
+    enum:
+      - null
+      - achievingHealthEquity
+      - behavioralAndMentalHealth
+      - beneficiaryEngagement
+      - careCoordination
+      - emergencyResponseAndPreparedness
+      - expandedPracticeAccess
+      - patientSafetyAndPracticeAssessment
+      - populationManagement
+
+  objectives:
+    enum:
+      - attestation
+      - publicHealthAndClinicalDataRegistryReporting
+      - healthInformationExchange
+      - electronicPrescribing
+      - coordinationOfCareThroughPatientEngagement
+      - patientElectronicAccess
+      - protectPatientHealthInformation
+      - publicHealthReporting
+      - medicationReconciliation
+      - patientSpecificEducation
+      - secureMessaging
+      - publicHealthAndClinicalDataExchange
+      - providerToPatientExchange
+
+  measureTypes:
+    enum:
+      - efficiency
+      - intermediateOutcome
+      - outcome
+      - patientEngagementExperience
+      - process
+      - structure
+      - patientReportedOutcome
+
+  methods:
+    enum:
+      - administrativeClaims
+      - claims
+      - certifiedSurveyVendor
+      - cmsWebInterface
+      - electronicHealthRecord
+      - registry
+
+  measureSpecification:
+    type: object
+    properties:
+      default:
+        type: string
+      registry:
+        type: string
+      claims:
+        type: string
+      cmsWebInterface:
+        type: string
+      measureInformation:
+        type: string
+
+  measureSets:
+    enum:
+      - transition # PI only
+      - allergyImmunology
+      - anesthesiology
+      - cardiology
+      - dentistry
+      - dermatology
+      - diagnosticRadiology
+      - electrophysiologyCardiacSpecialist
+      - emergencyMedicine
+      - gastroenterology
+      - generalSurgery
+      - hospitalists
+      - infectiousDisease
+      - internalMedicine
+      - interventionalRadiology
+      - mentalBehavioralHealth
+      - nephrology
+      - neurology
+      - neurosurgical
+      - obstetricsGynecology
+      - ophthalmology
+      - orthopedicSurgery
+      - otolaryngology
+      - pathology
+      - pediatrics
+      - physicalMedicine
+      - plasticSurgery
+      - podiatry
+      - preventiveMedicine
+      - radiationOncology
+      - rheumatology
+      - thoracicSurgery
+      - urology
+      - vascularSurgery
+      - familyMedicine
+      - oncology
+      - physicalTherapyOccupationalTherapy
+      - geriatrics
+      - urgentCare
+      - skilledNursingFacility
+      - generalPracticeFamilyMedicine
+      - endocrinology
+      - nutritionDietician
+      - pulmonology
+      - chiropracticMedicine
+      - clinicalSocialWork
+      - audiology
+      - speechLanguagePathology
+      - certifiedNurseMidwife
+
+  eligibilityOption:
+    type: object
+    properties:
+      sexCode:
+        description: Gender identifier in the case of measures that apply to one gender only.
+        enum: [M, F]
+      minAge:
+        description: The minimum patient age required for eligibility.
+        type: number
+      maxAge:
+        description: The maximum patient age required for eligibility.
+        type: number
+      diagnosisCodes: 
+        type: array
+        description: List of diagnosis codes and procedures of the patient.
+        items:
+          type: string
+      additionalDiagnosisCodes: 
+        type: array
+        description: Additional list of diagnosis codes and procedures of the patient for eligibility.
+        items:
+          type: string
+      procedureCodes:
+        description: A list of HCPCS or CPT codes, at least one of which must be present to meet the eligibility option.
+        type: array
+        items: { $ref: #/definitions/codeObject }
+      additionalProcedureCodes:
+        description: A list of HCPCS or CPT codes, at least one of which must be present to meet the eligibility option. If present, this field imposes a requirement in addition to the one from the procedureCodes field.
+        type: array
+        items: { $ref: #/definitions/codeObject }
+    anyOf:
+      - required: ['procedureCodes']
+      - required: ['diagnosisCodes']
+
+  performanceOption:
+    type: object
+    properties:
+      optionType:
+        description: The specific performance option corresponding to the quality codes (performance met, performance not met, etc.).
+        enum: [performanceMet, performanceNotMet, eligiblePopulationExclusion, eligiblePopulationException]
+      qualityCodes:
+        description: A list of quality codes, all of which must be present to meet the performance option.
+        type: array
+        items: { $ref: #/definitions/codeObject }
+    required: [optionType, qualityCodes]
+
+  programs:
+    enum:
+      - mips
+      - pcf
+      - app1
+
+  codeObject:
+    type: object
+    properties:
+      code:
+        description: The HCPCS or CPT code represented as a string.
+        type: string
+      modifiers:
+        type: array
+        description: List of modifier codes that are relevant to a claim, regarding additional information about a patient encounter.
+        items:
+          type: string
+      modifierExclusions:
+        type: array
+        description: List of modifier codes that are excluded because they are opposites of the measure and thus cannot be submitted in the same measurementSet.
+        items:
+          type: string
+      placesOfService:
+        type: array
+        description: List of Place of Service Codes which are two-digit codes placed on health care professional claims to indicate the setting in which a service was provided.
+        items:
+          type: string
+      placesOfServiceExclusions:
+        type: array
+        description: List of Place of Service Codes that are excluded.
+        items:
+          type: string
+    required: [code]
+
+  qualityCodesSubmissionMethods:
+    type: array
+    items:
+      enum:
+        - claims
+        - registry
+
+  arrayOfStringIdentifiers:
+    type: array
+    items:
+      type: string

--- a/scripts/measures/lib/merge-benchmark-metadata.js
+++ b/scripts/measures/lib/merge-benchmark-metadata.js
@@ -50,7 +50,7 @@ module.exports = (measures, benchmarkMetadata, benchmarkField = false) => {
       }
 
       if (benchmarkField) {
-        measure.benchmarks = aggregateBenchmarks(REMOVED_METHODS, benchmark, 'removed');
+        measure.historic_benchmarks = aggregateBenchmarks(REMOVED_METHODS, benchmark, 'removed');
       }
     }
   }

--- a/test/scripts/measures/lib/merge-benchmark-metadata-spec.js
+++ b/test/scripts/measures/lib/merge-benchmark-metadata-spec.js
@@ -64,8 +64,8 @@ describe('merge-benchmark-metadata', () => {
     ];
     const expectedMeasures = [
       {measureId: '0', measureSpecification: {}},
-      {measureId: '1', measureSpecification: {}, isIcdImpacted: false, icdImpacted: [], isClinicalGuidelineChanged: true, clinicalGuidelineChanged: ['electronicHealthRecord', 'cmsWebInterface'], benchmarks: { claims: 'removed' }},
-      {measureId: '2', measureSpecification: {}, isIcdImpacted: true, icdImpacted: ['claims'], isClinicalGuidelineChanged: false, clinicalGuidelineChanged: [], benchmarks: {registry: 'removed'}}
+      {measureId: '1', measureSpecification: {}, isIcdImpacted: false, icdImpacted: [], isClinicalGuidelineChanged: true, clinicalGuidelineChanged: ['electronicHealthRecord', 'cmsWebInterface'], historic_benchmarks: { claims: 'removed' }},
+      {measureId: '2', measureSpecification: {}, isIcdImpacted: true, icdImpacted: ['claims'], isClinicalGuidelineChanged: false, clinicalGuidelineChanged: [], historic_benchmarks: {registry: 'removed'}}
     ];
 
     mergeBenchmarkMetadata(measures, metadata, true);


### PR DESCRIPTION
- Change the benchmarks field in `measures-data.json` to `historic_benchmarks`. The change was made to PY22, but will populate to any year if the build script is rerun for that year.
- Initialize the PY 2023 repo.

These changes are made together in the same PR since the field change in 6517 affects 6772.

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-6517
* https://jira.cms.gov/browse/QPPA-6772

