### PR TITLE
QPPA-11094: PY26 historic benchmarks removed

### DIFF
--- a/measures/2026/measures-data.json
+++ b/measures/2026/measures-data.json
@@ -12907,6 +12907,9 @@
       "subgroup",
       "individual"
     ],
+    "historic_benchmarks": {
+      "registry": "removed"
+    },
     "strata": [
       {
         "name": "influenza",
@@ -13238,7 +13241,10 @@
       "group",
       "subgroup",
       "individual"
-    ]
+    ],
+    "historic_benchmarks": {
+      "registry": "removed"
+    }
   },
   {
     "category": "quality",
@@ -13280,7 +13286,10 @@
       "group",
       "subgroup",
       "individual"
-    ]
+    ],
+    "historic_benchmarks": {
+      "registry": "removed"
+    }
   },
   {
     "category": "quality",

--- a/mvp/2026/mvp-enriched.json
+++ b/mvp/2026/mvp-enriched.json
@@ -456,6 +456,9 @@
           "subgroup",
           "individual"
         ],
+        "historic_benchmarks": {
+          "registry": "removed"
+        },
         "strata": [
           {
             "name": "influenza",
@@ -24894,6 +24897,9 @@
           "subgroup",
           "individual"
         ],
+        "historic_benchmarks": {
+          "registry": "removed"
+        },
         "strata": [
           {
             "name": "influenza",
@@ -32495,6 +32501,9 @@
           "subgroup",
           "individual"
         ],
+        "historic_benchmarks": {
+          "registry": "removed"
+        },
         "strata": [
           {
             "name": "influenza",
@@ -36527,6 +36536,9 @@
           "subgroup",
           "individual"
         ],
+        "historic_benchmarks": {
+          "registry": "removed"
+        },
         "strata": [
           {
             "name": "influenza",
@@ -43474,6 +43486,9 @@
           "subgroup",
           "individual"
         ],
+        "historic_benchmarks": {
+          "registry": "removed"
+        },
         "strata": [
           {
             "name": "influenza",
@@ -54536,7 +54551,10 @@
           "group",
           "subgroup",
           "individual"
-        ]
+        ],
+        "historic_benchmarks": {
+          "registry": "removed"
+        }
       },
       {
         "category": "quality",
@@ -54578,7 +54596,10 @@
           "group",
           "subgroup",
           "individual"
-        ]
+        ],
+        "historic_benchmarks": {
+          "registry": "removed"
+        }
       },
       {
         "category": "quality",

--- a/updates/measures/2026/Quality_PY2026_Benchmark Removals_12152025.csv
+++ b/updates/measures/2026/Quality_PY2026_Benchmark Removals_12152025.csv
@@ -1,0 +1,4 @@
+﻿Category ,Measure Title,CMS eCQM ID,eCQM NQF,NQF,*** Quality Number (#) / QCDR #,Primary Measure Steward,Allowed QCDR Vendor ID,Measure Description,*** Measure Type  ,High Priority,First Performance Year,Year Removed,*** Collection Type(s) for Submission,Specialty Measure Sets,*** Inverse,*** Metric Type,*** Calculation Type,Collection Type(s) where Historic Benchmark Removed,Collection Type(s) where Suppressed,Collection Type(s) where Truncated,*** Collection Type(s) where 7-point Cap Removed,Collection Type(s) where Historic Benchmark Removed ** Special Rules **,Is Risk Adjusted 
+Quality,,,,,493,,,,,,,,,,,,,MIPS CQM,,,,,
+Quality,,,,,500,,,,,,,,,,,,,MIPS CQM,,,,,
+Quality,,,,,501,,,,,,,,,,,,,MIPS CQM,,,,,

--- a/updates/measures/2026/changes.meta.json
+++ b/updates/measures/2026/changes.meta.json
@@ -7,5 +7,6 @@
   "IA_PY26_CR_20251121_Final_Rule_Updates.csv",
   "PI_PY26_CR_20251118.csv",
   "Quality_2026_Annual Measure Revisions_CR_11212025.csv",
-  "2026_Quality_QCDR_CR_20251212.csv"
+  "2026_Quality_QCDR_CR_20251212.csv",
+  "Quality_PY2026_Benchmark Removals_12152025.csv"
 ]


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs when possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation.
-->

## Related Tickets & Documents
<!--
Mandatory if the ticket exists. Otherwise, the description section **must** contain the details.
-->
https://jira.cms.gov/browse/QPPA-11094

---

## Description
See ticket description.

---
## What type of PR is this?
<!--
(mark 'x' all applicable)
-->
- [x] 📊 Data Update
- [ ] 📝 Documentation Update
- [ ] 🧑‍💻 Code Update
- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore
- [ ] ⏩ Revert

---


## 🔴 IMPORTANT: Add required labels

At least one of each type of PR label should be added for checks to pass.

- `notes:*`
- `version:*`

**Patch** versions are code-only changes, with no data updates.
**Minor** versions are data changes, such as updates to the measures-data.json files.
**Major** versions are annual and tied to a PY's data becoming avaliable, determined by QPPA's PO.

---

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
---

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Confluence
- [x] 🙅 no documentation needed
