### PR TITLE
QPPA-7593: correct typo in benchmarks 2022

### DIFF
--- a/benchmarks/2022.json
+++ b/benchmarks/2022.json
@@ -4783,7 +4783,7 @@
     ]
   },
   {
-    "measureId": "COST_CCR_1",
+    "measureId": "COST_CRR_1",
     "benchmarkYear": 2022,
     "performanceYear": 2022,
     "submissionMethod": "administrativeClaims",


### PR DESCRIPTION
Change COST_CCR_1 to COST_CRR_1 in 2022 benchmarks

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-7593
