### PR TITLE
QPPA-6789: remove benchmarks for suppressed py22

### DIFF
--- a/benchmarks/2022.json
+++ b/benchmarks/2022.json
@@ -1,14 +1,15 @@
-[  
+[
   {
     "measureId": "001",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
-    "submissionMethod": "cmsWebInterface",
+    "submissionMethod": "claims",
     "isToppedOut": false,
+    "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      100,
+      80,
       70,
       60,
       50,
@@ -22,13 +23,12 @@
     "measureId": "001",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
-    "submissionMethod": "claims",
+    "submissionMethod": "cmsWebInterface",
     "isToppedOut": false,
-    "isHighPriority": true,
     "isToppedOutByProgram": false,
     "deciles": [
       100,
-      80,
+      100,
       70,
       60,
       50,
@@ -76,26 +76,6 @@
       30,
       20,
       10
-    ]
-  },
-  {
-    "measureId": "005",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      70.26,
-      75.76,
-      78.57,
-      81.82,
-      85.47,
-      88.89,
-      92.31,
-      95.39
     ]
   },
   {
@@ -899,26 +879,6 @@
     "measureId": "113",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      20.83,
-      33.33,
-      44.04,
-      52.82,
-      61.04,
-      69.01,
-      76.18,
-      84.34
-    ]
-  },
-  {
-    "measureId": "113",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
     "submissionMethod": "registry",
     "isToppedOut": false,
     "isHighPriority": false,
@@ -1233,26 +1193,6 @@
       100,
       100,
       100
-    ]
-  },
-  {
-    "measureId": "134",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      7.07,
-      13.94,
-      22.46,
-      33.22,
-      45.27,
-      58,
-      71.71,
-      88.83
     ]
   },
   {
@@ -2016,26 +1956,6 @@
     "measureId": "236",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      51.76,
-      56.81,
-      60.67,
-      64.11,
-      67.52,
-      71.11,
-      75.54,
-      81.43
-    ]
-  },
-  {
-    "measureId": "236",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
     "submissionMethod": "registry",
     "isToppedOut": false,
     "isHighPriority": true,
@@ -2050,26 +1970,6 @@
       70,
       80,
       90
-    ]
-  },
-  {
-    "measureId": "239",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      26.13,
-      29.54,
-      31.67,
-      33.33,
-      35.56,
-      41.23,
-      50.48,
-      64.8
     ]
   },
   {
@@ -2290,26 +2190,6 @@
       100,
       100,
       100
-    ]
-  },
-  {
-    "measureId": "281",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      7.41,
-      13.73,
-      21.94,
-      30.51,
-      41.46,
-      55.54,
-      71.43,
-      88.69
     ]
   },
   {

--- a/staging/2022/benchmarks/benchmarks.csv
+++ b/staging/2022/benchmarks/benchmarks.csv
@@ -4,7 +4,7 @@ Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),001,MIPS CQM,Intermediate Ou
 Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),001,Medicare Part B Claims,Intermediate Outcome,Y,21.106739210039187,17.85,80 - 70.01,70.00 - 60.01,60.00 - 50.01,50.00 - 40.01,40.00 - 30.01,30.00 - 20.01,20.00 - 10.01,<= 10.00,No,No,Y
 Diabetes: Hemoglobin A1c (HbA1c) Poor Control (>9%),001,eCQM,Intermediate Outcome,Y,25.499759638871495,44.92,80 - 70.01,70.00 - 60.01,60.00 - 50.01,50.00 - 40.01,40.00 - 30.01,30.00 - 20.01,20.00 - 10.01,<= 10.00,No,No,Y
 Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) or Angiotensin Receptor-Neprilysin Inhibitor (ARNI) Therapy for Left Ventricular Systolic Dysfunction (LVSD),005,MIPS CQM,Process,Y,12.879030068328849,94.02,92.00 - 96.29,96.30 - 98.28,98.29 - 99.99,--,--,--,--,100.00,Yes,Yes,N
-Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) or Angiotensin Receptor-Neprilysin Inhibitor (ARNI) Therapy for Left Ventricular Systolic Dysfunction (LVSD),005,eCQM,Process,Y,15.17672690103017,79.55,70.26 - 75.75,75.76 - 78.56,78.57 - 81.81,81.82 - 85.46,85.47 - 88.88,88.89 - 92.30,92.31 - 95.38,>= 95.39,No,No,N
+Heart Failure (HF): Angiotensin-Converting Enzyme (ACE) Inhibitor or Angiotensin Receptor Blocker (ARB) or Angiotensin Receptor-Neprilysin Inhibitor (ARNI) Therapy for Left Ventricular Systolic Dysfunction (LVSD),005,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
 Coronary Artery Disease (CAD): Antiplatelet Therapy,006,MIPS CQM,Process,Y,14.426340429782982,86.61,77.78 - 83.01,83.02 - 86.48,86.49 - 89.38,89.39 - 92.65,92.66 - 96.12,96.13 - 99.83,99.84 - 99.99,100.00,No,No,N
 Coronary Artery Disease (CAD): Beta-Blocker Therapy  Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF < 40%),007,MIPS CQM,Process,Y,10.617278602218505,90.27,80.76 - 86.80,86.81 - 89.99,90.00 - 91.85,91.86 - 96.91,96.92 - 99.99,--,--,100.00,No,No,N
 Coronary Artery Disease (CAD): Beta-Blocker Therapy  Prior Myocardial Infarction (MI) or Left Ventricular Systolic Dysfunction (LVEF < 40%),007,eCQM,Process,Y,9.680569585746442,86.90,82.14 - 84.74,84.75 - 86.58,86.59 - 88.45,88.46 - 90.17,90.18 - 91.79,91.80 - 93.58,93.59 - 95.99,>= 96.00,No,No,N
@@ -46,7 +46,7 @@ Breast Cancer Screening,112,Medicare Part B Claims,Process,Y,23.28285167494925,7
 Breast Cancer Screening,112,eCQM,Process,Y,24.713591636628415,51.60,28.57 - 39.38,39.39 - 48.51,48.52 - 55.55,55.56 - 61.47,61.48 - 67.43,67.44 - 73.50,73.51 - 81.08,>= 81.09,No,No,N
 Colorectal Cancer Screening,113,MIPS CQM,Process,Y,33.951884462952535,56.06,16.44 - 33.37,33.38 - 50.48,50.49 - 59.83,59.84 - 72.06,72.07 - 81.93,81.94 - 92.35,92.36 - 99.73,>= 99.74,No,No,N
 Colorectal Cancer Screening,113,Medicare Part B Claims,Process,Y,25.71613271656771,79.11,60.82 - 72.72,72.73 - 82.72,82.73 - 89.65,89.66 - 95.56,95.57 - 99.27,99.28 - 99.99,--,100.00,No,No,N
-Colorectal Cancer Screening,113,eCQM,Process,Y,27.823717452045507,49.56,20.83 - 33.32,33.33 - 44.03,44.04 - 52.81,52.82 - 61.03,61.04 - 69.00,69.01 - 76.17,76.18 - 84.33,>= 84.34,No,No,N
+Colorectal Cancer Screening,113,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
 Avoidance of Antibiotic Treatment for Acute Bronchitis/Bronchiolitis,116,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
 Diabetes: Eye Exam,117,MIPS CQM,Process,Y,24.243399386223125,89.67,93.62 - 97.56,97.57 - 99.21,99.22 - 99.81,99.82 - 99.99,--,--,--,100.00,Yes,Yes,N
 Diabetes: Eye Exam,117,Medicare Part B Claims,Process,Y,0.0,100.00,--,--,--,--,--,--,--,100.00,Yes,No,N
@@ -64,7 +64,7 @@ Documentation of Current Medications in the Medical Record,130,Medicare Part B C
 Documentation of Current Medications in the Medical Record,130,eCQM,Process,Y,20.129344894248955,87.03,80.60 - 88.40,88.41 - 92.51,92.52 - 95.31,95.32 - 97.15,97.16 - 98.39,98.40 - 99.30,99.31 - 99.88,>= 99.89,Yes,Yes,Y
 Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,MIPS CQM,Process,Y,34.366316149997004,73.86,37.96 - 66.95,66.96 - 84.56,84.57 - 92.90,92.91 - 98.11,98.12 - 99.68,99.69 - 99.99,--,100.00,No,No,N
 Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,Medicare Part B Claims,Process,Y,25.209449593035238,90.47,96.55 - 99.65,99.66 - 99.99,--,--,--,--,--,100.00,Yes,Yes,N
-Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,eCQM,Process,Y,31.314188671027285,39.20,7.07 - 13.93,13.94 - 22.45,22.46 - 33.21,33.22 - 45.26,45.27 - 57.99,58.00 - 71.70,71.71 - 88.82,>= 88.83,No,No,N
+Preventive Care and Screening: Screening for Depression and Follow-Up Plan,134,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
 Melanoma: Continuity of Care  Recall System,137,MIPS CQM,Structure,Y,17.060918576084326,94.40,98.15 - 99.99,--,--,--,--,--,--,100.00,No,No,Y
 Melanoma: Coordination of Care,138,MIPS CQM,Process,Y,24.51528699444679,87.95,81.28 - 96.02,96.03 - 99.99,--,--,--,--,--,100.00,Yes,Yes,Y
 Primary Open-Angle Glaucoma (POAG): Reduction of Intraocular Pressure (IOP) by 15% OR Documentation of a Plan of Care,141,MIPS CQM,Outcome,Y,29.77772980376029,75.58,46.51 - 68.60,68.61 - 81.77,81.78 - 90.39,90.40 - 95.41,95.42 - 98.37,98.38 - 99.99,--,100.00,No,No,Y
@@ -104,10 +104,10 @@ Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention
 Preventive Care and Screening: Tobacco Use: Screening and Cessation Intervention,226,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
 Controlling High Blood Pressure,236,MIPS CQM,Intermediate Outcome,Y,21.72239809372658,63.68,20.00 - 29.99,30.00 - 39.99,40.00 - 49.99,50.00 - 59.99,60.00 - 69.99,70.00 - 79.99,80.00 - 89.99,>= 90.00,No,No,Y
 Controlling High Blood Pressure,236,Medicare Part B Claims,Intermediate Outcome,Y,18.59809111261229,75.06,20.00 - 29.99,30.00 - 39.99,40.00 - 49.99,50.00 - 59.99,60.00 - 69.99,70.00 - 79.99,80.00 - 89.99,>= 90.00,No,No,Y
-Controlling High Blood Pressure,236,eCQM,Intermediate Outcome,Y,16.123326091295606,62.80,51.76 - 56.80,56.81 - 60.66,60.67 - 64.10,64.11 - 67.51,67.52 - 71.10,71.11 - 75.53,75.54 - 81.42,>= 81.43,No,No,Y
+Controlling High Blood Pressure,236,eCQM,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
 Use of High-Risk Medications in Older Adults,238,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
 Use of High-Risk Medications in Older Adults,238,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
-Weight Assessment and Counseling for Nutrition and Physical Activity for Children/Adolescents,239,eCQM,Process,Y,18.813389682017018,37.64,26.13 - 29.53,29.54 - 31.66,31.67 - 33.32,33.33 - 35.55,35.56 - 41.22,41.23 - 50.47,50.48 - 64.79,>= 64.80,No,No,N
+Weight Assessment and Counseling for Nutrition and Physical Activity for Children/Adolescents,239,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
 Childhood Immunization Status,240,eCQM,Process,Y,17.543140918768728,39.38,23.53 - 31.63,31.64 - 37.13,37.14 - 41.29,41.30 - 45.73,45.74 - 49.99,50.00 - 53.35,53.36 - 59.90,>= 59.91,No,No,N
 Cardiac Rehabilitation Patient Referral from an Outpatient Setting,243,MIPS CQM,Process,Y,27.892023705614434,37.34,13.27 - 17.47,17.48 - 23.75,23.76 - 29.86,29.87 - 36.45,36.46 - 45.75,45.76 - 59.00,59.01 - 90.90,>= 90.91,No,No,Y
 Barretts Esophagus,249,MIPS CQM,Process,Y,3.2902050122561315,99.65,--,--,--,--,--,--,--,100.00,Yes,Yes,N
@@ -126,7 +126,7 @@ Epilepsy: Counseling for Women of Childbearing Potential with Epilepsy,268,MIPS 
 Inflammatory Bowel Disease (IBD): Assessment of Hepatitis B Virus (HBV) Status Before Initiating Anti-TNF (Tumor Necrosis Factor) Therapy,275,MIPS CQM,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
 Sleep Apnea: Severity Assessment at Initial Diagnosis,277,MIPS CQM,Process,Y,36.28687335806643,64.77,24.14 - 40.33,40.34 - 56.46,56.47 - 77.77,77.78 - 93.87,93.88 - 99.99,--,--,100.00,No,No,N
 Sleep Apnea: Assessment of Adherence to Positive Airway Pressure Therapy,279,MIPS CQM,Process,Y,26.043663030419605,85.80,80.00 - 90.90,90.91 - 96.55,96.56 - 99.28,99.29 - 99.83,99.84 - 99.99,--,--,100.00,Yes,Yes,N
