### PR TITLE
QPPC-7309: Adding Cost National Averages Data for PY 2024

### DIFF
--- a/benchmarks/2024/cost-national-averages.json
+++ b/benchmarks/2024/cost-national-averages.json
@@ -1,0 +1,205 @@
+[
+  {
+    "measureId": "COST_ACOPD_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 4926.54,
+    "individualNationalAverage": 4926.54
+  },
+  {
+    "measureId": "COST_AKID_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 42167.68,
+    "individualNationalAverage": 48858.0
+  },
+  {
+    "measureId": "COST_CCLI_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 23353.41,
+    "individualNationalAverage": 23608.53
+  },
+  {
+    "measureId": "COST_COPDE_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 15888.58,
+    "individualNationalAverage": 17306.47
+  },
+  {
+    "measureId": "COST_CRR_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 27206.71,
+    "individualNationalAverage": 27208.8
+  },
+  {
+    "measureId": "COST_DEP_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 1772.44,
+    "individualNationalAverage": 1772.44
+  },
+  {
+    "measureId": "COST_D_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 7361.91,
+    "individualNationalAverage": 7361.91
+  },
+  {
+    "measureId": "COST_EDV_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 5968.7,
+    "individualNationalAverage": 6065.64
+  },
+  {
+    "measureId": "COST_EOPCI_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 11776.0,
+    "individualNationalAverage": 11778.88
+  },
+  {
+    "measureId": "COST_FIHR_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 5665.9,
+    "individualNationalAverage": 5709.21
+  },
+  {
+    "measureId": "COST_HAC_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 6646.57,
+    "individualNationalAverage": 6645.83
+  },
+  {
+    "measureId": "COST_HF_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 14168.1,
+    "individualNationalAverage": 14168.1
+  },
+  {
+    "measureId": "COST_IHCI_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 27918.13,
+    "individualNationalAverage": 32192.77
+  },
+  {
+    "measureId": "COST_IOL_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 3291.11,
+    "individualNationalAverage": 3291.1
+  },
+  {
+    "measureId": "COST_KA_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 16747.42,
+    "individualNationalAverage": 16686.44
+  },
+  {
+    "measureId": "COST_LBP_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 1847.18,
+    "individualNationalAverage": 1847.18
+  },
+  {
+    "measureId": "COST_LGH_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 13315.55,
+    "individualNationalAverage": 14626.84
+  },
+  {
+    "measureId": "COST_LPMSM_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 6835.08,
+    "individualNationalAverage": 6877.41
+  },
+  {
+    "measureId": "COST_LSFDD_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 40558.69,
+    "individualNationalAverage": 40756.76
+  },
+  {
+    "measureId": "COST_MR_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 1618.84,
+    "individualNationalAverage": 1646.75
+  },
+  {
+    "measureId": "COST_NECABG_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 48508.92,
+    "individualNationalAverage": 48400.14
+  },
+  {
+    "measureId": "COST_PHA_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 17580.65,
+    "individualNationalAverage": 17476.28
+  },
+  {
+    "measureId": "COST_PRC_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 20937.13,
+    "individualNationalAverage": 22973.6
+  },
+  {
+    "measureId": "COST_RUSST_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 6893.31,
+    "individualNationalAverage": 6903.69
+  },
+  {
+    "measureId": "COST_SSC_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 1173.31,
+    "individualNationalAverage": 1173.32
+  },
+  {
+    "measureId": "COST_STEMI_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 22229.75,
+    "individualNationalAverage": 23633.89
+  },
+  {
+    "measureId": "COST_S_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 23260.32,
+    "individualNationalAverage": 26072.63
+  },
+  {
+    "measureId": "MSPB_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 23605.38,
+    "individualNationalAverage": 23605.38
+  },
+  {
+    "measureId": "TPCC_1",
+    "performanceYear": 2024,
+    "benchmarkYear": 2024,
+    "groupNationalAverage": 1540.41,
+    "individualNationalAverage": 1544.89
+  }
+]


### PR DESCRIPTION
## Related Tickets & Documents
https://jira.cms.gov/browse/QPPC-7309

---

## Description
Adding in the PY 2024 `cost-national-averages.json` file.

---
## What type of PR is this?
<!--
(mark 'x' all applicable)
-->
- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore
- [ ] ⏩ Revert

---

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
---

## Added to documentation?
- [ ] 📜 README.md
- [x] 📓 Confluence - https://confluence.cms.gov/display/QPPCLAIM/PY24+-+EDA+-+Cost+National+Average
- [ ] 🙅 no documentation needed

## Added required labels?

At least one of each type of PR label should be added for checks to pass.

- `notes:*`
- `version:*`

Patch versions are code-only changes, with no data updates.
Minor versions are data changes, such as updates to the measures-data.json files.
Major versions are annual and tied to a PY's data becoming avaliable, determined by QPPA's PO.

<!--
Eg. If this PR contains a regular measures update, add the following labels:
- notes:measure-update
- version:minor
-->


---
### [ ⌥ Optional ] Are there any post-deployment tasks we need to perform?
---
