### PR TITLE
QPPA-8300: Update Quality measures for PY24

### DIFF
--- a/measures/2024/measures-data.json
+++ b/measures/2024/measures-data.json
@@ -4125,8 +4125,6 @@
     "clinicalGuidelineChanged": [],
     "metricType": "singlePerformanceRate",
     "allowedPrograms": [
-      "mips",
-      "pcf",
       "M1366"
     ],
     "submissionMethods": [
@@ -4159,10 +4157,7 @@
     "isIcdImpacted": false,
     "clinicalGuidelineChanged": [],
     "metricType": "singlePerformanceRate",
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
+    "allowedPrograms": [],
     "submissionMethods": [
       "claims",
       "electronicHealthRecord",
@@ -4379,8 +4374,6 @@
     "clinicalGuidelineChanged": [],
     "metricType": "singlePerformanceRate",
     "allowedPrograms": [
-      "mips",
-      "pcf",
       "G0055",
       "G0058",
       "M1367",
@@ -12042,6 +12035,1559 @@
     "strata": []
   },
   {
+    "measureId": "USWR36",
+    "title": "Pressure Ulcer* (PU) Healing or Closure (not on the lower extremity )",
+    "description": "Percentage of Stage 2, 3, or 4 pressure ulcers* (not on the lower extremity) among patients aged 18 or older that achieve healing or closure within 6 months, stratified by the Wound Healing Index (WHI). Healing or closure may occur by delayed secondary intention or may be the result of surgical intervention (e.g., rotational flap or skin graft). Lower extremity pressure ulcers are not included in this measure because they commonly overlap with arterial and diabetic foot ulcers and require a separate risk stratification model. [Note: The National Pressure Injury Advisory Panel (NPIA) (formerly the NPUAP) has renamed pressure ulcers “pressure injuries,” but the ICD-10-CM continues to use the term pressure “ulcers”. This measure is limited to open defects (stages 2, 3, 4) which heal by secondary intention or surgical closure, typically referred to as ulcers. We have chosen to use the ICD10 terminology of \"ulcers\".]",
+    "nqfId": null,
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "U.S. Wound Registry",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "6853338"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "USWR35",
+    "title": "Adequate Off-loading of Diabetic Foot Ulcers performed at each visit, appropriate to location of ulcer",
+    "description": "Percentage of visits in which diabetic foot ulcers among patients aged 18 years and received adequate off-loading during a 12-month reporting period, stratified by location of the ulcer. Off-loading is not a simple documentation process but may include performing a procedure such as Total Contact Casting or providing appropriate footwear.\n\nThe location of the diabetic foot ulcer on the foot (e.g., heel/midfoot vs. toes) determines the type of off-loading device that is appropriate, the patient’s risk of falling, the probability of successful off-loading and thus the likelihood of major amputation. The clinician needs to evaluate these factors and then provide the most appropriate off-loading option.",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "U.S. Wound Registry",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "6853338"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "USWR34",
+    "title": "Venous Leg Ulcer (VLU) Healing or Closure",
+    "description": "Percentage of venous leg ulcers among patients aged 18 or older that have achieved healing or closure within 12 months, stratified by the Wound Healing Index. Healing or closure is defined as complete epithelialization without drainage or the need for a dressing over the closed ulceration, although venous compression would still be required.",
+    "nqfId": null,
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "U.S. Wound Registry",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "6853338"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "USWR33",
+    "title": "Diabetic Foot Ulcer (DFU) Healing or Closure",
+    "description": "Percentage of diabetic foot ulcers among patients aged 18 or older that have achieved healing or closure within 6 months, stratified by the Wound Healing Index. Healing or closure is defined as complete epithelialization without drainage or the need for a dressing over the closed ulceration, although off-loading would still be required.",
+    "nqfId": null,
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "U.S. Wound Registry",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "6853338"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "THEPQR4",
+    "title": "Consultation to Palliative Care for Patients with End Stage Conditions",
+    "description": "The measure will identify patients with end stage diagnoses who meet any of the listed criteria for a palliative care consult",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "The PQR",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "1725296"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "THEPQR3",
+    "title": "SGLT-2 inhibitors for patients with HFrEF with or without Type 2 Diabetes",
+    "description": "Percentage of patients aged 18 years and older with a diagnosis of heart failure (HF) with a current or prior left ventricular ejection fraction (LVEF) ? 40% who were prescribed SGLT-2 Inhibitors with or without Type 2 diabetes during their SNF stay or at the time of discharge.",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "The PQR",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "1725296"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "RCOIR15",
+    "title": "Arteriovenous Graft Patency Rate",
+    "description": "Percentage of arteriovenous grafts (AVG) patent after creation in patients aged 18 and older.",
+    "nqfId": null,
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Renal and Vascular Outcomes Improvement Program, powered by Forward Health Group",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "4302083"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "RCOIR14",
+    "title": "Arteriovenous Fistula Patency Rate",
+    "description": "Percentage of arteriovenous fistulae (AVF) patent after creation in patients aged 18 and older.",
+    "nqfId": null,
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Renal and Vascular Outcomes Improvement Program, powered by Forward Health Group",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "4302083"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "QMM29",
+    "title": "Use of Appropriate Classification System for Lymphoma Specimen",
+    "description": "Percentage of Final Lymphoma Specimen Pathology Reports, regardless of patient age, that classify the lymphoma using a validated and published model for lymphoma classification**. \n   \n** Must be one of the models listed in the Numerator Instructions below.",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MSN Healthcare Solutions QCDR II",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "7418330"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "QMM28",
+    "title": "Reporting Breast Arterial Calcification (BAC) on Screening Mammography",
+    "description": "Percentage of Final Screening Mammography Reports for female patients aged 40 years or older that include documentation of the presence or absence of Breast Arterial Calcification (BAC) and its clinical relevance.",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MSN Healthcare Solutions, LLC",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "6394618"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "QMM27",
+    "title": "Appropriate Classification and Follow-up Imaging for Incidental Pancreatic Cysts",
+    "description": "Percentage of Final Reports for computed tomography (CT), computed tomography angiography (CTA), magnetic resonance imaging (MRI), or magnetic resonance angiography (MRA) of the abdomen or abdomen/pelvis for patients aged 18 years or older with a pancreatic cyst incidentally noted that include documentation of cyst classification and follow-up imaging recommendations in accordance with published guidelines.",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MSN Healthcare Solutions, LLC",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "6394618"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "QMM26",
+    "title": "Screening Abdominal Aortic Aneurysm Reporting with Recommendations",
+    "description": "Percentage of patients, aged 50-years-old or older, who have had a screening ultrasound for an abdominal aortic aneurysm, with positive or negative findings, that have recognized clinical follow up recommendations documented in the final report and direct communication of findings greater than or equal to 5.5 cm in size made to the ordering provider.",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "MSN Healthcare Solutions, LLC",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "5303416",
+      "6394618",
+      "6704504",
+      "7746687"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "MSK9",
+    "title": "Patients Suffering From a Lower Extremity Injury who Improve Pain",
+    "description": "Percentage of patients 18 years or older suffering from a lower extremity injury who achieve the Minimal Clinically Important Difference (MCID) in the Numeric Pain Rating Scale, or like mapped measure during the performance year. \n\n\nAdditionally, a risk-adjusted MCID proportional difference determined by calculating the difference between the risk model predicted and observed MCID proportion will be reported for each PT/OT/MSK Provider/Group. The risk adjustment will be calculated using a logistic regression model using: baseline function score, baseline pain score, age, sex, payer, surgical status, and symptom duration (time from surgery or symptom onset to baseline physical therapy visit) as well as instrument tool used. These measures will serve as a PT/OT/MSK Provider performance measure at the eligible PT/OT/MSK Provider or group level.\n\nThis measure will include one rate:\n1) The overall performance rate of non-surgical and surgical patients who achieve the MCID in the Numeric Pain Rating Scale like mapped measure.",
+    "nqfId": null,
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Advancing Musculoskeletal (MSK) Care and Rehabilitation QCDR; MSK and Rehabilitative Care Outcomes",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "3471690",
+      "3565744",
+      "1157686",
+      "7037323",
+      "3967247"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "MSK8",
+    "title": "Patients Suffering From a Back Injury who Improve Pain",
+    "description": "Percentage of patients 18 years or older suffering from a back injury who achieve the Minimal Clinically Important Difference (MCID) in the Numeric Pain Rating Scale, or like mapped measure during the performance year. \n\n\nAdditionally, a risk-adjusted MCID proportional difference determined by calculating the difference between the risk model predicted and observed MCID proportion will be reported for each PT/OT/MSK Provider/Group. The risk adjustment will be calculated using a logistic regression model using: baseline function score, baseline pain score, age, sex, payer, surgical status, and symptom duration (time from surgery or symptom onset to baseline physical therapy visit) as well as instrument tool used. These measures will serve as a PT/OT/MSK Provider performance measure at the eligible PT/OT/MSK Provider or group level.\n\nThis measure will include one rate:\n1) The overall performance rate of non-surgical and surgical patients who achieve the MCID in the Numeric Pain Rating Scale like mapped measure.",
+    "nqfId": null,
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Advancing Musculoskeletal (MSK) Care and Rehabilitation QCDR; MSK and Rehabilitative Care Outcomes",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "3471690",
+      "3565744",
+      "1157686",
+      "7037323",
+      "3967247"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "MSK7",
+    "title": "Patients Suffering From an Upper Extremity Injury who Improve Pain",
+    "description": "Percentage of patients 18 years or older suffering from an upper extremity injury who achieve the Minimal Clinically Important Difference (MCID) in the Numeric Pain Rating Scale, or like mapped measure during the performance year. \n\n\nAdditionally, a risk-adjusted MCID proportional difference determined by calculating the difference between the risk model predicted and observed MCID proportion will be reported for each PT/OT/MSK Provider/Group. The risk adjustment will be calculated using a logistic regression model using: baseline function score, baseline pain score, age, sex, payer, surgical status, and symptom duration (time from surgery or symptom onset to baseline physical therapy visit) as well as instrument tool used. These measures will serve as a PT/OT/MSK Provider performance measure at the eligible PT/OT/MSK Provider or group level.\n\nThis measure will include one rate:\n1) The overall performance rate of non-surgical and surgical patients who achieve the MCID in the Numeric Pain Rating Scale like mapped measure.",
+    "nqfId": null,
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Advancing Musculoskeletal (MSK) Care and Rehabilitation QCDR; MSK and Rehabilitative Care Outcomes",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "3471690",
+      "3565744",
+      "1157686",
+      "7037323",
+      "3967247"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "MSK6",
+    "title": "Patients Suffering From a Neck Injury who Improve Pain",
+    "description": "Percentage of patients 18 years or older suffering from a neck injury who achieve the Minimal Clinically Important Difference (MCID) in the Numeric Pain Rating Scale, or like mapped measure during the performance year. \n\n\nAdditionally, a risk-adjusted MCID proportional difference determined by calculating the difference between the risk model predicted and observed MCID proportion will be reported for each PT/OT/MSK Provider/Group. The risk adjustment will be calculated using a logistic regression model using: baseline function score, baseline pain score, age, sex, payer, surgical status, and symptom duration (time from surgery or symptom onset to baseline physical therapy visit) as well as instrument tool used. These measures will serve as a PT/OT/MSK Provider performance measure at the eligible PT/OT/MSK Provider or group level.\n\nThis measure will include one rate:\n1) The overall performance rate of non-surgical and surgical patients who achieve the MCID in the Numeric Pain Rating Scale like mapped measure.",
+    "nqfId": null,
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Advancing Musculoskeletal (MSK) Care and Rehabilitation QCDR; MSK and Rehabilitative Care Outcomes",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "3471690",
+      "3565744",
+      "1157686",
+      "7037323",
+      "3967247"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "MSK5",
+    "title": "Patients Suffering From a Knee Injury who Improve Physical Function",
+    "description": "Percentage of patients 18 years or older suffering from a knee injury who achieve the Minimal Clinically Important Difference (MCID) in the KOS or PROMIS Physical Function, or like mapped measure during the performance year. \n\n\nAdditionally, a risk-adjusted MCID proportional difference determined by calculating the difference between the risk model predicted and observed MCID proportion will be reported for each PT/OT/MSK Provider/Group. The risk adjustment will be calculated using a logistic regression model using: baseline function score, baseline pain score, age, sex, payer, surgical status, and symptom duration (time from surgery or symptom onset to baseline physical therapy visit) as well as instrument tool used. These measures will serve as a PT/OT/MSK Provider performance measure at the eligible PT/OT/MSK Provider or group level.\n\nThis measure will include one rate:\n1) The overall performance rate of non-surgical and surgical patients who achieve the MCID in KOS/PROMIS Physical Function/or like mapped measure.",
+    "nqfId": null,
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Advancing Musculoskeletal (MSK) Care and Rehabilitation QCDR; MSK and Rehabilitative Care Outcomes",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "3471690",
+      "3565744",
+      "1157686",
+      "7037323",
+      "3967247"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "MSK4",
+    "title": "Patients Suffering From a Lower Extremity Injury who Improve Physical Function",
+    "description": "Percentage of patients 18 years or older suffering from a lower extremity injury who achieve the Minimal Clinically Important Difference (MCID) in the LEFS or PROMIS Physical Function, or like mapped measure during the performance year. \n\n\nAdditionally, a risk-adjusted MCID proportional difference determined by calculating the difference between the risk model predicted and observed MCID proportion will be reported for each PT/OT/MSK Provider/Group. The risk adjustment will be calculated using a logistic regression model using: baseline function score, baseline pain score, age, sex, payer, surgical status, and symptom duration (time from surgery or symptom onset to baseline physical therapy visit) as well as instrument tool used. These measures will serve as a PT/OT/MSK Provider performance measure at the eligible PT/OT/MSK Provider or group level.\n\nThis measure will include one rate:\n1) The overall performance rate of non-surgical and surgical patients who achieve the MCID in LEFS/PROMIS Physical Function/or like mapped measure.",
+    "nqfId": null,
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Advancing Musculoskeletal (MSK) Care and Rehabilitation QCDR; MSK and Rehabilitative Care Outcomes",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "3471690",
+      "3565744",
+      "1157686",
+      "7037323",
+      "3967247"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "MSK3",
+    "title": "Patients Suffering From a Back Injury who Improve Physical Function",
+    "description": "Percentage of patients 18 years or older suffering from a back injury who achieve the Minimal Clinically Important Difference (MCID) in the MDQ or PROMIS Pain Interference, or like mapped measure during the performance year. \n\n\nAdditionally, a risk-adjusted MCID proportional difference determined by calculating the difference between the risk model predicted and observed MCID proportion will be reported for each PT/OT/MSK Provider/Group. The risk adjustment will be calculated using a logistic regression model using: baseline function score, baseline pain score, age, sex, payer, surgical status, and symptom duration (time from surgery or symptom onset to baseline physical therapy visit) as well as instrument tool used. These measures will serve as a PT/OT/MSK Provider performance measure at the eligible PT/OT/MSK Provider or group level.\n\nThis measure will include one rate:\n1) The overall performance rate of non-surgical and surgical patients who achieve the MCID in MDQ/PROMIS Pain Interference/or like mapped measure.",
+    "nqfId": null,
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Advancing Musculoskeletal (MSK) Care and Rehabilitation QCDR; MSK and Rehabilitative Care Outcomes",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "3471690",
+      "3565744",
+      "1157686",
+      "7037323",
+      "3967247"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "MSK2",
+    "title": "Patients Suffering From an Upper Extremity Injury who Improve Physical Function",
+    "description": "Percentage of patients 18 years or older suffering from an upper extremity injury who achieve the Minimal Clinically Important Difference (MCID) in the QDASH or PROMIS Upper Extremity, or like mapped measure during the performance year. \n\n\nAdditionally, a risk-adjusted MCID proportional difference determined by calculating the difference between the risk model predicted and observed MCID proportion will be reported for each PT/OT/MSK Provider/Group. The risk adjustment will be calculated using a logistic regression model using: baseline function score, baseline pain score, age, sex, payer, surgical status, and symptom duration (time from surgery or symptom onset to baseline physical therapy visit) as well as instrument tool used. These measures will serve as a PT/OT/MSK Provider performance measure at the eligible PT/OT/MSK Provider or group level.\n\nThis measure will include one rate:\n1) The overall performance rate of non-surgical and surgical patients who achieve the MCID in QDASH/PROMIS Upper Extremity/or like mapped measure.",
+    "nqfId": null,
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Advancing Musculoskeletal (MSK) Care and Rehabilitation QCDR; MSK and Rehabilitative Care Outcomes",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "3471690",
+      "3565744",
+      "1157686",
+      "7037323",
+      "3967247"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "MSK10",
+    "title": "Patients Suffering From a Knee Injury who Improve Pain",
+    "description": "Percentage of patients 18 years or older suffering from a knee injury who achieve the Minimal Clinically Important Difference (MCID) in the Numeric Pain Rating Scale, or like mapped measure during the performance year. \n\n\nAdditionally, a risk-adjusted MCID proportional difference determined by calculating the difference between the risk model predicted and observed MCID proportion will be reported for each PT/OT/MSK Provider/Group. The risk adjustment will be calculated using a logistic regression model using: baseline function score, baseline pain score, age, sex, payer, surgical status, and symptom duration (time from surgery or symptom onset to baseline physical therapy visit) as well as instrument tool used. These measures will serve as a PT/OT/MSK Provider performance measure at the eligible PT/OT/MSK Provider or group level.\n\nThis measure will include one rate:\n1) The overall performance rate of non-surgical and surgical patients who achieve the MCID in the Numeric Pain Rating Scale like mapped measure.",
+    "nqfId": null,
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Advancing Musculoskeletal (MSK) Care and Rehabilitation QCDR; MSK and Rehabilitative Care Outcomes",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "3471690",
+      "3565744",
+      "1157686",
+      "7037323",
+      "3967247"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "MSK1",
+    "title": "Patients Suffering From a Neck Injury who Improve Physical Function",
+    "description": "Percentage of patients 18 years or older suffering from a neck injury who achieve the Minimal Clinically Important Difference (MCID) in the NDI or PROMIS Pain Interference, or like mapped measure during the performance year. \n\n\nAdditionally, a risk-adjusted MCID proportional difference determined by calculating the difference between the risk model predicted and observed MCID proportion will be reported for each PT/OT/MSK Provider/Group. The risk adjustment will be calculated using a logistic regression model using: baseline function score, baseline pain score, age, sex, payer, surgical status, and symptom duration (time from surgery or symptom onset to baseline physical therapy visit) as well as instrument tool used. These measures will serve as a PT/OT/MSK Provider performance measure at the eligible PT/OT/MSK Provider or group level.\n\nThis measure will include one rate:\n1) The overall performance rate of non-surgical and surgical patients who achieve the MCID in NDI/PROMIS Pain Interference/or like mapped measure.",
+    "nqfId": null,
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": true,
+    "primarySteward": "Advancing Musculoskeletal (MSK) Care and Rehabilitation QCDR; MSK and Rehabilitative Care Outcomes",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "3471690",
+      "3565744",
+      "1157686",
+      "7037323",
+      "3967247"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "IRIS62",
+    "title": "Regaining Vision After Cataract Surgery",
+    "description": "Percentage of eyes of patients aged 18 years and older with a diagnosis of cataract and comorbidities and pre-operative visual acuity of 20/400 or worse who had cataract surgery and an improvement in best-corrected distance visual acuity within 30 days following the cataract surgery",
+    "nqfId": null,
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS¨ Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "IRIS61",
+    "title": "Visual Acuity Improvement Following Cataract Surgery and Minimally Invasive Glaucoma Surgery",
+    "description": "Percentage of eyes of patients aged 18 years and older with a diagnosis of cataract who had cataract surgery and minimally invasive glaucoma surgery and achieved 20/30 best-corrected distance visual acuity or better within 4 months following the cataract surgery.",
+    "nqfId": null,
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Ophthalmology IRIS¨ Registry (Intelligent Research in Sight)",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "3927141"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "HCPR27",
+    "title": "Point-of-Care Ultrasound: Evaluation for Pneumothorax after Central Venous Catheter (CVC) Placement",
+    "description": "Percentage of Patients Aged 18 years and Older Who Undergo Central Venous Catheter (CVC) Insertion for Whom Point-of-Care Ultrasound Was Performed to Evaluate for Pneumothorax.",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "H-CPR (Hospitalist –Clinical Performance Registry)",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "8483899",
+      "4757099",
+      "1725296"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "HCPR26",
+    "title": "Heart Failure (HF): SGLT-2 Inhibitor Therapy for Left Ventricular Systolic Dysfunction (LVSD)",
+    "description": "Percentage of Patients Aged 18 years and Older with a Diagnosis of Heart Failure (HF) With a Current or Prior Left Ventricular Ejection Fraction (LVEF) Less Than or Equal to 40% Who Were Prescribed SGLT-2 Inhibitor Therapy at Hospital Discharge.",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "H-CPR (Hospitalist –Clinical Performance Registry)",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "4757099",
+      "8483899"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "HCPR25",
+    "title": "Physician’s Orders for Life-Sustaining Treatment (POLST) Form",
+    "description": "Percentage of Patients Greater Than or Equal to 65 Years of Age with Physician’s Orders for Life-Sustaining Treatment (POLST) Forms Completed",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "H-CPR (Hospitalist ÐClinical Performance Registry)",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "4757099",
+      "8483899",
+      "1725296"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "GIQIC26",
+    "title": "Screening Colonoscopy Adenoma Detection Rate",
+    "description": "The percentage of patients aged 45 to 75 years with at least one conventional adenoma or colorectal cancer detected during screening colonoscopy",
+    "nqfId": null,
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "GIQuIC",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "5846856"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": [],
+    "overallAlgorithm": "simpleAverage",
+    "strata": [
+      {
+        "name": "PLACEHOLDER",
+        "description": "WARNING: Update strata file with new measure strata."
+      }
+    ]
+  },
+  {
+    "measureId": "ECPR59",
+    "title": "Patient Reported Trust in Provider",
+    "description": "Percentage of Adult Patients Who Completed a Survey Regarding Their Care Visit Who Reported They Would Trust the Doctor/Provider to Care for their Friends/Family",
+    "nqfId": null,
+    "measureType": "patientEngagementExperience",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "E-CPR (Emergency - Clinical Performance Registry)",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "1718371",
+      "4757099",
+      "8483899",
+      "1725296"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "CAP42",
+    "title": "Barrett’s Esophagus: Complete Analysis with Appropriate Consultation",
+    "description": "Percentage of esophageal biopsy reports for with a diagnosis of Barrett’s mucosa with dysplasia that include documentation of a consultation with a second pathologist for confirmation of dysplasia grading",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Pathologists Quality Registry",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "5688621"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "CAP41",
+    "title": "Basal Cell Skin Cancer: Complete Reporting",
+    "description": "Percentage of final pathology reports for excisions for basal cell carcinoma of the skin that include a comment on histologic subtype, margin status, and if applicable to the specimen - invasion of tumor beyond reticular dermis (or level of invasion, for Moh’s specimens), and perineural invasion",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Pathologists Quality Registry",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "5688621"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "CAP40",
+    "title": "Squamous Cell Skin Cancer: Complete Reporting",
+    "description": "Percentage of final pathology reports for excisions for squamous cell carcinoma of the skin that include a comment on margin status, degree of differentiation/histologic grade, depth or level of invasion, presence of perineural invasion and presence of lymphovascular invasion",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Pathologists Quality Registry",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "5688621"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "AQUA36",
+    "title": "Prostate Cancer: Confirmation Biopsy in Newly Diagnosed Patients on Active Surveillance",
+    "description": "Percentage of newly diagnosed low risk patients on active surveillance who receive confirmation testing within 24 months of diagnosis",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Urological Association Quality (AQUA) Registry",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "8758330"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "AQUA35",
+    "title": "Non-Muscle Invasive Bladder Cancer: Initial Management/Surveillance for Non-Muscle Invasive Bladder Cancer",
+    "description": "Percentage of patients with appropriate initial management/surveillance after initial diagnosis of non-muscle invasive bladder cancer",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Urological Association Quality (AQUA) Registry",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "8758330"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "AJRR12",
+    "title": "Physical Health Outcomes in Total Hip and Knee Arthroplasty",
+    "description": "Percentage of patients with patient-reported meaningful improvement in anatomic specific HOOS/KOOS JR after elective total hip and knee arthroplasty.",
+    "nqfId": null,
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "AAOS Orthopaedic Quality Resource Center",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "5224253",
+      "1157686"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registryMultiPerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": [],
+    "overallAlgorithm": "weightedAverage",
+    "strata": [
+      {
+        "name": "PLACEHOLDER",
+        "description": "WARNING: Update strata file with new measure strata."
+      }
+    ]
+  },
+  {
+    "measureId": "ACEP66",
+    "title": "Co-testing for HIV in high-risk patients in Emergency Department who are being tested for other sexually transmitted infections (STI) (Gonorrhea, Chlamydia, Syphilis or Trichomonas).",
+    "description": "Percentage of patients aged 18 and older in the Emergency Department who are being tested for other sexually transmitted infections (STI) (Gonorrhea, Chlamydia, Syphilis or Trichomonas) are also tested for HIV.",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "5133825"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "ACEP65",
+    "title": "Appropriate Utilization of Imaging in rAAA (ruptured Abdominal Aortic Aneurysm) patients in Emergency Department",
+    "description": "Percentage of adult patients aged 55 years and older presenting to the Emergency Department with abdominal pain or back pain and hypotension for whom a POC Ultrasound or CT scan was performed.",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "5133825"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "ACEP64",
+    "title": "Avoidance of admission for adult patients in Emergency Department with low-risk Deep Vein Thrombosis (DVT).",
+    "description": "Percentage of patients 18 years and older who present to the Emergency Department with low-risk Deep Vein Thrombosis (DVT) and are discharged home",
+    "nqfId": null,
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "5133825",
+      "1718371",
+      "1725296"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "ABFM13",
+    "title": "Measuring the Value-Functions of Primary Care: Comprehensiveness of Care",
+    "description": "This measure evaluates the extent primary care physicians (PCPs) provide care-based and procedural-based services core to primary care. For each PCP, the resulting value reflects an average of the weighted proportion of services within each category provided during the measurement period.      \nPrimary care providers (PCPs) caring for at least 30 patients per measurement year score between 0 and 100 in scaled scores of comprehensiveness. Scores are based on weighted averages of 19 care-based and 22 procedural-based core primary care services.\n\nInitial Population: Primary care physicians who have provided care to 30 or more patients regardless of age within the measurement period, see Figure 1: Physician and Care Site Identifier in the \"Additional Supporting Documentation\" Section. \n\nThroughout this application, since the fields do not accept scientific formulas, tables or figures, we have attached those items in the \"Additional Supporting Documentation\" section.",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": false,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "ABFM PRIME",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "4849508"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "AAO39",
+    "title": "Neck Mass Evaluation",
+    "description": "Percentage of patients aged 18 years and older diagnosed with a neck mass and suspected/increased risk of malignancy who had a fine needle aspiration (FNA), or refer the patient to someone who can perform FNA with tumor human papillomavirus (HPV) test and receive a neck computed tomography (or magnetic resonance imaging) with contrast.",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Otolaryngology – Head and Neck Surgery Foundation (AAO-HNSF) Reg-entSM Registry",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "8365868"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "AAO38",
+    "title": "Thyroidectomy and Parathyroidectomy Nerve Injury",
+    "description": "Percentage of patients that had a thyroidectomy, parathyroidectomy, or both, and experienced recurrent laryngeal nerve injury resulting in vocal cord paresis or palsy.",
+    "nqfId": null,
+    "measureType": "outcome",
+    "isHighPriority": true,
+    "isInverse": true,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Otolaryngology – Head and Neck Surgery Foundation (AAO-HNSF) Reg-entSM Registry",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "8365868"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "AAO37",
+    "title": "Dysphonia: Laryngeal Examination",
+    "description": "Percentage of patients who were diagnosed with dysphonia who received or were referred for a laryngeal examination within 4 weeks of initial diagnosis.",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "American Academy of Otolaryngology – Head and Neck Surgery Foundation (AAO-HNSF) Reg-entSM Registry",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "8365868"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "AAN36",
+    "title": "Seizure Type, Frequency, Time Since Last Seizure Recorded, and Seizure Reduction",
+    "description": "Percentage of patients or care partners who reported seizure type, seizure frequency for each type of seizure, time since last seizure for each seizure type at every visit in the measurement period recorded, AND, the same or decreased seizure frequency in the most recent 12 months compared to the prior 12 months (baseline).",
+    "nqfId": null,
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Axon Registry",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "8933551"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "AAN35",
+    "title": "Reduction of Pain for Patients with Polyneuropathy",
+    "description": "Percentage of patients 18 years and older diagnosed with polyneuropathy with associated neuropathic pain in the feet whose Visual Analog Scale (VAS) or Numeric Pain Rating Scale (NRS) pain score for patient’s feet at 12 months (+/- 60 days) was improved from the index score",
+    "nqfId": null,
+    "measureType": "patientReportedOutcome",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "Axon Registry",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "8933551"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
+    "measureId": "AAD19",
+    "title": "Psoriasis – Shared Decision Making in the Treatment of Psoriasis",
+    "description": "Percentage of patients with a diagnosis of psoriasis with a documented shared decision-making discussion that includes the patient’s treatment goals, preferences, and the risks & benefits of treatment options.",
+    "nqfId": null,
+    "measureType": "process",
+    "isHighPriority": true,
+    "isInverse": false,
+    "isRiskAdjusted": false,
+    "primarySteward": "AAD’s DataDerm™",
+    "firstPerformanceYear": 2024,
+    "allowedVendors": [
+      "4649789"
+    ],
+    "allowedPrograms": [
+      "mips",
+      "pcf"
+    ],
+    "category": "quality",
+    "lastPerformanceYear": null,
+    "eMeasureId": null,
+    "nqfEMeasureId": null,
+    "measureSets": [],
+    "isRegistryMeasure": true,
+    "isIcdImpacted": false,
+    "metricType": "registrySinglePerformanceRate",
+    "submissionMethods": [
+      "registry"
+    ],
+    "icdImpacted": [],
+    "isClinicalGuidelineChanged": false,
+    "clinicalGuidelineChanged": []
+  },
+  {
     "measureId": "AJRR9",
     "title": "Risk-Standardized Routine Discharge Rate Following Elective Primary Hip and Knee Arthroplasty",
     "description": "Risk-standardized rate for routine discharge for elective primary total hip and knee arthroplasty",
@@ -12053,7 +13599,8 @@
     "primarySteward": "AAOS Orthopaedic Quality Resource Center",
     "firstPerformanceYear": 2023,
     "allowedVendors": [
-      "5224253"
+      "5224253",
+      "1157686"
     ],
     "allowedPrograms": [
       "mips",
@@ -12086,50 +13633,6 @@
     ]
   },
   {
-    "measureId": "AJRR8",
-    "title": "Physical Health Outcomes in Total Hip and Knee Arthroplasty",
-    "description": "Percentage of patients with patient-reported meaningful improvement in quality of life (QOL) after elective total hip and knee arthroplasty",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "AAOS Orthopaedic Quality Resource Center",
-    "firstPerformanceYear": 2023,
-    "allowedVendors": [
-      "5224253"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "icdImpacted": [],
-    "isClinicalGuidelineChanged": false,
-    "clinicalGuidelineChanged": [],
-    "overallAlgorithm": "weightedAverage",
-    "strata": [
-      {
-        "name": "hip",
-        "description": "represents total hip arthroplasty"
-      },
-      {
-        "name": "knee",
-        "description": "represents total knee arthroplasty."
-      }
-    ]
-  },
-  {
     "measureId": "AJRR11",
     "title": "Improvement in Pain Assessment Following Spine Fusion Procedures",
     "description": "Percentage of patients with patient-reported meaningful improvement in pain following lumbar or cervical spine procedures",
@@ -12141,7 +13644,8 @@
     "primarySteward": "AAOS Orthopaedic Quality Resource Center",
     "firstPerformanceYear": 2023,
     "allowedVendors": [
-      "5224253"
+      "5224253",
+      "1157686"
     ],
     "allowedPrograms": [
       "mips",
@@ -12180,39 +13684,6 @@
         "description": "Percentage of denominator patients who showed a statistically significant improvement in comparison to initial assessment, measured by minimum clinically important difference (MCID) in leg pain."
       }
     ]
-  },
-  {
-    "measureId": "SPINETRACK9",
-    "title": "Unplanned Hospital Readmission Following Spinal Fusion Surgery",
-    "description": "Percentage of patients with an unplanned readmission within 90 days following lumbar or cervical spine procedures",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": true,
-    "isRiskAdjusted": false,
-    "primarySteward": "AAOS Orthopaedic Quality Resource Center",
-    "firstPerformanceYear": 2020,
-    "allowedVendors": [
-      "5224253"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "icdImpacted": [],
-    "isClinicalGuidelineChanged": false,
-    "clinicalGuidelineChanged": []
   },
   {
     "measureId": "REGCLR8",
@@ -12423,7 +13894,7 @@
   {
     "measureId": "AAD16",
     "title": "Avoidance of Post-operative Systemic Antibiotics for Office-based Closures and Reconstruction After Skin Cancer Procedures",
-    "description": "Percentage of procedures in patients aged 18 and older with a diagnosis of skin cancer who underwent intermediate layer or complex linear closure or reconstruction after skin cancer resection in the office-based* setting who were prescribed post-operative systemic antibiotics to be taken immediately following reconstruction surgery (inverse measure)\n\nThis measure is stratified by intermediate layer or complex linear closure or reconstructive procedures.",
+    "description": "Percentage of procedures in patients aged 18 and older with a diagnosis of skin cancer who underwent intermediate layer or complex linear closure or reconstruction after skin cancer resection in the office-based* setting who were prescribed post-operative systemic antibiotics to be taken immediately following reconstruction surgery (inverse measure).\n\nThis measure is stratified by intermediate layer or complex linear closure or reconstructive procedures.",
     "nqfId": null,
     "measureType": "process",
     "isHighPriority": true,
@@ -12480,7 +13951,8 @@
     "primarySteward": "Practice Insights by McKesson in Collaboration with The US Oncology Network - QCDR",
     "firstPerformanceYear": 2023,
     "allowedVendors": [
-      "8794712"
+      "8794712",
+      "7037323"
     ],
     "allowedPrograms": [
       "mips",
@@ -12647,40 +14119,8 @@
     "primarySteward": "MSN Healthcare Solutions QCDR II",
     "firstPerformanceYear": 2023,
     "allowedVendors": [
-      "7418330"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "icdImpacted": [],
-    "isClinicalGuidelineChanged": false,
-    "clinicalGuidelineChanged": []
-  },
-  {
-    "measureId": "CAP39",
-    "title": "High-Risk Human Papillomavirus Status to Inform Patient Prognosis in Oropharyngeal Squamous Cell Carcinoma",
-    "description": "Percentage of pathology reports for suspected or confirmed invasive oropharyngeal squamous cell carcinoma (OPSCC) with high-risk HPV status documented",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "Pathologists Quality Registry",
-    "firstPerformanceYear": 2023,
-    "allowedVendors": [
-      "5688621"
+      "7418330",
+      "6704504"
     ],
     "allowedPrograms": [
       "mips",
@@ -12713,7 +14153,8 @@
     "primarySteward": "The PQR",
     "firstPerformanceYear": 2023,
     "allowedVendors": [
-      "1725296"
+      "1725296",
+      "5133825"
     ],
     "allowedPrograms": [
       "mips",
@@ -12737,7 +14178,7 @@
   {
     "measureId": "QMM23",
     "title": "Low dose cancer screening recommendation for computed tomography (CT) and computed tomography angiography (CTA) of chest with diagnosis of Emphysema.",
-    "description": "Percentage of emphysema patients, aged 50-77 at the time of service, undergoing a CT/CTA of the chest with a recommendation made to consider patient for low dose cancer screening documented in the Final Report.",
+    "description": "Percentage of emphysema patients, aged 50-77 at the time of service, who undergo a CT/CTA of the chest in which the Final Report:\n1) Mentions that the presence of pulmonary emphysema on CT is an independent risk factor for lung cancer, AND\n2) Includes a recommendation to consider the patient for low dose CT (LDCT) lung cancer screening in the future (current chest CT serves as a baseline).",
     "nqfId": null,
     "measureType": "process",
     "isHighPriority": true,
@@ -12746,7 +14187,8 @@
     "primarySteward": "MSN Healthcare Solutions, LLC",
     "firstPerformanceYear": 2023,
     "allowedVendors": [
-      "6394618"
+      "6394618",
+      "7746687"
     ],
     "allowedPrograms": [
       "mips",
@@ -12779,7 +14221,8 @@
     "primarySteward": "The PQR",
     "firstPerformanceYear": 2023,
     "allowedVendors": [
-      "1725296"
+      "1725296",
+      "5133825"
     ],
     "allowedPrograms": [
       "mips",
@@ -12812,7 +14255,8 @@
     "primarySteward": "MSN Healthcare Solutions, LLC",
     "firstPerformanceYear": 2023,
     "allowedVendors": [
-      "6394618"
+      "6394618",
+      "7746687"
     ],
     "allowedPrograms": [
       "mips",
@@ -12836,7 +14280,7 @@
   {
     "measureId": "AAD15",
     "title": "Psoriasis – Appropriate Assessment & Treatment of Severe Psoriasis",
-    "description": "Percentage of patients with a diagnosis of severe psoriasis without a documented Body Surface Area (BSA) or a documented BSA greater than 10% for whom phototherapy or an oral systemic or biologic medication was prescribed.",
+    "description": "Percentage of patients with a diagnosis of psoriasis awith a documented Body Surface Area (BSA) greater than 10% for whom phototherapy or an oral systemic or biologic medication was prescribed.",
     "nqfId": null,
     "measureType": "process",
     "isHighPriority": false,
@@ -12878,7 +14322,11 @@
     "primarySteward": "ABG QCDR",
     "firstPerformanceYear": 2023,
     "allowedVendors": [
-      "5551268"
+      "5551268",
+      "6169123",
+      "6775913",
+      "9181695",
+      "7418330"
     ],
     "allowedPrograms": [
       "mips",
@@ -12902,8 +14350,8 @@
   },
   {
     "measureId": "ECPR58",
-    "title": "Patient-Reported Understanding of Discharge Diagnosis and Plan of Care after Emergency Department Visit",
-    "description": "Percentage of Adult Patients Who Completed a Survey Regarding Their Emergency Department Visit Who Reported Understanding of Their Discharge Diagnosis and Plan of Care",
+    "title": "Patient-Reported Understanding of Discharge Diagnosis and Plan of Care",
+    "description": "Percentage of Adult Patients Who Completed a Survey Regarding Their Care Visit Who Reported Understanding of Their Discharge Diagnosis and Plan of Care",
     "nqfId": null,
     "measureType": "patientReportedOutcome",
     "isHighPriority": true,
@@ -12912,7 +14360,9 @@
     "primarySteward": "E-CPR (Emergency - Clinical Performance Registry)",
     "firstPerformanceYear": 2023,
     "allowedVendors": [
-      "1718371"
+      "1718371",
+      "8483899",
+      "1725296"
     ],
     "allowedPrograms": [
       "mips",
@@ -12945,7 +14395,8 @@
     "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
     "firstPerformanceYear": 2023,
     "allowedVendors": [
-      "5133825"
+      "5133825",
+      "1725296"
     ],
     "allowedPrograms": [
       "mips",
@@ -12965,156 +14416,6 @@
     "icdImpacted": [],
     "isClinicalGuidelineChanged": false,
     "clinicalGuidelineChanged": []
-  },
-  {
-    "measureId": "AAAAI17",
-    "title": "Asthma Control: Minimal Important Difference Improvement",
-    "description": "Percentage of patients aged 12 years and older whose asthma is not well-controlled as indicated by the Asthma Control Test, Asthma Control Questionnaire, or Asthma Therapy Assessment Questionnaire and who demonstrated a minimal important difference improvement upon a subsequent office visit during the 12-month reporting period. National Quality Strategy Domain: Person and Caregiver-Centered Experience and Outcomes Outcome Measure",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "AAAAI QCDR - American Academy of Allergy, Asthma, and Immunology Quality Clinical Data Registry Powered by ArborMetrix",
-    "firstPerformanceYear": 2015,
-    "allowedVendors": [
-      "6273354"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "AAAAI18",
-    "title": "Penicillin Allergy: Appropriate Removal or Confirmation",
-    "description": "Percentage of patients, regardless of age, with a primary diagnosis of penicillin or ampicillin/amoxicillin allergy, who underwent elective skin testing or antibiotic challenge that resulted in the removal of the penicillin or ampicillin/amoxicillin allergy label from the medical record if negative or confirmation of the penicillin or ampicillin/amoxicillin allergy label if positive.",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "AAAAI QCDR - American Academy of Allergy, Asthma, and Immunology Quality Clinical Data Registry Powered by ArborMetrix",
-    "firstPerformanceYear": 2015,
-    "allowedVendors": [
-      "6273354"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "AAAAI2",
-    "title": "Asthma: Assessment of Asthma Control – Ambulatory Care Setting",
-    "description": "Percentage of patients aged 5 years and older with a diagnosis of asthma who were evaluated at least once during the measurement period for asthma control (comprising asthma impairment and asthma risk). National Quality Strategy Domain: Effective Clinical Care Process Measure",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": false,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "AAAAI QCDR - American Academy of Allergy, Asthma, and Immunology Quality Clinical Data Registry Powered by ArborMetrix",
-    "firstPerformanceYear": 2014,
-    "allowedVendors": [
-      "6273354"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "AAAAI8",
-    "title": "Achievement of Projected Effective Dose of Standardized Allergens for Patient Treated With Allergen Immunotherapy for at Least One Year",
-    "description": "Proportion of patients receiving subcutaneous allergen immunotherapy that contains at least one standardized extract (mite, ragweed, grass, and/or cat) who achieved the projected effective dose for all included standardized allergen extract(s) after at least one year of treatment.",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "AAAAI QCDR - American Academy of Allergy, Asthma, and Immunology Quality Clinical Data Registry Powered by ArborMetrix",
-    "firstPerformanceYear": 2014,
-    "allowedVendors": [
-      "6273354"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "AAD11",
-    "title": "Skin Cancer Surgery: Post-Operative Complications",
-    "description": "Percentage of procedures for basal cell carcinoma, squamous cell carcinoma, or melanoma (including in situ disease) with a post-operative complication including infection, bleeding, or hematoma following an excisional or Mohs surgery within 15 days of the procedure.",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": true,
-    "isRiskAdjusted": false,
-    "primarySteward": "AAD’s DataDerm™",
-    "firstPerformanceYear": 2020,
-    "allowedVendors": [
-      "4649789"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
   },
   {
     "measureId": "AAD12",
@@ -13340,96 +14641,6 @@
     ]
   },
   {
-    "measureId": "AAN26",
-    "title": "Activity counseling for back pain",
-    "description": "Percentage of patients 18 to 65 years of age who were counseled to remain active and exercise or were referred to physical therapy",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": false,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "Axon Registry",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "8933551"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "AAN29",
-    "title": "Comprehensive Epilepsy Care Center Referral or Discussion for Patients with Epilepsy",
-    "description": "Percentage of patients who were referred or had a discussion of evaluation at a comprehensive epilepsy care center.",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": false,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "Axon Registry",
-    "firstPerformanceYear": 2021,
-    "allowedVendors": [
-      "8933551"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "AAN30",
-    "title": "Migraine Preventive Therapy Management",
-    "description": "Percentage of patients aged 6 years and older with a diagnosis of migraine whose migraine frequency is greater than or equal to 6 days per month/4 attacks per month who were managed with an evidence-based preventive migraine therapy, including therapies prescribed by another clinician.",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": false,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "Axon Registry",
-    "firstPerformanceYear": 2021,
-    "allowedVendors": [
-      "8933551"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
     "measureId": "AAN31",
     "title": "Acute Treatment Prescribed for Cluster Headache",
     "description": "Percentage of patients greater than or equal to 18 years of age with a diagnosis of cluster headache (CH) who were prescribed an acute treatment, including treatments prescribed by a different clinician.",
@@ -13524,7 +14735,7 @@
   },
   {
     "measureId": "AAN5",
-    "title": "Medication Prescribed For Acute Migraine Attack",
+    "title": "Treatment Prescribed For Acute Migraine Attacks",
     "description": "Percentage of patients age 6 years and older with a diagnosis of migraine who were prescribed a guideline recommended or FDA approved/cleared treatment for acute migraine attacks within the measurement period.",
     "nqfId": null,
     "measureType": "process",
@@ -13829,36 +15040,6 @@
     ]
   },
   {
-    "measureId": "AAO34",
-    "title": "Dysphonia: Postoperative Laryngeal Examination",
-    "description": "Percentage of patients aged 18 years and older who were diagnosed with new onset dysphonia within 2 months after a thyroidectomy who received or were referred for a laryngeal examination to examine vocal fold/cord mobility, and, if abnormal vocal fold mobility is identified, receive a plan of care for voice rehabilitation",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": false,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "American Academy of Otolaryngology – Head and Neck Surgery Foundation (AAO-HNSF) Reg-entSM Registry",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "8365868"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
     "measureId": "AAO36",
     "title": "Tympanostomy Tubes: Resolution of Otitis Media with Effusion (OME) in Adults and Children",
     "description": "Percentage of patients aged 6 months and older with a diagnosis of otitis media with effusion (OME) who are seen 2 to 8 weeks after tympanostomy tube surgery and OME is resolved",
@@ -13871,96 +15052,6 @@
     "firstPerformanceYear": 2020,
     "allowedVendors": [
       "8365868"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "AASM1",
-    "title": "Pediatric OSA: Objective Assessment of Positive Airway Pressure Therapy Adherence",
-    "description": "Proportion of patients aged less than 18 years diagnosed with OSA that were prescribed positive airway pressure therapy and had documentation of objectively measured adherence to positive airway pressure therapy within 3 months of starting therapy",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": false,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "American Academy of Sleep Medicine Sleep Clinical Data Registry (Sleep CDR)",
-    "firstPerformanceYear": 2021,
-    "allowedVendors": [
-      "4076932"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "AASM2",
-    "title": "Pediatric OSA: Objective Assessment of OSA Signs and Symptoms in Children with Complex Medical Conditions",
-    "description": "Proportion of patients aged less than 18 years with complex medical conditions known to be at high risk for OSA and with signs and symptoms of OSA that underwent a PSG or were referred to a sleep specialist, otolaryngologist, or other specialist experienced in evaluation and management of OSA in children",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": false,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "American Academy of Sleep Medicine Sleep Clinical Data Registry (Sleep CDR)",
-    "firstPerformanceYear": 2021,
-    "allowedVendors": [
-      "4076932"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "AASM3",
-    "title": "Adult OSA: Screening for Adult OSA by Primary Care Physicians",
-    "description": "All patients aged 18 years and older at high risk for obstructive sleep apnea (OSA) with documentation of screening for OSA using an appropriate standardized tool at least every 12 months AND in whom a recommended follow-up plan is documented based upon the result of the screening",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": false,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "American Academy of Sleep Medicine Sleep Clinical Data Registry (Sleep CDR)",
-    "firstPerformanceYear": 2021,
-    "allowedVendors": [
-      "4076932"
     ],
     "allowedPrograms": [
       "mips",
@@ -14009,73 +15100,6 @@
     ]
   },
   {
-    "measureId": "ABG40",
-    "title": "Hypotension Prevention After Spinal Placement for Elective Cesarean Section",
-    "description": "Percentage of patients, who present for elective Caesarean section under spinal anesthesia who have phenylephrine infusions started prophylactically to prevent hypotension.",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "ABG QCDR",
-    "firstPerformanceYear": 2021,
-    "allowedVendors": [
-      "5551268",
-      "6775913",
-      "7418330"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "ABG41",
-    "title": "Upper Extremity Nerve Blockade in Shoulder Surgery",
-    "description": "Percentage of patients who undergo shoulder arthroscopy or shoulder arthroplasty who have an upper extremity nerve blockade performed before or immediately after the procedure.",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": false,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "ABG QCDR",
-    "firstPerformanceYear": 2021,
-    "allowedVendors": [
-      "6169123",
-      "5551268",
-      "6775913",
-      "9181695",
-      "7418330",
-      "7746687"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
     "measureId": "ABG42",
     "title": "Known or Suspected Difficult Airway Mitigation Strategies",
     "description": "Percentage of patients with a known or suspected difficult airway who undergo a planned general endotracheal anesthetic that have both a second provider present at the induction and placement of the endotracheal tube and have difficult airway equipment in the room prior to the induction.",
@@ -14090,104 +15114,8 @@
       "5551268",
       "6775913",
       "9181695",
-      "7418330"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "ABG43",
-    "title": "Use of Capnography for non-Operating Room anesthesia Measure",
-    "description": "Percentage of patients receiving anesthesia in a non-operating room setting who have end-tidal carbon dioxide (ETCO2) monitored using capnography.",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "ABG QCDR",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "6169123",
-      "5551268",
-      "6775913",
-      "9181695",
-      "7418330"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "ACEP19",
-    "title": "Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 18 Years and Older",
-    "description": "Percentage of emergency department visits for patients aged 18 years and older who presented with a minor blunt head trauma who had a head CT for trauma ordered by an emergency care provider who have an indication for a head CT",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
-    "firstPerformanceYear": 2016,
-    "allowedVendors": [
-      "5133825",
-      "1725296"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "ACEP21",
-    "title": "Coagulation Studies in Patients Presenting with Chest Pain with No Coagulopathy or Bleeding",
-    "description": "Percentage of emergency department visits for patients aged 18 years and older with an emergency department discharge diagnosis of chest pain during which coagulation studies were ordered by an emergency care provider",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": true,
-    "isInverse": true,
-    "isRiskAdjusted": false,
-    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
-    "firstPerformanceYear": 2016,
-    "allowedVendors": [
-      "5133825",
-      "1725296",
-      "3471690"
+      "7418330",
+      "7746687"
     ],
     "allowedPrograms": [
       "mips",
@@ -14267,7 +15195,7 @@
   },
   {
     "measureId": "ACEP30",
-    "title": "Sepsis Management: Septic Shock: Lactate Clearance Rate of >=10",
+    "title": "Sepsis Management: Septic Shock: Lactate Clearance Rate of >=10%",
     "description": "Percentage of emergency department visits for patients aged 18 years and older with septic shock resulting in hospital admission or transfers who had an elevated serum lactate result (>2mmol/L) and a subsequent serum lactate level measurement performed following the elevated serum lactate result with a lactate clearance rate of >= 10% during the emergency department visit",
     "nqfId": null,
     "measureType": "outcome",
@@ -14328,7 +15256,7 @@
   {
     "measureId": "ACEP48",
     "title": "Sepsis Management: Septic Shock: Lactate Level Measurement, Antibiotics Ordered, and Fluid Resuscitation",
-    "description": "Percentage of emergency department visits resulting in hospital admission or transfers for patients aged 18 years and older with septic shock who had an order for all the following during the emergency department visit: a serum lactate level, antibiotics, and >1L of crystalloids",
+    "description": "Percentage of emergency department visits resulting in hospital admission or transfers for patients aged 18 years and older with septic shock who had an order for all the following during the emergency department visit: a serum lactate level, antibiotics, and >=1L of crystalloids",
     "nqfId": null,
     "measureType": "process",
     "isHighPriority": false,
@@ -14367,8 +15295,7 @@
     "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
     "firstPerformanceYear": 2020,
     "allowedVendors": [
-      "5133825",
-      "3471690"
+      "5133825"
     ],
     "allowedPrograms": [
       "mips",
@@ -14430,8 +15357,7 @@
     "firstPerformanceYear": 2020,
     "allowedVendors": [
       "5133825",
-      "1725296",
-      "3471690"
+      "1718371"
     ],
     "allowedPrograms": [
       "mips",
@@ -14461,66 +15387,6 @@
     "isRiskAdjusted": false,
     "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
     "firstPerformanceYear": 2020,
-    "allowedVendors": [
-      "5133825"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "ACEP54",
-    "title": "Appropriate Utilization of Focused Assessment with Sonography for Trauma (FAST) Exam in the Emergency Department",
-    "description": "Percentage of emergency department visits for patients aged 18 years and older presenting with hemodynamically unstable blunt abdominal trauma (blunt trauma and a systolic blood pressure less than 90 mmHg or heart rate >120 bpm) or penetrating thoracoabdominal trauma who had a FAST exam ordered and/or performed during the emergency department visit",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
-    "firstPerformanceYear": 2021,
-    "allowedVendors": [
-      "5133825"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "ACEP55",
-    "title": "Emergency Department Utilization of CT for Minor Blunt Head Trauma for Patients Aged 2 Through 17 Years",
-    "description": "Percentage of emergency department visits for patients aged 2 through 17 years who presented with a minor blunt head trauma who had a head CT for trauma ordered by an emergency care provider who are classified as high risk according to the PECARN prediction rules for traumatic brain injury",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
-    "firstPerformanceYear": 2021,
     "allowedVendors": [
       "5133825"
     ],
@@ -14584,7 +15450,8 @@
     "allowedVendors": [
       "5133825",
       "4757099",
-      "1725296"
+      "1725296",
+      "1718371"
     ],
     "allowedPrograms": [
       "mips",
@@ -14614,7 +15481,9 @@
     "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
     "firstPerformanceYear": 2022,
     "allowedVendors": [
-      "5133825"
+      "5133825",
+      "1718371",
+      "1725296"
     ],
     "allowedPrograms": [
       "mips",
@@ -14694,126 +15563,6 @@
     ]
   },
   {
-    "measureId": "ACQR12",
-    "title": "ABCDEF Bundle - Early mobility for ICU patients",
-    "description": "Patients admitted to the intensive care unit (ICU) for > or = 4 days should be included in an early mobility program (E of ABCDEF Bundle) to improve their recovery process.",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "Acute Care Quality Registry",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "4672586"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "ACQR13",
-    "title": "Sepsis: Hour One bundle",
-    "description": "Surviving Sepsis Campaign's Hour One bundle initiation in patients with Sepsis and acute organ dysfunction",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": false,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "Acute Care Quality Registry",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "4672586"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "ACQR16",
-    "title": "COPD Exacerbation or CHF Exacerbation requiring Hospital Admission: Palliative Care Evaluation",
-    "description": "Patients admitted with 2 or more COPD exacerbations in 12 months or a single admission for COPD with hypercapnic respiratory failure, or being discharged to a SNF or LTACH should receive an evaluation from a palliative care professional, if available; and patients admitted with AHA Class D heart failure and/or patients admitted with Congestive Heart Failure (any class) being discharged to a SNF or LTACH should receive an evaluation from a palliative care professional, if available",
-    "nqfId": null,
-    "measureType": "efficiency",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "Acute Care Quality Registry",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "4672586"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "ACQR3",
-    "title": "COPD: Steroids for no more than 5 days in COPD Exacerbation",
-    "description": "Patients should receive no more than 5 days of steroids in treatment for COPD Exacerbation from all sources and routes. Sources may include outpatient, Emergency Department, and Inpatient/Observation treatment. i.e. Full course of steroids not to exceed 7 days.",
-    "nqfId": null,
-    "measureType": "efficiency",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "Acute Care Quality Registry",
-    "firstPerformanceYear": 2018,
-    "allowedVendors": [
-      "4672586"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
     "measureId": "ACR10",
     "title": "Hepatitis B Safety Screening",
     "description": "If a patient is newly initiating biologic OR new synthetic DMARD therapy (e.g. methotrexate, leflunomide, etc.), then the medical record should indicate appropriate screening for hepatitis B in the preceding 12 month period.",
@@ -14855,8 +15604,9 @@
     "primarySteward": "RISE (Rheumatology Informatics System for Effectiveness)",
     "firstPerformanceYear": 2020,
     "allowedVendors": [
+      "3471690",
       "5598408",
-      "3471690"
+      "3967247"
     ],
     "allowedPrograms": [
       "mips",
@@ -14887,8 +15637,9 @@
     "primarySteward": "RISE (Rheumatology Informatics System for Effectiveness)",
     "firstPerformanceYear": 2020,
     "allowedVendors": [
+      "3471690",
       "5598408",
-      "3471690"
+      "3967247"
     ],
     "allowedPrograms": [
       "mips",
@@ -14910,7 +15661,7 @@
   {
     "measureId": "ACR15",
     "title": "Safe Hydroxychloroquine Dosing",
-    "description": "If a patient is using hydroxychloroquine, then the average daily dose should be less than or equal to 5 mg/kg",
+    "description": "If a patient is using hydroxychloroquine, then the average daily dose should be less than or equal to 5 mg/kg.",
     "nqfId": null,
     "measureType": "process",
     "isHighPriority": true,
@@ -14919,8 +15670,9 @@
     "primarySteward": "RISE (Rheumatology Informatics System for Effectiveness)",
     "firstPerformanceYear": 2021,
     "allowedVendors": [
+      "3471690",
       "5598408",
-      "3471690"
+      "3967247"
     ],
     "allowedPrograms": [
       "mips",
@@ -14982,9 +15734,9 @@
     "firstPerformanceYear": 2017,
     "allowedVendors": [
       "5303416",
-      "7746687",
       "6704504",
-      "6394618"
+      "6394618",
+      "7037323"
     ],
     "allowedPrograms": [
       "mips",
@@ -15015,9 +15767,9 @@
     "firstPerformanceYear": 2017,
     "allowedVendors": [
       "5303416",
-      "7746687",
       "6704504",
-      "6394618"
+      "6394618",
+      "7037323"
     ],
     "allowedPrograms": [
       "mips",
@@ -15048,9 +15800,9 @@
     "firstPerformanceYear": 2017,
     "allowedVendors": [
       "5303416",
-      "7746687",
       "6704504",
-      "6394618"
+      "6394618",
+      "7037323"
     ],
     "allowedPrograms": [
       "mips",
@@ -15081,9 +15833,9 @@
     "firstPerformanceYear": 2017,
     "allowedVendors": [
       "5303416",
-      "7746687",
       "6704504",
-      "6394618"
+      "6394618",
+      "7037323"
     ],
     "allowedPrograms": [
       "mips",
@@ -15114,9 +15866,9 @@
     "firstPerformanceYear": 2017,
     "allowedVendors": [
       "5303416",
-      "7746687",
       "6704504",
-      "6394618"
+      "6394618",
+      "7037323"
     ],
     "allowedPrograms": [
       "mips",
@@ -15147,9 +15899,9 @@
     "firstPerformanceYear": 2017,
     "allowedVendors": [
       "5303416",
-      "7746687",
       "6704504",
-      "6394618"
+      "6394618",
+      "7037323"
     ],
     "allowedPrograms": [
       "mips",
@@ -15170,7 +15922,7 @@
   {
     "measureId": "ACRAD34",
     "title": "Multi-strata weighted average for 3 CT Exam Types: Overall Percent of CT exams for which Dose Length Product is at or below the size-specific diagnostic reference level (for CT Abdomen-pelvis with contrast/single phase scan, CT Chest without contrast/single phase scan and CT Head/Brain without contrast/single phase scan)",
-    "description": "Weighted average of 3 former QCDR measures, ACRad 31, ACRad 32, Acrid 33.",
+    "description": "Weighted average of 3 former QCDR measures, ACRad 31, ACRad 32, ACRad 33.",
     "nqfId": "3621",
     "measureType": "outcome",
     "isHighPriority": true,
@@ -15179,8 +15931,7 @@
     "primarySteward": "American College of Radiology National Radiology Data Registry",
     "firstPerformanceYear": 2019,
     "allowedVendors": [
-      "5303416",
-      "7746687"
+      "5303416"
     ],
     "allowedPrograms": [
       "mips",
@@ -15227,7 +15978,9 @@
     "allowedVendors": [
       "5303416",
       "6394618",
-      "7746687"
+      "7746687",
+      "6704504",
+      "7037323"
     ],
     "allowedPrograms": [
       "mips",
@@ -15258,72 +16011,10 @@
     "firstPerformanceYear": 2020,
     "allowedVendors": [
       "5303416",
+      "6704504",
+      "7037323",
       "6394618",
       "7746687"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "ACRAD38",
-    "title": "Use of Low Dose Cranial CT or MRI Examinations for Patients with Ventricular Shunts",
-    "description": "Percentage of patients aged less than 18 years with a ventricular shunt undergoing cranial imaging exams to evaluate for ventricular shunt malfunction undergoing either low dose cranial CT exams or MRI",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "American College of Radiology National Radiology Data Registry",
-    "firstPerformanceYear": 2020,
-    "allowedVendors": [
-      "5303416",
-      "7746687"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "ACRAD40",
-    "title": "Use of Structured Reporting in Prostate MRI",
-    "description": "Percentage of final reports for male patients aged 18 years and older undergoing prostate MRI for prostate cancer screening or surveillance that include reference to a validated scoring system such as Prostate Imaging Reporting and Data System (PI-RADS)",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "American College of Radiology National Radiology Data Registry",
-    "firstPerformanceYear": 2020,
-    "allowedVendors": [
-      "5303416",
-      "6394618",
-      "7746687",
-      "6704504"
     ],
     "allowedPrograms": [
       "mips",
@@ -15355,38 +16046,8 @@
     "allowedVendors": [
       "5303416",
       "6394618",
-      "7746687"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "ACRAD42",
-    "title": "Surveillance Imaging for Liver Nodules less than 10mm in Patients at Risk for Hepatocellular Carcinoma (HCC)",
-    "description": "Percentage of final ultrasound reports with findings of liver nodules less than 10 mm for patients aged 18 years and older with a diagnosis of hepatitis B or cirrhosis undergoing screening and/or surveillance imaging for hepatocellular carcinoma with a specific recommendation for follow-up ultrasound imaging in 3-6 months based on radiological findings",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "American College of Radiology National Radiology Data Registry",
-    "firstPerformanceYear": 2020,
-    "allowedVendors": [
-      "5303416",
-      "7746687"
+      "6704504",
+      "7037323"
     ],
     "allowedPrograms": [
       "mips",
@@ -15417,9 +16078,11 @@
     "firstPerformanceYear": 2016,
     "allowedVendors": [
       "5551268",
-      "6775913",
       "6169123",
-      "7418330"
+      "6775913",
+      "7418330",
+      "6704504",
+      "4757099"
     ],
     "allowedPrograms": [
       "mips",
@@ -15440,7 +16103,7 @@
   {
     "measureId": "AQI48",
     "title": "Patient-Reported Experience with Anesthesia",
-    "description": "Percentage of patients, aged 18 and older, who were surveyed on their patient experience and satisfaction with anesthesia care and who reported a positive experience. \n\nThis measure will consist of two performance rates:\n\nAQI48a: Percentage of patients, aged 18 and older, who were surveyed on their patient experience and satisfaction with anesthesia care \n\nAQI48b: Percentage of patients, aged 18 and older, who completed a survey on their patient experience and satisfaction with anesthesia care who report a positive experience with anesthesia care\n\nNOTE: The measure requires that a valid survey, as defined in the numerator of AQI48a, be sent to patients between discharge from the facility and within 30 days of facility discharge. To report AQI48b, a minimum number of 20 surveys with the mandatory question completed must be reported. ** In order to be scored on this measure, clinicians must report BOTH AQI48a AND AQI48b.",
+    "description": "Percentage of patients, aged 18 and older, who were surveyed on their patient experience and satisfaction with anesthesia care and who reported a positive experience. \n\nThis measure will consist of two performance rates:\n\nAQI48a: Percentage of patients, aged 18 and older, who were surveyed on their patient experience and satisfaction with anesthesia care \n\nAQI48b: Percentage of patients, aged 18 and older, who completed a survey on their patient experience and satisfaction with anesthesia care who report a positive experience with anesthesia care within 60 days of receipt of the survey.\n\nNOTE: The measure requires that a valid survey, as defined in the numerator of AQI48a, be sent to patients between discharge from the facility and within 30 days of facility discharge. To report AQI48b, a minimum number of 20 surveys with the mandatory question completed must be reported. ** In order to be scored on this measure, clinicians must report BOTH AQI48a AND AQI48b.",
     "nqfId": null,
     "measureType": "patientReportedOutcome",
     "isHighPriority": true,
@@ -15450,14 +16113,14 @@
     "firstPerformanceYear": 2017,
     "allowedVendors": [
       "5551268",
-      "6775913",
-      "7746687",
+      "3471690",
       "6169123",
+      "6775913",
       "6704504",
-      "4757099",
       "9181695",
+      "4757099",
       "7418330",
-      "3471690"
+      "3967247"
     ],
     "allowedPrograms": [
       "mips",
@@ -15501,43 +16164,10 @@
     "allowedVendors": [
       "5551268",
       "6169123",
-      "7418330"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "AQI56",
-    "title": "Use of Neuraxial Techniques and/or Peripheral Nerve Blocks for Total Knee Arthroplasty (TKA)",
-    "description": "Percentage of patients, regardless of age, that undergo primary total knee arthroplasty for whom neuraxial anesthesia and/or a peripheral nerve block is performed",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "Anesthesia Quality Institute (AQI) National Anesthesia Clinical Outcomes Registry (NACOR)",
-    "firstPerformanceYear": 2018,
-    "allowedVendors": [
-      "6169123",
-      "5551268",
+      "7418330",
       "6775913",
-      "7746687",
-      "6704504",
-      "9181695",
-      "7418330"
+      "4757099",
+      "7746687"
     ],
     "allowedPrograms": [
       "mips",
@@ -15568,9 +16198,10 @@
     "firstPerformanceYear": 2019,
     "allowedVendors": [
       "5551268",
-      "6775913",
       "6169123",
-      "7418330"
+      "6775913",
+      "7418330",
+      "4757099"
     ],
     "allowedPrograms": [
       "mips",
@@ -15600,86 +16231,12 @@
     "primarySteward": "Anesthesia Quality Institute (AQI) National Anesthesia Clinical Outcomes Registry (NACOR)",
     "firstPerformanceYear": 2019,
     "allowedVendors": [
-      "6169123",
       "5551268",
+      "6169123",
       "6775913",
       "6704504",
       "9181695",
-      "7746687",
-      ""
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "AQI68",
-    "title": "Obstructive Sleep Apnea: Mitigation Strategies",
-    "description": "Percentage of patients aged 18 years or older, who undergo an elective procedure requiring anesthesia services who are screened for obstructive sleep apnea (OSA) AND, if positive, for whom two or more selected mitigation strategies was used prior to PACU discharge",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "Anesthesia Quality Institute (AQI) National Anesthesia Clinical Outcomes Registry (NACOR)",
-    "firstPerformanceYear": 2020,
-    "allowedVendors": [
-      "5551268",
-      "6775913",
-      "6169123",
-      "9181695",
-      "7418330",
-      "7746687"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "AQI69",
-    "title": "Intraoperative Antibiotic Redosing",
-    "description": "Percentage of patients, aged 18 years and older, who received preoperative antibiotic prophylaxis within 60 minutes prior to incision (if fluoroquinolone or vancomycin, two hours) and undergo a procedure greater than two hours duration who received intraoperative antibiotic redosing at a maximum interval of two half-lives of the selected prophylactic antibiotic.",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "Anesthesia Quality Institute (AQI) National Anesthesia Clinical Outcomes Registry (NACOR)",
-    "firstPerformanceYear": 2021,
-    "allowedVendors": [
-      "5551268",
-      "6775913",
-      "4757099",
-      "7746687",
-      "6169123",
-      "6704504",
-      "9181695",
-      "7418330",
-      "3471690"
+      "4757099"
     ],
     "allowedPrograms": [
       "mips",
@@ -15710,10 +16267,11 @@
     "firstPerformanceYear": 2021,
     "allowedVendors": [
       "5551268",
-      "6775913",
       "6169123",
+      "6775913",
+      "7418330",
       "9181695",
-      "7418330"
+      "4757099"
     ],
     "allowedPrograms": [
       "mips",
@@ -15767,13 +16325,12 @@
     "firstPerformanceYear": 2021,
     "allowedVendors": [
       "5551268",
-      "6775913",
-      "4757099",
       "6169123",
+      "6775913",
       "6704504",
       "9181695",
-      "7418330",
-      "7746687"
+      "4757099",
+      "7418330"
     ],
     "allowedPrograms": [
       "mips",
@@ -15789,58 +16346,6 @@
     "metricType": "registrySinglePerformanceRate",
     "submissionMethods": [
       "registry"
-    ]
-  },
-  {
-    "measureId": "AQI73",
-    "title": "Prevention of Arterial Line-Related Bloodstream Infections",
-    "description": "Percentage of patients, regardless of age, who undergo placement of a peripheral intra-arterial catheter for whom the arterial line was inserted with all indicated elements of sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound techniques followed.\n\nThis measure will consist of two performance rates: \n\na.\t Percentage of patients, regardless of age, who undergo placement of a peripheral intra-arterial line in the brachial, radial, posterior tibial or dorsalis pedis artery for whom the arterial line was inserted with all indicated elements of sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound techniques followed\n\nb.\t Percentage of patients, regardless of age, who undergo placement of a peripheral intra-arterial line in the femoral or axillary artery for whom the arterial line was inserted with all indicated elements of maximal sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound technique is followed\n\nNote: The overall measure score will be calculated as an average of the total cases of part A and part B.",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "Anesthesia Quality Institute (AQI) National Anesthesia Clinical Outcomes Registry (NACOR)",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "5551268",
-      "6775913",
-      "4757099",
-      "7746687",
-      "6169123",
-      "6704504",
-      "9181695",
-      "7418330"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "overallAlgorithm": "overallStratumOnly",
-    "strata": [
-      {
-        "name": "overall",
-        "description": "The overall measure score will be calculated as an average of the total cases of Rate 2 and Rate 3. "
-      },
-      {
-        "name": "brachialRadialTibial",
-        "description": " Percentage of patients, regardless of age, who undergo placement of a peripheral intra-arterial line in the brachial, radial, posterior tibial or dorsalis pedis artery for whom the arterial line was inserted with all indicated elements of sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound techniques followed"
-      },
-      {
-        "name": "femoralAxillary",
-        "description": " Percentage of patients, regardless of age, who undergo placement of a peripheral intra-arterial line in the femoral or axillary artery for whom the arterial line was inserted with all indicated elements of maximal sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound technique is followed"
-      }
     ]
   },
   {
@@ -15875,8 +16380,8 @@
   },
   {
     "measureId": "AQUA15",
-    "title": "Stones: Urinalysis Performed Before Surgical Stone Procedures",
-    "description": "Percentage of patients with a documented urinalysis within 14 days prior to surgical stone procedures",
+    "title": "Stones: Urinalysis or Urine Culture Performed Before Surgical Stone Procedures",
+    "description": "Percentage of patients with a documented urinalysis or urine culture within 14 days prior to surgical stone procedures",
     "nqfId": null,
     "measureType": "process",
     "isHighPriority": true,
@@ -15907,36 +16412,6 @@
     "measureId": "AQUA16",
     "title": "Non-Muscle Invasive Bladder Cancer: Repeat Transurethral Resection of Bladder Tumor (TURBT) for T1 disease",
     "description": "Percentage of patients with T1 disease who had a second transurethral resection of bladder tumor (TURBT) within 6 weeks of the initial TURBT",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": false,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "American Urological Association Quality (AQUA) Registry",
-    "firstPerformanceYear": 2017,
-    "allowedVendors": [
-      "8758330"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "AQUA18",
-    "title": "Non-Muscle Invasive Bladder Cancer: Early Surveillance Cystoscopy for Non-Muscle Invasive Bladder Cancer",
-    "description": "Percentage of patients who had surveillance cystoscopy 12 to 20 weeks after undergoing initial Transurethral Resection for Bladder Tumor (TURBT)",
     "nqfId": null,
     "measureType": "process",
     "isHighPriority": false,
@@ -16025,7 +16500,7 @@
   },
   {
     "measureId": "CAP22",
-    "title": "Turnaround Time (TAT) - Biopsies",
+    "title": "Biopsy Reporting Time to Clinician",
     "description": "Percentage of final pathology reports for biopsies that meet the maximum 2 business day turnaround time (TAT) requirement (Report Date – Accession Date is less than or equal to 2 business days).\nINSTRUCTIONS: This measure is to be reported each time a biopsy is performed during the performance period.",
     "nqfId": null,
     "measureType": "process",
@@ -16055,8 +16530,8 @@
   },
   {
     "measureId": "CAP28",
-    "title": "Helicobacter pylori Status and Turnaround Time",
-    "description": "Percentage of stomach biopsy cases with gastritis that address the presence or absence of Helicobacter pylori \nAND\nmeet the maximum 2 business day turnaround time (TAT) requirement (Report Date – Accession Date is less than or equal to 2 business days).\nINSTRUCTIONS: This measure has two performance rates that contribute to the overall performance score:\nStratum 1. Percent of cases in which presence or absence of Helicobacter pylori is addressed.\nStratum 2. Percent of cases that meet the maximum 2 business day turnaround time.\nThe overall performance score submitted is a straight average of Stratum 1 and Stratum 2.",
+    "title": "Gastritis: Timely Helicobacter pylori Reporting",
+    "description": "Percentage of stomach biopsy cases with gastritis that address the presence or absence of Helicobacter pylori \nAND\nmeet the maximum 2 business day turnaround time (TAT) requirement (Report Date – Accession Date is less than or equal to 2 business days).\nINSTRUCTIONS: This measure has two performance rates that contribute to the overall performance score:\nStratum 1. Percent of cases in which presence or absence of Helicobacter pylori is addressed.\nStratum 2. Percent of cases that meet the maximum 2 business day turnaround time.\nThe overall performance score submitted is a simple average of Stratum 1 and Stratum 2.",
     "nqfId": null,
     "measureType": "process",
     "isHighPriority": true,
@@ -16085,7 +16560,7 @@
   },
   {
     "measureId": "CAP30",
-    "title": "Urinary Bladder Biopsy Diagnostic Requirements For Appropriate Patient Management",
+    "title": "Urinary Bladder Cancer: Complete Analysis and Timely Reporting",
     "description": "Percentage of urinary bladder carcinoma pathology reports that include the procedure, histologic tumor grade, histologic type, presence/absence of muscularis propria, presence/absence of lymphovascular invasion, and tumor extent. \nAND \nmeet the maximum 2 business day turnaround time (TAT) requirement (Report Date – Accession Date is less than or equal to 2 business days). \n\nINSTRUCTIONS: This measure has two performance rates that contribute to the overall performance score:\nStratum 1.\tPercent of cases for which all required data elements of the urinary bladder carcinoma pathology report are included.\nStratum 2.\tPercent of cases that meet the maximum 2 business day turnaround time.\nThe overall performance score submitted is a weighted average of: \n(Performance rate 1 x 70%)+(Performance rate 2 x 30%)",
     "nqfId": null,
     "measureType": "process",
@@ -16115,7 +16590,7 @@
   },
   {
     "measureId": "CAP34",
-    "title": "Biomarker Status to Inform Clinical Management and Treatment Decisions in Patients with Non-small Cell Lung Cancer",
+    "title": "Molecular Assessment: Biomarkers in Non-Small Cell Lung Cancer",
     "description": "Percentage of non-small cell lung cancer (NSCLC) surgical pathology reports that include anaplastic lymphoma kinase (ALK), epidermal growth factor receptor (EGFR), AND tyrosine protein kinase ROS1 mutation status.",
     "nqfId": null,
     "measureType": "process",
@@ -16145,7 +16620,7 @@
   },
   {
     "measureId": "CAP38",
-    "title": "Prostate Cancer Reporting Best Practices",
+    "title": "Prostate Cancer Reporting: Complete Analysis",
     "description": "Percentage of surgical pathology reports for biopsies or radical resections (radical prostatectomy) of primary prostate cancer that include total Gleason score, grade group classification, and Gleason patterns including percent of pattern 4 for specimens in grade group 2 or 3.",
     "nqfId": null,
     "measureType": "process",
@@ -16156,195 +16631,6 @@
     "firstPerformanceYear": 2022,
     "allowedVendors": [
       "5688621"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "CCOME7",
-    "title": "Patient-Reported Pain and/or Function Improvement after Total Hip Arthroplasty",
-    "description": "Percentage of patients 18 years of age and older who obtained an improvement of at least 1 minimal clinically important difference (MCID) in hip pain and/or function as measured by validated patient-reported outcome measures (PROMs) completed up to 90 days prior to and 9 to 15 months after undergoing primary total hip arthroplasty (THA) surgery. PROMs include any validated measures of hip-related pain and/or function with MCID thresholds supported by literature, including HOOS-Pain (24 points), HOOS-PS (23 points), and HOOS-JR (18 points).",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "Hawkins Foundation in Collaboration with Sharecare",
-    "firstPerformanceYear": 2021,
-    "allowedVendors": [
-      "1157686",
-      "6394618"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "CCOME8",
-    "title": "Patient-Reported Pain and/or Function Improvement after Total Shoulder Arthroplasty",
-    "description": "Percentage of patients 18 years of age and older who obtained an improvement of at least 1 minimal clinically important difference (MCIDO) in shoulder pain and/or function as measured by validated patient-reported outcome measures (PROMs) completed up to 90 days prior to and 9 to 15 months after undergoing primary total shoulder arthroplasty (TSA) surgery. PROMs include any validated measures of shoulder-related pain and/or function with MCID thresholds supported by literature, including PSS (11.4 points) and ASES (13.6 points).",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "Hawkins Foundation in Collaboration with Sharecare",
-    "firstPerformanceYear": 2021,
-    "allowedVendors": [
-      "1157686"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "CDR2",
-    "title": "Diabetic Foot Ulcer (DFU) Healing or Closure",
-    "description": "Percentage of diabetic foot ulcers among patients aged 18 or older that have achieved healing or closure within 6 months, stratified by the Wound Healing Index. Healing or closure is defined as complete epithelialization without drainage or the need for a dressing over the closed ulceration, although off-loading would still be required.",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": true,
-    "primarySteward": "U.S. Wound Registry",
-    "firstPerformanceYear": 2014,
-    "allowedVendors": [
-      "6853338"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "overallAlgorithm": "overallStratumOnly",
-    "strata": [
-      {
-        "name": "bucket1",
-        "description": "0.00 - 62.42"
-      },
-      {
-        "name": "bucket2",
-        "description": "62.42 - 73.19"
-      },
-      {
-        "name": "bucket3",
-        "description": "73.19 - 100"
-      },
-      {
-        "name": "overall",
-        "description": "The performance rate is the average of the 3 WHI risk categories described in the risk stratification document."
-      }
-    ]
-  },
-  {
-    "measureId": "CDR6",
-    "title": "Venous Leg Ulcer (VLU) Healing or Closure",
-    "description": "Percentage of venous leg ulcers among patients aged 18 or older that have achieved healing or closure within 12 months, stratified by the Wound Healing Index. Healing or closure is defined as complete epithelialization without drainage or the need for a dressing over the closed ulceration, although venous compression would still be required.",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": true,
-    "primarySteward": "U.S. Wound Registry",
-    "firstPerformanceYear": 2014,
-    "allowedVendors": [
-      "6853338"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "overallAlgorithm": "overallStratumOnly",
-    "strata": [
-      {
-        "name": "bucket1",
-        "description": "VLUs likely to heal with conservative care,"
-      },
-      {
-        "name": "bucket2",
-        "description": "VLUs which might or might not heal, and"
-      },
-      {
-        "name": "bucket3",
-        "description": "VLUs highly unlikely to heal with conservative care."
-      },
-      {
-        "name": "overall",
-        "description": "The performance rate is the average of the 3 stratified rates"
-      }
-    ]
-  },
-  {
-    "measureId": "CDR8",
-    "title": "Appropriate Use of hyperbaric oxygen therapy for patients with diabetic foot ulcers",
-    "description": "Percentage of patient with a diagnosis of a diabetic foot ulcer graded stage 3 or higher on the Wagner Grading System for Diabetic Foot Ulcers that received hyperbaric oxygen therapy (HBOT) appropriately, based on Medicare coverage criteria.",
-    "nqfId": null,
-    "measureType": "intermediateOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "U.S. Wound Registry",
-    "firstPerformanceYear": 2014,
-    "allowedVendors": [
-      "6853338"
     ],
     "allowedPrograms": [
       "mips",
@@ -16408,11 +16694,12 @@
     "primarySteward": "E-CPR (Emergency - Clinical Performance Registry)",
     "firstPerformanceYear": 2018,
     "allowedVendors": [
-      "1718371",
       "5133825",
+      "3471690",
+      "1718371",
       "4757099",
       "1725296",
-      "3471690"
+      "3967247"
     ],
     "allowedPrograms": [
       "mips",
@@ -16443,8 +16730,9 @@
     "primarySteward": "E-CPR (Emergency - Clinical Performance Registry)",
     "firstPerformanceYear": 2018,
     "allowedVendors": [
-      "5133825",
-      "1718371"
+      "1718371",
+      "4757099",
+      "1725296"
     ],
     "allowedPrograms": [
       "mips",
@@ -16508,7 +16796,6 @@
     "primarySteward": "E-CPR (Emergency - Clinical Performance Registry)",
     "firstPerformanceYear": 2019,
     "allowedVendors": [
-      "5133825",
       "1718371",
       "4757099",
       "1725296"
@@ -16541,9 +16828,9 @@
     "primarySteward": "E-CPR (Emergency - Clinical Performance Registry)",
     "firstPerformanceYear": 2020,
     "allowedVendors": [
-      "5133825",
       "1718371",
-      "4757099"
+      "4757099",
+      "1725296"
     ],
     "allowedPrograms": [
       "mips",
@@ -16627,8 +16914,8 @@
   },
   {
     "measureId": "EPREOP31",
-    "title": "Intraoperative Hypotension among Non-Emergent Noncardiac Surgical Cases",
-    "description": "Percentage of general anesthesia cases in which mean arterial pressure (MAP) fell below 65 mmHg for cumulative total of 15 minutes or more",
+    "title": "Intraoperative Hypotension (IOH) among Non-Emergent Noncardiac Surgical Cases",
+    "description": "Percentage of general, neuraxial, or regional anesthesia care cases in which the mean arterial pressure (MAP) fell below 65 mmHg for a cumulative total of 15 minutes or more",
     "nqfId": null,
     "measureType": "intermediateOutcome",
     "isHighPriority": true,
@@ -16661,7 +16948,7 @@
   {
     "measureId": "FOTO4",
     "title": "Functional Status Change for Patients with Upper or Lower Quadrant Edema",
-    "description": "This is a patient-reported outcome performance measure (PRO-PM) consisting of a patient-reported outcome measure (PROM) of risk-adjusted change in functional status (FS) for patients aged 14 years+ with lymphedema or other causes of edema. For patients with such conditions affecting the leg, foot, groin, or lower trunk regions, the change in FS is assessed using the FOTO Lower Quadrant Edema (LQE) FS PROM. For patients with such conditions affecting the arm, hand, chest, or breast body regions, the change in FS is assessed using the FOTO Upper Quadrant Edema (UQE) FS PROM. PROM scores were scaled to the 0-100 metric, with higher scores representing higher perceived functional status. In order to fairly measure performance between providers, the measure is risk-adjusted to patient characteristics known to be associated with FS outcomes and used as a performance measure at the patient and provider levels to assess quality.",
+    "description": "This is a patient-reported outcome performance measure (PRO-PM) consisting of a patient-reported outcome measure (PROM) of risk-adjusted change in functional status (FS) for patients aged 14 years and older with lymphedema or other causes of edema. \nFor patients with such conditions affecting the arm, hand, chest, or breast body regions, the change in FS is assessed using the FOTO Upper Quadrant Edema (UQE) FS PROM.  For patients with such conditions affecting the leg, foot, groin, or lower trunk regions, the change in FS is assessed using the FOTO Lower Quadrant Edema (LQE) FS PROM. \nPROM scores were scaled to the 0-100 metric, with higher scores representing higher perceived FS. To fairly measure performance between providers, the measure is risk-adjusted to patient characteristics known to be associated with FS outcomes and used as a performance measure at the patient and provider levels to assess quality.",
     "nqfId": null,
     "measureType": "patientReportedOutcome",
     "isHighPriority": true,
@@ -16691,7 +16978,7 @@
   {
     "measureId": "FOTO5",
     "title": "Functional Status Change in Balance Confidence",
-    "description": "This is a patient-reported outcome performance measure (PRO-PM) consisting of a patient-reported outcome measure (PROM) of risk-adjusted functional status (FS) change in balance confidence for patients aged 14+ with balance impairments. The change in FS is assessed using the FOTO Balance Confidence, an item-response theory-based PROM derived from the 16-items of the Activities-specific Balance Confidence (ABC) Scale©, scored using the T-score metric (mean=50, SD=10), with higher scores representing higher balance confidence. \n\nPatient responses to ABC Scale© items may be used to directly score Balance Confidence PROM, thus allowing clinicians  flexibility of choice of PROM used in routine clinical care without adding to patient response burden. In order to fairly measure performance between providers, this quality measure is risk-adjusted to patient characteristics known to be associated with FS outcomes and used as a performance measure  at the patient and provider levels to assess quality.\n\n1.\t© Dr. Anita M. Myers, University of Waterloo, Waterloo, Ontario, Canada.\n2.\tPowell LE & Myers AM.  The Activities-specific Balance Confidence (ABC) Scale. J Gerontol Med Sci 1995; 50 (1):M28-34.\n3.\tMyers AM, Powell LE, Maki BE et al. Psychological indicators of balance confidence: Relationship to actual and perceived abilities. J Gerontol Med Sci 1996; 51A: M37-43.\n4.\tMyers AM, Fletcher PC, Myers AH & Sherk W. Discriminative and evaluative properties of the Activities-specific Balance Confidence (ABC) Scale. J Gerontol Med Sci 1998; 53A: M287-M294.",
+    "description": "This is a patient-reported outcome performance measure (PRO-PM) consisting of a patient-reported outcome measure (PROM) of risk-adjusted functional status (FS) change in balance confidence for patients aged 14+ with balance impairments. The change in FS is assessed using the FOTO Balance Confidence, an item-response theory-based PROM derived from the 16-items of the Activities-specific Balance Confidence (ABC) Scale©, (1-3) scored using the T-score metric (mean=50, SD=10), with higher scores representing higher balance confidence. (4) \nPatient responses to ABC Scale© items may be used to directly score Balance Confidence PROM, thus allowing clinicians flexibility of choice of PROM used in routine clinical care without adding to patient response burden. In order to fairly measure performance between providers, this quality measure is risk-adjusted to patient characteristics known to be associated with FS outcomes and used as a performance measure at the patient and provider levels to assess quality.",
     "nqfId": null,
     "measureType": "patientReportedOutcome",
     "isHighPriority": true,
@@ -16721,7 +17008,7 @@
   {
     "measureId": "FOTO6",
     "title": "Functional Status Change in Dizziness",
-    "description": "This is a patient-reported outcome performance measure (PRO-PM) consisting of a patient-reported outcome measure (PROM) of risk-adjusted functional status (FS) change for patients aged 14 years and older with vestibular and other dizziness-related impairments. The change in FS is assessed using the FOTO Dizziness Positional Status (DPS) or Dizziness Functional Status (DFS) PROM; these are item-response theory-based PROMs developed using items from the Dizziness Handicap Inventory (DHI), scored using the T-score metric (mean=50, SD=10), with higher scores representing better FS. \n\nThe DPS and DFS measure separate domains represented within DHI items.  The DPS score will be applied to this quality measure for patients with a statistically derived DPS cut-score (T-score) of 55 or lower whereas the DFS score will be applied for patients with a DPS T-score of greater than 55 at initial evaluation.  This approach is consistent with clinical and research observations that two types of vestibular impairments, positional- and functional-dominant, may have distinctly different clinical presentations and expected outcomes.  \n\nUsing a single PROM score derived from all 25 DHI items is not recommended due to score validity weaknesses; robust analyses using extensive exploratory and confirmatory factor analyses based on over 28,000 episodes of care determined the DHI items represent multiple domains, thus using a single overall score would pose a threat to validity. However, patient responses to DHI items may be used to directly score the DPS and DFS, allowing clinicians greater flexibility of choice of PROM used in routine clinical care without adding to clinician nor patient burden.\n\nTo fairly measure performance between providers, this quality measure is risk-adjusted to patient characteristics known to be associated with FS outcomes and used as a performance measure at the patient and provider levels to assess quality.",
+    "description": "This is a patient-reported outcome performance measure (PRO-PM) consisting of a patient-reported outcome measure (PROM) of risk-adjusted functional status (FS) change for patients aged 14 years and older with vestibular and other dizziness-related impairments. The change in FS is assessed using the FOTO Dizziness Positional Status (DPS) or Dizziness Functional Status (DFS) PROM; these are item-response theory-based PROMs developed using items from the Dizziness Handicap Inventory (DHI), scored using the T-score metric (mean=50, SD=10), with higher scores representing better FS. (1 )\nThe DPS and DFS measure separate domains represented within DHI items.  The DPS score will be applied to this quality measure for patients with a statistically derived DPS cut-score (T-score) of 55 or lower; the DFS score will be applied for patients with a DPS T-score of greater than 55 at initial evaluation.  This approach is consistent with clinical and research observations that two types of vestibular impairments, positional- and functional-dominant, have distinctly different clinical presentations and expected outcomes.  \nUsing a single PROM score derived from all 25 DHI items is not recommended due to score validity weaknesses. (2-5 Robust analyses using extensive exploratory and confirmatory factor analyses based on over 28,000 episodes of care determined the DHI items represent multiple domains that are different from those originally hypothesized, (6) thus using a single overall score would pose a threat to validity. However, patient responses to DHI items may be used to directly score the DPS and DFS, thus allowing clinicians greater flexibility of choice of PROM used in routine clinical care without adding to clinician nor patient burden.\nTo fairly measure performance between providers, this quality measure is risk-adjusted to patient characteristics known to be associated with FS outcomes and used as a performance measure at the patient and provider levels to assess quality.",
     "nqfId": null,
     "measureType": "patientReportedOutcome",
     "isHighPriority": true,
@@ -16751,7 +17038,7 @@
   {
     "measureId": "FOTO7",
     "title": "Functional Status Change for Patients Post Stroke",
-    "description": "This is a patient-reported outcome performance measure (PRO-PM) consisting of a patient-reported outcome measure (PROM) of risk-adjusted change in functional status (FS) for patients aged 14 years and older who have experienced a stroke with sequelae impacting physical functional abilities. For patients with such conditions affecting use of the hand, arm, and upper trunk, the change in FS is assessed using the FOTO Stroke Upper Extremity (SUE) FS PROM. For patients with such conditions affecting the foot, leg, and lower trunk, the change in FS is assessed using the FOTO Stroke Lower Extremity (SLE) FS PROM. PROM cores were scaled to the 0-100 metric, with higher scores representing higher perceived functional status. In order to fairly measure performance between providers, the measure is risk-adjusted to patient characteristics known to be associated with FS outcomes and used as a performance measure (PM) at the patient and provider levels to assess quality.",
+    "description": "This is a patient-reported outcome performance measure (PRO-PM) consisting of a patient-reported outcome measure (PROM) of risk-adjusted change in functional status (FS) for patients aged 14 years and older who have experienced a stroke with sequelae impacting physical functional abilities. For patients with such conditions affecting use of the hand, arm, and upper trunk, the change in FS is assessed using the FOTO Stroke Upper Extremity (SUE) FS PROM. (1) For patients with such conditions affecting the foot, leg, and lower trunk, the change in FS is assessed using the FOTO Stroke Lower Extremity (SLE) FS PROM. (1) PROM cores were scaled to the 0-100 metric, with higher scores representing higher perceived functional status. In order to fairly measure performance between providers, the measure is risk-adjusted to patient characteristics known to be associated with FS outcomes and used as a performance measure (PM) at the patient and provider levels to assess quality.",
     "nqfId": null,
     "measureType": "patientReportedOutcome",
     "isHighPriority": true,
@@ -16761,36 +17048,6 @@
     "firstPerformanceYear": 2022,
     "allowedVendors": [
       "8311170"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "GIQIC10",
-    "title": "Appropriate management of anticoagulation in the peri-procedural period rate – EGD",
-    "description": "Percentage of patients undergoing an EGD on an anti-platelet agent or an anticoagulant who leave the endoscopy unit with instructions for management of this medication",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "GIQuIC",
-    "firstPerformanceYear": 2014,
-    "allowedVendors": [
-      "5846856"
     ],
     "allowedPrograms": [
       "mips",
@@ -16820,8 +17077,7 @@
     "primarySteward": "GIQuIC",
     "firstPerformanceYear": 2021,
     "allowedVendors": [
-      "5846856",
-      "6981170"
+      "5846856"
     ],
     "allowedPrograms": [
       "mips",
@@ -16871,132 +17127,6 @@
     ]
   },
   {
-    "measureId": "GIQIC24",
-    "title": "Screening Colonoscopy Adenoma Detection Rate - Male",
-    "description": "The percentage of male patients aged 45 to 75 years with at least one conventional adenoma or colorectal cancer detected during screening colonoscopy",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "GIQuIC",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "5846856",
-      "6981170"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "GIQIC25",
-    "title": "Screening Colonoscopy Adenoma Detection Rate - Female",
-    "description": "The percentage of female patients aged 45 to 75 years with at least one conventional adenoma or colorectal cancer detected during screening colonoscopy",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "GIQuIC",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "5846856",
-      "6981170"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "HCPR16",
-    "title": "Physician’s Orders for Life-Sustaining Treatment (POLST) Form",
-    "description": "Percentage of Patients Greater Than or Equal to 65 Years of Age with Physician’s Orders for Life-Sustaining Treatment (POLST) Forms Completed",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "H-CPR (Hospitalist –Clinical Performance Registry)",
-    "firstPerformanceYear": 2015,
-    "allowedVendors": [
-      "4757099",
-      "1725296",
-      "8483899"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "HCPR17",
-    "title": "Pressure Ulcers – Risk Assessment and Plan of Care",
-    "description": "Percentage of Adult Post-acute Facility Patients That Had a Risk Assessment for Pressure Ulcers and a Plan of Care for Pressure Ulcer Prevention/Treatment Completed",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "H-CPR (Hospitalist –Clinical Performance Registry)",
-    "firstPerformanceYear": 2017,
-    "allowedVendors": [
-      "4757099",
-      "1725296",
-      "8483899"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
     "measureId": "HCPR20",
     "title": "Clostridium Difficile – Risk Assessment and Plan of Care",
     "description": "Percentage of Adult Patients Who Had a Risk Assessment for C. difficile Infection and, If High-Risk, Had a Plan of Care for C. difficile Completed on the Day Of or Day After Hospital Admission",
@@ -17009,8 +17139,9 @@
     "firstPerformanceYear": 2018,
     "allowedVendors": [
       "4757099",
+      "8483899",
       "1725296",
-      "8483899"
+      "5133825"
     ],
     "allowedPrograms": [
       "mips",
@@ -17102,12 +17233,14 @@
     "measureType": "outcome",
     "isHighPriority": true,
     "isInverse": false,
-    "isRiskAdjusted": true,
+    "isRiskAdjusted": false,
     "primarySteward": "MIPSPRO ENTERPRISE",
     "firstPerformanceYear": 2020,
     "allowedVendors": [
-      "8411367",
-      "7037323"
+      "7037323",
+      "3471690",
+      "3565744",
+      "3967247"
     ],
     "allowedPrograms": [
       "mips",
@@ -17415,186 +17548,6 @@
     ]
   },
   {
-    "measureId": "IRIS41",
-    "title": "Improved visual acuity after epiretinal membrane treatment within 120 days",
-    "description": "Percentage of patients with a 20% improvement in visual acuity within 120 days following epiretinal membrane treatment",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "3927141"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "IRIS43",
-    "title": "Intraocular Pressure Reduction Following Laser Trabeculoplasty",
-    "description": "Percentage of patients who underwent laser trabeculoplasty who had IOP reduced by 20% or more from their pretreatment IOP or had a reduction in overall number of glaucoma medications.",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "3927141"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "IRIS44",
-    "title": "Visual Field Progression in Glaucoma",
-    "description": "Percentage of patients with a diagnosis of glaucoma with a mean deviation loss of 3dB or more from their baseline value.",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": true,
-    "isRiskAdjusted": false,
-    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "3927141"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "IRIS46",
-    "title": "Evidence of anatomic closure of macular hole within 90 days after surgery as documented by OCT",
-    "description": "Percentage of patients with a macular hole who have evidence of anatomic closure documented by OCT within 90 days after surgical treatment.",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "3927141"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "IRIS48",
-    "title": "Adult Surgical Esotropia: Postoperative alignment",
-    "description": "Percentage of adult esotropia patients receiving surgical treatment with a post treatment alignment of 12 prism diopters (PD) or less.",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "3927141"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "IRIS49",
-    "title": "Surgical Pediatric Esotropia: Postoperative alignment",
-    "description": "Percentage of surgical esotropia pediatric patients with a postoperative alignment of 12 prism diopters (PD) or less without a reoperation.",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "3927141"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
     "measureId": "IRIS50",
     "title": "Amblyopia: Interocular visual acuity",
     "description": "Percentage of newly diagnosed amblyopic patients with one or more of the following:\nA. a corrected interocular (or if not reported, the uncorrected) visual acuity difference less than 0.23 logMAR 3-12 months after first diagnosis of amblyopia\nOR\nB. an improvement in the corrected visual acuity of the amblyopic eye of 3 or more Snellen lines (> or = 0.30 logMAR) 3-12 months after first diagnosis of amblyopia \nOR\nC. a final visual acuity in the amblyopic eye equal to 20/30 or better (less than or equal to 0.18 log Mar) 3-12 months after first diagnosis of amblyopia",
@@ -17625,66 +17578,6 @@
     ]
   },
   {
-    "measureId": "IRIS51",
-    "title": "Acute Anterior Uveitis: Post-treatment visual acuity",
-    "description": "Percentage of acute anterior uveitis patients with a post-treatment best corrected visual acuity of 20/20 or better or patients whose visual acuity had returned to their baseline value prior to onset of uveitis.",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "3927141"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "IRIS53",
-    "title": "Chronic Anterior Uveitis - Post-treatment visual acuity",
-    "description": "Percentage of chronic anterior uveitis patients with a post-treatment best corrected visual acuity of 20/30 or better or patients whose visual acuity had returned to their baseline value prior to onset of uveitis.",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
-    "firstPerformanceYear": 2020,
-    "allowedVendors": [
-      "3927141"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
     "measureId": "IRIS54",
     "title": "Complications After Cataract Surgery",
     "description": "Percentage of eyes of patients aged 18 years and older with a diagnosis of cataract who had cataract surgery and had the following complications with 90 days after cataract surgery: prolonged inflammation, incision complications, iris complications, retinal detachment, cystoid macular edema, corneal complications, or a return to OR.",
@@ -17692,111 +17585,6 @@
     "measureType": "outcome",
     "isHighPriority": true,
     "isInverse": true,
-    "isRiskAdjusted": false,
-    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
-    "firstPerformanceYear": 2020,
-    "allowedVendors": [
-      "3927141"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "IRIS55",
-    "title": "Visual Acuity Improvement Following Cataract Surgery and Minimally Invasive Glaucoma Surgery",
-    "description": "Percentage of eyes of patients aged 18 years and older with a diagnosis of cataract who had cataract surgery and minimally invasive glaucoma surgery and achieved 20/30 best-corrected distance visual acuity or better OR an improvement in best-corrected distance visual acuity within 4 months following the cataract surgery. Weighted average of performance rates reported.",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
-    "firstPerformanceYear": 2020,
-    "allowedVendors": [
-      "3927141"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "overallAlgorithm": "weightedAverage",
-    "strata": [
-      {
-        "name": "20/30+",
-        "description": "Includes eyes of patients with mild to moderate stage glaucoma and a 20/30 or better post-operative best-corrected distance visual acuity"
-      },
-      {
-        "name": "20/200",
-        "description": "Includes eyes of patients with severe stage glaucoma or a pre-operative best-corrected visual acuity of 20/200 and a 2 lines or better improvement in the post-operative best-corrected distance visual acuity from preoperative visual acuity"
-      },
-      {
-        "name": "20/400",
-        "description": "Includes eyes of patients with a pre-operative best-corrected visual acuity of 20/400 and a 1 line or better improvement in the post-operative best-corrected distance visual acuity from pre-operative visual acuity"
-      }
-    ]
-  },
-  {
-    "measureId": "IRIS56",
-    "title": "Adult Diplopia: Improvement of ocular deviation or absence of diplopia or functional improvement",
-    "description": "Percentage of patients with a diagnosis of double vision (diplopia) who had an improvement of ocular deviation as determined by reduction of strabismus in primary gaze to less than 10 prism diopters horizontal or less than 2 prism diopters vertical deviation OR were absent of diplopia in primary gaze OR had functional improvement in ptosis within 6 months of initiating treatment.",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
-    "firstPerformanceYear": 2020,
-    "allowedVendors": [
-      "3927141"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "IRIS57",
-    "title": "Idiopathic Intracranial Hypertension: Improvement of mean deviation or stability of mean deviation",
-    "description": "Percentage of patients with improvement in mean deviation or stability of mean deviation (+1db) within 6 months of initiating therapy.",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
     "isRiskAdjusted": false,
     "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
     "firstPerformanceYear": 2020,
@@ -17850,1029 +17638,9 @@
     ]
   },
   {
-    "measureId": "IRIS59",
-    "title": "Regaining Vision After Cataract Surgery",
-    "description": "Percentage of eyes of patients aged 18 years and older with a diagnosis of cataract who had cataract surgery and 20/20 best-corrected distance visual acuity or better OR an improvement in best-corrected distance visual acuity within 30 days following the cataract surgery. Weighted average of performance rates reported.",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
-    "firstPerformanceYear": 2020,
-    "allowedVendors": [
-      "3927141"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "overallAlgorithm": "weightedAverage",
-    "strata": [
-      {
-        "name": "nocomorbidities",
-        "description": "Includes eyes of patients with no comorbidities or additional procedures on the same date as the cataract surgery,"
-      },
-      {
-        "name": "comorbidities&20/200",
-        "description": "Includes eyes of patients with comorbidities with a pre-operative visual acuity of 20/200 or better, and"
-      },
-      {
-        "name": "comorbidities&20/400",
-        "description": "Includes eyes of patients with comorbidities with a pre-operative visual acuity of 20/400 or worse"
-      }
-    ]
-  },
-  {
-    "measureId": "IRIS6",
-    "title": "Acquired Involutional Entropion: Normalized lid position after surgical repair",
-    "description": "Percentage of surgical entropion patients with normalized lid position within 90 days postoperatively.",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
-    "firstPerformanceYear": 2015,
-    "allowedVendors": [
-      "3927141"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "IRIS60",
-    "title": "Visual Acuity Improvement Following Cataract Surgery Combined with a Trabeculectomy or an Aqueous Shunt Procedure",
-    "description": "Percentage of eyes of patients who underwent cataract surgery combined with a trabeculectomy or an aqueous shunt procedure who had their visual acuity improve 1 or 2 or more Snellen lines from their preoperative visual acuity between 3 and 6 months postoperatively. Weighted average of performance rates reported.",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "American Academy of Ophthalmology IRIS® Registry (Intelligent Research in Sight)",
-    "firstPerformanceYear": 2020,
-    "allowedVendors": [
-      "3927141"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "overallAlgorithm": "weightedAverage",
-    "strata": [
-      {
-        "name": "better20/200",
-        "description": "Includes eyes of patients with a pre-operative visual acuity of better than 20/200 who had an improvement from their preoperative visual acuity of 2 or more lines between 3 and 6 months postoperatively"
-      },
-      {
-        "name": "20/200",
-        "description": "Includes eyes of patients with a pre-operative visual acuity of 20/200 who had an improvement from their preoperative visual acuity of 2 or more lines between 3 and 6 months postoperatively"
-      },
-      {
-        "name": "20/400",
-        "description": "Includes eyes of patients with a pre-operative visual acuity of 20/400 who had an improvement from their preoperative visual acuity of 1 or more lines between 3 and 6 months postoperatively"
-      }
-    ]
-  },
-  {
-    "measureId": "IROMS11",
-    "title": "Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) to indicate functional improvement in knee rehabilitation of patients with knee injury measured via their validated Knee Outcome Survey (KOS) score, or equivalent instrument which has undergone peer reviewed published validation and demonstrates a peer reviewed published MCID.",
-    "description": "The proportion of patients failing to achieve an MCID of ten (10) points or more improvement in the KOS change score for patients with knee injury treated during the observation period will be reported. \n\nAdditionally, a risk-adjusted MCID proportional difference will be determined by calculating the difference between the risk model predicted and observed MCID proportion will reported for each physical therapist or physical therapy group. The risk adjustment will be calculated using a logistic regression model using: baseline KOS score, baseline pain score, age, sex, payer, and symptom duration (time from surgery or injury to baseline physical therapy visit). \n\nThese measures will serve as a PT/OT performance measure at the eligible PT/OT or PT/OT group level.",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": true,
-    "isRiskAdjusted": true,
-    "primarySteward": "Keet Outcomes; MIPSPRO",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "8411367",
-      "7037323",
-      "1157686",
-      "3967247"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "overallAlgorithm": "overallStratumOnly",
-    "strata": [
-      {
-        "name": "notachieving",
-        "description": "Overall proportion of patients not achieving an MCID in KOS change score will be reported."
-      },
-      {
-        "name": "overall",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via KOS) proportion will be reported. "
-      },
-      {
-        "name": "operativeMCID",
-        "description": "The proportion of patients not achieving an MCID in KOS change score will be reported."
-      },
-      {
-        "name": "operativeRisk",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via KOS) proportion will be reported. "
-      },
-      {
-        "name": "nonOpMCID",
-        "description": "The proportion of patients not achieving an MCID in KOS change score will be reported."
-      },
-      {
-        "name": "nonOpRisk",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measure via KOS) proportion will be reported."
-      }
-    ]
-  },
-  {
-    "measureId": "IROMS12",
-    "title": "Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with knee injury pain.",
-    "description": "The proportion of patients failing to achieve MCID of two (2) points or more improvement in the NPRS change score for patients with knee injuries treated during the observation period will be reported. \n\nAdditionally, a risk-adjusted MCID proportional difference will be determined by calculating the difference between the risk model predicted and observed MCID proportion will reported for each physical therapist or physical therapy group. The risk adjustment will be calculated using a logistic regression model using: baseline KOS score, baseline pain score, age, sex, payer, and symptom duration (time from surgery or injury to baseline physical therapy visit). \n\nThese measures will serve as a physical or occupational therapy performance measure at the eligible physical or occupational therapist or physical or occupational therapy group level.",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": true,
-    "isRiskAdjusted": true,
-    "primarySteward": "Keet Outcomes; MIPSPRO",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "8411367",
-      "7037323",
-      "1157686",
-      "3967247"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "overallAlgorithm": "overallStratumOnly",
-    "strata": [
-      {
-        "name": "notachieving",
-        "description": "Overall proportion of patients not achieving an MCID in the NPRS change score will be reported. "
-      },
-      {
-        "name": "overall",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported. "
-      },
-      {
-        "name": "operativeMCID",
-        "description": "The proportion of patients not achieving an MCID in the NPRS change score will be reported. "
-      },
-      {
-        "name": "operativeRisk",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported. "
-      },
-      {
-        "name": "nonOpMCID",
-        "description": "The proportion of patients not achieving an MCID in the NPRS change score will be reported. "
-      },
-      {
-        "name": "nonOpRisk",
-        "description": " A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported."
-      }
-    ]
-  },
-  {
-    "measureId": "IROMS13",
-    "title": "Failure to Progress (FTP): Proportion of patients not achieving a Minimal Clinically Important Difference (MCID) to indicate functional improvement in rehabilitation of patients with hip, leg or ankle injuries using the validated Lower Extremity Function Scale (LEFS) score, or equivalent instrument which has undergone peer reviewed published validation and demonstrates a peer reviewed published MCID.",
-    "description": "The proportion of patients failing to achieve an MCID of nine (9) points or more improvement in the LEFS change score for patients with hip, leg, or ankle injuries treated during the observation period will be reported. \n\nAdditionally, a risk-adjusted MCID proportional difference will be determined by calculating the difference between the risk model predicted and observed MCID proportion will reported for each physical therapist or physical therapy group. The risk adjustment will be calculated using a logistic regression model using: baseline LEFS score, baseline pain score, age, sex, payer, and symptom duration (time from surgery or injury to baseline physical therapy visit). \n\nThese measures will serve as a physical or occupational therapy performance measure at the eligible physical or occupational therapist or physical or occupational therapy group level.",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": true,
-    "isRiskAdjusted": true,
-    "primarySteward": "Keet Outcomes; MIPSPRO",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "8411367",
-      "7037323",
-      "1157686",
-      "3967247"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "overallAlgorithm": "overallStratumOnly",
-    "strata": [
-      {
-        "name": "notachieving",
-        "description": "Overall proportion of patients not achieving an MCID in KOS change score will be reported."
-      },
-      {
-        "name": "overall",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via KOS) proportion will be reported. "
-      },
-      {
-        "name": "operativeMCID",
-        "description": "The proportion of patients not achieving an MCID in KOS change score will be reported."
-      },
-      {
-        "name": "operativeRisk",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via KOS) proportion will be reported. "
-      },
-      {
-        "name": "nonOpMCID",
-        "description": "The proportion of patients not achieving an MCID in KOS change score will be reported."
-      },
-      {
-        "name": "nonOpRisk",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measure via KOS) proportion will be reported."
-      }
-    ]
-  },
-  {
-    "measureId": "IROMS14",
-    "title": "Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with hip, leg or ankle (lower extremity except knee) injury.",
-    "description": "The proportion of patients failing to achieve an MCID of two (2) points or more improvement in the NPRS change score for patients with hip, leg, or ankle injuries treated during the observation period will be reported. \n\nAdditionally, a risk-adjusted MCID proportional difference will be determined by calculating the difference between the risk model predicted and observed MCID proportion will reported for each physical therapist or physical therapy group. The risk adjustment will be calculated using a logistic regression model using: LEFS score, baseline pain score, age, sex, payer, and symptom duration (time from surgery or injury to baseline physical therapy visit). \n\nThese measures will serve as a physical or occupational therapy performance measure at the eligible physical or occupational therapist or physical or occupational therapy group level.",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": true,
-    "isRiskAdjusted": true,
-    "primarySteward": "Keet Outcomes; MIPSPRO",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "8411367",
-      "7037323",
-      "1157686",
-      "3967247"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "overallAlgorithm": "overallStratumOnly",
-    "strata": [
-      {
-        "name": "notachieving",
-        "description": "Overall proportion of patients not achieving an MCID in the NPRS change score will be reported. "
-      },
-      {
-        "name": "overall",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported. "
-      },
-      {
-        "name": "operativeMCID",
-        "description": "The proportion of patients not achieving an MCID in the NPRS change score will be reported. "
-      },
-      {
-        "name": "operativeRisk",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported."
-      },
-      {
-        "name": "nonOpMCID",
-        "description": "The proportion of patients not achieving an MCID in the NPRS change score will be reported. "
-      },
-      {
-        "name": "nonOpRisk",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported."
-      }
-    ]
-  },
-  {
-    "measureId": "IROMS16",
-    "title": "Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with neck pain/injury.",
-    "description": "The proportion of patients failing to achieve an MCID of two (2) points or more improvement in the NPRS change score for patients with neck pain/injury treated during the observation period will be reported. \n\nAdditionally, a risk-adjusted MCID proportional difference will be determined by calculating the difference between the risk model predicted and observed MCID proportion will reported for each physical therapist or physical therapy group. The risk adjustment will be calculated using a logistic regression model using: baseline NDI score, baseline pain score, age, sex, payer, and symptom duration (time from surgery or injury to baseline physical therapy visit). \n\nThese measures will serve as a physical or occupational therapy performance measure at the eligible physical or occupational therapist or physical or occupational therapy group level.",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": true,
-    "isRiskAdjusted": true,
-    "primarySteward": "Keet Outcomes; MIPSPRO",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "8411367",
-      "7037323",
-      "1157686",
-      "3967247"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "overallAlgorithm": "overallStratumOnly",
-    "strata": [
-      {
-        "name": "notachieving",
-        "description": "Overall proportion of patients not achieving an MCID in the NPRS change score will be reported. "
-      },
-      {
-        "name": "overall",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported. "
-      },
-      {
-        "name": "operativeMCID",
-        "description": "The proportion of patients not achieving an MCID in the NPRS change score will be reported. "
-      },
-      {
-        "name": "operativeRisk",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported. "
-      },
-      {
-        "name": "nonOpMCID",
-        "description": "The proportion of patients not achieving an MCID in the NPRS change score will be reported. "
-      },
-      {
-        "name": "nonOpRisk",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported."
-      }
-    ]
-  },
-  {
-    "measureId": "IROMS17",
-    "title": "Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) to indicate functional improvement in rehabilitation patients with low back pain measured via the validated Modified Low Back Pain Disability Questionnaire (MDQ) score.",
-    "description": "The proportion of patients failing to achieve an MCID of six (6) points or more improvement in the MDQ change score for patients with low back pain treated during the observation period will be reported. \n\nAdditionally, a risk-adjusted MCID proportional difference will be determined by calculating the difference between the risk model predicted and observed MCID proportion will reported for each physical therapist or physical therapy group. The risk adjustment will be calculated using a logistic regression model using: baseline MDQ score, baseline pain score, age, sex, payer, and symptom duration (time from surgery or injury to baseline physical therapy visit). \n\nThese measures will serve as a physical or occupational therapy performance measure at the eligible physical or occupational therapist or physical or occupational therapy group level.",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": true,
-    "isRiskAdjusted": true,
-    "primarySteward": "Keet Outcomes; MIPSPRO",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "8411367",
-      "7037323",
-      "1157686",
-      "3967247"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "overallAlgorithm": "overallStratumOnly",
-    "strata": [
-      {
-        "name": "notachieving",
-        "description": "Overall proportion of patients not achieving an MCID in KOS change score will be reported."
-      },
-      {
-        "name": "overall",
-        "description": " A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via KOS) proportion will be reported. "
-      },
-      {
-        "name": "operativeMCID",
-        "description": "The proportion of patients not achieving an MCID in KOS change score will be reported."
-      },
-      {
-        "name": "operativeRisk",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via KOS) proportion will be reported. "
-      },
-      {
-        "name": "nonOpMCID",
-        "description": "The proportion of patients not achieving an MCID in KOS change score will be reported."
-      },
-      {
-        "name": "nonOpRisk",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measure via KOS) proportion will be reported."
-      }
-    ]
-  },
-  {
-    "measureId": "IROMS18",
-    "title": "Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with low back pain.",
-    "description": "The proportion of patients failing to achieve an MCID of two (2) points or more improvement in the NPRS change score for patients with low back pain treated during the observation period will be reported. \n\nAdditionally, a risk-adjusted MCID proportional difference will be determined by calculating the difference between the risk model predicted and observed MCID proportion will reported for each physical therapist or physical therapy group. The risk adjustment will be calculated using a logistic regression model using: baseline MDQ score, baseline pain score, age, sex, payer, and symptom duration (time from surgery or injury to baseline physical therapy visit). \n\nThese measures will serve as a physical or occupational therapy performance measure at the eligible physical or occupational therapist or physical or occupational therapy group level.",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": true,
-    "isRiskAdjusted": true,
-    "primarySteward": "Keet Outcomes; MIPSPRO",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "8411367",
-      "7037323",
-      "1157686",
-      "3967247"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "overallAlgorithm": "overallStratumOnly",
-    "strata": [
-      {
-        "name": "notachieving",
-        "description": "Overall proportion of patients not achieving an MCID in the NPRS change score will be reported. "
-      },
-      {
-        "name": "overall",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported. "
-      },
-      {
-        "name": "operativeMCID",
-        "description": "The proportion of patients not achieving an MCID in the NPRS change score will be reported. "
-      },
-      {
-        "name": "operativeRisk",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported. "
-      },
-      {
-        "name": "nonOpMCID",
-        "description": "The proportion of patients not achieving an MCID in the NPRS change score will be reported. "
-      },
-      {
-        "name": "nonOpRisk",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported."
-      }
-    ]
-  },
-  {
-    "measureId": "IROMS19",
-    "title": "Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) to indicate functional improvement in rehabilitation of patients with arm, shoulder, and hand injury measured via the validated Disability of Arm Shoulder and Hand (DASH) score, Quick Disability of Arm Shoulder and Hand (QDASH) score, or equivalent instrument which has undergone peer reviewed published validation and demonstrates a peer reviewed published MCID.",
-    "description": "The proportion of patients failing to achieve an MCID of ten (10) points or more improvement in the DASH change score or eight (8) points or more improvement in the QDASH change score for patients with arm, shoulder, and hand injury patients treated during the observation period will be reported. \n\nAdditionally, a risk-adjusted MCID change proportional difference will be determined by calculating the difference between the risk model predicted and observed MCID proportion will reported for each physical therapist or physical therapy group. The risk adjustment will be calculated using a logistic regression model using: baseline DASH score, baseline pain score, age, sex, payer, and symptom duration (time from surgery or injury to baseline physical therapy visit).\n\nThese measures will serve as a physical and occupational therapy performance measure at the eligible physical or occupational therapist or physical or occupational therapy group level.",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": true,
-    "isRiskAdjusted": true,
-    "primarySteward": "Keet Outcomes; MIPSPRO",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "8411367",
-      "7037323",
-      "1157686",
-      "3967247"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "overallAlgorithm": "overallStratumOnly",
-    "strata": [
-      {
-        "name": "notachieving",
-        "description": "Overall proportion of patients not achieving an MCID in DASH change score will be reported. "
-      },
-      {
-        "name": "overall",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via DASH) proportion will be reported. "
-      },
-      {
-        "name": "operativeMCID",
-        "description": "The proportion of patients not achieving an MCID in DASH change score will be reported. "
-      },
-      {
-        "name": "operativeRisk",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via DASH) proportion will be reported."
-      },
-      {
-        "name": "nonOpMCID",
-        "description": "The proportion of patients not achieving an MCID in DASH change score will be reported."
-      },
-      {
-        "name": "nonOpRisk",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via DASH) proportion will be reported."
-      }
-    ]
-  },
-  {
-    "measureId": "IROMS20",
-    "title": "Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) in improvement in pain score, measured via the Numeric Pain Rating Scale (NPRS), in rehabilitation patients with arm, shoulder, or hand injury.",
-    "description": "The proportion of patients failing to achieve an MCID of two (2) points or more improvement in the NPRS change score for patients with arm, shoulder, or hand injury treated during the observation period will be reported. \n\nAdditionally, a risk-adjusted MCID proportional difference will be determined by calculating the difference between the risk model predicted and observed MCID proportion will reported for each physical therapist or physical therapy group. The risk adjustment will be calculated using a logistic regression model using: baseline DASH score, baseline pain score, age, sex, payer, and symptom duration (time from surgery or injury to baseline physical therapy visit). \n\nThese measures will serve as a physical or occupational therapy performance measure at the eligible physical or occupational therapist or physical or occupational therapy group level.",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": true,
-    "isRiskAdjusted": true,
-    "primarySteward": "Keet Outcomes; MIPSPRO",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "8411367",
-      "7037323",
-      "1157686",
-      "3967247"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "overallAlgorithm": "overallStratumOnly",
-    "strata": [
-      {
-        "name": "notachieving",
-        "description": "Overall proportion of patients not achieving an MCID in the NPRS change score will be reported. "
-      },
-      {
-        "name": "overall",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported. "
-      },
-      {
-        "name": "operativeMCID",
-        "description": "The proportion of patients not achieving an MCID in the NPRS change score will be reported. "
-      },
-      {
-        "name": "operativeRisk",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported. "
-      },
-      {
-        "name": "nonOpMCID",
-        "description": "The proportion of patients not achieving an MCID in the NPRS change score will be reported. "
-      },
-      {
-        "name": "nonOpRisk",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported."
-      }
-    ]
-  },
-  {
-    "measureId": "KEET01",
-    "title": "Failure to Progress (FTP): Proportion of patients failing to achieve a Minimal Clinically Important Difference (MCID) to indicate functional improvement in rehabilitation of patients with neck pain/injury measured via the validated Neck Disability Index (NDI).",
-    "description": "The proportion of patients failing to achieve an MCID of seven and a half (7.5) points or more improvement in the NDI change score for neck pain/injury patients treated during the observation period will be reported. \n\nAdditionally, a risk-adjusted NDI change proportional difference will be determined by calculating the difference between the risk model predicted and observed MCID proportion will reported for each physical therapist or physical therapy group. The risk adjustment will be calculated using a logistic regression model using: baseline NDI score, baseline pain score, age, sex, payer, and symptom duration (time from surgery or injury to baseline physical therapy visit).\n\nThese measures will serve as a physical or occupational therapy performance measure at the eligible physical or occupational therapist or physical or occupational therapy group level.",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": true,
-    "isRiskAdjusted": true,
-    "primarySteward": "Keet Outcomes; MIPSPRO",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "8411367",
-      "7037323",
-      "1157686",
-      "3967247"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "overallAlgorithm": "overallStratumOnly",
-    "strata": [
-      {
-        "name": "notachieving",
-        "description": "Overall proportion of patients not achieving an MCID in NDI change score will be reported."
-      },
-      {
-        "name": "overall",
-        "description": " A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via NDI) proportion will be reported. "
-      },
-      {
-        "name": "operativeMCID",
-        "description": "The proportion of patients not achieving an MCID in NDI change score will be reported."
-      },
-      {
-        "name": "operativeRisk",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via NDI) proportion will be reported. "
-      },
-      {
-        "name": "nonOpMCID",
-        "description": "The proportion of patients not achieving an MCID in NDI change score will be reported."
-      },
-      {
-        "name": "nonOpRisk",
-        "description": "A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measure via NDI) proportion will be reported."
-      }
-    ]
-  },
-  {
-    "measureId": "LMBR1",
-    "title": "Patients Suffering From a Knee Injury who Improve Physical Function",
-    "description": "Percentage of patients 18 years or older suffering from a knee injury who achieve the Minimal Clinically Important Difference (MCID) in the PROMIS Upper Extremity Computer Adaptive Testing. The MCID for PROMIS Physical Function is unique and validated for patients suffering knee functional deficits. This measure will be reported as the overall number of patients of rate 1 and rate 2 combined. To qualify, the patient must complete a baseline score and then one follow-up or discharge score. \n\nIn order to fairly measure performance between providers' performance, the measure is risk-adjusted based on a proprietary assessment including age, sex, symptom characteristics, PROMIS baseline scores, social determinants of health, and psychosocial metrics. \n\nThis measure will include three rates:\n1) The number of non-surgical patients achieving a score change of 2.1 points  in PROMIS Physical Function \n2) The number of surgical patients achieving a  score change of 2.1 points  in PROMIS Physical Function \n3) The overall performance rate of Rate 1 and Rate 2 combined",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": true,
-    "primarySteward": "Patient360 in Collaboration with ETSU and Limber Health",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "3471690"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "LMBR10",
-    "title": "Patients Suffering From a Upper Extremity Injury who Demonstrate Improved Pain",
-    "description": "Percentage of patients 18 years or older suffering from shoulder, elbow, wrist/hand injury who achieve the Minimal Clinically Important Difference (MCID) in the PROMIS Pain Interference Computer Adaptive Testing (CAT), mapped legacy measure, or like tool of measurement. This measure will be reported as the overall number of patients of rate 1 and rate 2 combined. To qualify, the patient must complete a baseline score and then one follow-up or discharge score. \n\nIn order to fairly measure performance between providers, the measure is risk-adjusted based on age, sex, symptom characteristics, PROMIS baseline scores, social determinants of health, and psychosocial metrics. \n\nThis measure will include three rates:\n1) The number of non-surgical patients achieving a score change greater than or equal to the MCID in PROMIS Pain Interference or like mapped measure.\n2) The number of surgical patients achieving a  score change greater than or equal to the MCID in PROMIS Pain Interference or like mapped measure.\n3) The overall performance rate of Rate 1 and Rate 2 combined",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": true,
-    "primarySteward": "Patient360 in Collaboration with ETSU and Limber Health",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "3471690"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "LMBR2",
-    "title": "Patients Suffering From a Lumbar Spine (Low Back) Injury who Improve Physical Function",
-    "description": "Percentage of patients 18 years or older suffering from a lumbar spine (low back) injury who achieve the Minimal Clinically Important Difference (MCID) in the PROMIS Upper Extremity Computer Adaptive Testing. The MCID for PROMIS Physical Function is unique and validated for patients suffering low back functional deficits. This measure will be reported as the overall number of patients of rate 1 and rate 2 combined. To qualify, the patient must complete a baseline score and then one follow-up or discharge score. \n\nIn order to fairly measure performance between providers' performance, the measure is risk-adjusted based on a proprietary assessment including age, sex, symptom characteristics, PROMIS baseline scores, social determinants of health, and psychosocial metrics. \n\nThis measure will include three rates:\n1) The number of non-surgical patients achieving a score change of 2.1 points  in PROMIS Physical Function \n2) The number of surgical patients achieving a  score change of 2.1 points  in PROMIS Physical Function \n3) The overall performance rate of Rate 1 and Rate 2 combined",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": true,
-    "primarySteward": "Patient360 in Collaboration with ETSU and Limber Health",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "3471690"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "LMBR3",
-    "title": "Patients Suffering From a Cervical Spine (Neck) Injury who Improve Physical Function",
-    "description": "Percentage of patients 18 years or older suffering from a cervical spine (neck) injury who achieve the Minimal Clinically Important Difference (MCID) in the PROMIS Upper Extremity Computer Adaptive Testing. The MCID for PROMIS Physical Function is unique and validated for patients suffering neck functional deficits. This measure will be reported as the overall number of patients of rate 1 and rate 2 combined. To qualify, the patient must complete a baseline score and then one follow-up or discharge score. \n\nIn order to fairly measure performance between providers' performance, the measure is risk-adjusted based on a proprietary assessment including age, sex, symptom characteristics, PROMIS baseline scores, social determinants of health, and psychosocial metrics. \n\nThis measure will include three rates:\n1) The number of non-surgical patients achieving a score change of 2.1 points  in PROMIS Physical Function \n2) The number of surgical patients achieving a  score change of 2.1 points  in PROMIS Physical Function \n3) The overall performance rate of Rate 1 and Rate 2 combined",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": true,
-    "primarySteward": "Patient360 in Collaboration with ETSU and Limber Health",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "3471690"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "LMBR4",
-    "title": "Patients Suffering From a Lower Extremity Injury who Improve Physical Function",
-    "description": "Percentage of patients 18 years or older suffering from a hip, foot, or ankle injury who achieve the Minimal Clinically Important Difference (MCID) in the PROMIS Physical Function Computer Adaptive Testing, mapped legacy measure, or like tool of measurement. This measure will be reported as the overall number of patients of rate 1 and rate 2 combined. To qualify, the patient must complete a baseline score and then one follow-up or discharge score. \n\nIn order to fairly measure performance between providers, the measure is risk-adjusted based on age, sex, symptom characteristics, PROMIS baseline scores, social determinants of health, and psychosocial metrics. \n\nThis measure will include three rates:\n1) The number of non-surgical patients achieving a score change greater than or equal to the MCID in PROMIS Physical Function or like mapped measure.\n2) The number of surgical patients achieving a  score change greater than or equal to the MCID in PROMIS Physical Function or like mapped measure.\n3) The overall performance rate of Rate 1 and Rate 2 combined.",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": true,
-    "primarySteward": "Patient360 in Collaboration with ETSU and Limber Health",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "3471690"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "LMBR5",
-    "title": "Patients Suffering From a Upper Extremity Injury who Improve Physical Function",
-    "description": "Percentage of patients 18 years or older suffering from a shoulder, elbow, wrist/hand injury who achieve the Minimal Clinically Important Difference (MCID) in the PROMIS Upper Extremity Computer Adaptive Testing in the PROMIS Pain Interference Computer Adaptive Testing (CAT), mapped legacy measure, or like tool of measurement. This measure will be reported as the overall number of patients of rate 1 and rate 2 combined. To qualify, the patient must complete a baseline score and then one follow-up or discharge score. \n\nIn order to fairly measure performance between providers, the measure is risk-adjusted based on age, sex, symptom characteristics, PROMIS baseline scores, social determinants of health, and psychosocial metrics. \n\nThis measure will include three rates:\n1) The number of non-surgical patients achieving a score change greater than or equal to the MCID in PROMIS Upper Extremity Function or like mapped measure.\n2) The number of surgical patients achieving a  score change greater than or equal to the MCID in PROMIS PROMIS Upper Extremity Function or like mapped measure.\n3) The overall performance rate of Rate 1 and Rate 2 combined.",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": true,
-    "primarySteward": "Patient360 in Collaboration with ETSU and Limber Health",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "3471690"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "LMBR6",
-    "title": "Patients Suffering From a Knee Injury who Demonstrate Improved Pain",
-    "description": "Percentage of patients 18 years or older suffering from knee injury who achieve the Minimal Clinically Important Difference (MCID) in the PROMIS Pain Interference Computer Adaptive Testing (CAT). The MCID for PROMIS Pain Interference is unique and validated for patients suffering knee functional deficits. This measure will be reported as the overall number of patients of rate 1 and rate 2 combined. To qualify, the patient must complete a baseline score and then one follow-up or discharge score. \n\nIn order to fairly measure performance between providers' performance, the measure is risk-adjusted based on a proprietary assessment including age, sex, symptom characteristics, PROMIS baseline scores, social determinants of health, and psychosocial metrics. \n\nThis measure will include three rates:\n1) The number of non-surgical patients achieving a score change of 2.0 points  in PROMIS Pain Interference\n2) The number surgical patients achieving a  score change of 2.0 points  in PROMIS Pain Interference\n3) The overall performance rate of Rate 1 and Rate 2 combined",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": true,
-    "primarySteward": "Patient360 in Collaboration with ETSU and Limber Health",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "3471690"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "LMBR7",
-    "title": "Patients Suffering From a Lumbar Spine (Low Back) Injury who Demonstrate Improved Pain",
-    "description": "Percentage of patients 18 years or older suffering from lumbar spine (low back) pain who achieve the Minimal Clinically Important Difference (MCID) in the PROMIS Pain Interference Computer Adaptive Testing (CAT). The MCID for PROMIS Pain Interference is unique and validated for patients suffering low back functional deficits. This measure will be reported as the overall number of patients of rate 1 and rate 2 combined. To qualify, the patient must complete a baseline score and then one follow-up or discharge score. \n\nIn order to fairly measure performance between providers' performance, the measure is risk-adjusted based on a proprietary assessment including age, sex, symptom characteristics, PROMIS baseline scores, social determinants of health, and psychosocial metrics. \n\nThis measure will include three rates:\n1) The number of non-surgical patients achieving a score change of 2.0 points  in PROMIS Pain Interference\n2) The number of surgical patients achieving a  score change of 2.0 points  in PROMIS Pain Interference\n3) The overall performance rate of Rate 1 and Rate 2 combined",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": true,
-    "primarySteward": "Patient360 in Collaboration with ETSU and Limber Health",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "3471690"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "LMBR8",
-    "title": "Patients Suffering From a Cervical Spine (Neck) Injury who Demonstrate Improved Pain",
-    "description": "Percentage of patients 18 years or older suffering from cervical spine (neck) injury who achieve the Minimal Clinically Important Difference (MCID) in the PROMIS Pain Interference Computer Adaptive Testing (CAT). The MCID for PROMIS Pain Interference is unique and validated for patients suffering neck functional deficits. This measure will be reported as the overall number of patients of rate 1 and rate 2 combined. To qualify, the patient must complete a baseline score and then one follow-up or discharge score. \n\nIn order to fairly measure performance between providers' performance, the measure is risk-adjusted based on a proprietary assessment including age, sex, symptom characteristics, PROMIS baseline scores, social determinants of health, and psychosocial metrics. \n\nThis measure will include three rates:\n1) The number of non-surgical patients achieving a score change of 2.0 points  in PROMIS Pain Interference\n2) The number of surgical patients achieving a  score change of 2.0 points  in PROMIS Pain Interference\n3) The overall performance rate of Rate 1 and Rate 2 combined",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": true,
-    "primarySteward": "Patient360 in Collaboration with ETSU and Limber Health",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "3471690"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "LMBR9",
-    "title": "Patients Suffering From a Lower Extremity Injury who Demonstrate Improved Pain",
-    "description": "Percentage of patients 18 years or older suffering from hip, ankle, or foot injury who achieve the Minimal Clinically Important Difference (MCID) in the PROMIS Pain Interference Computer Adaptive Testing (CAT), mapped legacy measure, or like tool of measurement. This measure will be reported as the overall number of patients of rate 1 and rate 2 combined. To qualify, the patient must complete a baseline score and then one follow-up or discharge score. \n\nIn order to fairly measure performance between providers, the measure is risk-adjusted based on age, sex, symptom characteristics, PROMIS baseline scores, social determinants of health, and psychosocial metrics. \n\nThis measure will include three rates:\n1) The number of non-surgical patients achieving a score change greater than or equal to the MCID in PROMIS Pain Interference or like mapped measure.\n2) The number of surgical patients achieving a  score change greater than or equal to the MCID in PROMIS Pain Interference or like mapped measure.\n3) The overall performance rate of Rate 1 and Rate 2 combined.",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": true,
-    "primarySteward": "Patient360 in Collaboration with ETSU and Limber Health",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "3471690"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
     "measureId": "MBHR1",
     "title": "Use of Anxiety Severity Measure",
-    "description": "The percentage of adult patients (18 years and older) with an anxiety disorder diagnosis (e.g., generalized anxiety disorder, social anxiety disorder, or panic disorder) who have completed a standardized tool (e.g., GAD-7, BAI) during measurement period.",
+    "description": "The percentage of adult patients (18 years and older) with an anxiety disorder diagnosis (e.g., generalized anxiety disorder, social anxiety disorder, or panic disorder) who have completed a standardized tool (e.g., GAD-7, BAI) during measurement period",
     "nqfId": null,
     "measureType": "process",
     "isHighPriority": false,
@@ -19122,66 +17890,6 @@
     ]
   },
   {
-    "measureId": "MBHR3",
-    "title": "Pain Interference Response utilizing PROMIS",
-    "description": "The percentage of adult patients (18 years of age or older) who report chronic pain issues and demonstrated a response to treatment at one month from the index score",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "MBHR Mental and Behavioral Health Registry",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "4067715"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "MBHR5",
-    "title": "Monitoring for psychosocial problems among children and youth",
-    "description": "Percentage of children from 3 to 17 years of age who are receiving a psychiatric or behavioral health intake visit AND who demonstrated a reliable change in parent-reported problem behaviors 2 to 10 months after initial positive screen for externalizing and internalizing behavior problems.",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "MBHR Mental and Behavioral Health Registry",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "4067715"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
     "measureId": "MBHR7",
     "title": "Posttraumatic Stress Disorder (PTSD) Outcome Assessment for Adults and Children",
     "description": "The percentage of patients with a history of a traumatic event (i.e., an experience that was unusually or especially frightening, horrible, or traumatic) who report symptoms consistent with PTSD for at least one month following the traumatic event AND with documentation of a standardized symptom monitor (PCL-5 for adults, CATS for child/adolescent) AND demonstrated a response to treatment at six months (+/- 120 days) after the index visit.\n\nThis measure is a multi-strata measure, which addresses symptom monitoring for both child and adult patients being treated for post-traumatic stress symptoms. Assessment instruments monitoring severity of symptoms for PTSD are validated either for adult or child populations. Thus, while the measurement structure will be similar for both populations, the specified instruments for symptom monitoring will be different.",
@@ -19273,38 +17981,6 @@
     ]
   },
   {
-    "measureId": "MEDNAX54",
-    "title": "Labor Epidural Failure when Converting from Labor Analgesia to Cesarean Section Anesthesia",
-    "description": "The percentage of patients who have pre-existing labor epidural or combined epidural/spinal technique who require either repeat procedural epidural or spinal, general anesthesia, or supplemental sedation as defined below for cesarean section.",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": true,
-    "isRiskAdjusted": false,
-    "primarySteward": "ABG QCDR",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "5551268",
-      "6775913",
-      "9181695"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
     "measureId": "MEDNAX55",
     "title": "Use of ASPECTS (Alberta Stroke Program Early CT Score) for non-contrast CT Head performed for suspected acute stroke.",
     "description": "Percentage non-contrast CT Head performed for suspected acute stroke whose final reports include an ASPECTS value.",
@@ -19317,41 +17993,7 @@
     "firstPerformanceYear": 2019,
     "allowedVendors": [
       "5303416",
-      "6394618",
-      "7746687"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "MEDNAX56",
-    "title": "Use of a “PEG Test” to Manage Patients Receiving Opioids",
-    "description": "Percentage of patients in an outpatient setting, aged 18 and older, in whom a stable dose of opioids are prescribed for greater than 6 weeks for pain control, and the results of a “PEG Test” are correctly interpreted and applied to the management of their opioid prescriptions.",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "ABG QCDR",
-    "firstPerformanceYear": 2020,
-    "allowedVendors": [
-      "5551268",
-      "7746687",
-      "6775913",
-      "9181695"
+      "6394618"
     ],
     "allowedPrograms": [
       "mips",
@@ -19402,7 +18044,7 @@
   {
     "measureId": "MSN13",
     "title": "Screening Coronary Calcium Scoring for Cardiovascular Risk Assessment Including Coronary Artery Calcification Regional Distribution Scoring",
-    "description": "Percentage of patients, regardless of age, undergoing Coronary Calcium Scoring who have measurable coronary artery calcification (CAC) with total CACS and regional distribution scoring documented in the Final report.",
+    "description": "Percentage of patients, regardless of age, undergoing Coronary Calcium Scoring who have measurable coronary artery calcification (CAC) with total CACS, regional distribution scoring, AND whether or not the regional distribution/total CACS warrant further evaluation documented in the Final report.",
     "nqfId": null,
     "measureType": "process",
     "isHighPriority": false,
@@ -19411,9 +18053,9 @@
     "primarySteward": "MSN Healthcare Solutions, LLC",
     "firstPerformanceYear": 2020,
     "allowedVendors": [
-      "5303416",
       "6394618",
-      "7746687"
+      "5303416",
+      "6704504"
     ],
     "allowedPrograms": [
       "mips",
@@ -19445,39 +18087,7 @@
     "allowedVendors": [
       "5303416",
       "6394618",
-      "7746687"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "MSN16",
-    "title": "Screening Abdominal Aortic Aneurysm Reporting with Recommendations",
-    "description": "Percentage of patients, aged 50-years-old or older, who have had a screening ultrasound for an abdominal aortic aneurysm with a positive finding of abdominal aortic aneurysm (AAA), that have recognized clinical follow up recommendations documented in the final report and direct communication of findings greater than or equal to 5.5 cm in size made to the ordering provider.",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "MSN Healthcare Solutions, LLC",
-    "firstPerformanceYear": 2021,
-    "allowedVendors": [
-      "6394618",
-      "5303416",
-      "1725296"
+      "6704504"
     ],
     "allowedPrograms": [
       "mips",
@@ -19497,7 +18107,7 @@
   },
   {
     "measureId": "MUSIC4",
-    "title": "Prostate Cancer: Active Surveillance/Watchful Waiting for Newly-Diagnosed Low Risk Prostate Cancer Patients",
+    "title": "Prostate Cancer: Active Surveillance/Watchful Waiting for Newly Diagnosed Low Risk Prostate Cancer Patients",
     "description": "Proportion of patients newly diagnosed with low-risk prostate cancer managed with active surveillance or watchful waiting",
     "nqfId": null,
     "measureType": "process",
@@ -19534,41 +18144,11 @@
     "isHighPriority": true,
     "isInverse": false,
     "isRiskAdjusted": false,
-    "primarySteward": "GIQuIC; New Hampshire Colonoscopy Registry (NHCR)",
+    "primarySteward": "GIQuIC",
     "firstPerformanceYear": 2015,
     "allowedVendors": [
       "5846856",
       "6981170"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "NHII1",
-    "title": "Screening and Referral for Transportation Insecurity",
-    "description": "Percentage of patients aged 18 years and older who were screened for transportation insecurity within the measurement period AND/OR received a referral or intervention to address transportation insecurity.",
-    "nqfId": null,
-    "measureType": "intermediateOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "Nebraska Health information initiative",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "1573453"
     ],
     "allowedPrograms": [
       "mips",
@@ -19748,7 +18328,8 @@
     "primarySteward": "Practice Insights by McKesson in Collaboration with The US Oncology Network - QCDR",
     "firstPerformanceYear": 2018,
     "allowedVendors": [
-      "8794712"
+      "8794712",
+      "7037323"
     ],
     "allowedPrograms": [
       "mips",
@@ -19828,125 +18409,9 @@
     ]
   },
   {
-    "measureId": "PP10",
-    "title": "Measurement-based Care Processes: Index Assessment, Monitoring, and Care Plan Review",
-    "description": "Percentage of adults 18 years of age and older with a mental and/or substance use disorder, who had a comprehensive index assessment in the measurement period with monitoring and care plan review",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": false,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "PsychPRO",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "4078845"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "overallAlgorithm": "simpleAverage",
-    "strata": [
-      {
-        "name": "assessment",
-        "description": "Percentage of patients who had a comprehensive index assessment using standardized tools to assess at least three of the following six domains: (1) functioning, (2) recovery, (3) depression symptom severity, (4) anxiety symptom severity, (5) substance use symptoms severity, or (6) suicidal ideation and behavior symptoms severity."
-      },
-      {
-        "name": "monitorAt90Days",
-        "description": "Percentage of patients who were monitored 90 days (+/- 30 days) from the comprehensive index assessment using standardized tools to assess (1) functioning, (2) recovery, or (3) symptom severity in depression, anxiety, substance use, or suicidal ideation and behavior."
-      },
-      {
-        "name": "maintnCareAt180Days",
-        "description": "Percentage of patients with documentation of a clinical decision to adjust or maintain their care between 7 and 180 days from the comprehensive index assessment."
-      }
-    ]
-  },
-  {
     "measureId": "PP11",
     "title": "Improvement Or Maintenance In Recovery For All Individuals Seen For Mental Health And/Or Substance Use Care",
     "description": "The percentage of individuals aged 18 and older with a mental and/or substance use disorder who demonstrated improvement or maintenance in recovery (as defined, prioritized, and/or reported by the individual) based on results from the 24-item Recovery Assessment Scale (RAS-R) 150 to 210 days after an index assessment.",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "PsychPRO",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "4078845"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "PP12",
-    "title": "Initiation, Review, And/Or Update To Suicide Safety Plan For Individuals With Suicidal Thoughts, Behavior, Or Suicide Risk",
-    "description": "This measure assesses the percentage of adult aged 18 and older with a mental and/or substance use disorder with suicidal ideation or behavior symptoms (based on results of a standardized assessment tool) or increased suicide risk (based on the clinician’s evaluation) for whom a suicide safety plan is initiated, reviewed, and/or updated in collaboration between the patient and their clinician.",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": false,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "PsychPRO",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "4078845"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "overallAlgorithm": "overallStratumOnly",
-    "strata": [
-      {
-        "name": "safetyPlanWithIn24hr",
-        "description": "The percentage of individuals for whom a suicide safety plan is initiated, reviewed, or updated in collaboration between the individual and their clinician (concurrent or within 24 hours of clinical encounter). "
-      },
-      {
-        "name": "overall",
-        "description": "The percentage of individuals for whom a suicide safety plan is initiated, reviewed, or updated AND reviewed and updated in collaboration between the individual and their clinician within 120 days after initiation (+/- 30 days)."
-      }
-    ]
-  },
-  {
-    "measureId": "PP13",
-    "title": "Reduction in Suicidal Ideation or Behavior Symptoms",
-    "description": "The percentage of individuals aged 18 and older with mental health or substance use disorders who demonstrate a reduction in suicidal ideation and/or behavior symptoms based on results from the Columbia-Suicide Severity Rating Scale ‘Screen Version’ (CSSRS), within 120 days after an index assessment.",
     "nqfId": null,
     "measureType": "patientReportedOutcome",
     "isHighPriority": true,
@@ -19982,10 +18447,10 @@
     "isHighPriority": true,
     "isInverse": false,
     "isRiskAdjusted": false,
-    "primarySteward": "The PQR",
+    "primarySteward": "The PQR-ANES",
     "firstPerformanceYear": 2022,
     "allowedVendors": [
-      "1725296"
+      "7746687"
     ],
     "allowedPrograms": [
       "mips",
@@ -20015,9 +18480,9 @@
     "primarySteward": "MSN Healthcare Solutions, LLC",
     "firstPerformanceYear": 2021,
     "allowedVendors": [
-      "6394618",
       "5303416",
-      "1725296"
+      "6394618",
+      "7746687"
     ],
     "allowedPrograms": [
       "mips",
@@ -20047,9 +18512,10 @@
     "primarySteward": "MSN Healthcare Solutions, LLC",
     "firstPerformanceYear": 2021,
     "allowedVendors": [
-      "6394618",
       "5303416",
-      "7746687"
+      "6394618",
+      "7746687",
+      "6704504"
     ],
     "allowedPrograms": [
       "mips",
@@ -20081,7 +18547,8 @@
     "allowedVendors": [
       "5303416",
       "6394618",
-      "7746687"
+      "7746687",
+      "6704504"
     ],
     "allowedPrograms": [
       "mips",
@@ -20113,39 +18580,8 @@
     "allowedVendors": [
       "5303416",
       "6394618",
-      "7746687"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "QMM20",
-    "title": "Opening Pressure in Lumbar Puncture",
-    "description": "Percentage of final reports for patients aged 18 years or older, which include Documentation of Opening Pressure Value obtained during Lumbar Puncture",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": false,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "MSN Healthcare Solutions, LLC",
-    "firstPerformanceYear": 2021,
-    "allowedVendors": [
-      "5303416",
-      "6394618",
-      "1725296"
+      "7746687",
+      "6704504"
     ],
     "allowedPrograms": [
       "mips",
@@ -20166,7 +18602,7 @@
   {
     "measureId": "QMM21",
     "title": "Incorporating results of concurrent studies into Final Reports for Bone Marrow Aspirate of patients with Leukemia, Myelodysplastic syndrome, or Chronic Anemia",
-    "description": "The percentage of Final Bone Marrow Aspirate Reports of patients with Leukemia, Myelodysplastic syndrome, or Chronic Anemia with documentation of concurrent studies performed and their respective results.",
+    "description": "The percentage of Final Bone Marrow Aspirate Reports of patients with Leukemia, Myelodysplastic syndrome, or Chronic Anemia with documentation of concurrent studies performed, their respective results, and interpretation of those results.",
     "nqfId": null,
     "measureType": "process",
     "isHighPriority": true,
@@ -20175,7 +18611,8 @@
     "primarySteward": "MSN Healthcare Solutions QCDR II",
     "firstPerformanceYear": 2022,
     "allowedVendors": [
-      "7418330"
+      "7418330",
+      "6704504"
     ],
     "allowedPrograms": [
       "mips",
@@ -20196,7 +18633,7 @@
   {
     "measureId": "QMM22",
     "title": "Molecular Testing Recommended on Fine Needle Aspirations (FNA) of Thyroid Nodule(s) with Bethesda Category 3 or 4 Cytology Diagnosis",
-    "description": "The percentage of patients with a thyroid nodule fine needle aspiration (FNA) diagnosis by cytology of Bethesda category 3 or 4 with a recommendation for molecular testing in Final \nPathology Report, followed with direct communication to Patient/Ordering or Attending \nProvider regarding recommendation.",
+    "description": "The percentage of patients with a thyroid nodule fine needle aspiration (FNA) diagnosis by cytology of Bethesda category 3 or 4 with a recommendation for molecular testing in Final Pathology Report, followed with direct communication to Patient/Ordering or Attending Provider regarding recommendation.",
     "nqfId": null,
     "measureType": "process",
     "isHighPriority": true,
@@ -20205,37 +18642,8 @@
     "primarySteward": "MSN Healthcare Solutions QCDR II",
     "firstPerformanceYear": 2022,
     "allowedVendors": [
-      "7418330"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "RCOIR10",
-    "title": "Upper Extremity Edema Improvement",
-    "description": "Percentage of endovascular interventions that resulted in improvement in upper extremity edema in patients with end-stage renal disease (ESRD)",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "Renal and Vascular Outcomes Improvement Program, powered by Forward Health Group",
-    "firstPerformanceYear": 2017,
-    "allowedVendors": [
-      "4302083"
+      "7418330",
+      "6704504"
     ],
     "allowedPrograms": [
       "mips",
@@ -20255,7 +18663,7 @@
   },
   {
     "measureId": "RCOIR12",
-    "title": "Tunneled Hemodialysis Catheter Success",
+    "title": "Tunneled Hemodialysis Catheter Clinical Success Rate",
     "description": "Percentage of tunneled central venous access catheter insertions or replacements that resulted in successful dialysis treatment in patients with end-stage renal disease (ESRD).",
     "nqfId": null,
     "measureType": "outcome",
@@ -20286,7 +18694,7 @@
   {
     "measureId": "RCOIR13",
     "title": "Percutaneous Arteriovenous Fistula for Dialysis - Clinical Success Rate",
-    "description": "Percentage of clinically successful percutaneously created arteriovenous fistulae (pAVF) for patients aged 18 years and older on maintenance hemodialysis dialysis",
+    "description": "Percentage of clinically successful percutaneously created arteriovenous fistulae (pAVF) for patients on maintenance hemodialysis dialysis.",
     "nqfId": null,
     "measureType": "outcome",
     "isHighPriority": true,
@@ -20294,36 +18702,6 @@
     "isRiskAdjusted": false,
     "primarySteward": "Renal and Vascular Outcomes Improvement Program, powered by Forward Health Group",
     "firstPerformanceYear": 2021,
-    "allowedVendors": [
-      "4302083"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "RCOIR7",
-    "title": "Improved Access Site Bleeding",
-    "description": "Percentage of interventions for prolonged vascular access site bleeding that resulted in a reduction in bleeding.",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "Renal and Vascular Outcomes Improvement Program, powered by Forward Health Group",
-    "firstPerformanceYear": 2017,
     "allowedVendors": [
       "4302083"
     ],
@@ -20374,69 +18752,9 @@
     ]
   },
   {
-    "measureId": "REGCLR2",
-    "title": "Tendinitis/ Enthesopathy- Injection Treatment Outcomes for Adults",
-    "description": "Percentage of patients aged 18 or older with a diagnosis of Tendinitis that have a reduction in pain after injection therapy.",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "Registry Clearinghouse",
-    "firstPerformanceYear": 2021,
-    "allowedVendors": [
-      "4117893"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
     "measureId": "REGCLR3",
     "title": "Bunion Outcome - Adult and Adolescent",
     "description": "Percentage of patients with a who have a hallux valgus (bunion) deformity causing pain that receive an intervention and have clinically significant reduction in pain as a result of that intervention.",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "Registry Clearinghouse",
-    "firstPerformanceYear": 2021,
-    "allowedVendors": [
-      "4117893"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "REGCLR4",
-    "title": "Heel Pain Treatment Outcomes for Pediatric Patients",
-    "description": "Percentage of patients aged 6 to 18 years with a diagnosis of heel pain who receive an intervention intended to treat the heel pain and experience a clinically significant decrease in heel pain.\nPatients who have had at least two visits during the reporting period",
     "nqfId": null,
     "measureType": "patientReportedOutcome",
     "isHighPriority": true,
@@ -20494,39 +18812,9 @@
     ]
   },
   {
-    "measureId": "REGCLR7",
-    "title": "Use of Ankle Foot Orthotics to improve patient function",
-    "description": "This measures the improvement in function of patients who are prescribed foot and ankle braces for plantar fasciitis, Posterior Tibial Tendon Dysfunction, and ankle sprains",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "Registry Clearinghouse",
-    "firstPerformanceYear": 2021,
-    "allowedVendors": [
-      "4117893"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
     "measureId": "RPAQIR14",
-    "title": "Arteriovenous Graft Thrombectomy Success Rate",
-    "description": "Percentage of clinically successful arteriovenous graft (AVG) thrombectomies for patients aged 18 years and older on maintenance hemodialysis.",
+    "title": "Arteriovenous Graft Thrombectomy Clinical Success Rate",
+    "description": "Percentage of clinically successful arteriovenous graft (AVG) thrombectomies for patients on maintenance hemodialysis.",
     "nqfId": null,
     "measureType": "outcome",
     "isHighPriority": true,
@@ -20555,7 +18843,7 @@
   },
   {
     "measureId": "RPAQIR15",
-    "title": "Arteriovenous Fistulae Thrombectomy Success Rate",
+    "title": "Arteriovenous Fistulae Thrombectomy Clinical Success Rate",
     "description": "Percentage of clinically successful arteriovenous fistulae (AVF) thrombectomies for patients on maintenance hemodialysis dialysis",
     "nqfId": null,
     "measureType": "outcome",
@@ -20676,7 +18964,7 @@
   },
   {
     "measureId": "USWR22",
-    "title": "Patient Reported Nutritional Assessment and Intervention Plan in patients with Wounds and Ulcers",
+    "title": "Nutritional Assessment and Intervention Plan in patients with Wounds and Ulcers",
     "description": "The percentage of patients in the denominator for whom an appropriate intervention plan is recommended by the practitioner based on the assessment results.",
     "nqfId": null,
     "measureType": "process",
@@ -20705,83 +18993,8 @@
     ]
   },
   {
-    "measureId": "USWR26",
-    "title": "Patient Reported Outcome of late effects of radiation symptoms following treatment with Hyperbaric Oxygen Therapy (HBOT)",
-    "description": "The percentage of patients 18 or older undergoing 10 or more treatments with HBOT for late effects of radiation whose self reported symptoms improve by at least 2 categories on the appropriate questionnaire (e.g. the Hematuria classification scale, the Chandler grade, the Cystitis questionnaire, the Bowel questionnaire, the head and neck questionnaire).",
-    "nqfId": null,
-    "measureType": "patientReportedOutcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "U.S. Wound Registry",
-    "firstPerformanceYear": 2019,
-    "allowedVendors": [
-      "6853338"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registrySinglePerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ]
-  },
-  {
-    "measureId": "USWR29",
-    "title": "Adequate Off-loading of Diabetic Foot Ulcers performed at each visit, appropriate to location of ulcer",
-    "description": "Percentage of visits in which diabetic foot ulcers among patients aged 18 years and received adequate off-loading during a 12-month reporting period, stratified by location of the ulcer. Off-loading is not a simple documentation process but may include performing a procedure such as Total Contact Casting or providing appropriate footwear.\n\nThe location of the diabetic foot ulcer on the foot (e.g., heel/midfoot vs. toes) determines the type of off-loading device that is appropriate, the patient’s risk of falling, the probability of successful off-loading and thus the likelihood of major amputation. The clinician needs to evaluate these factors and then provide the most appropriate off-loading option.",
-    "nqfId": null,
-    "measureType": "process",
-    "isHighPriority": false,
-    "isInverse": false,
-    "isRiskAdjusted": false,
-    "primarySteward": "U.S. Wound Registry",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "6853338"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "overallAlgorithm": "overallStratumOnly",
-    "strata": [
-      {
-        "name": "midfootHeel",
-        "description": "Midfoot/heel Rate"
-      },
-      {
-        "name": "toes",
-        "description": "Toes Rate"
-      },
-      {
-        "name": "overall",
-        "description": "The average of the two risk stratified buckets which will be the performance rate in the JSON or XML file submitted."
-      }
-    ]
-  },
-  {
     "measureId": "USWR30",
-    "title": "Non-Invasive Arterial Assessment of patients with lower extremity wounds or ulcers for determination of healing potential at the initial visit",
+    "title": "Non-Invasive Arterial Assessment of patients with lower extremity wounds or ulcers for determination of healing potential",
     "description": "Percentage of patients aged 18 years or older with a non-healing lower extremity wound or ulcer that undergo a non-invasive arterial assessment at the initial visit for the wound or ulcer, once in a 12-month period",
     "nqfId": null,
     "measureType": "process",
@@ -20810,58 +19023,9 @@
     ]
   },
   {
-    "measureId": "USWR31",
-    "title": "Pressure Ulcer* (PU) Healing or Closure (not on the lower extremity )",
-    "description": "Percentage of Stage 2, 3, or 4 pressure ulcers* (not on the lower extremity) among patients aged 18 or older that achieve healing or closure within 6 months, stratified by the Wound Healing Index (WHI). Healing or closure may occur by delayed secondary intention or may be the result of surgical intervention (e.g., rotational flap or skin graft). Lower extremity pressure ulcers are not included in this measure because they commonly overlap with arterial and diabetic foot ulcers and require a separate risk stratification model. [Note: The National Pressure Injury Advisory Panel (NPIA) (formerly the NPUAP) has renamed pressure ulcers “pressure injuries,” but the ICD-10-CM continues to use the term pressure “ulcers”. This measure is limited to open defects (stages 2, 3, 4) which heal by secondary intention or surgical closure, typically referred to as ulcers. We have chosen to use the ICD10 terminology of \"ulcers\".]",
-    "nqfId": null,
-    "measureType": "outcome",
-    "isHighPriority": true,
-    "isInverse": false,
-    "isRiskAdjusted": true,
-    "primarySteward": "U.S. Wound Registry",
-    "firstPerformanceYear": 2022,
-    "allowedVendors": [
-      "6853338"
-    ],
-    "allowedPrograms": [
-      "mips",
-      "pcf"
-    ],
-    "category": "quality",
-    "lastPerformanceYear": null,
-    "eMeasureId": null,
-    "nqfEMeasureId": null,
-    "measureSets": [],
-    "isRegistryMeasure": true,
-    "isIcdImpacted": false,
-    "metricType": "registryMultiPerformanceRate",
-    "submissionMethods": [
-      "registry"
-    ],
-    "overallAlgorithm": "overallStratumOnly",
-    "strata": [
-      {
-        "name": "likelyToHeal",
-        "description": "pressure ulcers likely to heal with conservative care,"
-      },
-      {
-        "name": "mayHeal",
-        "description": "pressure ulcers which may or may not heal,"
-      },
-      {
-        "name": "unlikelyToHeal",
-        "description": "pressure ulcers which are unlikely to heal. The average of the three risk stratified buckets which will be the performance rate in the XML submitted."
-      },
-      {
-        "name": "overall",
-        "description": "The performance rate is the average of the three WHI stratified groups described in our risk stratification document."
-      }
-    ]
-  },
-  {
     "measureId": "USWR32",
     "title": "Adequate Compression at each visit for Patients with Venous Leg Ulcers (VLUs) appropriate to arterial supply",
-    "description": "Percentage of venous leg ulcer visits among patients aged 18 years and older in which adequate compression is performed at each treatment visit in the 12 month reporting period or until VLU outcome . Arterial status must first be assessed at least one time with any non-invasive method (see: USWR30: Arterial Screening Measure). Compression method should be appropriate to documented arterial supply.",
+    "description": "Percentage of venous leg ulcer visits among patients aged 18 years and older in which adequate compression is performed at each treatment visit in the 12 month reporting period or until VLU outcome . Arterial status must first be assessed at least one time with any non-invasive method and the device chosen for compression must be appropriate based on whether arterial supply is normal or reduced  (see: USWR30: Arterial Screening Measure).",
     "nqfId": null,
     "measureType": "intermediateOutcome",
     "isHighPriority": true,

--- a/mvp/2024/mvp-enriched.json
+++ b/mvp/2024/mvp-enriched.json
@@ -517,8 +517,9 @@
         "primarySteward": "RISE (Rheumatology Informatics System for Effectiveness)",
         "firstPerformanceYear": 2020,
         "allowedVendors": [
+          "3471690",
           "5598408",
-          "3471690"
+          "3967247"
         ],
         "allowedPrograms": [
           "mips",
@@ -549,8 +550,9 @@
         "primarySteward": "RISE (Rheumatology Informatics System for Effectiveness)",
         "firstPerformanceYear": 2020,
         "allowedVendors": [
+          "3471690",
           "5598408",
-          "3471690"
+          "3967247"
         ],
         "allowedPrograms": [
           "mips",
@@ -572,7 +574,7 @@
       {
         "measureId": "ACR15",
         "title": "Safe Hydroxychloroquine Dosing",
-        "description": "If a patient is using hydroxychloroquine, then the average daily dose should be less than or equal to 5 mg/kg",
+        "description": "If a patient is using hydroxychloroquine, then the average daily dose should be less than or equal to 5 mg/kg.",
         "nqfId": null,
         "measureType": "process",
         "isHighPriority": true,
@@ -581,8 +583,9 @@
         "primarySteward": "RISE (Rheumatology Informatics System for Effectiveness)",
         "firstPerformanceYear": 2021,
         "allowedVendors": [
+          "3471690",
           "5598408",
-          "3471690"
+          "3967247"
         ],
         "allowedPrograms": [
           "mips",
@@ -5382,8 +5385,6 @@
         "clinicalGuidelineChanged": [],
         "metricType": "singlePerformanceRate",
         "allowedPrograms": [
-          "mips",
-          "pcf",
           "G0055",
           "G0058",
           "M1367",
@@ -8388,8 +8389,7 @@
         "primarySteward": "ACEP's Clinical Emergency Data Registry (CEDR)",
         "firstPerformanceYear": 2020,
         "allowedVendors": [
-          "5133825",
-          "3471690"
+          "5133825"
         ],
         "allowedPrograms": [
           "mips",
@@ -8421,8 +8421,7 @@
         "firstPerformanceYear": 2020,
         "allowedVendors": [
           "5133825",
-          "1725296",
-          "3471690"
+          "1718371"
         ],
         "allowedPrograms": [
           "mips",
@@ -8453,11 +8452,12 @@
         "primarySteward": "E-CPR (Emergency - Clinical Performance Registry)",
         "firstPerformanceYear": 2018,
         "allowedVendors": [
-          "1718371",
           "5133825",
+          "3471690",
+          "1718371",
           "4757099",
           "1725296",
-          "3471690"
+          "3967247"
         ],
         "allowedPrograms": [
           "mips",
@@ -10488,8 +10488,6 @@
         "clinicalGuidelineChanged": [],
         "metricType": "singlePerformanceRate",
         "allowedPrograms": [
-          "mips",
-          "pcf",
           "G0055",
           "G0058",
           "M1367",
@@ -12998,7 +12996,11 @@
         "primarySteward": "ABG QCDR",
         "firstPerformanceYear": 2023,
         "allowedVendors": [
-          "5551268"
+          "5551268",
+          "6169123",
+          "6775913",
+          "9181695",
+          "7418330"
         ],
         "allowedPrograms": [
           "mips",
@@ -13023,7 +13025,7 @@
       {
         "measureId": "AQI48",
         "title": "Patient-Reported Experience with Anesthesia",
-        "description": "Percentage of patients, aged 18 and older, who were surveyed on their patient experience and satisfaction with anesthesia care and who reported a positive experience. \n\nThis measure will consist of two performance rates:\n\nAQI48a: Percentage of patients, aged 18 and older, who were surveyed on their patient experience and satisfaction with anesthesia care \n\nAQI48b: Percentage of patients, aged 18 and older, who completed a survey on their patient experience and satisfaction with anesthesia care who report a positive experience with anesthesia care\n\nNOTE: The measure requires that a valid survey, as defined in the numerator of AQI48a, be sent to patients between discharge from the facility and within 30 days of facility discharge. To report AQI48b, a minimum number of 20 surveys with the mandatory question completed must be reported. ** In order to be scored on this measure, clinicians must report BOTH AQI48a AND AQI48b.",
+        "description": "Percentage of patients, aged 18 and older, who were surveyed on their patient experience and satisfaction with anesthesia care and who reported a positive experience. \n\nThis measure will consist of two performance rates:\n\nAQI48a: Percentage of patients, aged 18 and older, who were surveyed on their patient experience and satisfaction with anesthesia care \n\nAQI48b: Percentage of patients, aged 18 and older, who completed a survey on their patient experience and satisfaction with anesthesia care who report a positive experience with anesthesia care within 60 days of receipt of the survey.\n\nNOTE: The measure requires that a valid survey, as defined in the numerator of AQI48a, be sent to patients between discharge from the facility and within 30 days of facility discharge. To report AQI48b, a minimum number of 20 surveys with the mandatory question completed must be reported. ** In order to be scored on this measure, clinicians must report BOTH AQI48a AND AQI48b.",
         "nqfId": null,
         "measureType": "patientReportedOutcome",
         "isHighPriority": true,
@@ -13033,14 +13035,14 @@
         "firstPerformanceYear": 2017,
         "allowedVendors": [
           "5551268",
-          "6775913",
-          "7746687",
+          "3471690",
           "6169123",
+          "6775913",
           "6704504",
-          "4757099",
           "9181695",
+          "4757099",
           "7418330",
-          "3471690"
+          "3967247"
         ],
         "allowedPrograms": [
           "mips",
@@ -13072,8 +13074,8 @@
       },
       {
         "measureId": "EPREOP31",
-        "title": "Intraoperative Hypotension among Non-Emergent Noncardiac Surgical Cases",
-        "description": "Percentage of general anesthesia cases in which mean arterial pressure (MAP) fell below 65 mmHg for cumulative total of 15 minutes or more",
+        "title": "Intraoperative Hypotension (IOH) among Non-Emergent Noncardiac Surgical Cases",
+        "description": "Percentage of general, neuraxial, or regional anesthesia care cases in which the mean arterial pressure (MAP) fell below 65 mmHg for a cumulative total of 15 minutes or more",
         "nqfId": null,
         "measureType": "intermediateOutcome",
         "isHighPriority": true,
@@ -15695,7 +15697,8 @@
         "primarySteward": "Practice Insights by McKesson in Collaboration with The US Oncology Network - QCDR",
         "firstPerformanceYear": 2023,
         "allowedVendors": [
-          "8794712"
+          "8794712",
+          "7037323"
         ],
         "allowedPrograms": [
           "mips",
@@ -15729,7 +15732,8 @@
         "primarySteward": "Practice Insights by McKesson in Collaboration with The US Oncology Network - QCDR",
         "firstPerformanceYear": 2018,
         "allowedVendors": [
-          "8794712"
+          "8794712",
+          "7037323"
         ],
         "allowedPrograms": [
           "mips",
@@ -20933,7 +20937,7 @@
       },
       {
         "measureId": "AAN5",
-        "title": "Medication Prescribed For Acute Migraine Attack",
+        "title": "Treatment Prescribed For Acute Migraine Attacks",
         "description": "Percentage of patients age 6 years and older with a diagnosis of migraine who were prescribed a guideline recommended or FDA approved/cleared treatment for acute migraine attacks within the measurement period.",
         "nqfId": null,
         "measureType": "process",
@@ -28562,8 +28566,6 @@
         "clinicalGuidelineChanged": [],
         "metricType": "singlePerformanceRate",
         "allowedPrograms": [
-          "mips",
-          "pcf",
           "M1366"
         ],
         "submissionMethods": [
@@ -31427,8 +31429,6 @@
         "clinicalGuidelineChanged": [],
         "metricType": "singlePerformanceRate",
         "allowedPrograms": [
-          "mips",
-          "pcf",
           "G0055",
           "G0058",
           "M1367",
@@ -39309,8 +39309,6 @@
         "clinicalGuidelineChanged": [],
         "metricType": "singlePerformanceRate",
         "allowedPrograms": [
-          "mips",
-          "pcf",
           "G0055",
           "G0058",
           "M1367",

--- a/updates/measures/2024/Quality_QCDR_PY24_CR_20231211.csv
+++ b/updates/measures/2024/Quality_QCDR_PY24_CR_20231211.csv
@@ -1,0 +1,331 @@
+﻿Category ,Measure Title,CMS eCQM ID,eCQM NQF,NQF,*** Quality Number (#) / QCDR #,Primary Measure Steward,Allowed QCDR Vendor ID,Measure Description,*** Measure Type  ,High Priority,First Performance Year,Year Removed,*** Collection Type(s) for Submission,Specialty Measure Sets,*** Inverse,*** Metric Type,*** Calculation Type,Collection Type(s) where Historic Benchmark Removed,Collection Type(s) where Suppressed,Collection Type(s) where Truncated,Is Risk Adjusted ,
+"Values,  Quality, QCDR ",,,,,,,** Comma delimited list  **,,"
+
+Values,  Efficiency, Intermediate Outcome, Outcome, Patient Engagement/Experience, Patient Reported Outcome, Patient-Reported Outcome-Based Performance Measure, Process, Structure","Values, Y, N",,Enter current PY if measure is to be removed,"** Comma delimited list  **
+
+Values,  Part B Claims, CSV, eCQM, CMS WI, Admin Claims, MIPS CQM, QCDR","** Comma delimited list  **
+
+Values, Allergy/ Immunology, Anesthesiology, Audiology, Cardiology, Certified Nurse Midwife, Chiropractic Medicine, Clinical Social Work, Dentistry, Dermatology, Diagnostic Radiology, Electro-physiology Cardiac Specialist, Emergency Medicine, Endocrinology, Family Medicine, Gastro-enterology, General Surgery, Geriatrics, Hospitalists, Infectious Disease, Internal Medicine, Interventional Radiology, Mental/Behavioral Health and Psychiatry, Nephrology, Neurology, Neurosurgical, Nutrition/ Dietician, Obstetrics/
+Gynecology, Oncology/ Hematology, Ophthalmology/Optometry, Orthopedic Surgery, Otolaryngology, Pathology, Pediatrics, Physical Medicine, Physical Therapy/ Occupational Therapy, Plastic 
+Surgery, Podiatry, Preventive Medicine, Pulmonology, Radiation Oncology, Rheumatology, Skilled Nursing Facility, Speech Language Pathology, Thoracic Surgery, Urgent Care, Urology, Vascular Surgery","Values, Y, N","Values, singlePerformanceRate, multiPerformanceRate, nonProportion, costScore","Values, weightedAverage, simpleAverage, overallStratumOnly, split","** Comma delimited list  **
+
+Values,  Part B Claims, CSV, eCQM, CMS WI, Admin Claims, MIPS CQM, QCDR","** Comma delimited list  **
+
+Values,  Part B Claims, CSV, eCQM, CMS WI, Admin Claims, MIPS CQM, QCDR","** Comma delimited list  **
+
+Values,  Part B Claims, CSV, eCQM, CMS WI, Admin Claims, MIPS CQM, QCDR","Values,  Y, N",
+QCDR,,,,,AAAAI17,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,AAAAI18,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,AAAAI2,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,AAAAI8,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,AAD11,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,AAD15,,,Percentage of patients with a diagnosis of psoriasis awith a documented Body Surface Area (BSA) greater than 10% for whom phototherapy or an oral systemic or biologic medication was prescribed.,,,,,,,,,,,,,,
+QCDR,,,,,AAD16,,,"Percentage of procedures in patients aged 18 and older with a diagnosis of skin cancer who underwent intermediate layer or complex linear closure or reconstruction after skin cancer resection in the office-based* setting who were prescribed post-operative systemic antibiotics to be taken immediately following reconstruction surgery (inverse measure).
+
+This measure is stratified by intermediate layer or complex linear closure or reconstructive procedures.",,,,,,,,,,,,,,
+QCDR,Psoriasis – Shared Decision Making in the Treatment of Psoriasis,,,,AAD19,AAD’s DataDerm™,4649789,"Percentage of patients with a diagnosis of psoriasis with a documented shared decision-making discussion that includes the patient’s treatment goals, preferences, and the risks & benefits of treatment options.",Process,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,,,,,AAN26,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,AAN29,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,AAN30,,,,,,,2024,,,,,,,,,,
+QCDR,Reduction of Pain for Patients with Polyneuropathy,,,,AAN35,Axon Registry,8933551,Percentage of patients 18 years and older diagnosed with polyneuropathy with associated neuropathic pain in the feet whose Visual Analog Scale (VAS) or Numeric Pain Rating Scale (NRS) pain score for patient’s feet at 12 months (+/- 60 days) was improved from the index score,Patient-Reported Outcome-Based Performance Measure,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,"Seizure Type, Frequency, Time Since Last Seizure Recorded, and Seizure Reduction",,,,AAN36,Axon Registry,8933551,"Percentage of patients or care partners who reported seizure type, seizure frequency for each type of seizure, time since last seizure for each seizure type at every visit in the measurement period recorded, AND, the same or decreased seizure frequency in the most recent 12 months compared to the prior 12 months (baseline).",Patient-Reported Outcome-Based Performance Measure,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,Treatment Prescribed For Acute Migraine Attacks,,,,AAN5,,,,,,,,,,,,,,,,,
+QCDR,,,,,AAO34,,,,,,,2024,,,,,,,,,,
+QCDR,Dysphonia: Laryngeal Examination,,,,AAO37,American Academy of Otolaryngology – Head and Neck Surgery Foundation (AAO-HNSF) Reg-entSM Registry,8365868,Percentage of patients who were diagnosed with dysphonia who received or were referred for a laryngeal examination within 4 weeks of initial diagnosis.,Process,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,Thyroidectomy and Parathyroidectomy Nerve Injury,,,,AAO38,American Academy of Otolaryngology – Head and Neck Surgery Foundation (AAO-HNSF) Reg-entSM Registry,8365868,"Percentage of patients that had a thyroidectomy, parathyroidectomy, or both, and experienced recurrent laryngeal nerve injury resulting in vocal cord paresis or palsy.",Outcome,Y,2024,,QCDR,,Y,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,Neck Mass Evaluation,,,,AAO39,American Academy of Otolaryngology – Head and Neck Surgery Foundation (AAO-HNSF) Reg-entSM Registry,8365868,"Percentage of patients aged 18 years and older diagnosed with a neck mass and suspected/increased risk of malignancy who had a fine needle aspiration (FNA), or refer the patient to someone who can perform FNA with tumor human papillomavirus (HPV) test and receive a neck computed tomography (or magnetic resonance imaging) with contrast.",Process,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,,,,,AASM1,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,AASM2,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,AASM3,,,,,,,2024,,,,,,,,,,
+QCDR,Measuring the Value-Functions of Primary Care: Comprehensiveness of Care,,,,ABFM13,ABFM PRIME,4849508,"This measure evaluates the extent primary care physicians (PCPs) provide care-based and procedural-based services core to primary care. For each PCP, the resulting value reflects an average of the weighted proportion of services within each category provided during the measurement period.      
+Primary care providers (PCPs) caring for at least 30 patients per measurement year score between 0 and 100 in scaled scores of comprehensiveness. Scores are based on weighted averages of 19 care-based and 22 procedural-based core primary care services.
+
+Initial Population: Primary care physicians who have provided care to 30 or more patients regardless of age within the measurement period, see Figure 1: Physician and Care Site Identifier in the ""Additional Supporting Documentation"" Section. 
+
+Throughout this application, since the fields do not accept scientific formulas, tables or figures, we have attached those items in the ""Additional Supporting Documentation"" section.",Process,N,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,,,,,ABG40,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,ABG41,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,ABG42,,"5551268 ,6775913, 9181695, 7418330, 7746687",,,,,,,,,,,,,,,
+QCDR,,,,,ABG43,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,ABG44,,"5551268, 6169123, 6775913, 9181695, 7418330",,,,,,,,,,,,,,,
+QCDR,,,,,ACEP19,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,ACEP21,,,,,,,2024,,,,,,,,,,
+QCDR,Sepsis Management: Septic Shock: Lactate Clearance Rate of >=10%,,,,ACEP30,,,,,,,,,,,,,,,,,
+QCDR,,,,,ACEP48,,,"Percentage of emergency department visits resulting in hospital admission or transfers for patients aged 18 years and older with septic shock who had an order for all the following during the emergency department visit: a serum lactate level, antibiotics, and >=1L of crystalloids",,,,,,,,,,,,,,
+QCDR,,,,,ACEP50,,5133825,,,,,,,,,,,,,,,
+QCDR,,,,,ACEP52,,"5133825, 1718371",,,,,,,,,,,,,,,
+QCDR,,,,,ACEP54,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,ACEP55,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,ACEP59,,"5133825, 4757099, 1725296, 1718371",,,,,,,,,,,,,,,
+QCDR,,,,,ACEP60,,"5133825, 1718371, 1725296",,,,,,,,,,,,,,,
+QCDR,,,,,ACEP63,,"5133825, 1725296",,,,,,,,,,,,,,,
+QCDR,Avoidance of admission for adult patients in Emergency Department with low-risk Deep Vein Thrombosis (DVT).,,,,ACEP64,ACEP's Clinical Emergency Data Registry (CEDR),"5133825, 1718371, 1725296",Percentage of patients 18 years and older who present to the Emergency Department with low-risk Deep Vein Thrombosis (DVT) and are discharged home,Outcome,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,Appropriate Utilization of Imaging in rAAA (ruptured Abdominal Aortic Aneurysm) patients in Emergency Department,,,,ACEP65,ACEP's Clinical Emergency Data Registry (CEDR),5133825,Percentage of adult patients aged 55 years and older presenting to the Emergency Department with abdominal pain or back pain and hypotension for whom a POC Ultrasound or CT scan was performed.,Process,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,"Co-testing for HIV in high-risk patients in Emergency Department who are being tested for other sexually transmitted infections (STI) (Gonorrhea, Chlamydia, Syphilis or Trichomonas).",,,,ACEP66,ACEP's Clinical Emergency Data Registry (CEDR),5133825,"Percentage of patients aged 18 and older in the Emergency Department who are being tested for other sexually transmitted infections (STI) (Gonorrhea, Chlamydia, Syphilis or Trichomonas) are also tested for HIV.",Process,N,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,,,,,ACQR12,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,ACQR13,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,ACQR16,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,ACQR3,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,ACR12,,"3471690, 5598408, 3967247",,,,,,,,,,,,,,,
+QCDR,,,,,ACR14,,"3471690, 5598408, 3967247",,,,,,,,,,,,,,,
+QCDR,,,,,ACR15,,"3471690, 5598408, 3967247","If a patient is using hydroxychloroquine, then the average daily dose should be less than or equal to 5 mg/kg.",,,,,,,,,,,,,,
+QCDR,,,,,ACRAD15,,"5303416, 6704504, 6394618, 7037323",,,,,,,,,,,,,,,
+QCDR,,,,,ACRAD16,,"5303416, 6704504, 6394618, 7037323",,,,,,,,,,,,,,,
+QCDR,,,,,ACRAD17,,"5303416, 6704504, 6394618, 7037323",,,,,,,,,,,,,,,
+QCDR,,,,,ACRAD18,,"5303416, 6704504, 6394618, 7037323",,,,,,,,,,,,,,,
+QCDR,,,,,ACRAD19,,"5303416, 6704504, 6394618, 7037323",,,,,,,,,,,,,,,
+QCDR,,,,,ACRAD25,,"5303416, 6704504, 6394618, 7037323",,,,,,,,,,,,,,,
+QCDR,,,,,ACRAD34,,5303416,"Weighted average of 3 former QCDR measures, ACRad 31, ACRad 32, ACRad 33.",,,,,,,,,,,,,,
+QCDR,,,,,ACRAD36,,"5303416, 6394618, 7746687, 6704504, 7037323",,,,,,,,,,,,,,,
+QCDR,,,,,ACRAD37,,"5303416, 6704504, 7037323, 6394618, 7746687 ",,,,,,,,,,,,,,,
+QCDR,,,,,ACRAD38,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,ACRAD40,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,ACRAD41,,"5303416, 6394618, 6704504, 7037323",,,,,,,,,,,,,,,
+QCDR,,,,,ACRAD42,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,AJRR11,,"5224253, 1157686",,,,,,,,,,,,,,,
+QCDR,Physical Health Outcomes in Total Hip and Knee Arthroplasty,,,,AJRR12,AAOS Orthopaedic Quality Resource Center,"5224253, 1157686",Percentage of patients with patient-reported meaningful improvement in anatomic specific HOOS/KOOS JR after elective total hip and knee arthroplasty.,Patient-Reported Outcome-Based Performance Measure,Y,2024,,QCDR,,N,multiPerformanceRate,weightedAverage,,,,N,
+QCDR,,,,,AJRR8,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,AJRR9,,"5224253, 1157686",,,,,,,,,,,,,,,
+QCDR,,,,,AQI18,,"5551268, 6169123, 6775913, 7418330, 6704504, 4757099",,,,,,,,,,,,,,,
+QCDR,,,,,AQI48,,"5551268, 3471690, 6169123, 6775913, 6704504, 9181695, 4757099, 7418330, 3967247","Percentage of patients, aged 18 and older, who were surveyed on their patient experience and satisfaction with anesthesia care and who reported a positive experience. 
+
+This measure will consist of two performance rates:
+
+AQI48a: Percentage of patients, aged 18 and older, who were surveyed on their patient experience and satisfaction with anesthesia care 
+
+AQI48b: Percentage of patients, aged 18 and older, who completed a survey on their patient experience and satisfaction with anesthesia care who report a positive experience with anesthesia care within 60 days of receipt of the survey.
+
+NOTE: The measure requires that a valid survey, as defined in the numerator of AQI48a, be sent to patients between discharge from the facility and within 30 days of facility discharge. To report AQI48b, a minimum number of 20 surveys with the mandatory question completed must be reported. ** In order to be scored on this measure, clinicians must report BOTH AQI48a AND AQI48b.",,,,,,,,,,,,,,
+QCDR,,,,,AQI49,,"5551268, 6169123, 7418330, 6775913, 4757099, 7746687",,,,,,,,,,,,,,,
+QCDR,,,,,AQI56,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,AQI65,,"5551268, 6169123, 6775913, 7418330, 4757099",,,,,,,,,,,,,,,
+QCDR,,,,,AQI67,,"5551268, 6169123, 6775913, 6704504, 9181695, 4757099",,,,,,,,,,,,,,,
+QCDR,,,,,AQI68,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,AQI69,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,AQI71,,"5551268, 6169123, 6775913, 7418330, 9181695, 4757099",,,,,,,,,,,,,,,
+QCDR,,,,,AQI72,,"5551268, 6169123, 6775913, 6704504, 9181695, 4757099, 7418330",,,,,,,,,,,,,,,
+QCDR,,,,,AQI73,,,,,,,2024,,,,,,,,,,
+QCDR,Stones: Urinalysis or Urine Culture Performed Before Surgical Stone Procedures,,,,AQUA15,,,Percentage of patients with a documented urinalysis or urine culture within 14 days prior to surgical stone procedures,,,,,,,,,,,,,,
+QCDR,,,,,AQUA18,,,,,,,2024,,,,,,,,,,
+QCDR,Non-Muscle Invasive Bladder Cancer: Initial Management/Surveillance for Non-Muscle Invasive Bladder Cancer,,,,AQUA35,American Urological Association Quality (AQUA) Registry,8758330,Percentage of patients with appropriate initial management/surveillance after initial diagnosis of non-muscle invasive bladder cancer,Process,N,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,Prostate Cancer: Confirmation Biopsy in Newly Diagnosed Patients on Active Surveillance,,,,AQUA36,American Urological Association Quality (AQUA) Registry,8758330,Percentage of newly diagnosed low risk patients on active surveillance who receive confirmation testing within 24 months of diagnosis,Process,N,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,Biopsy Reporting Time to Clinician,,,,CAP22,,,,,,,,,,,,,,,,,
+QCDR,Gastritis: Timely Helicobacter pylori Reporting,,,,CAP28,,,"Percentage of stomach biopsy cases with gastritis that address the presence or absence of Helicobacter pylori 
+AND
+meet the maximum 2 business day turnaround time (TAT) requirement (Report Date – Accession Date is less than or equal to 2 business days).
+INSTRUCTIONS: This measure has two performance rates that contribute to the overall performance score:
+Stratum 1. Percent of cases in which presence or absence of Helicobacter pylori is addressed.
+Stratum 2. Percent of cases that meet the maximum 2 business day turnaround time.
+The overall performance score submitted is a simple average of Stratum 1 and Stratum 2.",,,,,,,,,,,,,,
+QCDR,Urinary Bladder Cancer: Complete Analysis and Timely Reporting,,,,CAP30,,,,,,,,,,,,,,,,,
+QCDR,Molecular Assessment: Biomarkers in Non-Small Cell Lung Cancer,,,,CAP34,,,,,,,,,,,,,,,,,
+QCDR,Prostate Cancer Reporting: Complete Analysis,,,,CAP38,,,,,,,,,,,,,,,,,
+QCDR,,,,,CAP39,,,,,,,2024,,,,,,,,,,
+QCDR,Squamous Cell Skin Cancer: Complete Reporting,,,,CAP40,Pathologists Quality Registry,5688621,"Percentage of final pathology reports for excisions for squamous cell carcinoma of the skin that include a comment on margin status, degree of differentiation/histologic grade, depth or level of invasion, presence of perineural invasion and presence of lymphovascular invasion",Process,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,Basal Cell Skin Cancer: Complete Reporting,,,,CAP41,Pathologists Quality Registry,5688621,"Percentage of final pathology reports for excisions for basal cell carcinoma of the skin that include a comment on histologic subtype, margin status, and if applicable to the specimen - invasion of tumor beyond reticular dermis (or level of invasion, for Moh’s specimens), and perineural invasion",Process,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,Barrett’s Esophagus: Complete Analysis with Appropriate Consultation,,,,CAP42,Pathologists Quality Registry,5688621,Percentage of esophageal biopsy reports for with a diagnosis of Barrett’s mucosa with dysplasia that include documentation of a consultation with a second pathologist for confirmation of dysplasia grading,Process,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,,,,,CCOME7,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,CCOME8,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,CDR2,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,CDR6,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,CDR8,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,ECPR46,,"5133825, 3471690, 1718371, 4757099, 1725296, 3967247",,,,,,,,,,,,,,,
+QCDR,,,,,ECPR50,,"1718371, 4757099, 1725296",,,,,,,,,,,,,,,
+QCDR,,,,,ECPR52,,"1718371, 4757099, 1725296",,,,,,,,,,,,,,,
+QCDR,,,,,ECPR55,,"1718371, 4757099, 1725296",,,,,,,,,,,,,,,
+QCDR,Patient-Reported Understanding of Discharge Diagnosis and Plan of Care,,,,ECPR58,,"1718371, 8483899, 1725296",Percentage of Adult Patients Who Completed a Survey Regarding Their Care Visit Who Reported Understanding of Their Discharge Diagnosis and Plan of Care,,,,,,,,,,,,,,
+QCDR,Patient Reported Trust in Provider,,,,ECPR59,E-CPR (Emergency - Clinical Performance Registry),"1718371, 4757099, 8483899, 1725296",Percentage of Adult Patients Who Completed a Survey Regarding Their Care Visit Who Reported They Would Trust the Doctor/Provider to Care for their Friends/Family,Patient Engagement/Experience,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,,,,,EPREOP30,,"6775913, 7418330",,,,,,,,,,,,,,,
+QCDR,Intraoperative Hypotension (IOH) among Non-Emergent Noncardiac Surgical Cases,,,,EPREOP31,,,"Percentage of general, neuraxial, or regional anesthesia care cases in which the mean arterial pressure (MAP) fell below 65 mmHg for a cumulative total of 15 minutes or more",,,,,,,,,,,,,,
+QCDR,,,,,FOTO4,,,"This is a patient-reported outcome performance measure (PRO-PM) consisting of a patient-reported outcome measure (PROM) of risk-adjusted change in functional status (FS) for patients aged 14 years and older with lymphedema or other causes of edema. 
+For patients with such conditions affecting the arm, hand, chest, or breast body regions, the change in FS is assessed using the FOTO Upper Quadrant Edema (UQE) FS PROM.  For patients with such conditions affecting the leg, foot, groin, or lower trunk regions, the change in FS is assessed using the FOTO Lower Quadrant Edema (LQE) FS PROM. 
+PROM scores were scaled to the 0-100 metric, with higher scores representing higher perceived FS. To fairly measure performance between providers, the measure is risk-adjusted to patient characteristics known to be associated with FS outcomes and used as a performance measure at the patient and provider levels to assess quality.",,,,,,,,,,,,,,
+QCDR,,,,,FOTO5,,,"This is a patient-reported outcome performance measure (PRO-PM) consisting of a patient-reported outcome measure (PROM) of risk-adjusted functional status (FS) change in balance confidence for patients aged 14+ with balance impairments. The change in FS is assessed using the FOTO Balance Confidence, an item-response theory-based PROM derived from the 16-items of the Activities-specific Balance Confidence (ABC) Scale©, (1-3) scored using the T-score metric (mean=50, SD=10), with higher scores representing higher balance confidence. (4) 
+Patient responses to ABC Scale© items may be used to directly score Balance Confidence PROM, thus allowing clinicians flexibility of choice of PROM used in routine clinical care without adding to patient response burden. In order to fairly measure performance between providers, this quality measure is risk-adjusted to patient characteristics known to be associated with FS outcomes and used as a performance measure at the patient and provider levels to assess quality.",,,,,,,,,,,,,,
+QCDR,,,,,FOTO6,,,"This is a patient-reported outcome performance measure (PRO-PM) consisting of a patient-reported outcome measure (PROM) of risk-adjusted functional status (FS) change for patients aged 14 years and older with vestibular and other dizziness-related impairments. The change in FS is assessed using the FOTO Dizziness Positional Status (DPS) or Dizziness Functional Status (DFS) PROM; these are item-response theory-based PROMs developed using items from the Dizziness Handicap Inventory (DHI), scored using the T-score metric (mean=50, SD=10), with higher scores representing better FS. (1 )
+The DPS and DFS measure separate domains represented within DHI items.  The DPS score will be applied to this quality measure for patients with a statistically derived DPS cut-score (T-score) of 55 or lower; the DFS score will be applied for patients with a DPS T-score of greater than 55 at initial evaluation.  This approach is consistent with clinical and research observations that two types of vestibular impairments, positional- and functional-dominant, have distinctly different clinical presentations and expected outcomes.  
+Using a single PROM score derived from all 25 DHI items is not recommended due to score validity weaknesses. (2-5 Robust analyses using extensive exploratory and confirmatory factor analyses based on over 28,000 episodes of care determined the DHI items represent multiple domains that are different from those originally hypothesized, (6) thus using a single overall score would pose a threat to validity. However, patient responses to DHI items may be used to directly score the DPS and DFS, thus allowing clinicians greater flexibility of choice of PROM used in routine clinical care without adding to clinician nor patient burden.
+To fairly measure performance between providers, this quality measure is risk-adjusted to patient characteristics known to be associated with FS outcomes and used as a performance measure at the patient and provider levels to assess quality.",,,,,,,,,,,,,,
+QCDR,,,,,FOTO7,,,"This is a patient-reported outcome performance measure (PRO-PM) consisting of a patient-reported outcome measure (PROM) of risk-adjusted change in functional status (FS) for patients aged 14 years and older who have experienced a stroke with sequelae impacting physical functional abilities. For patients with such conditions affecting use of the hand, arm, and upper trunk, the change in FS is assessed using the FOTO Stroke Upper Extremity (SUE) FS PROM. (1) For patients with such conditions affecting the foot, leg, and lower trunk, the change in FS is assessed using the FOTO Stroke Lower Extremity (SLE) FS PROM. (1) PROM cores were scaled to the 0-100 metric, with higher scores representing higher perceived functional status. In order to fairly measure performance between providers, the measure is risk-adjusted to patient characteristics known to be associated with FS outcomes and used as a performance measure (PM) at the patient and provider levels to assess quality.",,,,,,,,,,,,,,
+QCDR,,,,,GIQIC10,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,GIQIC23,,5846856,,,,,,,,,,,,,,,
+QCDR,,,,,GIQIC24,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,GIQIC25,,,,,,,2024,,,,,,,,,,
+QCDR,Screening Colonoscopy Adenoma Detection Rate,,,,GIQIC26,GIQuIC,5846856,The percentage of patients aged 45 to 75 years with at least one conventional adenoma or colorectal cancer detected during screening colonoscopy,Outcome,Y,2024,,QCDR,,N,multiPerformanceRate,simpleAverage,,,,N,
+QCDR,,,,,HCPR16,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,HCPR17,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,HCPR20,,"4757099, 8483899, 1725296, 5133825",,,,,,,,,,,,,,,
+QCDR,Physician’s Orders for Life-Sustaining Treatment (POLST) Form,,,,HCPR25,H-CPR (Hospitalist ÐClinical Performance Registry),"4757099, 8483899, 1725296",Percentage of Patients Greater Than or Equal to 65 Years of Age with Physician’s Orders for Life-Sustaining Treatment (POLST) Forms Completed,Process,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,Heart Failure (HF): SGLT-2 Inhibitor Therapy for Left Ventricular Systolic Dysfunction (LVSD),,,,HCPR26,H-CPR (Hospitalist –Clinical Performance Registry),"4757099, 8483899",Percentage of Patients Aged 18 years and Older with a Diagnosis of Heart Failure (HF) With a Current or Prior Left Ventricular Ejection Fraction (LVEF) Less Than or Equal to 40% Who Were Prescribed SGLT-2 Inhibitor Therapy at Hospital Discharge.,Process,N,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,Point-of-Care Ultrasound: Evaluation for Pneumothorax after Central Venous Catheter (CVC) Placement,,,,HCPR27,H-CPR (Hospitalist –Clinical Performance Registry),"8483899, 4757099, 1725296",Percentage of Patients Aged 18 years and Older Who Undergo Central Venous Catheter (CVC) Insertion for Whom Point-of-Care Ultrasound Was Performed to Evaluate for Pneumothorax.,Process,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,,,,,HM7,,"7037323, 3471690, 3565744, 3967247",,,,,,,,,,,,,,N,
+QCDR,,,,,IRIS41,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IRIS43,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IRIS44,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IRIS46,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IRIS48,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IRIS49,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IRIS51,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IRIS53,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IRIS55,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IRIS56,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IRIS57,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IRIS59,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IRIS6,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IRIS60,,,,,,,2024,,,,,,,,,,
+QCDR,Visual Acuity Improvement Following Cataract Surgery and Minimally Invasive Glaucoma Surgery,,,,IRIS61,American Academy of Ophthalmology IRIS¨ Registry (Intelligent Research in Sight),3927141,Percentage of eyes of patients aged 18 years and older with a diagnosis of cataract who had cataract surgery and minimally invasive glaucoma surgery and achieved 20/30 best-corrected distance visual acuity or better within 4 months following the cataract surgery.,Outcome,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,Regaining Vision After Cataract Surgery,,,,IRIS62,American Academy of Ophthalmology IRIS¨ Registry (Intelligent Research in Sight),3927141,Percentage of eyes of patients aged 18 years and older with a diagnosis of cataract and comorbidities and pre-operative visual acuity of 20/400 or worse who had cataract surgery and an improvement in best-corrected distance visual acuity within 30 days following the cataract surgery,Outcome,Y,2024,,QCDR,,N,singlePerformanceRate, overallStratumOnly,,,,N,
+QCDR,,,,,IROMS11,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IROMS12,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IROMS13,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IROMS14,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IROMS16,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IROMS17,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IROMS18,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IROMS19,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,IROMS20,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,KEET01,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,LMBR1,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,LMBR10,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,LMBR2,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,LMBR3,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,LMBR4,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,LMBR5,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,LMBR6,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,LMBR7,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,LMBR8,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,LMBR9,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,MBHR1,,,"The percentage of adult patients (18 years and older) with an anxiety disorder diagnosis (e.g., generalized anxiety disorder, social anxiety disorder, or panic disorder) who have completed a standardized tool (e.g., GAD-7, BAI) during measurement period",,,,,,,,,,,,,,
+QCDR,,,,,MBHR3,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,MBHR5,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,MEDNAX54,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,MEDNAX55,,"5303416, 6394618",,,,,,,,,,,,,,,
+QCDR,,,,,MEDNAX56,,,,,,,2024,,,,,,,,,,
+QCDR,Patients Suffering From a Neck Injury who Improve Physical Function,,,,MSK1,Advancing Musculoskeletal (MSK) Care and Rehabilitation QCDR; MSK and Rehabilitative Care Outcomes,"3471690, 3565744, 1157686, 7037323, 3967247","Percentage of patients 18 years or older suffering from a neck injury who achieve the Minimal Clinically Important Difference (MCID) in the NDI or PROMIS Pain Interference, or like mapped measure during the performance year. 
+
+
+Additionally, a risk-adjusted MCID proportional difference determined by calculating the difference between the risk model predicted and observed MCID proportion will be reported for each PT/OT/MSK Provider/Group. The risk adjustment will be calculated using a logistic regression model using: baseline function score, baseline pain score, age, sex, payer, surgical status, and symptom duration (time from surgery or symptom onset to baseline physical therapy visit) as well as instrument tool used. These measures will serve as a PT/OT/MSK Provider performance measure at the eligible PT/OT/MSK Provider or group level.
+
+This measure will include one rate:
+1) The overall performance rate of non-surgical and surgical patients who achieve the MCID in NDI/PROMIS Pain Interference/or like mapped measure.",Patient-Reported Outcome-Based Performance Measure,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,Y,
+QCDR,Patients Suffering From a Knee Injury who Improve Pain,,,,MSK10,Advancing Musculoskeletal (MSK) Care and Rehabilitation QCDR; MSK and Rehabilitative Care Outcomes,"3471690, 3565744, 1157686, 7037323, 3967247","Percentage of patients 18 years or older suffering from a knee injury who achieve the Minimal Clinically Important Difference (MCID) in the Numeric Pain Rating Scale, or like mapped measure during the performance year. 
+
+
+Additionally, a risk-adjusted MCID proportional difference determined by calculating the difference between the risk model predicted and observed MCID proportion will be reported for each PT/OT/MSK Provider/Group. The risk adjustment will be calculated using a logistic regression model using: baseline function score, baseline pain score, age, sex, payer, surgical status, and symptom duration (time from surgery or symptom onset to baseline physical therapy visit) as well as instrument tool used. These measures will serve as a PT/OT/MSK Provider performance measure at the eligible PT/OT/MSK Provider or group level.
+
+This measure will include one rate:
+1) The overall performance rate of non-surgical and surgical patients who achieve the MCID in the Numeric Pain Rating Scale like mapped measure.",Patient-Reported Outcome-Based Performance Measure,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,Y,
+QCDR,Patients Suffering From an Upper Extremity Injury who Improve Physical Function,,,,MSK2,Advancing Musculoskeletal (MSK) Care and Rehabilitation QCDR; MSK and Rehabilitative Care Outcomes,"3471690, 3565744, 1157686, 7037323, 3967247","Percentage of patients 18 years or older suffering from an upper extremity injury who achieve the Minimal Clinically Important Difference (MCID) in the QDASH or PROMIS Upper Extremity, or like mapped measure during the performance year. 
+
+
+Additionally, a risk-adjusted MCID proportional difference determined by calculating the difference between the risk model predicted and observed MCID proportion will be reported for each PT/OT/MSK Provider/Group. The risk adjustment will be calculated using a logistic regression model using: baseline function score, baseline pain score, age, sex, payer, surgical status, and symptom duration (time from surgery or symptom onset to baseline physical therapy visit) as well as instrument tool used. These measures will serve as a PT/OT/MSK Provider performance measure at the eligible PT/OT/MSK Provider or group level.
+
+This measure will include one rate:
+1) The overall performance rate of non-surgical and surgical patients who achieve the MCID in QDASH/PROMIS Upper Extremity/or like mapped measure.",Patient-Reported Outcome-Based Performance Measure,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,Y,
+QCDR,Patients Suffering From a Back Injury who Improve Physical Function,,,,MSK3,Advancing Musculoskeletal (MSK) Care and Rehabilitation QCDR; MSK and Rehabilitative Care Outcomes,"3471690, 3565744, 1157686, 7037323, 3967247","Percentage of patients 18 years or older suffering from a back injury who achieve the Minimal Clinically Important Difference (MCID) in the MDQ or PROMIS Pain Interference, or like mapped measure during the performance year. 
+
+
+Additionally, a risk-adjusted MCID proportional difference determined by calculating the difference between the risk model predicted and observed MCID proportion will be reported for each PT/OT/MSK Provider/Group. The risk adjustment will be calculated using a logistic regression model using: baseline function score, baseline pain score, age, sex, payer, surgical status, and symptom duration (time from surgery or symptom onset to baseline physical therapy visit) as well as instrument tool used. These measures will serve as a PT/OT/MSK Provider performance measure at the eligible PT/OT/MSK Provider or group level.
+
+This measure will include one rate:
+1) The overall performance rate of non-surgical and surgical patients who achieve the MCID in MDQ/PROMIS Pain Interference/or like mapped measure.",Patient-Reported Outcome-Based Performance Measure,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,Y,
+QCDR,Patients Suffering From a Lower Extremity Injury who Improve Physical Function,,,,MSK4,Advancing Musculoskeletal (MSK) Care and Rehabilitation QCDR; MSK and Rehabilitative Care Outcomes,"3471690, 3565744, 1157686, 7037323, 3967247","Percentage of patients 18 years or older suffering from a lower extremity injury who achieve the Minimal Clinically Important Difference (MCID) in the LEFS or PROMIS Physical Function, or like mapped measure during the performance year. 
+
+
+Additionally, a risk-adjusted MCID proportional difference determined by calculating the difference between the risk model predicted and observed MCID proportion will be reported for each PT/OT/MSK Provider/Group. The risk adjustment will be calculated using a logistic regression model using: baseline function score, baseline pain score, age, sex, payer, surgical status, and symptom duration (time from surgery or symptom onset to baseline physical therapy visit) as well as instrument tool used. These measures will serve as a PT/OT/MSK Provider performance measure at the eligible PT/OT/MSK Provider or group level.
+
+This measure will include one rate:
+1) The overall performance rate of non-surgical and surgical patients who achieve the MCID in LEFS/PROMIS Physical Function/or like mapped measure.",Patient-Reported Outcome-Based Performance Measure,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,Y,
+QCDR,Patients Suffering From a Knee Injury who Improve Physical Function,,,,MSK5,Advancing Musculoskeletal (MSK) Care and Rehabilitation QCDR; MSK and Rehabilitative Care Outcomes,"3471690, 3565744, 1157686, 7037323, 3967247","Percentage of patients 18 years or older suffering from a knee injury who achieve the Minimal Clinically Important Difference (MCID) in the KOS or PROMIS Physical Function, or like mapped measure during the performance year. 
+
+
+Additionally, a risk-adjusted MCID proportional difference determined by calculating the difference between the risk model predicted and observed MCID proportion will be reported for each PT/OT/MSK Provider/Group. The risk adjustment will be calculated using a logistic regression model using: baseline function score, baseline pain score, age, sex, payer, surgical status, and symptom duration (time from surgery or symptom onset to baseline physical therapy visit) as well as instrument tool used. These measures will serve as a PT/OT/MSK Provider performance measure at the eligible PT/OT/MSK Provider or group level.
+
+This measure will include one rate:
+1) The overall performance rate of non-surgical and surgical patients who achieve the MCID in KOS/PROMIS Physical Function/or like mapped measure.",Patient-Reported Outcome-Based Performance Measure,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,Y,
+QCDR,Patients Suffering From a Neck Injury who Improve Pain,,,,MSK6,Advancing Musculoskeletal (MSK) Care and Rehabilitation QCDR; MSK and Rehabilitative Care Outcomes,"3471690, 3565744, 1157686, 7037323, 3967247","Percentage of patients 18 years or older suffering from a neck injury who achieve the Minimal Clinically Important Difference (MCID) in the Numeric Pain Rating Scale, or like mapped measure during the performance year. 
+
+
+Additionally, a risk-adjusted MCID proportional difference determined by calculating the difference between the risk model predicted and observed MCID proportion will be reported for each PT/OT/MSK Provider/Group. The risk adjustment will be calculated using a logistic regression model using: baseline function score, baseline pain score, age, sex, payer, surgical status, and symptom duration (time from surgery or symptom onset to baseline physical therapy visit) as well as instrument tool used. These measures will serve as a PT/OT/MSK Provider performance measure at the eligible PT/OT/MSK Provider or group level.
+
+This measure will include one rate:
+1) The overall performance rate of non-surgical and surgical patients who achieve the MCID in the Numeric Pain Rating Scale like mapped measure.",Patient-Reported Outcome-Based Performance Measure,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,Y,
+QCDR,Patients Suffering From an Upper Extremity Injury who Improve Pain,,,,MSK7,Advancing Musculoskeletal (MSK) Care and Rehabilitation QCDR; MSK and Rehabilitative Care Outcomes,"3471690, 3565744, 1157686, 7037323, 3967247","Percentage of patients 18 years or older suffering from an upper extremity injury who achieve the Minimal Clinically Important Difference (MCID) in the Numeric Pain Rating Scale, or like mapped measure during the performance year. 
+
+
+Additionally, a risk-adjusted MCID proportional difference determined by calculating the difference between the risk model predicted and observed MCID proportion will be reported for each PT/OT/MSK Provider/Group. The risk adjustment will be calculated using a logistic regression model using: baseline function score, baseline pain score, age, sex, payer, surgical status, and symptom duration (time from surgery or symptom onset to baseline physical therapy visit) as well as instrument tool used. These measures will serve as a PT/OT/MSK Provider performance measure at the eligible PT/OT/MSK Provider or group level.
+
+This measure will include one rate:
+1) The overall performance rate of non-surgical and surgical patients who achieve the MCID in the Numeric Pain Rating Scale like mapped measure.",Patient-Reported Outcome-Based Performance Measure,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,Y,
+QCDR,Patients Suffering From a Back Injury who Improve Pain,,,,MSK8,Advancing Musculoskeletal (MSK) Care and Rehabilitation QCDR; MSK and Rehabilitative Care Outcomes,"3471690, 3565744, 1157686, 7037323, 3967247","Percentage of patients 18 years or older suffering from a back injury who achieve the Minimal Clinically Important Difference (MCID) in the Numeric Pain Rating Scale, or like mapped measure during the performance year. 
+
+
+Additionally, a risk-adjusted MCID proportional difference determined by calculating the difference between the risk model predicted and observed MCID proportion will be reported for each PT/OT/MSK Provider/Group. The risk adjustment will be calculated using a logistic regression model using: baseline function score, baseline pain score, age, sex, payer, surgical status, and symptom duration (time from surgery or symptom onset to baseline physical therapy visit) as well as instrument tool used. These measures will serve as a PT/OT/MSK Provider performance measure at the eligible PT/OT/MSK Provider or group level.
+
+This measure will include one rate:
+1) The overall performance rate of non-surgical and surgical patients who achieve the MCID in the Numeric Pain Rating Scale like mapped measure.",Patient-Reported Outcome-Based Performance Measure,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,Y,
+QCDR,Patients Suffering From a Lower Extremity Injury who Improve Pain,,,,MSK9,Advancing Musculoskeletal (MSK) Care and Rehabilitation QCDR; MSK and Rehabilitative Care Outcomes,"3471690, 3565744, 1157686, 7037323, 3967247","Percentage of patients 18 years or older suffering from a lower extremity injury who achieve the Minimal Clinically Important Difference (MCID) in the Numeric Pain Rating Scale, or like mapped measure during the performance year. 
+
+
+Additionally, a risk-adjusted MCID proportional difference determined by calculating the difference between the risk model predicted and observed MCID proportion will be reported for each PT/OT/MSK Provider/Group. The risk adjustment will be calculated using a logistic regression model using: baseline function score, baseline pain score, age, sex, payer, surgical status, and symptom duration (time from surgery or symptom onset to baseline physical therapy visit) as well as instrument tool used. These measures will serve as a PT/OT/MSK Provider performance measure at the eligible PT/OT/MSK Provider or group level.
+
+This measure will include one rate:
+1) The overall performance rate of non-surgical and surgical patients who achieve the MCID in the Numeric Pain Rating Scale like mapped measure.",Patient-Reported Outcome-Based Performance Measure,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,Y,
+QCDR,,,,,MSN13,,"6394618, 5303416, 6704504","Percentage of patients, regardless of age, undergoing Coronary Calcium Scoring who have measurable coronary artery calcification (CAC) with total CACS, regional distribution scoring, AND whether or not the regional distribution/total CACS warrant further evaluation documented in the Final report.",,,,,,,,,,,,,,
+QCDR,,,,,MSN15,,"5303416, 6394618, 6704504",,,,,,,,,,,,,,,
+QCDR,,,,,MSN16,,,,,,,2024,,,,,,,,,,
+QCDR,Prostate Cancer: Active Surveillance/Watchful Waiting for Newly Diagnosed Low Risk Prostate Cancer Patients,,,,MUSIC4,,,,,,,,,,,,,,,,,
+QCDR,,,,,NHCR4,GIQuIC,,,,,,,,,,,,,,,,
+QCDR,,,,,NHII1,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,PIMSH13,,"8794712, 7037323",,,,,,,,,,,,,,,
+QCDR,,,,,PIMSH2,,"8794712, 7037323",,,,,,,,,,,,,,,
+QCDR,,,,,PP10,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,PP12,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,PP13,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,PQRANES1,The PQR-ANES,7746687,,,,,,,,,,,,,,,
+QCDR,,,,,QMM16,,"5303416, 6394618, 7746687",,,,,,,,,,,,,,,
+QCDR,,,,,QMM17,,"5303416, 6394618, 7746687, 6704504",,,,,,,,,,,,,,,
+QCDR,,,,,QMM18,,"5303416, 6394618, 7746687, 6704504",,,,,,,,,,,,,,,
+QCDR,,,,,QMM19,,"5303416, 6394618, 7746687, 6704504",,,,,,,,,,,,,,,
+QCDR,,,,,QMM20,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,QMM21,,"7418330, 6704504","The percentage of Final Bone Marrow Aspirate Reports of patients with Leukemia, Myelodysplastic syndrome, or Chronic Anemia with documentation of concurrent studies performed, their respective results, and interpretation of those results.",,,,,,,,,,,,,,
+QCDR,,,,,QMM22,,"7418330, 6704504","The percentage of patients with a thyroid nodule fine needle aspiration (FNA) diagnosis by cytology of Bethesda category 3 or 4 with a recommendation for molecular testing in Final Pathology Report, followed with direct communication to Patient/Ordering or Attending Provider regarding recommendation.",,,,,,,,,,,,,,
+QCDR,,,,,QMM23,,"6394618, 7746687","Percentage of emphysema patients, aged 50-77 at the time of service, who undergo a CT/CTA of the chest in which the Final Report:
+1) Mentions that the presence of pulmonary emphysema on CT is an independent risk factor for lung cancer, AND
+2) Includes a recommendation to consider the patient for low dose CT (LDCT) lung cancer screening in the future (current chest CT serves as a baseline).",,,,,,,,,,,,,,
+QCDR,,,,,QMM24,,"6394618, 7746687",,,,,,,,,,,,,,,
+QCDR,,,,,QMM25,,"7418330, 6704504",,,,,,,,,,,,,,,
+QCDR,Screening Abdominal Aortic Aneurysm Reporting with Recommendations,,,,QMM26,"MSN Healthcare Solutions, LLC","5303416, 6394618, 6704504, 7746687","Percentage of patients, aged 50-years-old or older, who have had a screening ultrasound for an abdominal aortic aneurysm, with positive or negative findings, that have recognized clinical follow up recommendations documented in the final report and direct communication of findings greater than or equal to 5.5 cm in size made to the ordering provider.",Process,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,Appropriate Classification and Follow-up Imaging for Incidental Pancreatic Cysts,,,,QMM27,"MSN Healthcare Solutions, LLC",6394618,"Percentage of Final Reports for computed tomography (CT), computed tomography angiography (CTA), magnetic resonance imaging (MRI), or magnetic resonance angiography (MRA) of the abdomen or abdomen/pelvis for patients aged 18 years or older with a pancreatic cyst incidentally noted that include documentation of cyst classification and follow-up imaging recommendations in accordance with published guidelines.",Process,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,Reporting Breast Arterial Calcification (BAC) on Screening Mammography,,,,QMM28,"MSN Healthcare Solutions, LLC",6394618,Percentage of Final Screening Mammography Reports for female patients aged 40 years or older that include documentation of the presence or absence of Breast Arterial Calcification (BAC) and its clinical relevance.,Process,N,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,Use of Appropriate Classification System for Lymphoma Specimen,,,,QMM29,MSN Healthcare Solutions QCDR II,7418330,"Percentage of Final Lymphoma Specimen Pathology Reports, regardless of patient age, that classify the lymphoma using a validated and published model for lymphoma classification**. 
+   
+** Must be one of the models listed in the Numerator Instructions below.",Process,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,,,,,RCOIR10,,,,,,,2024,,,,,,,,,,
+QCDR,Tunneled Hemodialysis Catheter Clinical Success Rate,,,,RCOIR12,,,,,,,,,,,,,,,,,
+QCDR,,,,,RCOIR13,,,Percentage of clinically successful percutaneously created arteriovenous fistulae (pAVF) for patients on maintenance hemodialysis dialysis.,,,,,,,,,,,,,,
+QCDR,Arteriovenous Fistula Patency Rate,,,,RCOIR14,"Renal and Vascular Outcomes Improvement Program, powered by Forward Health Group",4302083,Percentage of arteriovenous fistulae (AVF) patent after creation in patients aged 18 and older.,Outcome,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,Arteriovenous Graft Patency Rate,,,,RCOIR15,"Renal and Vascular Outcomes Improvement Program, powered by Forward Health Group",4302083,Percentage of arteriovenous grafts (AVG) patent after creation in patients aged 18 and older.,Outcome,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,,,,,RCOIR7,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,REGCLR2,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,REGCLR4,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,REGCLR7,,,,,,,2024,,,,,,,,,,
+QCDR,Arteriovenous Graft Thrombectomy Clinical Success Rate,,,,RPAQIR14,,,Percentage of clinically successful arteriovenous graft (AVG) thrombectomies for patients on maintenance hemodialysis.,,,,,,,,,,,,,,
+QCDR,Arteriovenous Fistulae Thrombectomy Clinical Success Rate,,,,RPAQIR15,,,,,,,,,,,,,,,,,
+QCDR,,,,,SPINETRACK9,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,THEPQR1,,"1725296, 5133825",,,,,,,,,,,,,,,
+QCDR,,,,,THEPQR2,,"1725296, 5133825",,,,,,,,,,,,,,,
+QCDR,SGLT-2 inhibitors for patients with HFrEF with or without Type 2 Diabetes,,,,THEPQR3,The PQR,1725296,Percentage of patients aged 18 years and older with a diagnosis of heart failure (HF) with a current or prior left ventricular ejection fraction (LVEF) ? 40% who were prescribed SGLT-2 Inhibitors with or without Type 2 diabetes during their SNF stay or at the time of discharge.,Process,N,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,Consultation to Palliative Care for Patients with End Stage Conditions,,,,THEPQR4,The PQR,1725296,The measure will identify patients with end stage diagnoses who meet any of the listed criteria for a palliative care consult,Process,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,Nutritional Assessment and Intervention Plan in patients with Wounds and Ulcers,,,,USWR22,,,,,,,,,,,,,,,,,
+QCDR,,,,,USWR26,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,USWR29,,,,,,,2024,,,,,,,,,,
+QCDR,Non-Invasive Arterial Assessment of patients with lower extremity wounds or ulcers for determination of healing potential,,,,USWR30,,,,,,,,,,,,,,,,,
+QCDR,,,,,USWR31,,,,,,,2024,,,,,,,,,,
+QCDR,,,,,USWR32,,,Percentage of venous leg ulcer visits among patients aged 18 years and older in which adequate compression is performed at each treatment visit in the 12 month reporting period or until VLU outcome . Arterial status must first be assessed at least one time with any non-invasive method and the device chosen for compression must be appropriate based on whether arterial supply is normal or reduced  (see: USWR30: Arterial Screening Measure).,,,,,,,,,,,,,,
+QCDR,Diabetic Foot Ulcer (DFU) Healing or Closure,,,,USWR33,U.S. Wound Registry,6853338,"Percentage of diabetic foot ulcers among patients aged 18 or older that have achieved healing or closure within 6 months, stratified by the Wound Healing Index. Healing or closure is defined as complete epithelialization without drainage or the need for a dressing over the closed ulceration, although off-loading would still be required.",Outcome,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,Y,
+QCDR,Venous Leg Ulcer (VLU) Healing or Closure,,,,USWR34,U.S. Wound Registry,6853338,"Percentage of venous leg ulcers among patients aged 18 or older that have achieved healing or closure within 12 months, stratified by the Wound Healing Index. Healing or closure is defined as complete epithelialization without drainage or the need for a dressing over the closed ulceration, although venous compression would still be required.",Outcome,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,Y,
+QCDR,"Adequate Off-loading of Diabetic Foot Ulcers performed at each visit, appropriate to location of ulcer",,,,USWR35,U.S. Wound Registry,6853338,"Percentage of visits in which diabetic foot ulcers among patients aged 18 years and received adequate off-loading during a 12-month reporting period, stratified by location of the ulcer. Off-loading is not a simple documentation process but may include performing a procedure such as Total Contact Casting or providing appropriate footwear.
+
+The location of the diabetic foot ulcer on the foot (e.g., heel/midfoot vs. toes) determines the type of off-loading device that is appropriate, the patient’s risk of falling, the probability of successful off-loading and thus the likelihood of major amputation. The clinician needs to evaluate these factors and then provide the most appropriate off-loading option.",Process,N,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,N,
+QCDR,Pressure Ulcer* (PU) Healing or Closure (not on the lower extremity ),,,,USWR36,U.S. Wound Registry,6853338,"Percentage of Stage 2, 3, or 4 pressure ulcers* (not on the lower extremity) among patients aged 18 or older that achieve healing or closure within 6 months, stratified by the Wound Healing Index (WHI). Healing or closure may occur by delayed secondary intention or may be the result of surgical intervention (e.g., rotational flap or skin graft). Lower extremity pressure ulcers are not included in this measure because they commonly overlap with arterial and diabetic foot ulcers and require a separate risk stratification model. [Note: The National Pressure Injury Advisory Panel (NPIA) (formerly the NPUAP) has renamed pressure ulcers “pressure injuries,” but the ICD-10-CM continues to use the term pressure “ulcers”. This measure is limited to open defects (stages 2, 3, 4) which heal by secondary intention or surgical closure, typically referred to as ulcers. We have chosen to use the ICD10 terminology of ""ulcers"".]",Outcome,Y,2024,,QCDR,,N,singlePerformanceRate,overallStratumOnly,,,,Y,

--- a/updates/measures/2024/changes.meta.json
+++ b/updates/measures/2024/changes.meta.json
@@ -7,5 +7,6 @@
   "Medicare_Quality_PY24_CR_11272023.csv",
   "Medicare_Quality_PY24_CR_20231206.csv",
   "Quality_PY24_CR_Split_20231201.csv",
-  "Cost_PY24_20231127.csv"
+  "Cost_PY24_20231127.csv",
+  "Quality_QCDR_PY24_CR_20231211.csv"
 ]

--- a/util/measures/2024/qcdr-strata.csv
+++ b/util/measures/2024/qcdr-strata.csv
@@ -19,8 +19,6 @@ AJRR11,armpain,"Percentage of denominator patients who showed a statistically si
 AJRR11,legpain,"Percentage of denominator patients who showed a statistically significant improvement in comparison to initial assessment, measured by minimum clinically important difference (MCID) in leg pain."
 AJRR7,hip,represents total hip arthroplasty
 AJRR7,knee,represents total knee arthroplasty.
-AJRR8,hip,represents total hip arthroplasty
-AJRR8,knee,represents total knee arthroplasty.
 AJRR9,hip,represents total hip arthroplasty
 AJRR9,knee,represents total knee arthroplasty.
 AQI48,surveyed,"The first performance rate, AQI48a, describes the percentage of surgical patients who receive a survey of their experience with anesthesia care."
@@ -30,17 +28,6 @@ AQI71,testedPrior,"Percentage of patients, aged 18 years and older, with a curre
 AQI71,insulinPrior,"Percentage of patients, aged 18 years and older, with a current diagnosis of diabetes mellitus receiving anesthesia services for office-based or ambulatory surgery who experienced a blood glucose level greater than 180 mg/dL (10.0 mmol/L) who received insulin prior to anesthesia end time"
 AQI71,insulinPostoperative,"Percentage of patients, aged 18 years and older, with a current diagnosis of diabetes mellitus receiving anesthesia services for office-based or ambulatory surgery who received insulin perioperatively and who received a follow-up blood glucose level check following the administration of insulin and prior to discharge"
 AQI71,glucoseEducation,"Percentage of patients, aged 18 years and older, with a current diagnosis of diabetes mellitus receiving anesthesia services for office-based or ambulatory surgery who experienced a blood glucose level greater than 180 mg/dL (10.0 mmol/L) who received education on managing their glucose in the postoperative period prior to discharge"
-AQI73,overall,The overall measure score will be calculated as an average of the total cases of Rate 2 and Rate 3. 
-AQI73,brachialRadialTibial," Percentage of patients, regardless of age, who undergo placement of a peripheral intra-arterial line in the brachial, radial, posterior tibial or dorsalis pedis artery for whom the arterial line was inserted with all indicated elements of sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound techniques followed"
-AQI73,femoralAxillary," Percentage of patients, regardless of age, who undergo placement of a peripheral intra-arterial line in the femoral or axillary artery for whom the arterial line was inserted with all indicated elements of maximal sterile barrier technique, hand hygiene, skin preparation and, if ultrasound is used, sterile ultrasound technique is followed"
-CDR2,bucket1,0.00 - 62.42
-CDR2,bucket2,62.42 - 73.19
-CDR2,bucket3,73.19 - 100
-CDR2,overall,The performance rate is the average of the 3 WHI risk categories described in the risk stratification document.
-CDR6,bucket1,"VLUs likely to heal with conservative care,"
-CDR6,bucket2,"VLUs which might or might not heal, and"
-CDR6,bucket3,VLUs highly unlikely to heal with conservative care.
-CDR6,overall,The performance rate is the average of the 3 stratified rates
 GIQIC23,overall,Overall percentage of procedures among average-risk patients aged 45 to 75 years receiving a screening colonoscopy with biopsy or polypectomy and pathology findings who had a follow-up interval consistent with US Multi-Society Task Force (USMSTF) recommendations for repeat colonoscopy documented in their colonoscopy report
 GIQIC23,hyperPolyps&FollowUp,Percentage of complete and adequately prepped screening colonoscopies of average-risk patients aged 45 to 75 years with biopsy or polypectomy and pathology findings of only hyperplastic polyps for which a recommended follow-up interval of 10 years for repeat colonoscopy was given to the patient
 GIQIC23,1-2adenoma&FollowUp,Percentage of complete and adequately prepped screening colonoscopies of average-risk patients aged 45 to 75 years with biopsy or polypectomy and pathology findings of 1-2 tubular adenoma(s) for which a recommended follow-up interval of not less than 7 years and not greater than 10 years was given to the patient
@@ -52,89 +39,8 @@ HM7,14to17,SUBMISSION CRITERIA 1: Patients aged 14-17 years of age on date of en
 HM7,18to64,SUBMISSION CRITERIA 2: Patients aged 18-64 years and older on date of encounter
 HM7,65over,SUBMISSION CRITERIA 3: Patients aged 65 years of age and older on date of encounter
 HM7,overall,SUBMISSION CRITERIA 4: Patients aged 14 years of age and older on date of encounter
-IRIS55,20/30+,Includes eyes of patients with mild to moderate stage glaucoma and a 20/30 or better post-operative best-corrected distance visual acuity
-IRIS55,20/200,Includes eyes of patients with severe stage glaucoma or a pre-operative best-corrected visual acuity of 20/200 and a 2 lines or better improvement in the post-operative best-corrected distance visual acuity from preoperative visual acuity
-IRIS55,20/400,Includes eyes of patients with a pre-operative best-corrected visual acuity of 20/400 and a 1 line or better improvement in the post-operative best-corrected distance visual acuity from pre-operative visual acuity
-IRIS59,nocomorbidities,"Includes eyes of patients with no comorbidities or additional procedures on the same date as the cataract surgery,"
-IRIS59,comorbidities&20/200,"Includes eyes of patients with comorbidities with a pre-operative visual acuity of 20/200 or better, and"
-IRIS59,comorbidities&20/400,Includes eyes of patients with comorbidities with a pre-operative visual acuity of 20/400 or worse
-IRIS60,better20/200,Includes eyes of patients with a pre-operative visual acuity of better than 20/200 who had an improvement from their preoperative visual acuity of 2 or more lines between 3 and 6 months postoperatively
-IRIS60,20/200,Includes eyes of patients with a pre-operative visual acuity of 20/200 who had an improvement from their preoperative visual acuity of 2 or more lines between 3 and 6 months postoperatively
-IRIS60,20/400,Includes eyes of patients with a pre-operative visual acuity of 20/400 who had an improvement from their preoperative visual acuity of 1 or more lines between 3 and 6 months postoperatively
-IROMS11,notachieving,Overall proportion of patients not achieving an MCID in KOS change score will be reported.
-IROMS11,overall,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via KOS) proportion will be reported. 
-IROMS11,operativeMCID,The proportion of patients not achieving an MCID in KOS change score will be reported.
-IROMS11,operativeRisk,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via KOS) proportion will be reported. 
-IROMS11,nonOpMCID,The proportion of patients not achieving an MCID in KOS change score will be reported.
-IROMS11,nonOpRisk,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measure via KOS) proportion will be reported.
-IROMS12,notachieving,Overall proportion of patients not achieving an MCID in the NPRS change score will be reported. 
-IROMS12,overall,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported. 
-IROMS12,operativeMCID,The proportion of patients not achieving an MCID in the NPRS change score will be reported. 
-IROMS12,operativeRisk,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported. 
-IROMS12,nonOpMCID,The proportion of patients not achieving an MCID in the NPRS change score will be reported. 
-IROMS12,nonOpRisk, A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will reported.
-IROMS13,notachieving,Overall proportion of patients not achieving an MCID in KOS change score will be reported.
-IROMS13,overall,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via KOS) proportion will be reported. 
-IROMS13,operativeMCID,The proportion of patients not achieving an MCID in KOS change score will be reported.
-IROMS13,operativeRisk,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via KOS) proportion will be reported. 
-IROMS13,nonOpMCID,The proportion of patients not achieving an MCID in KOS change score will be reported.
-IROMS13,nonOpRisk,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measure via KOS) proportion will be reported.
-IROMS14,notachieving,Overall proportion of patients not achieving an MCID in the NPRS change score will be reported. 
-IROMS14,overall,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported. 
-IROMS14,operativeMCID,The proportion of patients not achieving an MCID in the NPRS change score will be reported. 
-IROMS14,operativeRisk,"A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported."
-IROMS14,nonOpMCID,The proportion of patients not achieving an MCID in the NPRS change score will be reported. 
-IROMS14,nonOpRisk,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported.
-IROMS16,notachieving,Overall proportion of patients not achieving an MCID in the NPRS change score will be reported. 
-IROMS16,overall,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported. 
-IROMS16,operativeMCID,The proportion of patients not achieving an MCID in the NPRS change score will be reported. 
-IROMS16,operativeRisk,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported. 
-IROMS16,nonOpMCID,The proportion of patients not achieving an MCID in the NPRS change score will be reported. 
-IROMS16,nonOpRisk,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported.
-IROMS17,notachieving,Overall proportion of patients not achieving an MCID in KOS change score will be reported.
-IROMS17,overall, A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via KOS) proportion will be reported. 
-IROMS17,operativeMCID,The proportion of patients not achieving an MCID in KOS change score will be reported.
-IROMS17,operativeRisk,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via KOS) proportion will be reported. 
-IROMS17,nonOpMCID,The proportion of patients not achieving an MCID in KOS change score will be reported.
-IROMS17,nonOpRisk,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measure via KOS) proportion will be reported.
-IROMS18,notachieving,Overall proportion of patients not achieving an MCID in the NPRS change score will be reported. 
-IROMS18,overall,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported. 
-IROMS18,operativeMCID,The proportion of patients not achieving an MCID in the NPRS change score will be reported. 
-IROMS18,operativeRisk,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported. 
-IROMS18,nonOpMCID,The proportion of patients not achieving an MCID in the NPRS change score will be reported. 
-IROMS18,nonOpRisk,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported.
-IROMS19,notachieving,Overall proportion of patients not achieving an MCID in DASH change score will be reported. 
-IROMS19,overall,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via DASH) proportion will be reported. 
-IROMS19,operativeMCID,The proportion of patients not achieving an MCID in DASH change score will be reported. 
-IROMS19,operativeRisk,"A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via DASH) proportion will be reported."
-IROMS19,nonOpMCID,The proportion of patients not achieving an MCID in DASH change score will be reported.
-IROMS19,nonOpRisk,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via DASH) proportion will be reported.
-IROMS20,notachieving,Overall proportion of patients not achieving an MCID in the NPRS change score will be reported. 
-IROMS20,overall,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported. 
-IROMS20,operativeMCID,The proportion of patients not achieving an MCID in the NPRS change score will be reported. 
-IROMS20,operativeRisk,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported. 
-IROMS20,nonOpMCID,The proportion of patients not achieving an MCID in the NPRS change score will be reported. 
-IROMS20,nonOpRisk,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID proportion will be reported.
-KEET01,notachieving,Overall proportion of patients not achieving an MCID in NDI change score will be reported.
-KEET01,overall, A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via NDI) proportion will be reported. 
-KEET01,operativeMCID,The proportion of patients not achieving an MCID in NDI change score will be reported.
-KEET01,operativeRisk,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measured via NDI) proportion will be reported. 
-KEET01,nonOpMCID,The proportion of patients not achieving an MCID in NDI change score will be reported.
-KEET01,nonOpRisk,A risk-adjusted MCID proportional difference will be reported where the difference between the risk model predicted and observed MCID (measure via NDI) proportion will be reported.
 MBHR10,screening,"Documentation of a standardized tool to assess ADHD (i.e., ASRS checklist) and a document care of plan "
 MBHR10,overall,"Patient demonstrated an ASRS score that is reduced by 25% or greater from the index score, 2-10 months after index date"
-PP10,assessment,"Percentage of patients who had a comprehensive index assessment using standardized tools to assess at least three of the following six domains: (1) functioning, (2) recovery, (3) depression symptom severity, (4) anxiety symptom severity, (5) substance use symptoms severity, or (6) suicidal ideation and behavior symptoms severity."
-PP10,monitorAt90Days,"Percentage of patients who were monitored 90 days (+/- 30 days) from the comprehensive index assessment using standardized tools to assess (1) functioning, (2) recovery, or (3) symptom severity in depression, anxiety, substance use, or suicidal ideation and behavior."
-PP10,maintnCareAt180Days,Percentage of patients with documentation of a clinical decision to adjust or maintain their care between 7 and 180 days from the comprehensive index assessment.
-PP12,safetyPlanWithIn24hr,"The percentage of individuals for whom a suicide safety plan is initiated, reviewed, or updated in collaboration between the individual and their clinician (concurrent or within 24 hours of clinical encounter). "
-PP12,overall,"The percentage of individuals for whom a suicide safety plan is initiated, reviewed, or updated AND reviewed and updated in collaboration between the individual and their clinician within 120 days after initiation (+/- 30 days)."
-USWR29,midfootHeel,Midfoot/heel Rate
-USWR29,toes,Toes Rate
-USWR29,overall,The average of the two risk stratified buckets which will be the performance rate in the JSON or XML file submitted.
-USWR31,likelyToHeal,"pressure ulcers likely to heal with conservative care,"
-USWR31,mayHeal,"pressure ulcers which may or may not heal,"
-USWR31,unlikelyToHeal,pressure ulcers which are unlikely to heal. The average of the three risk stratified buckets which will be the performance rate in the XML submitted.
-USWR31,overall,The performance rate is the average of the three WHI stratified groups described in our risk stratification document.
 USWR32,noRestrictions,Normal arterial supply based on testing- No restrictions on type of compression
 USWR32,specialConsideration,"Compression bandaging with special considerations (e.g., short stretch bandaging, warnings to the patient to remove bandages if they feel too tight, etc.)"
 USWR32,notRecommended,Compression bandaging not recommended


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs when possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation.
-->

[![ICF](https://th.bing.com/th/id/OIP.3z-X0lRS3oSl7MwvlsX72AAAAA?pid=ImgDet&rs=1)](https://www.icf.com/)

---
## Related Tickets & Documents
<!--
Mandatory if the ticket exists. Otherwise, the description section **must** contain the details.
-->
https://jira.cms.gov/browse/QPPA-8300
https://jira.cms.gov/browse/QPPA-8464

---

## Description
New measure 'AAD19' added.
New measure 'AAN35' added.
New measure 'AAN36' added.
New measure 'AAO37' added.
New measure 'AAO38' added.
New measure 'AAO39' added.
New measure 'ABFM13' added.
New measure 'ACEP64' added.
New measure 'ACEP65' added.
New measure 'ACEP66' added.
New measure 'AJRR12' added.
New measure 'AQUA35' added.
New measure 'AQUA36' added.
New measure 'CAP40' added.
New measure 'CAP41' added.
New measure 'CAP42' added.
New measure 'ECPR59' added.
New measure 'GIQIC26' added.
New measure 'HCPR25' added.
New measure 'HCPR26' added.
New measure 'HCPR27' added.
New measure 'IRIS61' added.
New measure 'IRIS62' added.
New measure 'MSK1' added.
New measure 'MSK10' added.
New measure 'MSK2' added.
New measure 'MSK3' added.
New measure 'MSK4' added.
New measure 'MSK5' added.
New measure 'MSK6' added.
New measure 'MSK7' added.
New measure 'MSK8' added.
New measure 'MSK9' added.
New measure 'QMM26' added.
New measure 'QMM27' added.
New measure 'QMM28' added.
New measure 'QMM29' added.
New measure 'RCOIR14' added.
New measure 'RCOIR15' added.
New measure 'THEPQR3' added.
New measure 'THEPQR4' added.
New measure 'USWR33' added.
New measure 'USWR34' added.
New measure 'USWR35' added.
New measure 'USWR36' added.
Measure 'AAAAI17' removed.
Measure 'AAAAI18' removed.
Measure 'AAAAI2' removed.
Measure 'AAAAI8' removed.
Measure 'AAD11' removed.
Measure 'AAN26' removed.
Measure 'AAN29' removed.
Measure 'AAN30' removed.
Measure 'AAO34' removed.
Measure 'AASM1' removed.
Measure 'AASM2' removed.
Measure 'AASM3' removed.
Measure 'ABG40' removed.
Measure 'ABG41' removed.
Measure 'ABG43' removed.
Measure 'ACEP19' removed.
Measure 'ACEP21' removed.
Measure 'ACEP54' removed.
Measure 'ACEP55' removed.
Measure 'ACQR12' removed.
Measure 'ACQR13' removed.
Measure 'ACQR16' removed.
Measure 'ACQR3' removed.
Measure 'ACRAD38' removed.
Measure 'ACRAD40' removed.
Measure 'ACRAD42' removed.
Measure 'AJRR8' removed.
Measure 'AQI56' removed.
Measure 'AQI68' removed.
Measure 'AQI69' removed.
Measure 'AQI73' removed.
Measure 'AQUA18' removed.
Measure 'CAP39' removed.
Measure 'CCOME7' removed.
Measure 'CCOME8' removed.
Measure 'CDR2' removed.
Measure 'CDR6' removed.
Measure 'CDR8' removed.
Measure 'GIQIC10' removed.
Measure 'GIQIC24' removed.
Measure 'GIQIC25' removed.
Measure 'HCPR16' removed.
Measure 'HCPR17' removed.
Measure 'IRIS41' removed.
Measure 'IRIS43' removed.
Measure 'IRIS44' removed.
Measure 'IRIS46' removed.
Measure 'IRIS48' removed.
Measure 'IRIS49' removed.
Measure 'IRIS51' removed.
Measure 'IRIS53' removed.
Measure 'IRIS55' removed.
Measure 'IRIS56' removed.
Measure 'IRIS57' removed.
Measure 'IRIS59' removed.
Measure 'IRIS6' removed.
Measure 'IRIS60' removed.
Measure 'IROMS11' removed.
Measure 'IROMS12' removed.
Measure 'IROMS13' removed.
Measure 'IROMS14' removed.
Measure 'IROMS16' removed.
Measure 'IROMS17' removed.
Measure 'IROMS18' removed.
Measure 'IROMS19' removed.
Measure 'IROMS20' removed.
Measure 'KEET01' removed.
Measure 'LMBR1' removed.
Measure 'LMBR10' removed.
Measure 'LMBR2' removed.
Measure 'LMBR3' removed.
Measure 'LMBR4' removed.
Measure 'LMBR5' removed.
Measure 'LMBR6' removed.
Measure 'LMBR7' removed.
Measure 'LMBR8' removed.
Measure 'LMBR9' removed.
Measure 'MBHR3' removed.
Measure 'MBHR5' removed.
Measure 'MEDNAX54' removed.
Measure 'MEDNAX56' removed.
Measure 'MSN16' removed.
Measure 'NHII1' removed.
Measure 'PP10' removed.
Measure 'PP12' removed.
Measure 'PP13' removed.
Measure 'QMM20' removed.
Measure 'RCOIR10' removed.
Measure 'RCOIR7' removed.
Measure 'REGCLR2' removed.
Measure 'REGCLR4' removed.
Measure 'REGCLR7' removed.
Measure 'SPINETRACK9' removed.
Measure 'USWR26' removed.
Measure 'USWR29' removed.
Measure 'USWR31' removed.
Measure 'AAD15' updated.
Measure 'AAD16' updated.
Measure 'AAN5' updated.
Measure 'ABG42' updated.
Measure 'ABG44' updated.
Measure 'ACEP30' updated.
Measure 'ACEP48' updated.
Measure 'ACEP50' updated.
Measure 'ACEP52' updated.
Measure 'ACEP59' updated.
Measure 'ACEP60' updated.
Measure 'ACEP63' updated.
Measure 'ACR12' updated.
Measure 'ACR14' updated.
Measure 'ACR15' updated.
Measure 'ACRAD15' updated.
Measure 'ACRAD16' updated.
Measure 'ACRAD17' updated.
Measure 'ACRAD18' updated.
Measure 'ACRAD19' updated.
Measure 'ACRAD25' updated.
Measure 'ACRAD34' updated.
Measure 'ACRAD36' updated.
Measure 'ACRAD37' updated.
Measure 'ACRAD41' updated.
Measure 'AJRR11' updated.
Measure 'AJRR9' updated.
Measure 'AQI18' updated.
Measure 'AQI48' updated.
Measure 'AQI49' updated.
Measure 'AQI65' updated.
Measure 'AQI67' updated.
Measure 'AQI71' updated.
Measure 'AQI72' updated.
Measure 'AQUA15' updated.
Measure 'CAP22' updated.
Measure 'CAP28' updated.
Measure 'CAP30' updated.
Measure 'CAP34' updated.
Measure 'CAP38' updated.
Measure 'ECPR46' updated.
Measure 'ECPR50' updated.
Measure 'ECPR52' updated.
Measure 'ECPR55' updated.
Measure 'ECPR58' updated.
Measure 'EPREOP30' updated.
Measure 'EPREOP31' updated.
Measure 'FOTO4' updated.
Measure 'FOTO5' updated.
Measure 'FOTO6' updated.
Measure 'FOTO7' updated.
Measure 'GIQIC23' updated.
Measure 'HCPR20' updated.
Measure 'HM7' updated.
Measure 'MBHR1' updated.
Measure 'MEDNAX55' updated.
Measure 'MSN13' updated.
Measure 'MSN15' updated.
Measure 'MUSIC4' updated.
Measure 'NHCR4' updated.
Measure 'PIMSH13' updated.
Measure 'PIMSH2' updated.
Measure 'PQRANES1' updated.
Measure 'QMM16' updated.
Measure 'QMM17' updated.
Measure 'QMM18' updated.
Measure 'QMM19' updated.
Measure 'QMM21' updated.
Measure 'QMM22' updated.
Measure 'QMM23' updated.
Measure 'QMM24' updated.
Measure 'QMM25' updated.
Measure 'RCOIR12' updated.
Measure 'RCOIR13' updated.
Measure 'RPAQIR14' updated.
Measure 'RPAQIR15' updated.
Measure 'THEPQR1' updated.
Measure 'THEPQR2' updated.
Measure 'USWR22' updated.
Measure 'USWR30' updated.
Measure 'USWR32' updated.

---
## What type of PR is this?
<!--
(mark 'x' all applicable)
-->
- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore
- [ ] ⏩ Revert

---

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
---

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Confluence
- [x] 🙅 no documentation needed

---
### [ ⌥ Optional ] Are there any post-deployment tasks we need to perform?
---
