### PR TITLE
QPPSE-6358: Remove Suppressed Cost Measures COST_AKID_1,COST_EDV_1

### DIFF
--- a/benchmarks/2025.json
+++ b/benchmarks/2025.json
@@ -6874,30 +6874,6 @@
     }
   },
   {
-    "measureId": "COST_AKID_1",
-    "benchmarkYear": 2025,
-    "performanceYear": 2025,
-    "submissionMethod": "administrativeClaims",
-    "isToppedOut": false,
-    "isInverse": true,
-    "metricType": "costScore",
-    "isToppedOutByProgram": false,
-    "averagePerformanceRate": 48566.93,
-    "percentiles": {
-      "1": 0,
-      "10": 33155.43,
-      "20": 37819.58,
-      "30": 42483.74,
-      "40": 51812.06,
-      "50": 56476.22,
-      "60": 61140.37,
-      "70": 65804.53,
-      "80": 68136.61,
-      "90": 70468.69,
-      "99": 72800.77
-    }
-  },
-  {
     "measureId": "COST_CCLI_1",
     "benchmarkYear": 2025,
     "performanceYear": 2025,
@@ -7039,30 +7015,6 @@
       "80": 11643.72,
       "90": 12118.38,
       "99": 12593.04
-    }
-  },
-  {
-    "measureId": "COST_EDV_1",
-    "benchmarkYear": 2025,
-    "performanceYear": 2025,
-    "submissionMethod": "administrativeClaims",
-    "isToppedOut": false,
-    "isInverse": true,
-    "metricType": "costScore",
-    "isToppedOutByProgram": false,
-    "averagePerformanceRate": 6490.71,
-    "percentiles": {
-      "1": 0,
-      "10": 5239.69,
-      "20": 5625.29,
-      "30": 6010.89,
-      "40": 6782.09,
-      "50": 7167.69,
-      "60": 7553.29,
-      "70": 7938.89,
-      "80": 8131.69,
-      "90": 8324.49,
-      "99": 8517.29
     }
   },
   {


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs when possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation.
-->

## Related Tickets & Documents
<!--
Mandatory if the ticket exists. Otherwise, the description section **must** contain the details.
-->
https://jira.cms.gov/browse/QPPSE-6358

---

## Description
[PY25] [FS] [Benchmarks Repo] Remove Suppressed measures
COST_EDV_1
COST_AKID_1

---
## What type of PR is this?
<!--
(mark 'x' all applicable)
-->
- [X] 📊 Data Update
- [ ] 📝 Documentation Update
- [ ] 🧑‍💻 Code Update
- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore
- [ ] ⏩ Revert

---


## 🔴 IMPORTANT: Add required labels

At least one of each type of PR label should be added for checks to pass.

- `notes:*`
- `version:*`

**Patch** versions are code-only changes, with no data updates.
**Minor** versions are data changes, such as updates to the measures-data.json files.
**Major** versions are annual and tied to a PY's data becoming avaliable, determined by QPPA's PO.

---

## Added tests?
- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
---

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Confluence
- [X] 🙅 no documentation needed
