### PR TITLE
QPPSF-11656 - Placeholder PY22 Cost Benchmarks

### DIFF
--- a/benchmarks/2022.json
+++ b/benchmarks/2022.json
@@ -3652,6 +3652,57 @@
     ]
   },
   {
+    "measureId": "479",
+    "performanceYear": 2022,
+    "benchmarkYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "deciles": [
+      0.1634,
+      0.1595,
+      0.1555,
+      0.1519,
+      0.1483,
+      0.1446,
+      0.1402,
+      0.1343,
+      0.0927
+    ]
+  },
+  {
+    "measureId": "480",
+    "performanceYear": 2022,
+    "benchmarkYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "deciles": [
+      0.0269,
+      0.0251,
+      0.0239,
+      0.0229,
+      0.0218,
+      0.0209,
+      0.02,
+      0.0186,
+      0.0105
+    ]
+  },
+  {
+    "measureId": "484",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "deciles": [
+      46.2917,
+      42.8243,
+      40.9992,
+      39.6749,
+      38.7387,
+      38.0701,
+      37.093,
+      35.6894,
+      33.4776
+    ]
+  },
+  {
     "measureId": "AAD12",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
@@ -4672,6 +4723,466 @@
     ]
   },
   {
+    "measureId": "COST_ACOPD_1",
+    "benchmarkYear": 202,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      8117.16,
+      7152.14,
+      6224.44,
+      5334.65,
+      4531.58,
+      3987.52,
+      3256.56,
+      2783.44,
+      2371.29
+    ]
+  },
+  {
+    "measureId": "COST_AKID_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      75411.91,
+      61532.27,
+      54903.61,
+      50235.43,
+      46611.89,
+      43257.38,
+      40079.11,
+      36465.24,
+      29549.94
+    ]
+  },
+  {
+    "measureId": "COST_CCLI_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      28304.29,
+      25817.94,
+      24441.25,
+      23218.77,
+      22313.44,
+      21390.54,
+      20464.67,
+      19368.21,
+      18031.78
+    ]
+  },
+  {
+    "measureId": "COST_CCR_1",
+    "benchmarkYear": 202,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      24945.16,
+      24017.35,
+      23543.17,
+      22871.39,
+      21674.13,
+      20929.32,
+      19836.13,
+      18533.44,
+      17873.49
+    ]
+  },
+  {
+    "measureId": "COST_COPDE_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      18675.31,
+      17307.43,
+      16372.54,
+      15604.94,
+      14970.38,
+      14430.86,
+      13892.49,
+      13295.73,
+      12546.32
+    ]
+  },
+  {
+    "measureId": "COST_D_1",
+    "benchmarkYear": 202,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      11117.16,
+      10452.14,
+      9324.44,
+      7534.65,
+      6723.58,
+      5943.52,
+      5196.56,
+      4753.44,
+      4074.29
+    ]
+  },
+  {
+    "measureId": "COST_EOPCI_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      12929.59,
+      12361.93,
+      12020.77,
+      11718.3,
+      11423.62,
+      11139.06,
+      10833.26,
+      10451.74,
+      9804.94
+    ]
+  },
+  {
+    "measureId": "COST_FIHR_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      5349.95,
+      5249.09,
+      5182.94,
+      5125.83,
+      5063.77,
+      4981.84,
+      4848.65,
+      4595.73,
+      4057.33
+    ]
+  },
+  {
+    "measureId": "COST_HAC_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      7936.06,
+      7156.14,
+      6742.84,
+      6420.16,
+      6135.27,
+      5874.23,
+      5622.11,
+      5299.2,
+      4874.37
+    ]
+  },
+  {
+    "measureId": "COST_IHCI_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      37760.09,
+      34337.22,
+      31954.77,
+      29919.7,
+      28180.2,
+      26419.68,
+      24764.81,
+      23085.95,
+      20765.67
+    ]
+  },
+  {
+    "measureId": "COST_IOL_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      3446.1,
+      3278.32,
+      3202.36,
+      3138.86,
+      3085.63,
+      3044.62,
+      3008.15,
+      2968.21,
+      2908.57
+    ]
+  },
+  {
+    "measureId": "COST_KA_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      18603.96,
+      18033.9,
+      17582.21,
+      17153.79,
+      16763.84,
+      16389.29,
+      16018.28,
+      15551.42,
+      14823.17
+    ]
+  },
+  {
+    "measureId": "COST_LGH_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      14461.56,
+      13583.97,
+      13044.92,
+      12621.13,
+      12286.48,
+      11976.22,
+      11690.77,
+      11368.37,
+      10905.85
+    ]
+  },
+  {
+    "measureId": "COST_LPMSM_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      7512.47,
+      7155.65,
+      6942.79,
+      6757.64,
+      6581.98,
+      6422.52,
+      6242.21,
+      5988.81,
+      5523.27
+    ]
+  },
+  {
+    "measureId": "COST_LSFDD_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      41199.35,
+      39116.85,
+      37816.66,
+      36897.05,
+      36038.59,
+      35260.7,
+      34602.95,
+      33808.5,
+      32751.41
+    ]
+  },
+  {
+    "measureId": "COST_MR_1",
+    "benchmarkYear": 202,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      4326.22,
+      3544.78,
+      3014.65,
+      2401.34,
+      1707.71,
+      1019.62,
+      857.36,
+      787.23,
+      674.29
+    ]
+  },
+  {
+    "measureId": "COST_NECABG_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      50004.26,
+      47692.97,
+      46434.35,
+      45489.06,
+      44767.53,
+      44132.86,
+      43474.72,
+      42695.9,
+      41765.37
+    ]
+  },
+  {
+    "measureId": "COST_PHA_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      19547.39,
+      18685.87,
+      18139.75,
+      17635.8,
+      17175.66,
+      16720.87,
+      16319.13,
+      15863.63,
+      15189.45
+    ]
+  },
+  {
+    "measureId": "COST_RUSST_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      7287.49,
+      6798.04,
+      6522.46,
+      6322.33,
+      6149.46,
+      5991.96,
+      5825.88,
+      5636.74,
+      5373.93
+    ]
+  },
+  {
+    "measureId": "COST_SPH_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      13917.97,
+      12954.9,
+      12321.48,
+      11885.72,
+      11511.13,
+      11175.66,
+      10847.72,
+      10462.67,
+      9966.92
+    ]
+  },
+  {
+    "measureId": "COST_SSC_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      29471.65,
+      28407.35,
+      27845.67,
+      27084.59,
+      26065.01,
+      25354.21,
+      24896.32,
+      24153.44,
+      23374.29
+    ]
+  },
+  {
+    "measureId": "COST_STEMI_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      24153.19,
+      23037.58,
+      22206.35,
+      21586.59,
+      21115.32,
+      20628.56,
+      20101.73,
+      19646.36,
+      18970.29
+    ]
+  },
+  {
+    "measureId": "COST_S_1",
+    "benchmarkYear": 202,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      1117.16,
+      1057.5,
+      1018.17,
+      987.99,
+      959.01,
+      929.52,
+      896.56,
+      853.44,
+      774.29
+    ]
+  },
+  {
     "measureId": "ECPR39",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
@@ -4952,6 +5463,26 @@
     ]
   },
   {
+    "measureId": "MSPB_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      26868.88,
+      25613.44,
+      24791.16,
+      24125.77,
+      23540.52,
+      22978.77,
+      22403.35,
+      21736.57,
+      20821.58
+    ]
+  },
+  {
     "measureId": "NHCR4",
     "benchmarkYear": 2020,
     "performanceYear": 2022,
@@ -5189,6 +5720,26 @@
       92.31,
       93.73,
       95.74
+    ]
+  },
+  {
+    "measureId": "TPCC_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      1619.29,
+      1444.45,
+      1345.87,
+      1273.47,
+      1211.21,
+      1151.86,
+      1089.71,
+      1014.26,
+      901.81
     ]
   },
   {

--- a/benchmarks/2022.json
+++ b/benchmarks/2022.json
@@ -4724,7 +4724,7 @@
   },
   {
     "measureId": "COST_ACOPD_1",
-    "benchmarkYear": 202,
+    "benchmarkYear": 2022,
     "performanceYear": 2022,
     "submissionMethod": "administrativeClaims",
     "isToppedOut": false,
@@ -4784,7 +4784,7 @@
   },
   {
     "measureId": "COST_CCR_1",
-    "benchmarkYear": 202,
+    "benchmarkYear": 2022,
     "performanceYear": 2022,
     "submissionMethod": "administrativeClaims",
     "isToppedOut": false,
@@ -4824,7 +4824,7 @@
   },
   {
     "measureId": "COST_D_1",
-    "benchmarkYear": 202,
+    "benchmarkYear": 2022,
     "performanceYear": 2022,
     "submissionMethod": "administrativeClaims",
     "isToppedOut": false,
@@ -5024,7 +5024,7 @@
   },
   {
     "measureId": "COST_MR_1",
-    "benchmarkYear": 202,
+    "benchmarkYear": 2022,
     "performanceYear": 2022,
     "submissionMethod": "administrativeClaims",
     "isToppedOut": false,
@@ -5164,7 +5164,7 @@
   },
   {
     "measureId": "COST_S_1",
-    "benchmarkYear": 202,
+    "benchmarkYear": 2022,
     "performanceYear": 2022,
     "submissionMethod": "administrativeClaims",
     "isToppedOut": false,

--- a/staging/2022/benchmarks/json/mock-cost-benchmarks.json
+++ b/staging/2022/benchmarks/json/mock-cost-benchmarks.json
@@ -1,0 +1,553 @@
+[
+  {
+    "measureId": "479",
+    "performanceYear": 2022,
+    "benchmarkYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "deciles": [
+      0.1634,
+      0.1595,
+      0.1555,
+      0.1519,
+      0.1483,
+      0.1446,
+      0.1402,
+      0.1343,
+      0.0927
+    ]
+  },
+  {
+    "measureId": "480",
+    "performanceYear": 2022,
+    "benchmarkYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "deciles": [
+      0.0269,
+      0.0251,
+      0.0239,
+      0.0229,
+      0.0218,
+      0.0209,
+      0.02,
+      0.0186,
+      0.0105
+    ]
+  },
+  {
+    "measureId": "484",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "deciles": [
+      46.2917,
+      42.8243,
+      40.9992,
+      39.6749,
+      38.7387,
+      38.0701,
+      37.093,
+      35.6894,
+      33.4776
+    ]
+  },
+  {
+    "measureId": "MSPB_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      26868.88,
+      25613.44,
+      24791.16,
+      24125.77,
+      23540.52,
+      22978.77,
+      22403.35,
+      21736.57,
+      20821.58
+    ]
+  },
+  {
+    "measureId": "TPCC_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      1619.29,
+      1444.45,
+      1345.87,
+      1273.47,
+      1211.21,
+      1151.86,
+      1089.71,
+      1014.26,
+      901.81
+    ]
+  },
+  {
+    "measureId": "COST_COPDE_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      18675.31,
+      17307.43,
+      16372.54,
+      15604.94,
+      14970.38,
+      14430.86,
+      13892.49,
+      13295.73,
+      12546.32
+    ]
+  },
+  {
+    "measureId": "COST_IHCI_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      37760.09,
+      34337.22,
+      31954.77,
+      29919.7,
+      28180.2,
+      26419.68,
+      24764.81,
+      23085.95,
+      20765.67
+    ]
+  },
+  {
+    "measureId": "COST_LGH_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      14461.56,
+      13583.97,
+      13044.92,
+      12621.13,
+      12286.48,
+      11976.22,
+      11690.77,
+      11368.37,
+      10905.85
+    ]
+  },
+  {
+    "measureId": "COST_SPH_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      13917.97,
+      12954.9,
+      12321.48,
+      11885.72,
+      11511.13,
+      11175.66,
+      10847.72,
+      10462.67,
+      9966.92
+    ]
+  },
+  {
+    "measureId": "COST_STEMI_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      24153.19,
+      23037.58,
+      22206.35,
+      21586.59,
+      21115.32,
+      20628.56,
+      20101.73,
+      19646.36,
+      18970.29
+    ]
+  },
+  {
+    "measureId": "COST_AKID_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      75411.91,
+      61532.27,
+      54903.61,
+      50235.43,
+      46611.89,
+      43257.38,
+      40079.11,
+      36465.24,
+      29549.94
+    ]
+  },
+  {
+    "measureId": "COST_CCLI_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      28304.29,
+      25817.94,
+      24441.25,
+      23218.77,
+      22313.44,
+      21390.54,
+      20464.67,
+      19368.21,
+      18031.78
+    ]
+  },
+  {
+    "measureId": "COST_EOPCI_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      12929.59,
+      12361.93,
+      12020.77,
+      11718.3,
+      11423.62,
+      11139.06,
+      10833.26,
+      10451.74,
+      9804.94
+    ]
+  },
+  {
+    "measureId": "COST_FIHR_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      5349.95,
+      5249.09,
+      5182.94,
+      5125.83,
+      5063.77,
+      4981.84,
+      4848.65,
+      4595.73,
+      4057.33
+    ]
+  },
+  {
+    "measureId": "COST_HAC_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      7936.06,
+      7156.14,
+      6742.84,
+      6420.16,
+      6135.27,
+      5874.23,
+      5622.11,
+      5299.2,
+      4874.37
+    ]
+  },
+  {
+    "measureId": "COST_IOL_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      3446.1,
+      3278.32,
+      3202.36,
+      3138.86,
+      3085.63,
+      3044.62,
+      3008.15,
+      2968.21,
+      2908.57
+    ]
+  },
+  {
+    "measureId": "COST_KA_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      18603.96,
+      18033.9,
+      17582.21,
+      17153.79,
+      16763.84,
+      16389.29,
+      16018.28,
+      15551.42,
+      14823.17
+    ]
+  },
+  {
+    "measureId": "COST_LPMSM_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      7512.47,
+      7155.65,
+      6942.79,
+      6757.64,
+      6581.98,
+      6422.52,
+      6242.21,
+      5988.81,
+      5523.27
+    ]
+  },
+  {
+    "measureId": "COST_LSFDD_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      41199.35,
+      39116.85,
+      37816.66,
+      36897.05,
+      36038.59,
+      35260.7,
+      34602.95,
+      33808.5,
+      32751.41
+    ]
+  },
+  {
+    "measureId": "COST_NECABG_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      50004.26,
+      47692.97,
+      46434.35,
+      45489.06,
+      44767.53,
+      44132.86,
+      43474.72,
+      42695.9,
+      41765.37
+    ]
+  },
+  {
+    "measureId": "COST_PHA_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      19547.39,
+      18685.87,
+      18139.75,
+      17635.8,
+      17175.66,
+      16720.87,
+      16319.13,
+      15863.63,
+      15189.45
+    ]
+  },
+  {
+    "measureId": "COST_RUSST_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      7287.49,
+      6798.04,
+      6522.46,
+      6322.33,
+      6149.46,
+      5991.96,
+      5825.88,
+      5636.74,
+      5373.93
+    ]
+  },
+  {
+    "measureId": "COST_SSC_1",
+    "benchmarkYear": 2022,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      29471.65,
+      28407.35,
+      27845.67,
+      27084.59,
+      26065.01,
+      25354.21,
+      24896.32,
+      24153.44,
+      23374.29
+    ]
+  },
+  {
+    "measureId": "COST_CCR_1",
+    "benchmarkYear": 202,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      24945.16,
+      24017.35,
+      23543.17,
+      22871.39,
+      21674.13,
+      20929.32,
+      19836.13,
+      18533.44,
+      17873.49
+    ]
+  },
+  {
+    "measureId": "COST_MR_1",
+    "benchmarkYear": 202,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      4326.22,
+      3544.78,
+      3014.65,
+      2401.34,
+      1707.71,
+      1019.62,
+      857.36,
+      787.23,
+      674.29
+    ]
+  },
+  {
+    "measureId": "COST_S_1",
+    "benchmarkYear": 202,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      1117.16,
+      1057.5,
+      1018.17,
+      987.99,
+      959.01,
+      929.52,
+      896.56,
+      853.44,
+      774.29
+    ]
+  },
+  {
+    "measureId": "COST_D_1",
+    "benchmarkYear": 202,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      11117.16,
+      10452.14,
+      9324.44,
+      7534.65,
+      6723.58,
+      5943.52,
+      5196.56,
+      4753.44,
+      4074.29
+    ]
+  },
+  {
+    "measureId": "COST_ACOPD_1",
+    "benchmarkYear": 202,
+    "performanceYear": 2022,
+    "submissionMethod": "administrativeClaims",
+    "isToppedOut": false,
+    "isHighPriority": false,
+    "isToppedOutByProgram": false,
+    "deciles": [
+      8117.16,
+      7152.14,
+      6224.44,
+      5334.65,
+      4531.58,
+      3987.52,
+      3256.56,
+      2783.44,
+      2371.29
+    ]
+  }
+]