-Dementia: Cognitive Assessment,281,eCQM,Process,Y,31.035204075430485,38.40,7.41 - 13.72,13.73 - 21.93,21.94 - 30.50,30.51 - 41.45,41.46 - 55.53,55.54 - 71.42,71.43 - 88.68,>= 88.69,No,No,N
+Dementia: Cognitive Assessment,281,eCQM,Process,N,,--,--,--,--,--,--,--,--,--,No,No,N
 Dementia: Functional Status Assessment,282,MIPS CQM,Process,Y,26.82081348085345,87.57,84.02 - 98.27,98.28 - 99.99,--,--,--,--,--,100.00,Yes,No,N
 Dementia Associated Behavioral and Psychiatric Symptoms Screening and Management,283,MIPS CQM,Process,Y,20.422302856549972,91.97,93.95 - 99.85,99.86 - 99.99,--,--,--,--,--,100.00,Yes,Yes,N
 Dementia: Safety Concern Screening and Follow-Up for Patients with Dementia,286,MIPS CQM,Process,Y,21.09926404231887,92.12,94.56 - 99.87,99.88 - 99.99,--,--,--,--,--,100.00,Yes,Yes,Y

--- a/staging/2022/benchmarks/json/benchmarks.json
+++ b/staging/2022/benchmarks/json/benchmarks.json
@@ -63,26 +63,6 @@
     "measureId": "005",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      70.26,
-      75.76,
-      78.57,
-      81.82,
-      85.47,
-      88.89,
-      92.31,
-      95.39
-    ]
-  },
-  {
-    "measureId": "005",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
     "submissionMethod": "registry",
     "isToppedOut": true,
     "isHighPriority": false,
@@ -823,26 +803,6 @@
     "measureId": "113",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      20.83,
-      33.33,
-      44.04,
-      52.82,
-      61.04,
-      69.01,
-      76.18,
-      84.34
-    ]
-  },
-  {
-    "measureId": "113",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
     "submissionMethod": "registry",
     "isToppedOut": false,
     "isHighPriority": false,
@@ -1157,26 +1117,6 @@
       100,
       100,
       100
-    ]
-  },
-  {
-    "measureId": "134",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      7.07,
-      13.94,
-      22.46,
-      33.22,
-      45.27,
-      58,
-      71.71,
-      88.83
     ]
   },
   {
@@ -1883,26 +1823,6 @@
     "measureId": "236",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      51.76,
-      56.81,
-      60.67,
-      64.11,
-      67.52,
-      71.11,
-      75.54,
-      81.43
-    ]
-  },
-  {
-    "measureId": "236",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
     "submissionMethod": "registry",
     "isToppedOut": false,
     "isHighPriority": true,
@@ -1917,26 +1837,6 @@
       70,
       80,
       90
-    ]
-  },
-  {
-    "measureId": "239",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      26.13,
-      29.54,
-      31.67,
-      33.33,
-      35.56,
-      41.23,
-      50.48,
-      64.8
     ]
   },
   {
@@ -2157,26 +2057,6 @@
       100,
       100,
       100
-    ]
-  },
-  {
-    "measureId": "281",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "electronicHealthRecord",
-    "isToppedOut": false,
-    "isHighPriority": false,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      7.41,
-      13.73,
-      21.94,
-      30.51,
-      41.46,
-      55.54,
-      71.43,
-      88.69
     ]
   },
   {


### PR DESCRIPTION
Remove benchmarks for eCQM suppressed measures for PY22

005 submissionMethod = electronicHealthRecord
113 submissionMethod = electronicHealthRecord
134 submissionMethod = electronicHealthRecord
236 submissionMethod = electronicHealthRecord
239 submissionMethod = electronicHealthRecord
281 submissionMethod = electronicHealthRecord

NOTES:

(No action needed for 366 as it's benchmarks are already removed)

In the past there was a `source.csv` that also needed to be updated. This does not exist for 2022 for some reason, but does not affect the rest of the process.

An example of a previous similar PR for 2021: https://github.com/CMSgov/qpp-measures-data/pull/521/files

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-7189
