### PR TITLE
QPPSE-1513: Updated measures data based on the conversion tool git issue #1400

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # These owners will be the default owners for everything in the repo.
-*       @branonbarrett @saquino0827 @KyleApfel @nickelstar @sivaksb @jpec07
+*       @saquino0827 @KyleApfel @sivaksb @jpec07

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # These owners will be the default owners for everything in the repo.
-*       @branonbarrett @saquino0827 @KyleApfel @nickelstar
+*       @branonbarrett @saquino0827 @KyleApfel @nickelstar @sivaksb @jpec07

--- a/measures/2023/measures-data.json
+++ b/measures/2023/measures-data.json
@@ -6081,6 +6081,7 @@
           "initialPopulationUuid": "5E28FE53-02D9-4A14-9721-74729FBF2F73",
           "denominatorUuid": "5BE6C6E2-64FA-49D5-8D2E-B977E2AB62A7",
           "numeratorUuid": "5577FDAE-5153-4B75-9B85-59CEF09CFC82",
+          "numeratorExclusionUuid": "C813AAC7-6D05-45D0-838D-467A837ECEC0",
           "denominatorExclusionUuid": "82D62AA5-015B-4256-AF2B-C43D52622EFB"
         },
         "name": "appropriateDiagnosis"
@@ -10101,7 +10102,43 @@
     "measureSpecification": {
       "registry": "http://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2023_Measure_438_MIPSCQM.pdf",
       "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ec/2023/cms347v6"
-    }
+    },
+    "eMeasureUuid": "2c928082-7fac-c041-017f-b8180fec068b",
+    "strata": [
+      {
+        "name": "clinicalASCVD",
+        "description": "All patients with an active diagnosis of clinical atherosclerotic cardiovascular disease (ASCVD) or ever had an ASCVD procedure",
+        "eMeasureUuids": {
+          "initialPopulationUuid": "B12E750E-E32A-4DAF-93A4-2902B9A7A006",
+          "denominatorUuid": "D7210073-99D6-4616-8511-B15FF2C0DC36",
+          "denominatorExclusionUuid": "5912E99B-963C-4F45-AD54-95D17670B56C",
+          "numeratorUuid": "0DEB457A-D340-42D2-BD19-8038E502F8AA",
+          "denominatorExceptionUuid": "2F1166B5-43F2-4E45-BC3D-2E399BBD41FF"
+        }
+      },
+      {
+        "name": ">=20Familial",
+        "description": "Patients aged >= 20 years who have ever had a low-density lipoprotein cholesterol (LDL-C) level >= 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial hypercholesterolemia",
+        "eMeasureUuids": {
+          "initialPopulationUuid": "0EC4214D-3153-4AAB-84E0-E9F18EB384B5",
+          "denominatorUuid": "4138280C-EE28-4B9D-A963-B9EB69CA2C8B",
+          "denominatorExclusionUuid": "EC8E047A-242B-4798-8A75-09BADEF9C278",
+          "numeratorUuid": "52221AD6-F254-4BD4-9FB5-07B0D9E14F32",
+          "denominatorExceptionUuid": "9F91E492-AEFF-45D3-8637-24DA32CC3363"
+        }
+      },
+      {
+        "name": "between40And75",
+        "description": "Patients aged 40-75 years with a diagnosis of diabetes",
+        "eMeasureUuids": {
+          "initialPopulationUuid": "B2FD2F54-F64B-446A-B8D6-69E87CF6B1DB",
+          "denominatorUuid": "733BFDF4-72B5-4474-95CA-AD14BDD0F739",
+          "denominatorExclusionUuid": "800774E8-D7E7-45CF-8EF6-8D6F8538F60F",
+          "numeratorUuid": "C7164728-E597-499F-80DD-F6E42981E34F",
+          "denominatorExceptionUuid": "64BF25A1-2691-494E-B51F-1B99F5FCE795"
+        }
+      }
+    ]
   },
   {
     "title": "Age Appropriate Screening Colonoscopy",
@@ -10897,6 +10934,7 @@
           "initialPopulationUuid": "4B34F4ED-1A49-4A8B-87E8-FABF70962F2B",
           "denominatorUuid": "A89FF41B-8F0B-486D-A640-945054FB9CA4",
           "numeratorUuid": "C86B7AF8-F152-478F-8CFC-ACCC0D4BA376",
+          "numeratorExclusionUuid": "D50C3A0F-57E4-4491-85AA-FA542D717E87",
           "denominatorExclusionUuid": "1865BCB7-B020-4329-A3B7-7AEA32E0AC81"
         }
       }

