### PR TITLE
QPPA-7299: clean up CSV exporter script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5956,25 +5956,6 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "json2csv": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-5.0.7.tgz",
-      "integrity": "sha512-YRZbUnyaJZLZUJSRi2G/MqahCyRv9n/ds+4oIetjDF3jWQA7AG7iSeKTiZiCNqtMZM7HDyt0e/W6lEnoGEmMGA==",
-      "dev": true,
-      "requires": {
-        "commander": "^6.1.0",
-        "jsonparse": "^1.3.1",
-        "lodash.get": "^4.4.2"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-          "dev": true
-        }
-      }
-    },
     "json5": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
@@ -5983,12 +5964,6 @@
       "requires": {
         "minimist": "^1.2.0"
       }
-    },
-    "jsonparse": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
-      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -6112,12 +6087,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
-      "dev": true
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "lodash.memoize": {
@@ -6783,6 +6752,11 @@
         "lodash.flattendeep": "^4.4.0",
         "release-zalgo": "^1.0.0"
       }
+    },
+    "papaparse": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
     },
     "parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-react": "^7.20.0",
     "jest": "^29.1.1",
-    "json2csv": "^5.0.7",
     "lodash": "^4.17.21",
     "mocha": "10.1.0",
     "mock-fs": "^5.1.4",
@@ -56,6 +55,7 @@
   "dependencies": {
     "app-root-path": "^3.1.0",
     "load-yaml-file": "^1.0.0",
+    "papaparse": "^5.4.1",
     "pre-commit": "^1.2.2",
     "xregexp": "^5.1.1",
     "yamljs": "^0.3.0"

--- a/scripts/measures/export-measures
+++ b/scripts/measures/export-measures
@@ -21,7 +21,6 @@ if (( $currentPerformanceYear >= 2018 )) && (( $currentPerformanceYear <= $maxPe
     node dist/measures/json-to-csv.js \
       $currentPerformanceYear $category
 
-    json2csv -i tmp/$currentPerformanceYear/$category-measures.json -o tmp/$currentPerformanceYear/$category-measures.csv
   done
   
   echo -e "${Green}CSVs created: tmp/measures.csv"

--- a/scripts/measures/json-to-csv.ts
+++ b/scripts/measures/json-to-csv.ts
@@ -48,7 +48,16 @@ function createJson() {
     setCategoriesArray(category, measuresOfCategory);
 
     writeToJsonFile(measuresOfCategory, `tmp/${performanceYear}/${category}-measures.json`);
-    writeToCSVFile(measuresOfCategory, `tmp/${performanceYear}/${category}-measures.csv`);
+
+    //strata field is not suited for CSVs, change to bool value (TRUE if exists).
+    if (['qcdr', 'quality'].includes(category)) {
+        const simplifiedForCSV = measuresOfCategory.map(measure => {
+            return { ...measure, strata: !!measure.strata }
+        });
+        writeToCSVFile(simplifiedForCSV, `tmp/${performanceYear}/${category}-measures.csv`);
+    } else {
+        writeToCSVFile(measuresOfCategory, `tmp/${performanceYear}/${category}-measures.csv`);
+    }
 }
 
 function getAllQcdrOrQualityMeasures() {


### PR DESCRIPTION
correctly labeled QCDRs and Qualities (they were reversed).
Include all columns in CSV (some were missing).
Change `strata` field to boolean for the CSV (array of objects not suited for CSV format).

##### Associated JIRA tickets:
* https://jira.cms.gov/browse/QPPA-7299
