### PR TITLE
QPPA-7596: Add measureId validation to benchmarks build

### DIFF
--- a/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js
+++ b/scripts/benchmarks/helpers/merge-benchmark-data-helpers.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');
+const measuresData = require('../../../index');
 
 const UNIQUE_COLUMN_CONSTRAINT = [
   'measureId',
@@ -137,7 +138,7 @@ const mergeBenchmarkFiles = (benchmarkFileNames, benchmarkJsonDir) => {
       if (isPerformanceBenchmark) {
         benchmark = processPerformanceBenchmark(benchmark);
       }
-      const benchmarkKey = getBenchmarkKey(!isPerformanceBenchmark ? benchmark : {...benchmark, benchmarkYear: benchmark.performanceYear - 2});
+      const benchmarkKey = getBenchmarkKey(!isPerformanceBenchmark ? benchmark : { ...benchmark, benchmarkYear: benchmark.performanceYear - 2 });
       if (mergedBenchmarks.has(benchmarkKey) && !_.isEqual(mergedBenchmarks.get(benchmarkKey), benchmark)) {
         if (!isPerformanceBenchmark) {
           mergeConflicts.push({
@@ -196,9 +197,44 @@ const validateUniqueConstraints = (benchmarks) => {
   }
 };
 
+/**
+ * Function to ensure that the benchmarks are all associated with existing measures for that year
+ * @param {[{
+ *   measureId: String,
+ *   performanceYear: Number,
+ *   benchmarkYear: Number,
+ *   submissionMethod: String,
+ *   deciles: [Number],
+ *   isToppedOut: Boolean,
+ *   isToppedOutByProgram: Boolean
+ * }]} benchmarks - the collection of benchmarks to evaluate
+ * @returns {void}
+ */
+const validateMeasureIdsConstraints = (benchmarks) => {
+  benchmarks = benchmarks || [];
+  let failedCount = 0;
+  for (const benchmark of benchmarks) {
+    if (measuresData.getMeasuresData(benchmark.performanceYear)
+      .find(measure => measure.measureId == benchmark.measureId)) {
+      continue;
+    } else {
+      console.log('Valid measureId constraint failed for benchmark:');
+      UNIQUE_COLUMN_CONSTRAINT.forEach(key => {
+        console.log(`  ${key}: ${benchmark[key]}`);
+      });
+      failedCount++;
+    }
+  }
+  if (failedCount > 0) {
+    console.log('Invalid measureIds found. Exiting.');
+    process.exit(failedCount);
+  }
+};
+
 module.exports = {
   getOrderedFileNames,
   getBenchmarkKey,
   mergeBenchmarkFiles,
-  validateUniqueConstraints
+  validateUniqueConstraints,
+  validateMeasureIdsConstraints
 };

--- a/scripts/benchmarks/merge-benchmark-data.js
+++ b/scripts/benchmarks/merge-benchmark-data.js
@@ -1,4 +1,9 @@
-const { getOrderedFileNames, mergeBenchmarkFiles, validateUniqueConstraints } = require('./helpers/merge-benchmark-data-helpers.js');
+const {
+  getOrderedFileNames,
+  mergeBenchmarkFiles,
+  validateUniqueConstraints,
+  validateMeasureIdsConstraints,
+} = require('./helpers/merge-benchmark-data-helpers.js');
 const path = require('path');
 
 const performanceYear = process.argv[2];
@@ -23,6 +28,7 @@ if (performanceYear) {
   const formattedBenchmarks = mergeBenchmarkFiles(benchmarkLayerFiles, jsonDir);
 
   validateUniqueConstraints(formattedBenchmarks);
+  validateMeasureIdsConstraints(formattedBenchmarks);
 
   process.stdout.write(JSON.stringify(formattedBenchmarks, null, 2));
 } else {


### PR DESCRIPTION
Add measureId validation to benchmarks build, so that it fails and throws an error if a benchmark has a measureId which is not present in the measures-data for that perfYear.

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-7596