--- a/mvp/2023/mvp-enriched.json
+++ b/mvp/2023/mvp-enriched.json
@@ -2596,7 +2596,43 @@
         "measureSpecification": {
           "registry": "http://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2023_Measure_438_MIPSCQM.pdf",
           "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ec/2023/cms347v6"
-        }
+        },
+        "eMeasureUuid": "2c928082-7fac-c041-017f-b8180fec068b",
+        "strata": [
+          {
+            "name": "clinicalASCVD",
+            "description": "All patients with an active diagnosis of clinical atherosclerotic cardiovascular disease (ASCVD) or ever had an ASCVD procedure",
+            "eMeasureUuids": {
+              "initialPopulationUuid": "B12E750E-E32A-4DAF-93A4-2902B9A7A006",
+              "denominatorUuid": "D7210073-99D6-4616-8511-B15FF2C0DC36",
+              "denominatorExclusionUuid": "5912E99B-963C-4F45-AD54-95D17670B56C",
+              "numeratorUuid": "0DEB457A-D340-42D2-BD19-8038E502F8AA",
+              "denominatorExceptionUuid": "2F1166B5-43F2-4E45-BC3D-2E399BBD41FF"
+            }
+          },
+          {
+            "name": ">=20Familial",
+            "description": "Patients aged >= 20 years who have ever had a low-density lipoprotein cholesterol (LDL-C) level >= 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial hypercholesterolemia",
+            "eMeasureUuids": {
+              "initialPopulationUuid": "0EC4214D-3153-4AAB-84E0-E9F18EB384B5",
+              "denominatorUuid": "4138280C-EE28-4B9D-A963-B9EB69CA2C8B",
+              "denominatorExclusionUuid": "EC8E047A-242B-4798-8A75-09BADEF9C278",
+              "numeratorUuid": "52221AD6-F254-4BD4-9FB5-07B0D9E14F32",
+              "denominatorExceptionUuid": "9F91E492-AEFF-45D3-8637-24DA32CC3363"
+            }
+          },
+          {
+            "name": "between40And75",
+            "description": "Patients aged 40-75 years with a diagnosis of diabetes",
+            "eMeasureUuids": {
+              "initialPopulationUuid": "B2FD2F54-F64B-446A-B8D6-69E87CF6B1DB",
+              "denominatorUuid": "733BFDF4-72B5-4474-95CA-AD14BDD0F739",
+              "denominatorExclusionUuid": "800774E8-D7E7-45CF-8EF6-8D6F8538F60F",
+              "numeratorUuid": "C7164728-E597-499F-80DD-F6E42981E34F",
+              "denominatorExceptionUuid": "64BF25A1-2691-494E-B51F-1B99F5FCE795"
+            }
+          }
+        ]
       },
       {
         "title": "Ischemic Vascular Disease (IVD) All or None Outcome Measure (Optimal Control)",
@@ -4825,6 +4861,7 @@
               "initialPopulationUuid": "5E28FE53-02D9-4A14-9721-74729FBF2F73",
               "denominatorUuid": "5BE6C6E2-64FA-49D5-8D2E-B977E2AB62A7",
               "numeratorUuid": "5577FDAE-5153-4B75-9B85-59CEF09CFC82",
+              "numeratorExclusionUuid": "C813AAC7-6D05-45D0-838D-467A837ECEC0",
               "denominatorExclusionUuid": "82D62AA5-015B-4256-AF2B-C43D52622EFB"
             },
             "name": "appropriateDiagnosis"
