### PR TITLE
QPPA-0000: fix draft-release action

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -15,10 +15,10 @@ jobs:
 
       - name: Detect and tag new version
         id: package-version
-        uses: salsify/action-detect-and-tag-new-version@68bbe8670f415d304e02942186441939c4692aa6 #v1.0.3
+        uses: salsify/action-detect-and-tag-new-version@v2
 
       - name: Draft release notes
-        uses: release-drafter/release-drafter@06d4616a80cd7c09ea3cf12214165ad6c1859e67 #v5.11
+        uses: release-drafter/release-drafter@v5
         with:
           config-name: release-draft.yml
           version: v${{ steps.package-version.outputs.current-version }}


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs when possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation.
-->

## Related Tickets & Documents
<!--
Mandatory if the ticket exists. Otherwise, the description section **must** contain the details.
-->
https://jira.cms.gov/browse/QPPA-0000

---

## Description
The Draft-release Action is throwing warnings that a package uses node v12 which will soon be removed. This PR updates the packages to use their latest versions

---
## What type of PR is this?
<!--
(mark 'x' all applicable)
-->
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore
- [ ] ⏩ Revert

---

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
---

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Confluence
- [x] 🙅 no documentation needed

---
### [ ⌥ Optional ] Are there any post-deployment tasks we need to perform?
---
