### PR TITLE
QPPA-12011: Add min-release-age flag and dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,12 @@ updates:
     allow:
       - dependency-name: "qpp*"
       - dependency-name: "@cmsgov/*"
+    cooldown:
+      default-days: 7
+      exclude:
+        - "@cmsgov/qpp-scoring-engines"
+        - "qpp-measures-data"
+        - "qpp-shared-logger-node"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       exclude:
         - "@cmsgov/qpp-scoring-engines"
         - "qpp-measures-data"
-        - "qpp-shared-logger-node"
+        - "@cmsgov/qpp-shared-logger-node"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,7 @@
+# Require packages to be published for at least 7 days before they can be
+# installed, to align with Snyk's AI-assisted security remediation policy.
+# CMS-internal/trusted packages are exempt so they can be deployed same-day
+# or next-day without being blocked.
 min-release-age=7
 min-release-age-exclude[]=@cmsgov/*
 min-release-age-exclude[]=qpp-*

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+min-release-age=7
+min-release-age-exclude[]=@cmsgov/*
+min-release-age-exclude[]=qpp-*


### PR DESCRIPTION
## Summary
Implements [QPPA-12011](https://jira.cms.gov/browse/QPPA-12011) — adds a 7-day minimum release age restriction to align with the Snyk AI-assisted security remediation policy, while exempting CMS-internal/trusted packages so they remain deployable same-day/next-day.

## Changes
- **`.npmrc`** (new): adds `min-release-age=7` and excludes `@cmsgov/*` and `qpp-*` scoped/named packages from the restriction.
- **`.github/dependabot.yml`**: adds a `cooldown` block (7-day default) to the npm update entry, excluding `@cmsgov/qpp-scoring-engines`, `qpp-measures-data`, and `qpp-shared-logger-node`.

## Testing
- `npm run lint` — passes (note: npm emits a harmless warning that it doesn't yet recognize the `min-release-age-exclude` array syntax with the locally installed npm version; this matches the exact config specified in the ticket).
- `npm test` — all 32 suites / 306 tests pass.
- Verified `.github/dependabot.yml` is valid YAML.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>