@@ -7365,7 +7402,43 @@
         "measureSpecification": {
           "registry": "http://qpp.cms.gov/docs/QPP_quality_measure_specifications/CQM-Measures/2023_Measure_438_MIPSCQM.pdf",
           "electronicHealthRecord": "https://ecqi.healthit.gov/ecqm/ec/2023/cms347v6"
-        }
+        },
+        "eMeasureUuid": "2c928082-7fac-c041-017f-b8180fec068b",
+        "strata": [
+          {
+            "name": "clinicalASCVD",
+            "description": "All patients with an active diagnosis of clinical atherosclerotic cardiovascular disease (ASCVD) or ever had an ASCVD procedure",
+            "eMeasureUuids": {
+              "initialPopulationUuid": "B12E750E-E32A-4DAF-93A4-2902B9A7A006",
+              "denominatorUuid": "D7210073-99D6-4616-8511-B15FF2C0DC36",
+              "denominatorExclusionUuid": "5912E99B-963C-4F45-AD54-95D17670B56C",
+              "numeratorUuid": "0DEB457A-D340-42D2-BD19-8038E502F8AA",
+              "denominatorExceptionUuid": "2F1166B5-43F2-4E45-BC3D-2E399BBD41FF"
+            }
+          },
+          {
+            "name": ">=20Familial",
+            "description": "Patients aged >= 20 years who have ever had a low-density lipoprotein cholesterol (LDL-C) level >= 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial hypercholesterolemia",
+            "eMeasureUuids": {
+              "initialPopulationUuid": "0EC4214D-3153-4AAB-84E0-E9F18EB384B5",
+              "denominatorUuid": "4138280C-EE28-4B9D-A963-B9EB69CA2C8B",
+              "denominatorExclusionUuid": "EC8E047A-242B-4798-8A75-09BADEF9C278",
+              "numeratorUuid": "52221AD6-F254-4BD4-9FB5-07B0D9E14F32",
+              "denominatorExceptionUuid": "9F91E492-AEFF-45D3-8637-24DA32CC3363"
+            }
+          },
+          {
+            "name": "between40And75",
+            "description": "Patients aged 40-75 years with a diagnosis of diabetes",
+            "eMeasureUuids": {
+              "initialPopulationUuid": "B2FD2F54-F64B-446A-B8D6-69E87CF6B1DB",
+              "denominatorUuid": "733BFDF4-72B5-4474-95CA-AD14BDD0F739",
+              "denominatorExclusionUuid": "800774E8-D7E7-45CF-8EF6-8D6F8538F60F",
+              "numeratorUuid": "C7164728-E597-499F-80DD-F6E42981E34F",
+              "denominatorExceptionUuid": "64BF25A1-2691-494E-B51F-1B99F5FCE795"
+            }
+          }
+        ]
       },
       {
         "title": "Person-Centered Primary Care Measure Patient Reported Outcome Performance Measure (PCPCM PRO-PM)",
@@ -25128,6 +25201,7 @@
               "initialPopulationUuid": "5E28FE53-02D9-4A14-9721-74729FBF2F73",
               "denominatorUuid": "5BE6C6E2-64FA-49D5-8D2E-B977E2AB62A7",
               "numeratorUuid": "5577FDAE-5153-4B75-9B85-59CEF09CFC82",
+              "numeratorExclusionUuid": "C813AAC7-6D05-45D0-838D-467A837ECEC0",
               "denominatorExclusionUuid": "82D62AA5-015B-4256-AF2B-C43D52622EFB"
             },
             "name": "appropriateDiagnosis"

