### PR TITLE
QPPA-9692: supress measure 488 & 389

### DIFF
--- a/measures/2024/measures-data.json
+++ b/measures/2024/measures-data.json
@@ -26912,9 +26912,11 @@
     "isRegistryMeasure": false,
     "isRiskAdjusted": false,
     "icdImpacted": [],
-    "isClinicalGuidelineChanged": false,
+    "isClinicalGuidelineChanged": true,
     "isIcdImpacted": false,
-    "clinicalGuidelineChanged": [],
+    "clinicalGuidelineChanged": [
+      "registry"
+    ],
     "metricType": "singlePerformanceRate",
     "companionMeasureId": [],
     "allowedPrograms": [
@@ -38992,9 +38994,11 @@
     "isRegistryMeasure": false,
     "isRiskAdjusted": false,
     "icdImpacted": [],
-    "isClinicalGuidelineChanged": false,
+    "isClinicalGuidelineChanged": true,
     "isIcdImpacted": false,
-    "clinicalGuidelineChanged": [],
+    "clinicalGuidelineChanged": [
+      "electronicHealthRecord"
+    ],
     "metricType": "singlePerformanceRate",
     "companionMeasureId": [],
     "allowedPrograms": [

--- a/mvp/2024/mvp-enriched.json
+++ b/mvp/2024/mvp-enriched.json
@@ -31592,9 +31592,11 @@
         "isRegistryMeasure": false,
         "isRiskAdjusted": false,
         "icdImpacted": [],
-        "isClinicalGuidelineChanged": false,
+        "isClinicalGuidelineChanged": true,
         "isIcdImpacted": false,
-        "clinicalGuidelineChanged": [],
+        "clinicalGuidelineChanged": [
+          "electronicHealthRecord"
+        ],
         "metricType": "singlePerformanceRate",
         "companionMeasureId": [],
         "allowedPrograms": [

--- a/scripts/measures/2024/update-measures.ts
+++ b/scripts/measures/2024/update-measures.ts
@@ -151,7 +151,7 @@ export function ingestChangeFile(
 
         //ingest changed measures
         for (let i = 0; i < acceptedChangeStack.length; i++) {
-            Lib.updateMeasure(acceptedChangeStack[i], measuresJson);
+            Lib.updateMeasure(acceptedChangeStack[i], measuresJson, performanceYear);
         }
 
         if (testMode === 'false') {

--- a/scripts/measures/2025/update-measures.ts
+++ b/scripts/measures/2025/update-measures.ts
@@ -151,7 +151,7 @@ export function ingestChangeFile(
 
         //ingest changed measures
         for (let i = 0; i < acceptedChangeStack.length; i++) {
-            Lib.updateMeasure(acceptedChangeStack[i], measuresJson);
+            Lib.updateMeasure(acceptedChangeStack[i], measuresJson, performanceYear);
         }
 
         if (testMode === 'false') {

--- a/scripts/measures/lib/measures-lib.spec.ts
+++ b/scripts/measures/lib/measures-lib.spec.ts
@@ -220,6 +220,19 @@ describe('#update-measures-util', () => {
             }));
         });
 
+        it('should not add isSevenPointCapRemoved when performanceYear is 2024 or less', () => {
+            const change: MeasuresChange = {
+                measureId: '001',
+                category: 'quality',
+                sevenPointCapRemoved: ['registry'],
+            };
+
+            MeasuresLib.updateMeasure(change, volatileMeasures, '2024');
+
+            const updatedMeasure = _.find(volatileMeasures, { measureId: '001' });
+            expect(updatedMeasure.isSevenPointCapRemoved).toBeUndefined();
+        });
+
         it('should update isSevenPointCapRemoved to true when sevenPointCapRemoved has values', () => {
             const change: MeasuresChange = {
                 measureId: '001',
@@ -227,7 +240,7 @@ describe('#update-measures-util', () => {
                 sevenPointCapRemoved: ['registry'],
             };
 
-            MeasuresLib.updateMeasure(change, volatileMeasures);
+            MeasuresLib.updateMeasure(change, volatileMeasures, '2025');
 
             const updatedMeasure = _.find(volatileMeasures, { measureId: '001' });
             expect(updatedMeasure.isSevenPointCapRemoved).toBe(true);
@@ -241,7 +254,7 @@ describe('#update-measures-util', () => {
                 sevenPointCapRemoved: [],
             };
 
-            MeasuresLib.updateMeasure(change, volatileMeasures);
+            MeasuresLib.updateMeasure(change, volatileMeasures, '2025');
 
             const updatedMeasure = _.find(volatileMeasures, { measureId: '001' });
             expect(updatedMeasure.isSevenPointCapRemoved).toBe(false);

--- a/scripts/measures/lib/measures-lib.ts
+++ b/scripts/measures/lib/measures-lib.ts
@@ -74,7 +74,7 @@ export function deleteMeasure(measureId: string, category: string, measuresJson:
  * Updates the specified measure.
  * Will throw a warning if any changed exclusions or substitutes do not exist in the measures-data.json.
  */
-export function updateMeasure(change: MeasuresChange, measuresJson: any) {
+export function updateMeasure(change: MeasuresChange, measuresJson: any, performanceYear?: string) {
     for (let i = 0; i < measuresJson.length; i++) {
         if (measuresJson[i].measureId == change.measureId) {
             // check if new exclusions and substitutes exist.
@@ -96,7 +96,7 @@ export function updateMeasure(change: MeasuresChange, measuresJson: any) {
             if (change.category === 'quality') {
                 measuresJson[i] = {
                     ...measuresJson[i],
-                    ...updateBenchmarksMetaData(change),
+                    ...updateBenchmarksMetaData(change, performanceYear),
                 }
             }
             orderFields(measuresJson[i]);
@@ -291,17 +291,23 @@ function populatePreProdArray(change: MeasuresChange, measuresJson: any): string
  * Updates the fields indicating whether ICD, Clinical Guidelines, or the Seven Point Cap removal are impacted
  * based on the presence and length of respective arrays in the measure change data.
  */
-function updateBenchmarksMetaData(change: MeasuresChange): {
+export function updateBenchmarksMetaData(
+    change: MeasuresChange,
+    performanceYear?: string
+): {
     isIcdImpacted: boolean,
     isClinicalGuidelineChanged: boolean,
-    isSevenPointCapRemoved: boolean,
+    isSevenPointCapRemoved?: boolean,
 } {
     return {
-        isIcdImpacted: change.icdImpacted ? !!change.icdImpacted.length : false,
-        isClinicalGuidelineChanged: change.clinicalGuidelineChanged ? !!change.clinicalGuidelineChanged.length : false,
-        isSevenPointCapRemoved: Array.isArray(change.sevenPointCapRemoved) && change.sevenPointCapRemoved.length > 0
+        isIcdImpacted: !!(change.icdImpacted && change.icdImpacted.length),
+        isClinicalGuidelineChanged: !!(change.clinicalGuidelineChanged && change.clinicalGuidelineChanged.length),
+        ...(performanceYear && parseInt(performanceYear, 10) > 2024 && {
+            isSevenPointCapRemoved: Array.isArray(change.sevenPointCapRemoved) && change.sevenPointCapRemoved.length > 0,
+        }),
     };
 }
+
 
 /**
  * Returns the last measure of a specified category in the measures json.

--- a/updates/measures/2024/Quality_2024_Suppression_488_389_CR_03182025.csv
+++ b/updates/measures/2024/Quality_2024_Suppression_488_389_CR_03182025.csv
@@ -1,0 +1,3 @@
+﻿Category ,Measure Title,CMS eCQM ID,eCQM NQF,NQF,*** Quality Number (#) / QCDR #,Primary Measure Steward,Allowed QCDR Vendor ID,Measure Description,*** Measure Type  ,High Priority,First Performance Year,Year Removed,*** Collection Type(s) for Submission,Specialty Measure Sets,*** Inverse,*** Metric Type,*** Calculation Type,Collection Type(s) where Historic Benchmark Removed,Collection Type(s) where Suppressed,Collection Type(s) where Truncated,Collection Type(s) where Historic Benchmark Removed ** Special Rules **,Is Risk Adjusted 
+Quality,,,,,488,,,,,,,,,,,,,,eCQM,,eCQM,
+Quality,,,,,389,,,,,,,,,,,,,,MIPS CQM,,,

--- a/updates/measures/2024/changes.meta.json
+++ b/updates/measures/2024/changes.meta.json
@@ -21,5 +21,6 @@
   "QCDR_2024_ABFM13_AnalyticUpdate_CR_10042024.csv",
   "Quality_PY24_CR_10182024.csv",
   "Quality_PY24_CR_20250103.csv",
-  "QCDR_PY24_CR_20250314.csv"
+  "QCDR_PY24_CR_20250314.csv",
+  "Quality_2024_Suppression_488_389_CR_03182025.csv"
 ]


### PR DESCRIPTION
## Related Tickets & Documents
<!--
Mandatory if the ticket exists. Otherwise, the description section **must** contain the details.
-->
https://jira.cms.gov/browse/QPPA-9692

---

## Description
PY24 - Suppress measure 488
collectionType = eCQM
isClinicalGuidelineChanged = true
clinicalGuidelineChanged = electronicHealthRecord

PY24 - Suppress measure 389
collectionType = MIPS CQM
isClinicalGuidelineChanged = true
clinicalGuidelineChanged = registry

---
## What type of PR is this?
<!--
(mark 'x' all applicable)
-->
- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore
- [ ] ⏩ Revert

---

## Added tests?
- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
---

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Confluence
- [x] 🙅 no documentation needed