--- a/staging/2022/benchmarks/json/mock-cost-benchmarks.json
+++ b/staging/2022/benchmarks/json/mock-cost-benchmarks.json
@@ -452,7 +452,7 @@
   },
   {
     "measureId": "COST_CCR_1",
-    "benchmarkYear": 202,
+    "benchmarkYear": 2022,
     "performanceYear": 2022,
     "submissionMethod": "administrativeClaims",
     "isToppedOut": false,
@@ -472,7 +472,7 @@
   },
   {
     "measureId": "COST_MR_1",
-    "benchmarkYear": 202,
+    "benchmarkYear": 2022,
     "performanceYear": 2022,
     "submissionMethod": "administrativeClaims",
     "isToppedOut": false,
@@ -492,7 +492,7 @@
   },
   {
     "measureId": "COST_S_1",
-    "benchmarkYear": 202,
+    "benchmarkYear": 2022,
     "performanceYear": 2022,
     "submissionMethod": "administrativeClaims",
     "isToppedOut": false,
@@ -512,7 +512,7 @@
   },
   {
     "measureId": "COST_D_1",
-    "benchmarkYear": 202,
+    "benchmarkYear": 2022,
     "performanceYear": 2022,
     "submissionMethod": "administrativeClaims",
     "isToppedOut": false,
@@ -532,7 +532,7 @@
   },
   {
     "measureId": "COST_ACOPD_1",
-    "benchmarkYear": 202,
+    "benchmarkYear": 2022,
     "performanceYear": 2022,
     "submissionMethod": "administrativeClaims",
     "isToppedOut": false,


### PR DESCRIPTION
#### Motivation for change

To aid in testing AC and Cost measures adding in benchmark placeholders copied from previous years data and updating the performance year information. This will not be used for any Final Scoring in production and is for test purposes only. These are expected to be replace by the final AC and Cost benchmarks in Summer 2023. 

#### What is being changed

Placeholder PY22 AC and Cost benchmarks added.

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [ ] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [ ] Unit tests added/passing
* [ ] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPSF-11656