--- a/scripts/measures/2023/get-strata-uuids-from-ecqm-zip.js
+++ b/scripts/measures/2023/get-strata-uuids-from-ecqm-zip.js
@@ -112,7 +112,7 @@ Promise.all(
       const measure = doc.QualityMeasureDocument;
       const emeasureid = measure.subjectOf[0].measureAttribute[0].value[0].$.value;
       // These must all be manually added. No accurate way to parse their uuid's
-      const ignoredMeasureIds = ['145', '157', '347'];
+      const ignoredMeasureIds = ['145', '156', '157', '249', '347'];
       if (ignoredMeasureIds.includes(emeasureid)) {
         console.warn('WARNING: CMS' + emeasureid + ' has one numerator but multiple populations and needs to be added manually');
         return;

--- a/util/measures/2023/generated-ecqm-data.json
+++ b/util/measures/2023/generated-ecqm-data.json
@@ -449,49 +449,6 @@
     "metricType": "multiPerformanceRate"
   },
   {
-    "eMeasureId": "CMS156v11",
-    "eMeasureUuid": "2c928084-808a-9589-0180-d74bf7b7164d",
-    "strata": [
-      {
-        "description": "Rate 1: Patients with at least two orders of high-risk medications from the same drug class on different days.",
-        "eMeasureUuids": {
-          "initialPopulationUuid": "064940DC-3F04-4B31-88CA-367BE20AC510",
-          "denominatorUuid": "CD3CCAD3-3E90-4094-9987-9A9D2A5D574D",
-          "numeratorUuid": "E384D9B0-6AD6-45BC-B562-A57E46FC1E90",
-          "denominatorExclusionUuid": "CEC58D2D-4525-45B8-B320-FFB35B654DA8"
-        }
-      },
-      {
-        "description": "a. At least two orders of high-risk medications from the same drug class.",
-        "eMeasureUuids": {
-          "initialPopulationUuid": "5E28FE53-02D9-4A14-9721-74729FBF2F73",
-          "denominatorUuid": "5BE6C6E2-64FA-49D5-8D2E-B977E2AB62A7",
-          "numeratorUuid": "5577FDAE-5153-4B75-9B85-59CEF09CFC82",
-          "denominatorExclusionUuid": "82D62AA5-015B-4256-AF2B-C43D52622EFB"
-        }
-      },
-      {
-        "description": "b. At least two orders of high-risk medications from the same drug class with summed days supply greater than 90 days.",
-        "eMeasureUuids": {
-          "initialPopulationUuid": "2B4CFB1B-43D2-4ABA-AE55-CCF174208A3B",
-          "denominatorUuid": "725E725B-DF32-429A-BAEE-444AD4CE5FC7",
-          "numeratorUuid": "35C1118F-EBF8-470F-8B70-150CB04435AA",
-          "denominatorExclusionUuid": "AEA06864-DA4F-4ECD-93EC-BA6B94930337"
-        }
-      },
-      {
-        "description": "c. At least two orders of high-risk medications from the same drug class each exceeding average daily dose criteria."
-      },
-      {
-        "description": "Rate 2: Patients with at least two orders of high-risk medications from the same drug class (i.e., antipsychotics and benzodiazepines) on different days."
-      },
-      {
-        "description": "Total rate (the sum of the two previous numerators, deduplicated)."
-      }
-    ],
-    "metricType": "multiPerformanceRate"
-  },
-  {
     "eMeasureId": "CMS159v11",
     "eMeasureUuid": "2c928082-7fac-c041-017f-aee6377002a5",
     "strata": [
@@ -565,22 +522,6 @@
           "numeratorUuid": "CC44A071-CADC-414C-A55C-574E04A1E414",
           "denominatorExceptionUuid": "DF696C0F-8D01-4A4C-B00F-E1A2C59B9358",
           "denominatorExclusionUuid": "4EA871D1-4D5A-4347-9F69-B50C7E03381A"
-        }
-      }
-    ],
-    "metricType": "singlePerformanceRate"
-  },
-  {
-    "eMeasureId": "CMS249v5",
-    "eMeasureUuid": "2c928082-7ac4-569d-017a-ca2f0fa10205",
-    "strata": [
-      {
-        "description": "Female patients who received an order for at least one DXA scan in the measurement period",
-        "eMeasureUuids": {
-          "initialPopulationUuid": "4B34F4ED-1A49-4A8B-87E8-FABF70962F2B",
-          "denominatorUuid": "A89FF41B-8F0B-486D-A640-945054FB9CA4",
-          "numeratorUuid": "C86B7AF8-F152-478F-8CFC-ACCC0D4BA376",
-          "denominatorExclusionUuid": "1865BCB7-B020-4329-A3B7-7AEA32E0AC81"
         }
       }
     ],

--- a/util/measures/2023/manually-created-missing-measures.json
+++ b/util/measures/2023/manually-created-missing-measures.json
@@ -27,6 +27,44 @@
     "metricType": "singlePerformanceRate"
   },
   {
+    "eMeasureId": "CMS156v11",
+    "eMeasureUuid": "2c928084-808a-9589-0180-d74bf7b7164d",
+    "strata": [
+      {
+        "description": "Percentage of patients 65 years of age and older who were ordered at least two high-risk medications from the same drug class.",
+        "eMeasureUuids": {
+          "initialPopulationUuid": "064940DC-3F04-4B31-88CA-367BE20AC510",
+          "denominatorUuid": "CD3CCAD3-3E90-4094-9987-9A9D2A5D574D",
+          "numeratorUuid": "E384D9B0-6AD6-45BC-B562-A57E46FC1E90",
+          "denominatorExclusionUuid": "CEC58D2D-4525-45B8-B320-FFB35B654DA8"
+        },
+        "name": "overall"
+      },
+      {
+        "description": "Percentage of patients 65 years of age and older who were ordered at least two high-risk medications from the same drug class, except for appropriate diagnoses.",
+        "eMeasureUuids": {
+          "initialPopulationUuid": "5E28FE53-02D9-4A14-9721-74729FBF2F73",
+          "denominatorUuid": "5BE6C6E2-64FA-49D5-8D2E-B977E2AB62A7",
+          "numeratorUuid": "5577FDAE-5153-4B75-9B85-59CEF09CFC82",
+          "numeratorExclusionUuid": "C813AAC7-6D05-45D0-838D-467A837ECEC0",
+          "denominatorExclusionUuid": "82D62AA5-015B-4256-AF2B-C43D52622EFB"
+        },
+        "name": "appropriateDiagnosis"
+      },
+      {
+        "description": "Total rate (the sum of the two numerators divided by the denominator, deduplicating for patients in both numerators).",
+        "eMeasureUuids": {
+          "initialPopulationUuid": "2B4CFB1B-43D2-4ABA-AE55-CCF174208A3B",
+          "denominatorUuid": "725E725B-DF32-429A-BAEE-444AD4CE5FC7",
+          "numeratorUuid": "35C1118F-EBF8-470F-8B70-150CB04435AA",
+          "denominatorExclusionUuid": "AEA06864-DA4F-4ECD-93EC-BA6B94930337"
+        },
+        "name": "totalRate"
+      }
+    ],
+    "metricType": "multiPerformanceRate"
+  },
+  {
     "eMeasureId": "CMS157v11",
     "eMeasureUuid": "2c928084-7b7e-655a-017b-88e5bfb80591",
     "strata": [
@@ -52,12 +90,29 @@
     "metricType": "singlePerformanceRate"
   },
   {
-    "eMeasureId": "CMS347v5",
+    "eMeasureId": "CMS249v5",
+    "eMeasureUuid": "2c928082-7ac4-569d-017a-ca2f0fa10205",
+    "strata": [
+      {
+        "description": "Female patients who received an order for at least one DXA scan in the measurement period",
+        "eMeasureUuids": {
+          "initialPopulationUuid": "4B34F4ED-1A49-4A8B-87E8-FABF70962F2B",
+          "denominatorUuid": "A89FF41B-8F0B-486D-A640-945054FB9CA4",
+          "numeratorUuid": "C86B7AF8-F152-478F-8CFC-ACCC0D4BA376",
+          "numeratorExclusionUuid": "D50C3A0F-57E4-4491-85AA-FA542D717E87",
+          "denominatorExclusionUuid": "1865BCB7-B020-4329-A3B7-7AEA32E0AC81"
+        }
+      }
+    ],
+    "metricType": "singlePerformanceRate"
+  },
+  {
+    "eMeasureId": "CMS347v6",
     "eMeasureUuid": "2c928082-7fac-c041-017f-b8180fec068b",
     "strata": [
       {
         "name": "clinicalASCVD",
-        "description": "Adults aged >= 21 years who were previously diagnosed with or currently have an active diagnosis of clinical atherosclerotic cardiovascular disease (ASCVD)",
+        "description": "All patients with an active diagnosis of clinical atherosclerotic cardiovascular disease (ASCVD) or ever had an ASCVD procedure",
         "eMeasureUuids": {
           "initialPopulationUuid": "B12E750E-E32A-4DAF-93A4-2902B9A7A006",
           "denominatorUuid": "D7210073-99D6-4616-8511-B15FF2C0DC36",
@@ -67,8 +122,8 @@
         }
       },
       {
-        "name": ">21Familial",
-        "description": "Adults aged >= 21 years who have ever had a fasting or direct low-density lipoprotein cholesterol (LDL-C) level >= 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial or pure hypercholesterolemia",
+        "name": ">=20Familial",
+        "description": "Patients aged >= 20 years who have ever had a low-density lipoprotein cholesterol (LDL-C) level >= 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial hypercholesterolemia",
         "eMeasureUuids": {
           "initialPopulationUuid": "0EC4214D-3153-4AAB-84E0-E9F18EB384B5",
           "denominatorUuid": "4138280C-EE28-4B9D-A963-B9EB69CA2C8B",
@@ -79,7 +134,7 @@
       },
       {
         "name": "between40And75",
-        "description": "Adults aged 40-75 years with a diagnosis of diabetes with a fasting or direct LDL-C level of 70-189 mg/dL",
+        "description": "Patients aged 40-75 years with a diagnosis of diabetes",
         "eMeasureUuids": {
           "initialPopulationUuid": "B2FD2F54-F64B-446A-B8D6-69E87CF6B1DB",
           "denominatorUuid": "733BFDF4-72B5-4474-95CA-AD14BDD0F739",


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs when possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation.
-->

[![ICF](https://th.bing.com/th/id/OIP.3z-X0lRS3oSl7MwvlsX72AAAAA?pid=ImgDet&rs=1)](https://www.icf.com/)

---
## Related Tickets & Documents
<!--
Mandatory if the ticket exists. Otherwise, the description section **must** contain the details.
-->
https://jira.cms.gov/browse/QPPSE-1513
https://github.com/CMSgov/qpp-conversion-tool/issues/1400

---

## Description
Added strata for measure `CMS347v6` and missing field `numeratorExclusionUuid` for `CMS156v11` and `CMS249v5`

---
## What type of PR is this?
<!--
(mark 'x' all applicable)
-->
- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore
- [ ] ⏩ Revert

---

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
---

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Confluence
- [x] 🙅 no documentation needed
