### PR TITLE
QPPA-7285: Remove the historic-benchmarks-removed flag from IROMS measures PY22

### DIFF
--- a/benchmarks/2022.json
+++ b/benchmarks/2022.json
@@ -4792,26 +4792,6 @@
     ]
   },
   {
-    "measureId": "IRIS2",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      23.43,
-      28.9,
-      32.89,
-      38.04,
-      41.36,
-      45.88,
-      57.53,
-      78.28
-    ]
-  },
-  {
     "measureId": "IRIS23",
     "benchmarkYear": 2020,
     "performanceYear": 2022,

--- a/measures/2022/measures-data.json
+++ b/measures/2022/measures-data.json
@@ -18093,9 +18093,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "historic_benchmarks": {
-      "registry": "removed"
-    }
+    "historic_benchmarks": {}
   },
   {
     "measureId": "IROMS12",
@@ -18158,9 +18156,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "historic_benchmarks": {
-      "registry": "removed"
-    }
+    "historic_benchmarks": {}
   },
   {
     "measureId": "IROMS13",
@@ -18223,9 +18219,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "historic_benchmarks": {
-      "registry": "removed"
-    }
+    "historic_benchmarks": {}
   },
   {
     "measureId": "IROMS14",
@@ -18288,9 +18282,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "historic_benchmarks": {
-      "registry": "removed"
-    }
+    "historic_benchmarks": {}
   },
   {
     "measureId": "IROMS16",
@@ -18353,9 +18345,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "historic_benchmarks": {
-      "registry": "removed"
-    }
+    "historic_benchmarks": {}
   },
   {
     "measureId": "IROMS17",
@@ -18418,9 +18408,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "historic_benchmarks": {
-      "registry": "removed"
-    }
+    "historic_benchmarks": {}
   },
   {
     "measureId": "IROMS18",
@@ -18483,9 +18471,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "historic_benchmarks": {
-      "registry": "removed"
-    }
+    "historic_benchmarks": {}
   },
   {
     "measureId": "IROMS19",
@@ -18548,9 +18534,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "historic_benchmarks": {
-      "registry": "removed"
-    }
+    "historic_benchmarks": {}
   },
   {
     "measureId": "IROMS20",
@@ -18613,9 +18597,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "historic_benchmarks": {
-      "registry": "removed"
-    }
+    "historic_benchmarks": {}
   },
   {
     "measureId": "KEET01",

--- a/measures/2022/measures-data.json
+++ b/measures/2022/measures-data.json
@@ -17301,9 +17301,7 @@
     "submissionMethods": [
       "registry"
     ],
-    "historic_benchmarks": {
-      "registry": "removed"
-    }
+    "historic_benchmarks": {}
   },
   {
     "measureId": "IRIS23",

--- a/staging/2022/benchmarks/benchmarks.csv
+++ b/staging/2022/benchmarks/benchmarks.csv
@@ -433,7 +433,7 @@ Myocardial Perfusion Imaging (MPI) or Stress Echocardiography Imaging Studies - 
 "Myocardial Perfusion Imaging (MPI) Studies, Transthoracic Echo (TTE), or Stress Echocardiography Imaging Studies - Adequate Reporting for Appropriate Interventions",IGR16,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,Y
 Myocardial Perfusion Imaging (MPI) or Stress Echocardiography imaging studies - Improving Image Quality,IGR18,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
 Appropriate diagnosis verification and severity grading for valve disease through transthoracic echocardiography (TTE) quantitative parameters.,IGR12,QCDR Measure,Process,N,,--,--,--,--,--,--,--,--,--,--,--,N
-Glaucoma – Intraocular Pressure Reduction,IRIS2,QCDR Measure,Intermediate Outcome,Y,23.009698244985675,41.35,23.43 - 28.89,28.90 - 32.88,32.89 - 38.03,38.04 - 41.35,41.36 - 45.87,45.88 - 57.52,57.53 - 78.27,>= 78.28,No,No,Y
+Glaucoma – Intraocular Pressure Reduction,IRIS2,QCDR Measure,Intermediate Outcome,N,,--,--,--,--,--,--,--,--,--,No,No,Y
 Visual Field Progression in Glaucoma,IRIS44,QCDR Measure,Outcome,N,,--,--,--,--,--,--,--,--,--,--,--,Y
 Intraocular Pressure Reduction Following Laser Trabeculoplasty,IRIS43,QCDR Measure,Outcome,Y,32.34965066704075,37.17,11.00 - 13.63,13.64 - 15.72,15.73 - 20.82,20.83 - 26.38,26.39 - 54.96,54.97 - 74.99,75.00 - 90.31,>= 90.32,No,No,Y
 Evidence of anatomic closure of macular hole within 90 days after surgery as documented by OCT,IRIS46,QCDR Measure,Outcome,Y,30.830950733769924,58.58,15.79 - 51.91,51.92 - 61.21,61.22 - 68.21,68.22 - 71.99,72.00 - 73.32,73.33 - 88.09,88.10 - 97.55,>= 97.56,No,No,Y

--- a/staging/2022/benchmarks/json/benchmarks.json
+++ b/staging/2022/benchmarks/json/benchmarks.json
@@ -4460,26 +4460,6 @@
     ]
   },
   {
-    "measureId": "IRIS2",
-    "benchmarkYear": 2020,
-    "performanceYear": 2022,
-    "submissionMethod": "registry",
-    "isToppedOut": false,
-    "isHighPriority": true,
-    "isToppedOutByProgram": false,
-    "deciles": [
-      0,
-      23.43,
-      28.9,
-      32.89,
-      38.04,
-      41.36,
-      45.88,
-      57.53,
-      78.28
-    ]
-  },
-  {
     "measureId": "IRIS23",
     "benchmarkYear": 2020,
     "performanceYear": 2022,


### PR DESCRIPTION
Remove the historic-benchmarks-removed flag from IROMS measures PY22

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-7285
