### PR TITLE
QPPA-0000: fix benchmarks schema py22

### DIFF
--- a/benchmarks/2022/benchmarks-schema.yaml
+++ b/benchmarks/2022/benchmarks-schema.yaml
@@ -1,4 +1,4 @@
-id: https://github.com/CMSgov/qpp-measures-data/versions/0.0.1/benchmarks-schema.yaml
+$id: https://github.com/CMSgov/qpp-measures-data/versions/0.0.1/benchmarks-schema.yaml
 $schema: http://json-schema.org/schema#
 type: array
 items: { $ref: #/definitions/benchmark }


### PR DESCRIPTION
The latest version of avj is more strict and complains about the lack of a dollar sign in front of the id.