### PR TITLE
QPPA-0000: allows deciles 1 and 2 for PY22 benchmarks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2536,7 +2536,7 @@
     },
     "commander": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true,
       "requires": {
@@ -3194,7 +3194,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
@@ -3874,7 +3874,7 @@
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true
         }

--- a/scripts/benchmarks/format-benchmark-record.js
+++ b/scripts/benchmarks/format-benchmark-record.js
@@ -294,7 +294,7 @@ const formatBenchmarkRecord = function(record, options) {
     metricType: options.performanceYear >= 2022 ? record.metricType : undefined,
     isToppedOutByProgram: formatIsToppedOutByProgram(record.isToppedOutByProgram),
     deciles,
-    percentiles: {
+    percentiles: options.performanceYear >= 2023 ? {
       1: record.percentile1 ? parseFloat(record.percentile1) : undefined,
       10: record.percentile10 ? parseFloat(record.percentile10) : undefined,
       20: record.percentile20 ? parseFloat(record.percentile20) : undefined,
@@ -306,7 +306,7 @@ const formatBenchmarkRecord = function(record, options) {
       80: record.percentile80 ? parseFloat(record.percentile80) : undefined,
       90: record.percentile90 ? parseFloat(record.percentile90) : undefined,
       99: record.percentile99 ? parseFloat(record.percentile99) : undefined
-    }
+    } : undefined
   };
 };
 

--- a/scripts/benchmarks/parse-benchmarks-data.js
+++ b/scripts/benchmarks/parse-benchmarks-data.js
@@ -65,16 +65,19 @@ if (performanceYear >= 2020) {
   MCC_BENCHMARK_CSV_COLUMNS.push('isHighPriority');
 }
 
+// New 2022 data update
+if (performanceYear >= 2022) {
+  const decile3Index = BENCHMARK_CSV_COLUMNS.findIndex((string) => string === 'decile3');
+  BENCHMARK_CSV_COLUMNS.splice(decile3Index, 0, 'decile2');
+  BENCHMARK_CSV_COLUMNS.splice(decile3Index, 0, 'decile1');
+}
+
 // New 2023 data update
 if (performanceYear >= 2023) {
   BENCHMARK_CSV_COLUMNS.push('isInverse');
   BENCHMARK_CSV_COLUMNS.push('metricType');
   MCC_BENCHMARK_CSV_COLUMNS.push('isInverse');
   MCC_BENCHMARK_CSV_COLUMNS.push('metricType');
-
-  const decile3Index = BENCHMARK_CSV_COLUMNS.findIndex((string) => string === 'decile3');
-  BENCHMARK_CSV_COLUMNS.splice(decile3Index, 0, 'decile2');
-  BENCHMARK_CSV_COLUMNS.splice(decile3Index, 0, 'decile1');
 
   const isHighPriorityIndex = BENCHMARK_CSV_COLUMNS.findIndex((string) => string === 'isHighPriority');
   BENCHMARK_CSV_COLUMNS.splice(isHighPriorityIndex, 0, 'percentile99');


### PR DESCRIPTION
#### What is being changed

- allows deciles 1 and 2 for PY22 benchmarks
- fixes bug inserting an empty `percentiles` object when running benchmarks script for PYs prior to 2023.

#### Release checklist:
Tasks that must be done prior to merging this PR, including testing.

* [ ] [Package version updated](https://github.com/CMSgov/qpp-measures-data/blob/master/CONTRIBUTING.md#versioning-publishing-and-creating-new-releases)
* [ ] Documentation updated
* [x] Unit tests added/passing
* [x] Verified working locally

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-XXXX
