### PR TITLE
QPPA-6932: remove mips and pcf from 110 and 111 py23

### DIFF
--- a/measures/2023/measures-data.json
+++ b/measures/2023/measures-data.json
@@ -2838,10 +2838,7 @@
     "isIcdImpacted": false,
     "clinicalGuidelineChanged": [],
     "metricType": "singlePerformanceRate",
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
+    "allowedPrograms": [],
     "submissionMethods": [
       "claims",
       "electronicHealthRecord",
@@ -2892,8 +2889,6 @@
     "clinicalGuidelineChanged": [],
     "metricType": "singlePerformanceRate",
     "allowedPrograms": [
-      "mips",
-      "pcf",
       "G0053"
     ],
     "submissionMethods": [


### PR DESCRIPTION
Rmove mips and pcf from the allowedPrograms of 110 and 111 for PY2023, as those measures will only be allowed for their mvps.

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-6932
