### PR TITLE
QPPA-0000: fix publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,14 +42,14 @@ jobs:
     strategy:
       matrix:
         repo:
-          - CMSgov/qpp-scoring-engines
-          - CMSgov/beneficiary-reporting-api
+          # - CMSgov/qpp-scoring-engines
+          # - CMSgov/beneficiary-reporting-api
           - CMSgov/qpp-submissions-api
-          - CMSgov/self-nomination-api
-          - CMSgov/beneficiary-reporting-client
-          - CMSgov/qpp-submission-client
-          - CMSgov/claims-to-quality-analyzer
-          - CMSgov/qpp-ui
+          # - CMSgov/self-nomination-api
+          # - CMSgov/beneficiary-reporting-client
+          # - CMSgov/qpp-submission-client
+          # - CMSgov/claims-to-quality-analyzer
+          # - CMSgov/qpp-ui
 
     steps:
       - name: Repository Dispatch


### PR DESCRIPTION
Comments out other repos (except Sub API) from the publish Action. If other teams want to use this functionality, we can add it back and create a new Personal Access Token that includes writes to their repo in it's scope.