### PR TITLE
QPPA-10625: Remove strata from SPR measures during initialization

### DIFF
--- a/measures/2026/measures-data.json
+++ b/measures/2026/measures-data.json
@@ -4321,11 +4321,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients whose most recent glycemic status assessment (HbA1c or GMI) (performed during the measurement period) is >9.0% or is missing, or was not performed during the measurement period"
-      }
     ]
   },
   {
@@ -4419,11 +4414,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients who were prescribed or already taking ACE inhibitor or ARB or ARNI therapy during the measurement period"
-      }
     ]
   },
   {
@@ -4515,14 +4505,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients with left ventricular systolic dysfunction (LVEF <=40%)"
-      },
-      {
-        "description": "Patients with a prior (within the past 3 years) myocardial infarction"
-      }
     ]
   },
   {
@@ -4570,11 +4552,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients who were prescribed or already taking beta-blocker therapy during the measurement period"
-      }
     ]
   },
   {
@@ -4672,11 +4649,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients who have an optic nerve head evaluation during one or more visits within 12 months"
-      }
     ]
   },
   {
@@ -4720,11 +4692,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients with documentation, at least once within the measurement period, of the findings of the dilated macular or fundus exam via communication to the physician who manages the patient's diabetic care"
-      }
     ]
   },
   {
@@ -5091,11 +5058,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "URI episodes without a prescription for antibiotic medication on or three days after the outpatient visit, telephone visit, virtual encounter, or emergency department visit for an upper respiratory infection"
-      }
     ]
   },
   {
@@ -5143,11 +5105,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "A group A streptococcus test in the seven-day period from three days prior to the episode date through three days after the episode date"
-      }
     ]
   },
   {
@@ -5193,11 +5150,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients who did not have a bone scan performed after diagnosis of prostate cancer and before the end of the measurement period"
-      }
     ]
   },
   {
@@ -5242,11 +5194,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Women with one or more mammograms any time on or between October 1 two years prior to the measurement period and the end of the measurement period"
-      }
     ]
   },
   {
@@ -5328,11 +5275,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients with one or more screenings for colorectal cancer. Appropriate screenings are defined by any one of the following criteria: \n- Fecal occult blood test (FOBT) during the measurement period\n- Stool DNA (sDNA) with FIT test during the measurement period or the two years prior to the measurement period\n- Flexible sigmoidoscopy during the measurement period or the four years prior to the measurement period\n- CT Colonography during the measurement period or the four years prior to the measurement period\n- Colonoscopy during the measurement period or the nine years prior to the measurement period"
-      }
     ]
   },
   {
@@ -5427,11 +5369,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients with an eye screening for diabetic retinal disease. This includes diabetics who had one of the following:\n- Diabetic with a diagnosis of retinopathy in any part of the measurement period and a retinal or dilated eye exam by an eye care professional in the measurement period\n- Diabetic with no diagnosis of retinopathy in any part of the measurement period and a retinal or dilated eye exam by an eye care professional in the measurement period or the year prior to the measurement period"
-      }
     ]
   },
   {
@@ -5609,11 +5546,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients with a documented BMI during the encounter or during the measurement period, AND when the BMI is outside of normal parameters, a follow-up plan is documented during the encounter or during the measurement period"
-      }
     ]
   },
   {
@@ -5698,11 +5630,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Eligible clinician attests to documenting, updating, or reviewing the patient's current medications using all immediate resources available on the date of the encounter"
-      }
     ]
   },
   {
@@ -5773,11 +5700,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients screened for depression on the date of the encounter or up to 14 days prior to the date of the encounter using an age-appropriate standardized tool AND if positive, a follow-up plan is documented on the date of or up to two days after the date of the qualifying encounter"
-      }
     ]
   },
   {
@@ -5923,14 +5845,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Visits for patients with a diagnosis of cancer who are currently receiving chemotherapy"
-      },
-      {
-        "description": "Visits for patients with a diagnosis of cancer who are currently receiving radiation therapy"
-      }
     ]
   },
   {
@@ -6603,11 +6517,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Cataract surgeries with best-corrected visual acuity of 20/40 or better (distance or near) achieved in the operative eye within 90 days following cataract surgery"
-      }
     ]
   },
   {
@@ -6652,11 +6561,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients who were tested for each of the following at least once during the measurement period: chlamydia, gonorrhea, and syphilis"
-      }
     ]
   },
   {
@@ -7076,11 +6980,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients whose most recent blood pressure is adequately controlled (systolic blood pressure < 140 mmHg and diastolic blood pressure < 90 mmHg) during the measurement period"
-      }
     ]
   },
   {
@@ -7301,11 +7200,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "DTaP\nChildren with any of the following on or before the child’s second birthday meet criteria:\n- At least four DTaP vaccinations, with different dates of service. Do not count a vaccination administered prior to 42 days after birth.\n- Anaphylaxis due to the diphtheria, tetanus or pertussis vaccine.\n- Encephalitis due to the diphtheria, tetanus or pertussis vaccine.\n\nIPV\nChildren with either of the following on or before the child’s second birthday meet criteria:\n- At least three IPV vaccinations, with different dates of service. Do not count a vaccination administered prior to 42 days after birth.\n- Anaphylaxis due to the IPV vaccine.\n\nMMR\nChildren with any of the following meet criteria:\n- At least one MMR vaccination on or between the child’s first and second birthdays.\n- Anaphylaxis due to the MMR vaccine on or before the child’s second birthday.\n- All of the following anytime on or before the child’s second birthday (on the same or different date of service):\n       - History of measles.\n       - History of mumps.\n       - History of rubella.\n\nHiB\nChildren with either of the following meet criteria on or before the child’s second birthday:\n- At least three HiB vaccinations, with different dates of service. Do not count a vaccination administered prior to 42 days after birth.\n- Anaphylaxis due to the HiB vaccine.\n\nHepB\nChildren with any of the following on or before the child’s second birthday meet criteria:\n- At least three hepatitis B vaccinations, with different dates of service.\n       - One of the three vaccinations can be a newborn hepatitis B vaccination during the eight-day period that begins on the date of birth and ends seven days after the date of birth. For example, if the member’s date of birth is December 1, the newborn hepatitis B vaccination must be on or between December 1 and December 8.\n- Anaphylaxis due to the hepatitis B vaccine.\n- History of hepatitis B illness.\n\nVZV\nChildren with any of the following meet criteria:\n- At least one VZV vaccination, with a date of service on or between the child’s first and second birthdays.\n- Anaphylaxis due to the VZV vaccine on or before the child’s second birthday.\n- History of varicella zoster (e.g., chicken pox) illness on or before the child’s second birthday.\n\nPCV\nChildren with either of the following on or before the child’s second birthday meet criteria:\n- At least four pneumococcal conjugate vaccinations, with different dates of service on or before the child’s second birthday. Do not count a vaccination administered prior to 42 days after birth.\n- Anaphylaxis due to the pneumococcal vaccine.\n\nHepA\nChildren with any of the following meet criteria:\n- At least one hepatitis A vaccination, with a date of service on or between the child’s first and second birthdays.\n- Anaphylaxis due to the hepatitis A vaccine on or before the child’s second birthday.\n- History of hepatitis A illness on or before the child’s second birthday.\n\nRV\nChildren with any of the following meet criteria:\n- At least two doses of the two-dose rotavirus vaccine on different dates of service on or before the child’s second birthday. Do not count a vaccination administered prior to 42 days after birth.\n- At least three doses of the three-dose rotavirus vaccine on different dates of service on or before the child’s second birthday. Do not count a vaccination administered prior to 42 days after birth.\n- At least one dose of the two-dose rotavirus vaccine and at least two doses of the three-dose rotavirus vaccine, all on different dates of service, on or before the child’s second birthday. Do not count a vaccination administered prior to 42 days after birth.\n- Anaphylaxis due to the rotavirus vaccine on or before the child’s second birthday.\n\nFlu\nChildren with either of the following on or before their second birthday meet criteria:\n- At least two influenza vaccinations, with different dates of service on or before the child’s second birthday. Do not count a vaccination administered prior to 6 months (180 days) after birth.\n       - One of the two vaccinations can be a Live Attenuated Influenza Vaccine (LAIV) vaccination administered on the child’s second birthday. Do not count a LAIV vaccination administered before the child’s second birthday.\n- Anaphylaxis due to the influenza vaccine."
-      }
     ]
   },
   {
@@ -7782,11 +7676,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients for whom an assessment of cognition is performed and the results reviewed at least once within a 12-month period"
-      }
     ]
   },
   {
@@ -8241,11 +8130,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Women with one or more screenings for cervical cancer. Appropriate screenings are defined by any one of the following criteria:\n- Cervical cytology performed during the measurement period or the two years prior to the measurement period for women 24-64 years of age by the end of the measurement period.\n\n- Cervical human papillomavirus (HPV) testing performed during the measurement period or the four years prior to the measurement period for women who are 30 years or older at the time of the test."
-      }
     ]
   },
   {
@@ -8290,11 +8174,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Women with at least one chlamydia test during the measurement period"
-      }
     ]
   },
   {
@@ -8358,11 +8237,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patient visits where patients were screened for high blood pressure AND have a recommended follow-up plan documented, as indicated, if the blood pressure is elevated or hypertensive"
-      }
     ]
   },
   {
@@ -8413,11 +8287,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients who were screened for future fall risk at least once within the measurement period"
-      }
     ]
   },
   {
@@ -8825,11 +8694,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients with a last HIV viral load test result of less than 200 copies/mL during the measurement period"
-      }
     ]
   },
   {
@@ -8874,11 +8738,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Number of patients who had at least one eligible encounter and one HIV viral load test at least 90 days apart during the measurement period, or who had at least two eligible encounters at least 90 days apart during the measurement period"
-      }
     ]
   },
   {
@@ -9494,11 +9353,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Number of patients with a referral on or before October 31, for which the referring clinician received a report from the clinician to whom the patient was referred"
-      }
     ]
   },
   {
@@ -9541,11 +9395,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients with patient-reported functional status assessment results (i.e., Veterans RAND 12-item health survey [VR-12], Patient-Reported Outcomes Measurement Information System [PROMIS]-10-Global Health, Hip Disability and Osteoarthritis Outcome Score [HOOS], HOOS Jr.) in the 90 days prior to or on the day of the primary THA procedure, and in the 300 - 425 days after the THA procedure"
-      }
     ]
   },
   {
@@ -9589,11 +9438,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients with patient-reported functional status assessment results (i.e., Veterans RAND 12-item health survey [VR-12]; VR-36; Kansas City Cardiomyopathy Questionnaire [KCCQ]; KCCQ-12; Minnesota Living with Heart Failure Questionnaire [MLHFQ]; Patient-Reported Outcomes Measurement Information System [PROMIS]-10 Global Health; PROMIS-29) present in the EHR within two weeks before or during the initial FSA encounter and results for the follow-up FSA at least 30 days but no more than 180 days after the initial FSA"
-      }
     ]
   },
   {
@@ -9635,11 +9479,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Children who had a diagnosis of cavities or decayed teeth in any part of the measurement period"
-      }
     ]
   },
   {
@@ -9681,11 +9520,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Children who receive two fluoride varnish applications on different days during the measurement period"
-      }
     ]
   },
   {
@@ -9730,11 +9564,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patient visits with an assessment for suicide risk"
-      }
     ]
   },
   {
@@ -11238,20 +11067,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "All patients who were previously diagnosed with or currently have a diagnosis of clinical atherosclerotic cardiovascular disease (ASCVD), including an ASCVD procedure"
-      },
-      {
-        "description": "Patients aged 20 to 75 years who have ever had a low-density lipoprotein cholesterol (LDL-C) level >= 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial hypercholesterolemia"
-      },
-      {
-        "description": "Patients aged 40-75 years with a diagnosis of diabetes"
-      },
-      {
-        "description": "Patients aged 40 to 75 with a 10-year ASCVD risk score of >= 20 percent."
-      }
     ]
   },
   {
@@ -11791,11 +11606,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients with a bone density evaluation within the two years prior to the start of or less than three months after the start of ADT treatment"
-      }
     ]
   },
   {
@@ -12113,11 +11923,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients with documentation of an HIV test performed on or after their 15th birthday and before their 66th birthday"
-      }
     ]
   },
   {
@@ -12163,11 +11968,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients with a documented improvement of at least 3 points in their urinary symptom score during the measurement period"
-      }
     ]
   },
   {
@@ -12400,11 +12200,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Intravesical Bacillus-Calmette Guerin (BCG) instillation for initial dose or series:\nBCG is initiated within 6 months of the bladder cancer staging"
-      }
     ]
   },
   {
@@ -12786,11 +12581,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients who received a kidney health evaluation defined by an eGFR AND uACR within the measurement period"
-      }
     ]
   },
   {
@@ -13076,11 +12866,6 @@
       "group",
       "subgroup",
       "individual"
-    ],
-    "strata": [
-      {
-        "description": "Patients with one or more eligible CT scans with calculated CT Size-Adjusted Dose greater than or equal to a threshold specific to the CT Dose and Image Quality Category, or Calculated CT Global Noise value greater than or equal to a threshold specific to the CT Dose and Image Quality Category"
-      }
     ]
   },
   {

--- a/mvp/2026/mvp-enriched.json
+++ b/mvp/2026/mvp-enriched.json
@@ -143,11 +143,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Eligible clinician attests to documenting, updating, or reviewing the patient's current medications using all immediate resources available on the date of the encounter"
-          }
         ]
       },
       {
@@ -218,11 +213,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients screened for depression on the date of the encounter or up to 14 days prior to the date of the encounter using an age-appropriate standardized tool AND if positive, a follow-up plan is documented on the date of or up to two days after the date of the qualifying encounter"
-          }
         ]
       },
       {
@@ -3678,11 +3668,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients whose most recent blood pressure is adequately controlled (systolic blood pressure < 140 mmHg and diastolic blood pressure < 90 mmHg) during the measurement period"
-          }
         ]
       },
       {
@@ -3864,20 +3849,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "All patients who were previously diagnosed with or currently have a diagnosis of clinical atherosclerotic cardiovascular disease (ASCVD), including an ASCVD procedure"
-          },
-          {
-            "description": "Patients aged 20 to 75 years who have ever had a low-density lipoprotein cholesterol (LDL-C) level >= 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial hypercholesterolemia"
-          },
-          {
-            "description": "Patients aged 40-75 years with a diagnosis of diabetes"
-          },
-          {
-            "description": "Patients aged 40 to 75 with a 10-year ASCVD risk score of >= 20 percent."
-          }
         ]
       },
       {
@@ -6651,11 +6622,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients who were prescribed or already taking ACE inhibitor or ARB or ARNI therapy during the measurement period"
-          }
         ]
       },
       {
@@ -6747,14 +6713,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients with left ventricular systolic dysfunction (LVEF <=40%)"
-          },
-          {
-            "description": "Patients with a prior (within the past 3 years) myocardial infarction"
-          }
         ]
       },
       {
@@ -6802,11 +6760,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients who were prescribed or already taking beta-blocker therapy during the measurement period"
-          }
         ]
       },
       {
@@ -6968,11 +6921,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients with a documented BMI during the encounter or during the measurement period, AND when the BMI is outside of normal parameters, a follow-up plan is documented during the encounter or during the measurement period"
-          }
         ]
       },
       {
@@ -7043,11 +6991,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients screened for depression on the date of the encounter or up to 14 days prior to the date of the encounter using an age-appropriate standardized tool AND if positive, a follow-up plan is documented on the date of or up to two days after the date of the qualifying encounter"
-          }
         ]
       },
       {
@@ -7253,11 +7196,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients with patient-reported functional status assessment results (i.e., Veterans RAND 12-item health survey [VR-12]; VR-36; Kansas City Cardiomyopathy Questionnaire [KCCQ]; KCCQ-12; Minnesota Living with Heart Failure Questionnaire [MLHFQ]; Patient-Reported Outcomes Measurement Information System [PROMIS]-10 Global Health; PROMIS-29) present in the EHR within two weeks before or during the initial FSA encounter and results for the follow-up FSA at least 30 days but no more than 180 days after the initial FSA"
-          }
         ]
       },
       {
@@ -10397,11 +10335,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "URI episodes without a prescription for antibiotic medication on or three days after the outpatient visit, telephone visit, virtual encounter, or emergency department visit for an upper respiratory infection"
-          }
         ]
       },
       {
@@ -13416,11 +13349,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients with a documented BMI during the encounter or during the measurement period, AND when the BMI is outside of normal parameters, a follow-up plan is documented during the encounter or during the measurement period"
-          }
         ]
       },
       {
@@ -13547,11 +13475,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients with patient-reported functional status assessment results (i.e., Veterans RAND 12-item health survey [VR-12], Patient-Reported Outcomes Measurement Information System [PROMIS]-10-Global Health, Hip Disability and Osteoarthritis Outcome Score [HOOS], HOOS Jr.) in the 90 days prior to or on the day of the primary THA procedure, and in the 300 - 425 days after the THA procedure"
-          }
         ]
       },
       {
@@ -19316,11 +19239,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients who did not have a bone scan performed after diagnosis of prostate cancer and before the end of the measurement period"
-          }
         ]
       },
       {
@@ -19391,11 +19309,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients screened for depression on the date of the encounter or up to 14 days prior to the date of the encounter using an age-appropriate standardized tool AND if positive, a follow-up plan is documented on the date of or up to two days after the date of the qualifying encounter"
-          }
         ]
       },
       {
@@ -19440,14 +19353,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Visits for patients with a diagnosis of cancer who are currently receiving chemotherapy"
-          },
-          {
-            "description": "Visits for patients with a diagnosis of cancer who are currently receiving radiation therapy"
-          }
         ]
       },
       {
@@ -19756,11 +19661,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients with a bone density evaluation within the two years prior to the start of or less than three months after the start of ADT treatment"
-          }
         ]
       },
       {
@@ -22979,11 +22879,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients whose most recent glycemic status assessment (HbA1c or GMI) (performed during the measurement period) is >9.0% or is missing, or was not performed during the measurement period"
-          }
         ]
       },
       {
@@ -23140,11 +23035,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Eligible clinician attests to documenting, updating, or reviewing the patient's current medications using all immediate resources available on the date of the encounter"
-          }
         ]
       },
       {
@@ -23202,11 +23092,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients whose most recent blood pressure is adequately controlled (systolic blood pressure < 140 mmHg and diastolic blood pressure < 90 mmHg) during the measurement period"
-          }
         ]
       },
       {
@@ -23400,11 +23285,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients who received a kidney health evaluation defined by an eGFR AND uACR within the measurement period"
-          }
         ]
       },
       {
@@ -26626,11 +26506,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Eligible clinician attests to documenting, updating, or reviewing the patient's current medications using all immediate resources available on the date of the encounter"
-          }
         ]
       },
       {
@@ -26844,11 +26719,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients for whom an assessment of cognition is performed and the results reviewed at least once within a 12-month period"
-          }
         ]
       },
       {
@@ -30094,11 +29964,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients whose most recent glycemic status assessment (HbA1c or GMI) (performed during the measurement period) is >9.0% or is missing, or was not performed during the measurement period"
-          }
         ]
       },
       {
@@ -30241,11 +30106,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients screened for depression on the date of the encounter or up to 14 days prior to the date of the encounter using an age-appropriate standardized tool AND if positive, a follow-up plan is documented on the date of or up to two days after the date of the qualifying encounter"
-          }
         ]
       },
       {
@@ -30303,11 +30163,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients whose most recent blood pressure is adequately controlled (systolic blood pressure < 140 mmHg and diastolic blood pressure < 90 mmHg) during the measurement period"
-          }
         ]
       },
       {
@@ -30464,20 +30319,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "All patients who were previously diagnosed with or currently have a diagnosis of clinical atherosclerotic cardiovascular disease (ASCVD), including an ASCVD procedure"
-          },
-          {
-            "description": "Patients aged 20 to 75 years who have ever had a low-density lipoprotein cholesterol (LDL-C) level >= 190 mg/dL or were previously diagnosed with or currently have an active diagnosis of familial hypercholesterolemia"
-          },
-          {
-            "description": "Patients aged 40-75 years with a diagnosis of diabetes"
-          },
-          {
-            "description": "Patients aged 40 to 75 with a 10-year ASCVD risk score of >= 20 percent."
-          }
         ]
       },
       {
@@ -30527,11 +30368,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients with documentation of an HIV test performed on or after their 15th birthday and before their 66th birthday"
-          }
         ]
       },
       {
@@ -33717,11 +33553,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Women with one or more mammograms any time on or between October 1 two years prior to the measurement period and the end of the measurement period"
-          }
         ]
       },
       {
@@ -33792,11 +33623,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients screened for depression on the date of the encounter or up to 14 days prior to the date of the encounter using an age-appropriate standardized tool AND if positive, a follow-up plan is documented on the date of or up to two days after the date of the qualifying encounter"
-          }
         ]
       },
       {
@@ -33938,11 +33764,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Women with one or more screenings for cervical cancer. Appropriate screenings are defined by any one of the following criteria:\n- Cervical cytology performed during the measurement period or the two years prior to the measurement period for women 24-64 years of age by the end of the measurement period.\n\n- Cervical human papillomavirus (HPV) testing performed during the measurement period or the four years prior to the measurement period for women who are 30 years or older at the time of the test."
-          }
         ]
       },
       {
@@ -33987,11 +33808,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Women with at least one chlamydia test during the measurement period"
-          }
         ]
       },
       {
@@ -34397,11 +34213,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients with documentation of an HIV test performed on or after their 15th birthday and before their 66th birthday"
-          }
         ]
       },
       {
@@ -37255,11 +37066,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients with a documented BMI during the encounter or during the measurement period, AND when the BMI is outside of normal parameters, a follow-up plan is documented during the encounter or during the measurement period"
-          }
         ]
       },
       {
@@ -40270,11 +40076,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "URI episodes without a prescription for antibiotic medication on or three days after the outpatient visit, telephone visit, virtual encounter, or emergency department visit for an upper respiratory infection"
-          }
         ]
       },
       {
@@ -40359,11 +40160,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Eligible clinician attests to documenting, updating, or reviewing the patient's current medications using all immediate resources available on the date of the encounter"
-          }
         ]
       },
       {
@@ -40434,11 +40230,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients screened for depression on the date of the encounter or up to 14 days prior to the date of the encounter using an age-appropriate standardized tool AND if positive, a follow-up plan is documented on the date of or up to two days after the date of the qualifying encounter"
-          }
         ]
       },
       {
@@ -40483,11 +40274,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients who were tested for each of the following at least once during the measurement period: chlamydia, gonorrhea, and syphilis"
-          }
         ]
       },
       {
@@ -40531,11 +40317,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "DTaP\nChildren with any of the following on or before the child’s second birthday meet criteria:\n- At least four DTaP vaccinations, with different dates of service. Do not count a vaccination administered prior to 42 days after birth.\n- Anaphylaxis due to the diphtheria, tetanus or pertussis vaccine.\n- Encephalitis due to the diphtheria, tetanus or pertussis vaccine.\n\nIPV\nChildren with either of the following on or before the child’s second birthday meet criteria:\n- At least three IPV vaccinations, with different dates of service. Do not count a vaccination administered prior to 42 days after birth.\n- Anaphylaxis due to the IPV vaccine.\n\nMMR\nChildren with any of the following meet criteria:\n- At least one MMR vaccination on or between the child’s first and second birthdays.\n- Anaphylaxis due to the MMR vaccine on or before the child’s second birthday.\n- All of the following anytime on or before the child’s second birthday (on the same or different date of service):\n       - History of measles.\n       - History of mumps.\n       - History of rubella.\n\nHiB\nChildren with either of the following meet criteria on or before the child’s second birthday:\n- At least three HiB vaccinations, with different dates of service. Do not count a vaccination administered prior to 42 days after birth.\n- Anaphylaxis due to the HiB vaccine.\n\nHepB\nChildren with any of the following on or before the child’s second birthday meet criteria:\n- At least three hepatitis B vaccinations, with different dates of service.\n       - One of the three vaccinations can be a newborn hepatitis B vaccination during the eight-day period that begins on the date of birth and ends seven days after the date of birth. For example, if the member’s date of birth is December 1, the newborn hepatitis B vaccination must be on or between December 1 and December 8.\n- Anaphylaxis due to the hepatitis B vaccine.\n- History of hepatitis B illness.\n\nVZV\nChildren with any of the following meet criteria:\n- At least one VZV vaccination, with a date of service on or between the child’s first and second birthdays.\n- Anaphylaxis due to the VZV vaccine on or before the child’s second birthday.\n- History of varicella zoster (e.g., chicken pox) illness on or before the child’s second birthday.\n\nPCV\nChildren with either of the following on or before the child’s second birthday meet criteria:\n- At least four pneumococcal conjugate vaccinations, with different dates of service on or before the child’s second birthday. Do not count a vaccination administered prior to 42 days after birth.\n- Anaphylaxis due to the pneumococcal vaccine.\n\nHepA\nChildren with any of the following meet criteria:\n- At least one hepatitis A vaccination, with a date of service on or between the child’s first and second birthdays.\n- Anaphylaxis due to the hepatitis A vaccine on or before the child’s second birthday.\n- History of hepatitis A illness on or before the child’s second birthday.\n\nRV\nChildren with any of the following meet criteria:\n- At least two doses of the two-dose rotavirus vaccine on different dates of service on or before the child’s second birthday. Do not count a vaccination administered prior to 42 days after birth.\n- At least three doses of the three-dose rotavirus vaccine on different dates of service on or before the child’s second birthday. Do not count a vaccination administered prior to 42 days after birth.\n- At least one dose of the two-dose rotavirus vaccine and at least two doses of the three-dose rotavirus vaccine, all on different dates of service, on or before the child’s second birthday. Do not count a vaccination administered prior to 42 days after birth.\n- Anaphylaxis due to the rotavirus vaccine on or before the child’s second birthday.\n\nFlu\nChildren with either of the following on or before their second birthday meet criteria:\n- At least two influenza vaccinations, with different dates of service on or before the child’s second birthday. Do not count a vaccination administered prior to 6 months (180 days) after birth.\n       - One of the two vaccinations can be a Live Attenuated Influenza Vaccine (LAIV) vaccination administered on the child’s second birthday. Do not count a LAIV vaccination administered before the child’s second birthday.\n- Anaphylaxis due to the influenza vaccine."
-          }
         ]
       },
       {
@@ -40580,11 +40361,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Women with at least one chlamydia test during the measurement period"
-          }
         ]
       },
       {
@@ -40631,11 +40407,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients with a last HIV viral load test result of less than 200 copies/mL during the measurement period"
-          }
         ]
       },
       {
@@ -40680,11 +40451,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Number of patients who had at least one eligible encounter and one HIV viral load test at least 90 days apart during the measurement period, or who had at least two eligible encounters at least 90 days apart during the measurement period"
-          }
         ]
       },
       {
@@ -40880,11 +40646,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients with documentation of an HIV test performed on or after their 15th birthday and before their 66th birthday"
-          }
         ]
       },
       {
@@ -43668,11 +43429,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients screened for depression on the date of the encounter or up to 14 days prior to the date of the encounter using an age-appropriate standardized tool AND if positive, a follow-up plan is documented on the date of or up to two days after the date of the qualifying encounter"
-          }
         ]
       },
       {
@@ -43888,11 +43644,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patient visits with an assessment for suicide risk"
-          }
         ]
       },
       {
@@ -47027,11 +46778,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients with a documented BMI during the encounter or during the measurement period, AND when the BMI is outside of normal parameters, a follow-up plan is documented during the encounter or during the measurement period"
-          }
         ]
       },
       {
@@ -50266,11 +50012,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients who have an optic nerve head evaluation during one or more visits within 12 months"
-          }
         ]
       },
       {
@@ -50314,11 +50055,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients with documentation, at least once within the measurement period, of the findings of the dilated macular or fundus exam via communication to the physician who manages the patient's diabetic care"
-          }
         ]
       },
       {
@@ -50366,11 +50102,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients with an eye screening for diabetic retinal disease. This includes diabetics who had one of the following:\n- Diabetic with a diagnosis of retinopathy in any part of the measurement period and a retinal or dilated eye exam by an eye care professional in the measurement period\n- Diabetic with no diagnosis of retinopathy in any part of the measurement period and a retinal or dilated eye exam by an eye care professional in the measurement period or the year prior to the measurement period"
-          }
         ]
       },
       {
@@ -50455,11 +50186,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Eligible clinician attests to documenting, updating, or reviewing the patient's current medications using all immediate resources available on the date of the encounter"
-          }
         ]
       },
       {
@@ -50546,11 +50272,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Cataract surgeries with best-corrected visual acuity of 20/40 or better (distance or near) achieved in the operative eye within 90 days following cataract surgery"
-          }
         ]
       },
       {
@@ -50798,11 +50519,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Number of patients with a referral on or before October 31, for which the referring clinician received a report from the clinician to whom the patient was referred"
-          }
         ]
       },
       {
@@ -54107,11 +53823,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Eligible clinician attests to documenting, updating, or reviewing the patient's current medications using all immediate resources available on the date of the encounter"
-          }
         ]
       },
       {
@@ -57527,11 +57238,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients with one or more screenings for colorectal cancer. Appropriate screenings are defined by any one of the following criteria: \n- Fecal occult blood test (FOBT) during the measurement period\n- Stool DNA (sDNA) with FIT test during the measurement period or the two years prior to the measurement period\n- Flexible sigmoidoscopy during the measurement period or the four years prior to the measurement period\n- CT Colonography during the measurement period or the four years prior to the measurement period\n- Colonoscopy during the measurement period or the nine years prior to the measurement period"
-          }
         ]
       },
       {
@@ -57616,11 +57322,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Eligible clinician attests to documenting, updating, or reviewing the patient's current medications using all immediate resources available on the date of the encounter"
-          }
         ]
       },
       {
@@ -57911,11 +57612,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Number of patients with a referral on or before October 31, for which the referring clinician received a report from the clinician to whom the patient was referred"
-          }
         ]
       },
       {
@@ -60961,11 +60657,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients who were screened for future fall risk at least once within the measurement period"
-          }
         ]
       },
       {
@@ -61111,11 +60802,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients with a bone density evaluation within the two years prior to the start of or less than three months after the start of ADT treatment"
-          }
         ]
       },
       {
@@ -61161,11 +60847,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients with a documented improvement of at least 3 points in their urinary symptom score during the measurement period"
-          }
         ]
       },
       {
@@ -61208,11 +60889,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Intravesical Bacillus-Calmette Guerin (BCG) instillation for initial dose or series:\nBCG is initiated within 6 months of the bladder cancer staging"
-          }
         ]
       },
       {
@@ -64432,11 +64108,6 @@
           "group",
           "subgroup",
           "individual"
-        ],
-        "strata": [
-          {
-            "description": "Patients with a documented BMI during the encounter or during the measurement period, AND when the BMI is outside of normal parameters, a follow-up plan is documented during the encounter or during the measurement period"
-          }
         ]
       },
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "qpp-measures-data",
-      "version": "v8.25.0",
+      "version": "v8.26.0",
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^11.0.4",

