### PR TITLE
QPPA-10834, QPPA-10835: Add programName appPlus to CAHPS measures for PY25 and PY26

### DIFF
--- a/measures/2025/measures-data.json
+++ b/measures/2025/measures-data.json
@@ -19221,7 +19221,8 @@
     "companionMeasureId": [],
     "allowedPrograms": [
       "mips",
-      "app1"
+      "app1",
+      "appPlus"
     ],
     "submissionMethods": [
       "certifiedSurveyVendor"
@@ -19260,7 +19261,8 @@
     "companionMeasureId": [],
     "allowedPrograms": [
       "mips",
-      "app1"
+      "app1",
+      "appPlus"
     ],
     "submissionMethods": [
       "certifiedSurveyVendor"
@@ -19299,7 +19301,8 @@
     "companionMeasureId": [],
     "allowedPrograms": [
       "mips",
-      "app1"
+      "app1",
+      "appPlus"
     ],
     "submissionMethods": [
       "certifiedSurveyVendor"
@@ -19338,7 +19341,8 @@
     "companionMeasureId": [],
     "allowedPrograms": [
       "mips",
-      "app1"
+      "app1",
+      "appPlus"
     ],
     "submissionMethods": [
       "certifiedSurveyVendor"
@@ -19377,7 +19381,8 @@
     "companionMeasureId": [],
     "allowedPrograms": [
       "mips",
-      "app1"
+      "app1",
+      "appPlus"
     ],
     "submissionMethods": [
       "certifiedSurveyVendor"
@@ -19416,7 +19421,8 @@
     "companionMeasureId": [],
     "allowedPrograms": [
       "mips",
-      "app1"
+      "app1",
+      "appPlus"
     ],
     "submissionMethods": [
       "certifiedSurveyVendor"
@@ -19455,7 +19461,8 @@
     "companionMeasureId": [],
     "allowedPrograms": [
       "mips",
-      "app1"
+      "app1",
+      "appPlus"
     ],
     "submissionMethods": [
       "certifiedSurveyVendor"
@@ -19494,7 +19501,8 @@
     "companionMeasureId": [],
     "allowedPrograms": [
       "mips",
-      "app1"
+      "app1",
+      "appPlus"
     ],
     "submissionMethods": [
       "certifiedSurveyVendor"
@@ -19533,7 +19541,8 @@
     "companionMeasureId": [],
     "allowedPrograms": [
       "mips",
-      "app1"
+      "app1",
+      "appPlus"
     ],
     "submissionMethods": [
       "certifiedSurveyVendor"
@@ -19572,7 +19581,8 @@
     "companionMeasureId": [],
     "allowedPrograms": [
       "mips",
-      "app1"
+      "app1",
+      "appPlus"
     ],
     "submissionMethods": [
       "certifiedSurveyVendor"

--- a/measures/2026/measures-data.json
+++ b/measures/2026/measures-data.json
@@ -17787,7 +17787,8 @@
     "companionMeasureId": [],
     "allowedPrograms": [
       "mips",
-      "app1"
+      "app1",
+      "appPlus"
     ],
     "submissionMethods": [
       "certifiedSurveyVendor"
@@ -17826,7 +17827,8 @@
     "companionMeasureId": [],
     "allowedPrograms": [
       "mips",
-      "app1"
+      "app1",
+      "appPlus"
     ],
     "submissionMethods": [
       "certifiedSurveyVendor"
@@ -17865,7 +17867,8 @@
     "companionMeasureId": [],
     "allowedPrograms": [
       "mips",
-      "app1"
+      "app1",
+      "appPlus"
     ],
     "submissionMethods": [
       "certifiedSurveyVendor"
@@ -17904,7 +17907,8 @@
     "companionMeasureId": [],
     "allowedPrograms": [
       "mips",
-      "app1"
+      "app1",
+      "appPlus"
     ],
     "submissionMethods": [
       "certifiedSurveyVendor"
@@ -17943,7 +17947,8 @@
     "companionMeasureId": [],
     "allowedPrograms": [
       "mips",
-      "app1"
+      "app1",
+      "appPlus"
     ],
     "submissionMethods": [
       "certifiedSurveyVendor"
@@ -17982,7 +17987,8 @@
     "companionMeasureId": [],
     "allowedPrograms": [
       "mips",
-      "app1"
+      "app1",
+      "appPlus"
     ],
     "submissionMethods": [
       "certifiedSurveyVendor"
@@ -18021,7 +18027,8 @@
     "companionMeasureId": [],
     "allowedPrograms": [
       "mips",
-      "app1"
+      "app1",
+      "appPlus"
     ],
     "submissionMethods": [
       "certifiedSurveyVendor"
@@ -18060,7 +18067,8 @@
     "companionMeasureId": [],
     "allowedPrograms": [
       "mips",
-      "app1"
+      "app1",
+      "appPlus"
     ],
     "submissionMethods": [
       "certifiedSurveyVendor"
@@ -18099,7 +18107,8 @@
     "companionMeasureId": [],
     "allowedPrograms": [
       "mips",
-      "app1"
+      "app1",
+      "appPlus"
     ],
     "submissionMethods": [
       "certifiedSurveyVendor"
@@ -18138,7 +18147,8 @@
     "companionMeasureId": [],
     "allowedPrograms": [
       "mips",
-      "app1"
+      "app1",
+      "appPlus"
     ],
     "submissionMethods": [
       "certifiedSurveyVendor"


### PR DESCRIPTION
…nd PY26

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs when possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation.
-->

## Related Tickets & Documents
<!--
Mandatory if the ticket exists. Otherwise, the description section **must** contain the details.
-->
https://jira.cms.gov/browse/QPPA-10834
https://jira.cms.gov/browse/QPPA-10835

---

## Description
See ticket description.

---
## What type of PR is this?
<!--
(mark 'x' all applicable)
-->
- [x] 📊 Data Update
- [ ] 📝 Documentation Update
- [ ] 🧑‍💻 Code Update
- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore
- [ ] ⏩ Revert

---


## 🔴 IMPORTANT: Add required labels

At least one of each type of PR label should be added for checks to pass.

- `notes:*`
- `version:*`

**Patch** versions are code-only changes, with no data updates.
**Minor** versions are data changes, such as updates to the measures-data.json files.
**Major** versions are annual and tied to a PY's data becoming avaliable, determined by QPPA's PO.

---

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
---

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Confluence
- [x] 🙅 no documentation needed
