### PR TITLE
QPPA-7249: remove historic bmark iris2 py22

### DIFF
--- a/measures/2022/measures-data.json
+++ b/measures/2022/measures-data.json
@@ -17300,7 +17300,10 @@
     "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
-    ]
+    ],
+    "historic_benchmarks": {
+      "registry": "removed"
+    }
   },
   {
     "measureId": "IRIS23",


### PR DESCRIPTION
Remove historic benchmark for IRIS2 in PY2022.

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-7249
