### PR TITLE
QPPC-0000: Remove `COST_AKID_1` and `COST_EDV_1`

### DIFF
--- a/benchmarks/2025/cost-national-averages.json
+++ b/benchmarks/2025/cost-national-averages.json
@@ -7,13 +7,6 @@
     "individualNationalAverage": 5158.59
   },
   {
-    "measureId": "COST_AKID_1",
-    "performanceYear": 2025,
-    "benchmarkYear": 2025,
-    "groupNationalAverage": 41481.12,
-    "individualNationalAverage": 48180.4
-  },
-  {
     "measureId": "COST_CCLI_1",
     "performanceYear": 2025,
     "benchmarkYear": 2025,
@@ -54,13 +47,6 @@
     "benchmarkYear": 2025,
     "groupNationalAverage": 7557.12,
     "individualNationalAverage": 7557.12
-  },
-  {
-    "measureId": "COST_EDV_1",
-    "performanceYear": 2025,
-    "benchmarkYear": 2025,
-    "groupNationalAverage": 6091.56,
-    "individualNationalAverage": 6195.78
   },
   {
     "measureId": "COST_EOPCI_1",


### PR DESCRIPTION
Remove the two suppressed cost measures from the 2025 cost-national-averages.json.

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs when possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation.
-->

## Related Tickets & Documents
<!--
Mandatory if the ticket exists. Otherwise, the description section **must** contain the details.
-->
https://jira.cms.gov/browse/QPPA-XXXX

---

## Description
See ticket description.

---
## What type of PR is this?
<!--
(mark 'x' all applicable)
-->
- [x] 📊 Data Update
- [ ] 📝 Documentation Update
- [ ] 🧑‍💻 Code Update
- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore
- [ ] ⏩ Revert

---


## 🔴 IMPORTANT: Add required labels

At least one of each type of PR label should be added for checks to pass.

- `notes:*`
- `version:*`

**Patch** versions are code-only changes, with no data updates.
**Minor** versions are data changes, such as updates to the measures-data.json files.
**Major** versions are annual and tied to a PY's data becoming avaliable, determined by QPPA's PO.

---

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
---

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📓 Confluence
- [x] 🙅 no documentation needed
