### PR TITLE
QPPA-8708: Remove PI_EP_2_EX_3 from PY2024

### DIFF
--- a/measures/2024/measures-data.json
+++ b/measures/2024/measures-data.json
@@ -2097,8 +2097,7 @@
     "measureSets": [],
     "exclusion": [
       "PI_EP_2_EX_1",
-      "PI_EP_2_EX_2",
-      "PI_EP_2_EX_3"
+      "PI_EP_2_EX_2"
     ],
     "allowedPrograms": [
       "mips",

--- a/mvp/2024/mvp-enriched.json
+++ b/mvp/2024/mvp-enriched.json
@@ -1088,8 +1088,7 @@
         "measureSets": [],
         "exclusion": [
           "PI_EP_2_EX_1",
-          "PI_EP_2_EX_2",
-          "PI_EP_2_EX_3"
+          "PI_EP_2_EX_2"
         ],
         "allowedPrograms": [
           "mips",
@@ -3596,8 +3595,7 @@
         "measureSets": [],
         "exclusion": [
           "PI_EP_2_EX_1",
-          "PI_EP_2_EX_2",
-          "PI_EP_2_EX_3"
+          "PI_EP_2_EX_2"
         ],
         "allowedPrograms": [
           "mips",
@@ -6574,8 +6572,7 @@
         "measureSets": [],
         "exclusion": [
           "PI_EP_2_EX_1",
-          "PI_EP_2_EX_2",
-          "PI_EP_2_EX_3"
+          "PI_EP_2_EX_2"
         ],
         "allowedPrograms": [
           "mips",
@@ -9053,8 +9050,7 @@
         "measureSets": [],
         "exclusion": [
           "PI_EP_2_EX_1",
-          "PI_EP_2_EX_2",
-          "PI_EP_2_EX_3"
+          "PI_EP_2_EX_2"
         ],
         "allowedPrograms": [
           "mips",
@@ -11366,8 +11362,7 @@
         "measureSets": [],
         "exclusion": [
           "PI_EP_2_EX_1",
-          "PI_EP_2_EX_2",
-          "PI_EP_2_EX_3"
+          "PI_EP_2_EX_2"
         ],
         "allowedPrograms": [
           "mips",
@@ -13774,8 +13769,7 @@
         "measureSets": [],
         "exclusion": [
           "PI_EP_2_EX_1",
-          "PI_EP_2_EX_2",
-          "PI_EP_2_EX_3"
+          "PI_EP_2_EX_2"
         ],
         "allowedPrograms": [
           "mips",
@@ -16657,8 +16651,7 @@
         "measureSets": [],
         "exclusion": [
           "PI_EP_2_EX_1",
-          "PI_EP_2_EX_2",
-          "PI_EP_2_EX_3"
+          "PI_EP_2_EX_2"
         ],
         "allowedPrograms": [
           "mips",
@@ -19342,8 +19335,7 @@
         "measureSets": [],
         "exclusion": [
           "PI_EP_2_EX_1",
-          "PI_EP_2_EX_2",
-          "PI_EP_2_EX_3"
+          "PI_EP_2_EX_2"
         ],
         "allowedPrograms": [
           "mips",
@@ -21928,8 +21920,7 @@
         "measureSets": [],
         "exclusion": [
           "PI_EP_2_EX_1",
-          "PI_EP_2_EX_2",
-          "PI_EP_2_EX_3"
+          "PI_EP_2_EX_2"
         ],
         "allowedPrograms": [
           "mips",
@@ -24634,8 +24625,7 @@
         "measureSets": [],
         "exclusion": [
           "PI_EP_2_EX_1",
-          "PI_EP_2_EX_2",
-          "PI_EP_2_EX_3"
+          "PI_EP_2_EX_2"
         ],
         "allowedPrograms": [
           "mips",
@@ -27561,8 +27551,7 @@
         "measureSets": [],
         "exclusion": [
           "PI_EP_2_EX_1",
-          "PI_EP_2_EX_2",
-          "PI_EP_2_EX_3"
+          "PI_EP_2_EX_2"
         ],
         "allowedPrograms": [
           "mips",
@@ -30550,8 +30539,7 @@
         "measureSets": [],
         "exclusion": [
           "PI_EP_2_EX_1",
-          "PI_EP_2_EX_2",
-          "PI_EP_2_EX_3"
+          "PI_EP_2_EX_2"
         ],
         "allowedPrograms": [
           "mips",
@@ -33076,8 +33064,7 @@
         "measureSets": [],
         "exclusion": [
           "PI_EP_2_EX_1",
-          "PI_EP_2_EX_2",
-          "PI_EP_2_EX_3"
+          "PI_EP_2_EX_2"
         ],
         "allowedPrograms": [
           "mips",
@@ -35810,8 +35797,7 @@
         "measureSets": [],
         "exclusion": [
           "PI_EP_2_EX_1",
-          "PI_EP_2_EX_2",
-          "PI_EP_2_EX_3"
+          "PI_EP_2_EX_2"
         ],
         "allowedPrograms": [
           "mips",
@@ -38615,8 +38601,7 @@
         "measureSets": [],
         "exclusion": [
           "PI_EP_2_EX_1",
-          "PI_EP_2_EX_2",
-          "PI_EP_2_EX_3"
+          "PI_EP_2_EX_2"
         ],
         "allowedPrograms": [
           "mips",
@@ -41144,8 +41129,7 @@
         "measureSets": [],
         "exclusion": [
           "PI_EP_2_EX_1",
-          "PI_EP_2_EX_2",
-          "PI_EP_2_EX_3"
+          "PI_EP_2_EX_2"
         ],
         "allowedPrograms": [
           "mips",


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs when possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation.
-->

## Related Tickets & Documents
<!--
Mandatory if the ticket exists. Otherwise, the description section **must** contain the details.
-->
https://jira.cms.gov/browse/QPPA-8708

---

## Description
See ticket description.

---
## What type of PR is this?
<!--
(mark 'x' all applicable)
-->
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore
- [ ] ⏩ Revert

---

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
---

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Confluence
- [x] 🙅 no documentation needed

---
### [ ⌥ Optional ] Are there any post-deployment tasks we need to perform?
---