--- a/scripts/measures/initialize-measures-data.ts
+++ b/scripts/measures/initialize-measures-data.ts
@@ -30,6 +30,7 @@ function initMeasuresData() {
     removeBenchmarksRemoved();
     removeEMeasureUuids();
     initializeSevenPointCapRemoved();
+    removeStrataForSPR();
 
     writeToFile(measuresJson, measuresPath);
 }
@@ -113,6 +114,25 @@ function initializeSevenPointCapRemoved() {
         if (year >= 2025 && measuresJson[i].category === 'quality') {
             measuresJson[i].isSevenPointCapRemoved = false;
             measuresJson[i].sevenPointCapRemoved = [];
+        }
+    }
+}
+
+function removeStrataForSPR() {
+    const year = parseInt(performanceYear, 10);
+
+    if (isNaN(year) || year <= 2025) {
+        return;
+    }
+
+    // For 2026 and beyond, remove strata for SPR measures
+    for (let i = 0; i < measuresJson.length; i++) {
+        const metricType = measuresJson[i]?.metricType?.toLowerCase();
+
+        if (metricType === 'singleperformancerate' || metricType === 'registrysingleperformancerate') {
+            if (measuresJson[i].strata) {
+                delete measuresJson[i].strata;
+            }
         }
     }
 }

--- a/scripts/measures/initialize-measures-data.ts
+++ b/scripts/measures/initialize-measures-data.ts
@@ -118,14 +118,8 @@ function initializeSevenPointCapRemoved() {
     }
 }
 
+// remove strata for SPR measures
 function removeStrataForSPR() {
-    const year = parseInt(performanceYear, 10);
-
-    if (isNaN(year) || year <= 2025) {
-        return;
-    }
-
-    // For 2026 and beyond, remove strata for SPR measures
     for (let i = 0; i < measuresJson.length; i++) {
         const metricType = measuresJson[i]?.metricType?.toLowerCase();
 


### PR DESCRIPTION
## Related Tickets & Documents
<!--
Mandatory if the ticket exists. Otherwise, the description section **must** contain the details.
-->
https://jira.cms.gov/browse/QPPA-10625

---

## Description
Added logic to remove strata for measures with metricType = singlePerformanceRate or registrySinglePerformanceRate when initializing years > 2025.

Applied update to PY2026 measures-data.json to remove existing SPR strata.

---
## What type of PR is this?
<!--
(mark 'x' all applicable)
-->
- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [x] 📦 Chore
- [ ] ⏩ Revert

---

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
---

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Confluence
- [ ] 🙅 no documentation needed
