### PR TITLE
QPPA-6893 Enforce name and description on strata

### DIFF
--- a/measures/2023/measures-schema.yaml
+++ b/measures/2023/measures-schema.yaml
@@ -256,25 +256,7 @@ definitions:
         type: string
         description: a one-word tag, unique to the strata.
         maxLength: 20
-      eMeasureUuids:
-        type: object
-        description: UUID for Electronic Clinical Quality Measures (ECQM).
-        properties:
-          initialPopulationUuid:
-            type: string
-            description: UUID for the initial population.
-          denominatorUuid:
-            type: string
-            description: UUID for the denominator.
-          numeratorUuid:
-            type: string
-            description: UUID for the numerator.
-          denominatorExclusionUuid:
-            type: string
-            description: UUID for the denominator exclusion.
-          denominatorExceptionUuid:
-            type: string
-            description: UUID for the denominator exception.
+    required: [description, name]
 
   subcategoryIds:
     enum:

--- a/scripts/measures/2023/ingest-strata.ts
+++ b/scripts/measures/2023/ingest-strata.ts
@@ -1,15 +1,17 @@
 /**
  * @IngestStrata
  *  Instead of utilizing an update process (as we do for measures),
- * we handle strata by updating the CSVs in /util and 
+ * we handle strata by updating the CSVs in /util and
  * re-inject the data into the measures-data.json.
  */
 
-import _ from 'lodash';
-import fs from 'fs';
-import parse from 'csv-parse/lib/sync';
-import path from 'path';
 import appRoot from 'app-root-path';
+import parse from 'csv-parse/lib/sync';
+import fs from 'fs';
+import _ from 'lodash';
+import path from 'path';
+
+import { DataValidationError } from '../lib/errors';
 
 const performanceYear = process.argv[2];
 const strataPath = process.argv[3];
@@ -17,31 +19,46 @@ const strataPath = process.argv[3];
 const measuresPath = `measures/${performanceYear}/measures-data.json`;
 
 const measuresJson = JSON.parse(
-    fs.readFileSync(path.join(appRoot+'', measuresPath), 'utf8')
+  fs.readFileSync(path.join(appRoot + "", measuresPath), "utf8")
 );
 const strata = parse(
-    fs.readFileSync(path.join(appRoot+'', strataPath), 'utf8'),
-    { columns: true, skip_empty_lines: true },
+  fs.readFileSync(path.join(appRoot + "", strataPath), "utf8"),
+  { columns: true, skip_empty_lines: true }
 );
 
 export function ingestStrata() {
-    const uniqueMeasureIds = [...new Set(strata.map(stratum => stratum.measureId))];
-    for (let i = 0; i < uniqueMeasureIds.length; i++) {
-        const measureStrata = _.filter(strata, {'measureId': uniqueMeasureIds[i]});
-        const mappedStrata = measureStrata.map(stratum => {
-            return {
-                name: stratum.stratumName,
-                description: stratum.description,
-        }});
-        measuresJson.find(measure => measure.measureId === uniqueMeasureIds[i]).strata = mappedStrata;
-    }
-    writeToFile(measuresJson, measuresPath);
+  const uniqueMeasureIds = [
+    ...new Set(strata.map((stratum) => stratum.measureId)),
+  ];
+  for (let i = 0; i < uniqueMeasureIds.length; i++) {
+    const measureStrata = _.filter(strata, { measureId: uniqueMeasureIds[i] });
+    const mappedStrata = measureStrata.map((stratum) => {
+      if (!stratum.name || !stratum.description) {
+        throw new DataValidationError(
+          strataPath,
+          "Name and description are required."
+        );
+      }
+      return {
+        name: stratum.stratumName,
+        description: stratum.description,
+      };
+    });
+    measuresJson.find(
+      (measure) => measure.measureId === uniqueMeasureIds[i]
+    ).strata = mappedStrata;
+  }
+  writeToFile(measuresJson, measuresPath);
 }
 
 function writeToFile(file: any, filePath: string) {
-    fs.writeFile(path.join(appRoot+'', filePath), JSON.stringify(file, null, 2), function writeJSON(err) {
-        if (err) return console.log(err);
-    });
+  fs.writeFile(
+    path.join(appRoot + "", filePath),
+    JSON.stringify(file, null, 2),
+    function writeJSON(err) {
+      if (err) return console.log(err);
+    }
+  );
 }
 
 ingestStrata();

--- a/scripts/measures/2023/ingest-strata.ts
+++ b/scripts/measures/2023/ingest-strata.ts
@@ -33,7 +33,7 @@ export function ingestStrata() {
   for (let i = 0; i < uniqueMeasureIds.length; i++) {
     const measureStrata = _.filter(strata, { measureId: uniqueMeasureIds[i] });
     const mappedStrata = measureStrata.map((stratum) => {
-      if (!stratum.name || !stratum.description) {
+      if (!stratum.stratumName || !stratum.description) {
         throw new DataValidationError(
           strataPath,
           "Name and description are required."


### PR DESCRIPTION
#### Motivation for change

QPPA-6893 Enforce name and description on strata

#### What is being changed

Mark as required in yaml. Check that a `name` and `description` exist when ingesting the strata. If not, throw an error.
Also removes `eMeasureUuids` from yaml since they are no longer used

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [ ] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [ ] Unit tests added/passing
* [ ] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-6893