### PR TITLE
QPPA-0000: post hotfix cleanup

### DIFF
--- a/staging/2022/benchmarks/json/mock-cost-benchmarks.json
+++ b/staging/2022/benchmarks/json/mock-cost-benchmarks.json
@@ -451,7 +451,7 @@
     ]
   },
   {
-    "measureId": "COST_CCR_1",
+    "measureId": "COST_CRR_1",
     "benchmarkYear": 2022,
     "performanceYear": 2022,
     "submissionMethod": "administrativeClaims",


### PR DESCRIPTION
Fixes the ingestion data for 2022 benchmarks to correct mistyped measureId